### PR TITLE
Allow task pin to core, helper for spi_flash_* operations in task without set core affinity

### DIFF
--- a/components/pincore/Kconfig
+++ b/components/pincore/Kconfig
@@ -1,0 +1,18 @@
+if FREERTOS_UNICORE
+
+comment "FreeRTOS set to run unicore, PinCore module disabled"
+
+endif
+
+if !FREERTOS_UNICORE
+
+config PINCORE_MODULE_ENABLED
+	bool "Enable functions pinning thread to specific or current core"
+    default "y"
+    help
+    	Enable if you use functions that don't feel good when they
+    	swap to a different core, and want to secure them to stay
+    	on current or dedicated core for a specific code area.
+
+
+endif

--- a/components/pincore/component.mk
+++ b/components/pincore/component.mk
@@ -1,0 +1,2 @@
+
+COMPONENT_EXTRA_INCLUDES := $(IDF_PATH)/components/freertos/include/freertos

--- a/components/pincore/include/pincore.h
+++ b/components/pincore/include/pincore.h
@@ -1,0 +1,49 @@
+#ifndef __PINCORE_H_
+#define __PINCORE_H_
+
+#include "esp_log.h"
+
+#ifdef CONFIG_PINCORE_MODULE_ENABLED
+
+#define PINCORE_SELECT_CURRENT_CORE 0x00000100
+
+#define PINCORE_START_CORE_PINNED_SECTION() \
+	do { \
+		int __pincore_save = 0x00000100; \
+		ESP_LOGV("PINCORE", "[A] Pinning task to current core"); \
+		pincore_alter_current_freertos_task(&__pincore_save); \
+		ESP_LOGV("PINCORE", "[B] Task was pinned to %x",__pincore_save) 
+
+#define PINCORE_STOP_CORE_PINNED_SECTION() \
+		ESP_LOGV("PINCORE", "[C] Pinnig task back to %x",__pincore_save); \
+		pincore_alter_current_freertos_task(&__pincore_save); \
+		ESP_LOGV("PINCORE", "[D] Task was pinned to %x",__pincore_save); \
+	} while(0)
+
+#define PINCORE_RETURN_FROM_SECTION(x) \
+	pincore_alter_current_freertos_task(&__pincore_save); \
+	return x
+
+#define PINCORE_EXIT_FROM_SECTION(x) \
+	pincore_alter_current_freertos_task(&__pincore_save); \
+	return
+
+void pincore_alter_current_freertos_task(int * coreaff);
+
+#else
+
+#define PINCORE_START_CORE_PINNED_SECTION() \
+	do {
+
+#define PINCORE_STOP_CORE_PINNED_SECTION() \
+	} while(0)
+
+#define PINCORE_RETURN_FROM_SECTION(x) \
+	return x
+
+#define PINCORE_EXIT_FROM_SECTION() \
+	return
+
+#endif
+
+#endif

