### PR TITLE
Create temp config in the same dir as target

### DIFF
--- a/tools/kconfig/confdata.c
+++ b/tools/kconfig/confdata.c
@@ -771,7 +771,7 @@ int conf_write(const char *name)
 	sprintf(newname, "%s%s", dirname, basename);
 	env = getenv("KCONFIG_OVERWRITECONFIG");
 	if (!env || !*env) {
-		sprintf(tmpname, "%s.tmpconfig.%d", dirname, (int)getpid());
+		sprintf(tmpname, "%s.tmpconfig.%d", newname, (int)getpid());
 		out = fopen(tmpname, "w");
 	} else {
 		*tmpname = 0;


### PR DESCRIPTION
Fixes case where SDK and app are on different mounts