### PR TITLE
Minor fix to spi_master so it works when #devices per bus >1

### DIFF
--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -502,6 +502,7 @@ static void IRAM_ATTR spi_intr(void *arg)
         //We have a transaction. Send it.
         spi_device_t *dev=host->device[i];
         host->cur_trans=trans;
+        host->cur_cs=i;
         //We should be done with the transmission.
         assert(host->hw->cmd.usr == 0);
         
@@ -510,7 +511,7 @@ static void IRAM_ATTR spi_intr(void *arg)
             trans->rxlength=trans->length;
         }
         
-        //Reconfigure accoding to device settings, but only if we change CSses.
+        //Reconfigure according to device settings, but only if we change CSses.
         if (i!=prevCs) {
             //Assumes a hardcoded 80MHz Fapb for now. ToDo: figure out something better once we have
             //clock scaling working.


### PR DESCRIPTION
[Oops, fixing broken pull request by recreating it]

I am not especially familiar with this platform or with esp-idf -- so review with care.

The spi-master driver would not work for me when the number of devices on a bus exceeded 1 (caused device hang). I believe this is because cur_cs is not properly set (anywhere), and yet is used. This is likely just not noticed because 0 is presumably the correct value when there's only 1 device (and I'm guessing multi-device setup is not tested as thoroughly).

Simply setting cur_cs to the correct slot value resolves the problem and multiple devices on a single bus behave correctly in my test environment.