--- a/components/pincore/pincore.S
+++ b/components/pincore/pincore.S
@@ -1,0 +1,48 @@
+#define NOERROR #
+NOERROR: .error "C preprocessor needed for this file: make sure its filename\
+ ends in uppercase .S, or use xt-xcc's -x assembler-with-cpp option."
+
+#include "xtensa_rtos.h"
+#include "sdkconfig.h"
+
+#define PINCORE_SELECT_CURRENT_CORE 0x00000100
+
+#define PINCORE_MASKED_INT_LEVEL 15
+
+#define PINCORE_TASKTCB_XCOREID_OFFSET ((0x38+configMAX_TASK_NAME_LEN+3)&~3)
+
+.extern pxCurrentTCB
+
+/*
+Obeys ABI conventions per prototype:
+    void pincore_alter_current_freertos_task(int * coreaff)
+*/
+
+    .section	.iram1
+    .global		pincore_alter_current_freertos_task
+    .type		pincore_alter_current_freertos_task,@function
+    .align		4
+
+pincore_alter_current_freertos_task:
+    ENTRY0
+
+    rsil        a7, PINCORE_MASKED_INT_LEVEL
+
+    getcoreid	a3									/* a3 = current core */
+    l32i		a4, a2, 0							/* a4 = *coreaff */
+    bnei		a4, PINCORE_SELECT_CURRENT_CORE, core_provided		/* if a4 == PINCORE_SELECT_CURRENT_CORE {					*/
+    mov			a4, a3								/* 		a4 = a3 // new core = current core	*/
+    												/* }										*/
+core_provided:
+    movi		a5, pxCurrentTCB
+    addx4     	a5, a3, a5					
+    l32i		a5, a5, 0                   		/* a5 = start of pxCurrentTCB[cpuid] */
+    addi		a5, a5, PINCORE_TASKTCB_XCOREID_OFFSET  	/* a5 += offset to xCoreID in tcb struct */
+    l32i    	a6, a5, 0                       	/* a6 = current task core assignment */
+    s32i		a6, a2, 0							/* *coreaff = a6 */
+    s32i		a4, a5, 0							/* current_task_core_assg = a4 // store new core in the TCB struct */
+	
+	wsr.ps		a7
+    rsync
+
+    RET0


### PR DESCRIPTION
As I was experimenting with esp-idf in mutlicore mode, I have noticed that certain issues are more/less likely to occur when the task affinity is being set to a specific core, rather to be allowing task run on any core. As I did not want my application tasks to be permanently tied to specific core, due to huge workload on the system, I have created this small component that allows to pin a running task to specific core, and macros to enter/exit a block during which task is guaranteed to be pinned to specific core.

This adds a menuconfig option to enable/disable these functions.

This was a must to be able to run the spi_flash functions frequently in a task with no core affinity, as these functionsl are likely to fail otherwise (they have a check that aborts if they started and stopped on different cores). I got such issues prior to implementing this.

Example:

1. Include, considering this might not be available at all in given esp-idf clone
```
#if CONFIG_PINCORE_MODULE_ENABLED
#include "pincore.h"
#else
#define PINCORE_START_CORE_PINNED_SECTION() \
	do {
#define PINCORE_STOP_CORE_PINNED_SECTION() \
	} while(0)
#define PINCORE_RETURN_FROM_SECTION(x) \
	return x
#define PINCORE_EXIT_FROM_SECTION() \
	return
#endif
```

2. Actual usage in module
```
	PINCORE_START_CORE_PINNED_SECTION();
	if (mptrs[fd].partition_ptr == NULL) {
		r = spi_flash_erase_range(file_start_address_page_start, FFS_ESP_FLASH_WRITE_BOUNDARY);
	} else {
		r = esp_partition_erase_range(mptrs[fd].partition_ptr,
		                              file_start_address_page_start, FFS_ESP_FLASH_WRITE_BOUNDARY);
	}
	PINCORE_STOP_CORE_PINNED_SECTION();
	FILE_CHECK_IF_SPI_OK(r)
	// write
	ESP_LOGV("FFS", "Writing %x bytes at %x%s%s",
	         FFS_ESP_FLASH_WRITE_BOUNDARY, file_start_address_page_start,
	         (mptrs[fd].partition_ptr == NULL) ? "" : " partition ",
	         ffs_file_metadata[fd].plabel);
	PINCORE_START_CORE_PINNED_SECTION();
	if (mptrs[fd].partition_ptr == NULL) {
		r = spi_flash_write(file_start_address_page_start, tmp, FFS_ESP_FLASH_WRITE_BOUNDARY);
	} else {
		r = esp_partition_write(mptrs[fd].partition_ptr,
		                        file_start_address_page_start, tmp, FFS_ESP_FLASH_WRITE_BOUNDARY);
	}
	PINCORE_STOP_CORE_PINNED_SECTION();
```
