### PR TITLE
Example 10_openssl_server should use TLSv1.2 instead of SSLv3

### DIFF
--- a/examples/10_openssl_server/main/openssl_server.c
+++ b/examples/10_openssl_server/main/openssl_server.c
@@ -37,7 +37,7 @@ const static char *TAG = "Openssl_demo";
 
 #define OPENSSL_DEMO_SERVER_ACK "HTTP/1.1 200 OK\r\n" \
                                 "Content-Type: text/html\r\n" \
-                                "Content-Length: 98\r\n" \
+                                "Content-Length: 98\r\n\r\n" \
                                 "<html>\r\n" \
                                 "<head>\r\n" \
                                 "<title>OpenSSL demo</title></head><body>\r\n" \
@@ -70,7 +70,7 @@ static void openssl_demo_thread(void *p)
     const unsigned int prvtkey_pem_bytes = prvtkey_pem_end - prvtkey_pem_start;   
 
     ESP_LOGI(TAG, "SSL server context create ......");
-    ctx = SSL_CTX_new(SSLv3_server_method());
+    ctx = SSL_CTX_new(TLSv1_2_server_method());
     if (!ctx) {
         ESP_LOGI(TAG, "failed");
         goto failed1;


### PR DESCRIPTION
For security reasons modern browsers, curl and openssl do not support the SSLv3 protocol anymore.
You should use TLSv1.2 instead.

Also there was a bug in the HTTP header.