### PR TITLE
Update windows install prerequisites script (IDFGH-17743)

### DIFF
--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -48,9 +48,7 @@ cd /opt
 unzip ~/${TOOLCHAIN_ZIP}
 rm ~/${TOOLCHAIN_ZIP}
 
-cat > /etc/profile.d/esp32_toolchain.sh << EOF
-export PATH="$PATH:/opt/xtensa-esp32-elf/bin"
-EOF
+echo 'export PATH="$PATH:/opt/xtensa-esp32-elf/bin"' > /etc/profile.d/esp32_toolchain.sh
 
 # clean up pacman packages to save some disk space
 pacman --noconfirm -R unzip

--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -36,7 +36,7 @@ python -m pip install --upgrade pip
 pip install pyserial
 
 # TODO: automatically download precompiled toolchain, unpack at /opt/xtensa-esp32-elf/
-TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-59.zip
+TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-61-gab8375a-5.2.0.zip
 echo "Downloading precompiled toolchain ${TOOLCHAIN_ZIP}..."
 cd ~
 curl -LO --retry 10 http://dl.espressif.com/dl/${TOOLCHAIN_ZIP}

--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -40,6 +40,7 @@ TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-61-gab8375a-5.2.0.zip
 echo "Downloading precompiled toolchain ${TOOLCHAIN_ZIP}..."
 cd ~
 curl -LO --retry 10 http://dl.espressif.com/dl/${TOOLCHAIN_ZIP}
+[ -d /opt ] || mkdir /opt
 cd /opt
 unzip ~/${TOOLCHAIN_ZIP}
 rm ~/${TOOLCHAIN_ZIP}

--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -25,6 +25,12 @@ pacman --noconfirm -Syu
 
 pacman --noconfirm -S gettext-devel gcc git make ncurses-devel flex bison gperf vim mingw-w64-i686-python2-pip unzip
 
+echo 'export PATH="$PATH:/mingw32/bin"' > /etc/profile.d/mingw32.sh
+
+set +e
+. /etc/profile
+set -e
+
 python -m pip install --upgrade pip
 
 pip install pyserial

--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -39,7 +39,10 @@ pip install pyserial
 TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-61-gab8375a-5.2.0.zip
 echo "Downloading precompiled toolchain ${TOOLCHAIN_ZIP}..."
 cd ~
-curl -LO --retry 10 http://dl.espressif.com/dl/${TOOLCHAIN_ZIP}
+if [ ! -e ${TOOLCHAIN_ZIP} ] || ! unzip -t ${TOOLCHAIN_ZIP}; then
+    [ -e ${TOOLCHAIN_ZIP} ] && rm ${TOOLCHAIN_ZIP}
+    curl -LO --retry 10 http://dl.espressif.com/dl/${TOOLCHAIN_ZIP}
+fi
 [ -d /opt ] || mkdir /opt
 cd /opt
 unzip ~/${TOOLCHAIN_ZIP}


### PR DESCRIPTION
The script for installing prerequisites on windows has he following shortcomings:
- it does not work on a fresh msys installation
- it fails to extend PATH so that it can use the python interpreter it installs
- it incorrectly adds the toolchain to PATH
- it does not gracefully handle a failed download of the toolchain zip file
- it references an outdated toolchain zip file