### PR TITLE
BLE Advertisement flags not working

### DIFF
--- a/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
+++ b/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
@@ -109,6 +109,7 @@ static void btc_to_bta_adv_data(esp_ble_adv_data_t *p_adv_data, tBTA_BLE_ADV_DAT
 
     if (p_adv_data->flag != 0) {
         mask = BTM_BLE_AD_BIT_FLAGS;
+        bta_adv_data->flag = p_adv_data->flag;
     }
 
     if (p_adv_data->include_name) {

--- a/examples/14_gatt_server/main/gatts_demo.c
+++ b/examples/14_gatt_server/main/gatts_demo.c
@@ -60,7 +60,7 @@ static esp_ble_adv_data_t test_adv_data = {
     .p_service_data = NULL,
     .service_uuid_len = 32,
     .p_service_uuid = test_service_uuid128,
-    .flag = 0x2,
+    .flag = 0x6,
 };
 
 static esp_ble_adv_params_t test_adv_params = {


### PR DESCRIPTION
I noticed the flag parameter of the ESP API structs was not being passed through correctly.  This patch fixes it.  Additionally, some users have reported not being able to connect on certain Android devices: http://www.esp32.com/viewtopic.php?t=787.  I verified this on my Sony Xperia Z3 with Android 5.1.1.  Specifying the BR/EDR unsupported flag in the advertisement fixes it on my device, but unsure about others.