### PR TITLE
Replace outdated use of c_types.h with stdint

### DIFF
--- a/components/lwip/port/netif/wlanif.c
+++ b/components/lwip/port/netif/wlanif.c
@@ -175,7 +175,7 @@ void
 #ifdef LWIP_ESP8266
 wlanif_input(struct netif *netif, void *buffer, u16_t len, void* eb)
 #else
-wlanif_input(struct netif *netif, void *buffer, uint16 len)
+wlanif_input(struct netif *netif, void *buffer, uint16_t len)
 #endif
 {
   struct pbuf *p;


### PR DESCRIPTION
Replace outdated use of c_types.h with stdint
uint16 -> uint16_t