### PR TITLE
Rename i2s_get_period to i2c_get_period.

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -494,7 +494,7 @@ esp_err_t i2c_set_period(i2c_port_t i2c_num, int high_period, int low_period)
     return ESP_OK;
 }
 
-esp_err_t i2s_get_period(i2c_port_t i2c_num, int* high_period, int* low_period)
+esp_err_t i2c_get_period(i2c_port_t i2c_num, int* high_period, int* low_period)
 {
     I2C_CHECK(i2c_num < I2C_NUM_MAX, I2C_NUM_ERROR_STR, ESP_ERR_INVALID_ARG);
     I2C_ENTER_CRITICAL(&i2c_spinlock[i2c_num]);

--- a/components/driver/include/driver/i2c.h
+++ b/components/driver/include/driver/i2c.h
@@ -401,7 +401,7 @@ esp_err_t i2c_set_period(i2c_port_t i2c_num, int high_period, int low_period);
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t i2s_get_period(i2c_port_t i2c_num, int* high_period, int* low_period);
+esp_err_t i2c_get_period(i2c_port_t i2c_num, int* high_period, int* low_period);
 
 /**
  * @brief set I2C master start signal timing


### PR DESCRIPTION
The `i2s_get_period()` function name is probably a typo and should be called `i2c_get_period()`.
