### PR TITLE
gpio: Attach gpio intr to the isr_server on the right core.

### DIFF
--- a/components/lwip/api/api_lib.c
+++ b/components/lwip/api/api_lib.c
@@ -880,10 +880,11 @@ netconn_gethostbyname(const char *name, ip_addr_t *addr)
 {
 
   API_VAR_DECLARE(struct dns_api_msg, msg);
+  err_t localerr;
 #if !LWIP_MPU_COMPATIBLE
   sys_sem_t sem;
 #endif /* LWIP_MPU_COMPATIBLE */
-  err_t err;
+  err_t err = ERR_OK;
 
   LWIP_ERROR("netconn_gethostbyname: invalid name", (name != NULL), return ERR_ARG;);
   LWIP_ERROR("netconn_gethostbyname: invalid addr", (addr != NULL), return ERR_ARG;);
@@ -918,14 +919,14 @@ netconn_gethostbyname(const char *name, ip_addr_t *addr)
   }
 #endif /* LWIP_NETCONN_SEM_PER_THREAD */
 
-  err = tcpip_callback(lwip_netconn_do_gethostbyname, &API_VAR_REF(msg));
-  if (err != ERR_OK) {
+  localerr = tcpip_callback(lwip_netconn_do_gethostbyname, &API_VAR_REF(msg));
+  if (localerr != ERR_OK) {
 #if !LWIP_NETCONN_SEM_PER_THREAD
     sys_sem_free(API_EXPR_REF(API_VAR_REF(msg).sem));
 #endif /* !LWIP_NETCONN_SEM_PER_THREAD */
 
     API_VAR_FREE(MEMP_DNS_API_MSG, msg);
-    return err;
+    return localerr;
   }
 
   sys_sem_wait(API_EXPR_REF_SEM(API_VAR_REF(msg).sem));


### PR DESCRIPTION
Make sure GPIO interrupts get attached to the core that
the ISR service routine is running on, otherwise they
don't arrive.