### PR TITLE
Allow task pin to core, helper for spi_flash_* operations in task without set core affinity.

### DIFF
--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -71,9 +71,11 @@ static bool app_cpu_started = false;
 #endif //!CONFIG_FREERTOS_UNICORE
 
 static void do_global_ctors(void);
-static void do_phy_init();
 static void main_task(void* args);
 extern void app_main(void);
+#if CONFIG_ESP32_PHY_AUTO_INIT
+static void do_phy_init();
+#endif
 
 extern int _bss_start;
 extern int _bss_end;
@@ -264,6 +266,7 @@ static void main_task(void* args)
     vTaskDelete(NULL);
 }
 
+#if CONFIG_ESP32_PHY_AUTO_INIT
 static void do_phy_init()
 {
     esp_phy_calibration_mode_t calibration_mode = PHY_RF_CAL_PARTIAL;
@@ -297,3 +300,5 @@ static void do_phy_init()
     esp_phy_release_init_data(init_data);
     free(cal_data); // PHY maintains a copy of calibration data, so we can free this
 }
+#endif //CONFIG_ESP32_PHY_AUTO_INIT
+

--- a/components/esp32/phy_init.c
+++ b/components/esp32/phy_init.c
@@ -23,10 +23,12 @@
 #include "esp_err.h"
 #include "esp_phy_init.h"
 #include "esp_system.h"
-#include "phy.h"
 #include "esp_log.h"
 #include "nvs.h"
 #include "sdkconfig.h"
+
+#ifdef CONFIG_WIFI_ENABLED
+#include "phy.h"
 #include "phy_init_data.h"
 
 static const char* TAG = "phy_init";
@@ -219,6 +221,4 @@ static esp_err_t store_cal_data_to_nvs_handle(nvs_handle handle,
     return err;
 }
 
-void register_chipv7_phy_stub()
-{
-}
+#endif // CONFIG_WIFI_ENABLED

--- a/components/pincore/Kconfig
+++ b/components/pincore/Kconfig
@@ -1,0 +1,18 @@
+if FREERTOS_UNICORE
+
+comment "FreeRTOS set to run unicore, PinCore module disabled"
+
+endif
+
+if !FREERTOS_UNICORE
+
+config PINCORE_MODULE_ENABLED
+	bool "Enable functions pinning thread to specific or current core"
+    default "y"
+    help
+    	Enable if you use functions that don't feel good when they
+    	swap to a different core, and want to secure them to stay
+    	on current or dedicated core for a specific code area.
+
+
+endif

--- a/components/pincore/component.mk
+++ b/components/pincore/component.mk
@@ -1,0 +1,2 @@
+
+COMPONENT_EXTRA_INCLUDES := $(IDF_PATH)/components/freertos/include/freertos

--- a/components/pincore/include/pincore.h
+++ b/components/pincore/include/pincore.h
@@ -1,0 +1,49 @@
+#ifndef __PINCORE_H_
+#define __PINCORE_H_
+
+#include "esp_log.h"
+
+#ifdef CONFIG_PINCORE_MODULE_ENABLED
+
+#define PINCORE_SELECT_CURRENT_CORE 0x00000100
+
+#define PINCORE_START_CORE_PINNED_SECTION() \
+	do { \
+		int __pincore_save = 0x00000100; \
+		ESP_LOGV("PINCORE", "[A] Pinning task to current core"); \
+		pincore_alter_current_freertos_task(&__pincore_save); \
+		ESP_LOGV("PINCORE", "[B] Task was pinned to %x",__pincore_save) 
+
+#define PINCORE_STOP_CORE_PINNED_SECTION() \
+		ESP_LOGV("PINCORE", "[C] Pinnig task back to %x",__pincore_save); \
+		pincore_alter_current_freertos_task(&__pincore_save); \
+		ESP_LOGV("PINCORE", "[D] Task was pinned to %x",__pincore_save); \
+	} while(0)
+
+#define PINCORE_RETURN_FROM_SECTION(x) \
+	pincore_alter_current_freertos_task(&__pincore_save); \
+	return x
+
+#define PINCORE_EXIT_FROM_SECTION(x) \
+	pincore_alter_current_freertos_task(&__pincore_save); \
+	return
+
+void pincore_alter_current_freertos_task(int * coreaff);
+
+#else
+
+#define PINCORE_START_CORE_PINNED_SECTION() \
+	do {
+
+#define PINCORE_STOP_CORE_PINNED_SECTION() \
+	} while(0)
+
+#define PINCORE_RETURN_FROM_SECTION(x) \
+	return x
+
+#define PINCORE_EXIT_FROM_SECTION() \
+	return
+
+#endif
+
+#endif

