### PR TITLE
gatts_demo: re-enter advertising after client disconnects

### DIFF
--- a/examples/14_gatt_server/main/gatts_demo.c
+++ b/examples/14_gatt_server/main/gatts_demo.c
@@ -210,6 +210,8 @@ static void gatts_profile_a_event_handler(esp_gatts_cb_event_t event, esp_gatt_i
         gl_profile_tab[PROFILE_A_APP_ID].conn_id = param->connect.conn_id;
         break;
     case ESP_GATTS_DISCONNECT_EVT:
+        esp_ble_gap_start_advertising(&test_adv_params);
+        break;
     case ESP_GATTS_OPEN_EVT:
     case ESP_GATTS_CANCEL_OPEN_EVT:
     case ESP_GATTS_CLOSE_EVT:


### PR DESCRIPTION
In the existing tree, after a connected client disconnects the device
will never re-enter the advertising state. Additional clients will not
be able to discover or connect to the device. This patch forces the
device back into the advertising state upon disconnection.