### PR TITLE
Add missing bit from LEDC interrupt state struct.

### DIFF
--- a/components/esp32/include/soc/ledc_struct.h
+++ b/components/esp32/include/soc/ledc_struct.h
@@ -122,6 +122,7 @@ typedef volatile struct {
             uint32_t lstimer1_ovf:        1;            /*The interrupt status bit for low speed channel1  counter overflow event.*/
             uint32_t lstimer2_ovf:        1;            /*The interrupt status bit for low speed channel2  counter overflow event.*/
             uint32_t lstimer3_ovf:        1;            /*The interrupt status bit for low speed channel3  counter overflow event.*/
+            uint32_t duty_chng_end_hsch0: 1;            /*The interrupt enable bit for high speed channel 0 duty change done event.*/
             uint32_t duty_chng_end_hsch1: 1;            /*The interrupt status bit for high speed channel 1 duty change done event.*/
             uint32_t duty_chng_end_hsch2: 1;            /*The interrupt status bit for high speed channel 2 duty change done event.*/
             uint32_t duty_chng_end_hsch3: 1;            /*The interrupt status bit for high speed channel 3 duty change done event.*/


### PR DESCRIPTION
It appears as though duty_chng_end_hsch0 has been accidentally omitted from 'int_st', when it is present in the 'int_raw', 'int_ena' and 'int_clr' unions. Simple testing appears to show it working correctly once it is added here -- so I cannot tell why it has been omitted other than perhaps accidental omission.

Note: I am not especially familiar with this codebase or platform, so please take this with a pinch of salt.