### PR TITLE
Sync PART_FLAG_ENCRYPTED value with gen_esp32part.py

### DIFF
--- a/components/esp32/include/esp_flash_data_types.h
+++ b/components/esp32/include/esp_flash_data_types.h
@@ -64,7 +64,7 @@ typedef struct {
 #define PART_TYPE_END 0xff
 #define PART_SUBTYPE_END 0xff
 
-#define PART_FLAG_ENCRYPTED (1<<0)
+#define PART_FLAG_ENCRYPTED (1<<1)
 
 #ifdef __cplusplus
 }

--- a/components/esp32/include/esp_flash_data_types.h
+++ b/components/esp32/include/esp_flash_data_types.h
@@ -64,7 +64,7 @@ typedef struct {
 #define PART_TYPE_END 0xff
 #define PART_SUBTYPE_END 0xff
 
-#define PART_FLAG_ENCRYPTED (1<<1)
+#define PART_FLAG_ENCRYPTED (1<<0)
 
 #ifdef __cplusplus
 }

--- a/components/partition_table/gen_esp32part.py
+++ b/components/partition_table/gen_esp32part.py
@@ -144,7 +144,7 @@ class PartitionDefinition(object):
     # dictionary maps flag name (as used in CSV flags list, property name)
     # to bit set in flags words in binary format
     FLAGS = {
-        "encrypted" : 1
+        "encrypted" : 0
     }
 
     # add subtypes for the 16 OTA slot values ("ota_XXX, etc.")


### PR DESCRIPTION
Currently paritions marked as encrypted by gen_esp32part.py are not
recognized as such and encrypted writes don't work.

This is part of espressif/esp-idf#253