### PR TITLE
Ensure ISR relevant core code sits in IRAM

### DIFF
--- a/components/esp32/ld/esp32.common.ld
+++ b/components/esp32/ld/esp32.common.ld
@@ -78,6 +78,7 @@ SECTIONS
     *(.iram1 .iram1.*)
     *libfreertos.a:(.literal .text .literal.* .text.*)
     *libesp32.a:panic.o(.literal .text .literal.* .text.*)
+    *libesp32.a:crosscore_int.o(.literal .text .literal.* .text.*)
     *libphy.a:(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
     *libpp.a:(.literal .text .literal.* .text.*)


### PR DESCRIPTION
Traced Issue #212 back to a piece of ESP32 code which is being used by the UART interrupt handling code, thru FreeRTOS libraries. It's void esp_crosscore_int_send_yield(int coreId); in file components/esp32/crosscore_int.c. As this code was not in IRAM, there were issues when UART ISR got triggered by incoming UART data and SPI Flash operations happened at the same time. I have discovered this on UART but can imagine multiple scenarios where ISR routines using FreeRTOS code would end up with the same issue.

I have resolved this issue by asking the linker to put the crosscore_int.o module into IRAM. Not sure if the whole module is needed in IRAM, software now works perfectly.