--- a/components/pincore/pincore.S
+++ b/components/pincore/pincore.S
@@ -1,0 +1,48 @@
+#define NOERROR #
+NOERROR: .error "C preprocessor needed for this file: make sure its filename\
+ ends in uppercase .S, or use xt-xcc's -x assembler-with-cpp option."
+
+#include "xtensa_rtos.h"
+#include "sdkconfig.h"
+
+#define PINCORE_SELECT_CURRENT_CORE 0x00000100
+
+#define PINCORE_MASKED_INT_LEVEL 15
+
+#define PINCORE_TASKTCB_XCOREID_OFFSET ((0x38+configMAX_TASK_NAME_LEN+3)&~3)
+
+.extern pxCurrentTCB
+
+/*
+Obeys ABI conventions per prototype:
+    void pincore_alter_current_freertos_task(int * coreaff)
+*/
+
+    .section	.iram1
+    .global		pincore_alter_current_freertos_task
+    .type		pincore_alter_current_freertos_task,@function
+    .align		4
+
+pincore_alter_current_freertos_task:
+    ENTRY0
+
+    rsil        a7, PINCORE_MASKED_INT_LEVEL
+
+    getcoreid	a3									/* a3 = current core */
+    l32i		a4, a2, 0							/* a4 = *coreaff */
+    bnei		a4, PINCORE_SELECT_CURRENT_CORE, core_provided		/* if a4 == PINCORE_SELECT_CURRENT_CORE {					*/
+    mov			a4, a3								/* 		a4 = a3 // new core = current core	*/
+    												/* }										*/
+core_provided:
+    movi		a5, pxCurrentTCB
+    addx4     	a5, a3, a5					
+    l32i		a5, a5, 0                   		/* a5 = start of pxCurrentTCB[cpuid] */
+    addi		a5, a5, PINCORE_TASKTCB_XCOREID_OFFSET  	/* a5 += offset to xCoreID in tcb struct */
+    l32i    	a6, a5, 0                       	/* a6 = current task core assignment */
+    s32i		a6, a2, 0							/* *coreaff = a6 */
+    s32i		a4, a5, 0							/* current_task_core_assg = a4 // store new core in the TCB struct */
+	
+	wsr.ps		a7
+    rsync
+
+    RET0


### PR DESCRIPTION
1. There is a fix to add another cross-core interrupt function to IRAM. It's called from an another IRAM function (vPortYieldOtherCore()) and I have encountered IllegalInstruction issues with this one.

2. As I was experimenting with esp-idf in mutlicore mode, I have noticed that certain issues are more/less likely to occur when the task affinity is being set to a specific core, rather to be allowing task run on any core. As I did not want my application tasks to be permanently tied to specific core, due to huge workload on the system, I have created this small component that allows to pin a running task to specific core, and macros to enter/exit a block during which task is guaranteed to be pinned to specific core.

Example:

```
#if CONFIG_PINCORE_MODULE_ENABLED
#include "pincore.h"
#else
#define PINCORE_START_CORE_PINNED_SECTION() \
	do {
#define PINCORE_STOP_CORE_PINNED_SECTION() \
	} while(0)
#define PINCORE_RETURN_FROM_SECTION(x) \
	return x
#define PINCORE_EXIT_FROM_SECTION() \
	return
#endif
```

```
	PINCORE_START_CORE_PINNED_SECTION();
	if (mptrs[fd].partition_ptr == NULL) {
		r = spi_flash_erase_range(file_start_address_page_start, FFS_ESP_FLASH_WRITE_BOUNDARY);
	} else {
		r = esp_partition_erase_range(mptrs[fd].partition_ptr,
		                              file_start_address_page_start, FFS_ESP_FLASH_WRITE_BOUNDARY);
	}
	PINCORE_STOP_CORE_PINNED_SECTION();
	FILE_CHECK_IF_SPI_OK(r)
	// write
	ESP_LOGV("FFS", "Writing %x bytes at %x%s%s",
	         FFS_ESP_FLASH_WRITE_BOUNDARY, file_start_address_page_start,
	         (mptrs[fd].partition_ptr == NULL) ? "" : " partition ",
	         ffs_file_metadata[fd].plabel);
	PINCORE_START_CORE_PINNED_SECTION();
	if (mptrs[fd].partition_ptr == NULL) {
		r = spi_flash_write(file_start_address_page_start, tmp, FFS_ESP_FLASH_WRITE_BOUNDARY);
	} else {
		r = esp_partition_write(mptrs[fd].partition_ptr,
		                        file_start_address_page_start, tmp, FFS_ESP_FLASH_WRITE_BOUNDARY);
	}
	PINCORE_STOP_CORE_PINNED_SECTION();
```


This was a must to be able to run the spi_flash functions frequently in a task with no core affinity, as they are likely to fail otherwise. These functions have a check that aborts if they started and stopped on different cores, which got triggered before I added the above to my code.