### PR TITLE
Updated routines in intr_alloc and cross_core to stay in IRAM

### DIFF
--- a/components/esp32/crosscore_int.c
+++ b/components/esp32/crosscore_int.c
@@ -82,7 +82,7 @@ void esp_crosscore_int_init() {
     assert(err == ESP_OK);
 }
 
-void esp_crosscore_int_send_yield(int coreId) {
+void IRAM_ATTR esp_crosscore_int_send_yield(int coreId) {
     assert(coreId<portNUM_PROCESSORS);
     //Mark the reason we interrupt the other CPU
     portENTER_CRITICAL(&reasonSpinlock);
@@ -95,4 +95,3 @@ void esp_crosscore_int_send_yield(int coreId) {
         WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_1_REG, DPORT_CPU_INTR_FROM_CPU_1);
     }
 }
-

--- a/components/esp32/intr_alloc.c
+++ b/components/esp32/intr_alloc.c
@@ -691,8 +691,7 @@ esp_err_t IRAM_ATTR esp_intr_disable(intr_handle_t handle)
     return ESP_OK;
 }
 
-
-void esp_intr_noniram_disable() 
+void IRAM_ATTR esp_intr_noniram_disable() 
 {
     int oldint;
     int cpu=xPortGetCoreID();
@@ -711,7 +710,7 @@ void esp_intr_noniram_disable()
     non_iram_int_disabled[cpu]=oldint&non_iram_int_mask[cpu];
 }
 
-void esp_intr_noniram_enable() 
+void IRAM_ATTR esp_intr_noniram_enable() 
 {
     int cpu=xPortGetCoreID();
     int intmask=non_iram_int_disabled[cpu];
@@ -739,7 +738,3 @@ void IRAM_ATTR ets_isr_unmask(unsigned int mask) {
 void IRAM_ATTR ets_isr_mask(unsigned int mask) {
     xt_ints_off(mask);
 }
-
-
-
-


### PR DESCRIPTION
I got randomly a GuruMeditation with a IllegalInstruction while using SPI Flash commands, referring to line 164 of cache_utils.c - where spi_flash_enable_interrupts_caches_no_os() calls esp_intr_noniram_enable(). In theory the call is made after the spi_flash_restore_cache() call happens, but somehow it did not work well. Also I thought it might be better to have a function called from a IRAM function to also be in IRAM. After applying, the issues with spi_flash_* did not occur again.

There is also a fix to add another cross-core interrupt function to IRAM. It's called from an another IRAM function (vPortYieldOtherCore()) and I have encountered IllegalInstruction issues with this one as well.