### PR TITLE
Allow gw to be null

### DIFF
--- a/components/lwip/apps/dhcpserver.c
+++ b/components/lwip/apps/dhcpserver.c
@@ -268,12 +268,14 @@ static u8_t *add_offer_options(u8_t *optptr)
 
         tcpip_adapter_get_ip_info(ESP_IF_WIFI_AP, &if_ip);
 
-        *optptr++ = DHCP_OPTION_ROUTER;
-        *optptr++ = 4;
-        *optptr++ = ip4_addr1(&if_ip.gw);
-        *optptr++ = ip4_addr2(&if_ip.gw);
-        *optptr++ = ip4_addr3(&if_ip.gw);
-        *optptr++ = ip4_addr4(&if_ip.gw);
+        if (!ip4_addr_isany_val(if_ip.gw)) {
+            *optptr++ = DHCP_OPTION_ROUTER;
+            *optptr++ = 4;
+            *optptr++ = ip4_addr1(&if_ip.gw);
+            *optptr++ = ip4_addr2(&if_ip.gw);
+            *optptr++ = ip4_addr3(&if_ip.gw);
+            *optptr++ = ip4_addr4(&if_ip.gw);
+        }
     }
 
 #ifdef USE_DNS

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -213,7 +213,7 @@ esp_err_t tcpip_adapter_set_ip_info(tcpip_adapter_if_t tcpip_if, tcpip_adapter_i
     tcpip_adapter_dhcp_status_t status;
 
     if (tcpip_if >= TCPIP_ADAPTER_IF_MAX || ip_info == NULL ||
-            ip4_addr_isany_val(ip_info->ip) || ip4_addr_isany_val(ip_info->netmask) || ip4_addr_isany_val(ip_info->gw)) {
+            ip4_addr_isany_val(ip_info->ip) || ip4_addr_isany_val(ip_info->netmask)) {
         return ESP_ERR_TCPIP_ADAPTER_INVALID_PARAMS;
     }
 


### PR DESCRIPTION
Allow interfaces to be configured without a default gateway, for
local-only communication.

In case of the AP interface, if gw is not set, do not offer it.