### PR TITLE
Install dependencies for Ubuntu 16.04

### DIFF
--- a/docs/linux-setup.rst
+++ b/docs/linux-setup.rst
@@ -69,6 +69,10 @@ In any case, here are the steps to compile the toolchain yourself.
 
         sudo apt-get install gawk gperf grep gettext ncurses python python-dev automake bison flex texinfo help2man libtool
 
+  - Ubuntu 16.04::
+  
+        sudo apt-get install gawk gperf grep gettext python python-dev automake bison flex texinfo help2man libtool libtool-bin
+
   - Debian::
 
         TODO


### PR DESCRIPTION
Not sure which Ubuntu is used in the installation guide but for the latest LTS release 16.04 we need libtool-bin for compiling crosstool-NG proper
