### PR TITLE
Major refactoring of OTA (IDFGH-1431)

### DIFF
--- a/components/bootloader/src/main/bootloader_config.h
+++ b/components/bootloader/src/main/bootloader_config.h
@@ -33,8 +33,6 @@ typedef struct {
     esp_partition_pos_t factory;
     esp_partition_pos_t test;
     esp_partition_pos_t ota[16];
-    uint32_t app_count;
-    uint32_t selected_subtype;
 } bootloader_state_t;
 
 bool flash_encrypt(bootloader_state_t *bs);

--- a/components/bootloader/src/main/bootloader_start.c
+++ b/components/bootloader/src/main/bootloader_start.c
@@ -45,6 +45,7 @@
 #include "esp_secure_boot.h"
 #include "esp_flash_encrypt.h"
 #include "esp_flash_partitions.h"
+#include "esp_ota_select.h"
 #include "bootloader_flash.h"
 #include "bootloader_random.h"
 #include "bootloader_config.h"
@@ -60,7 +61,6 @@ We arrive here after the bootloader finished loading the program from flash. The
 flash cache is down and the app CPU is in reset. We do have a stack, so we can do the initialization in C.
 */
 
-
 void bootloader_main();
 static void unpack_load_app(const esp_partition_pos_t *app_node);
 void print_flash_info(const esp_image_header_t* pfhdr);
@@ -70,7 +70,8 @@ static void set_cache_and_start_app(uint32_t drom_addr,
     uint32_t irom_addr,
     uint32_t irom_load_addr,
     uint32_t irom_size,
-    uint32_t entry_addr);
+    uint32_t entry_addr,
+    uint32_t image_flash_addr);
 static void update_flash_config(const esp_image_header_t* pfhdr);
 static void clock_configure(void);
 static void uart_console_configure(void);
@@ -152,7 +153,7 @@ bool load_partition_table(bootloader_state_t* bs)
     }
 
     ESP_LOGI(TAG, "Partition Table:");
-    ESP_LOGI(TAG, "## Label            Usage          Type ST Offset   Length");
+    ESP_LOGI(TAG, "## Label            Usage          Type ST Offset   Length   Flags");
 
     for(int i = 0; i < num_partitions; i++) {
         const esp_partition_info_t *partition = &partitions[i];
@@ -174,9 +175,8 @@ bool load_partition_table(bootloader_state_t* bs)
                 break;
             default:
                 /* OTA binary */
-                if ((partition->subtype & ~PART_SUBTYPE_OTA_MASK) == PART_SUBTYPE_OTA_FLAG) {
+                if ((partition->subtype & ~PART_SUBTYPE_OTA_MASK) == PART_SUBTYPE_OTA_MIN) {
                     bs->ota[partition->subtype & PART_SUBTYPE_OTA_MASK] = partition->pos;
-                    ++bs->app_count;
                     partition_usage = "OTA app";
                 }
                 else {
@@ -197,6 +197,9 @@ bool load_partition_table(bootloader_state_t* bs)
             case PART_SUBTYPE_DATA_WIFI:
                 partition_usage = "WiFi data";
                 break;
+            case PART_SUBTYPE_DATA_SPIFFS:
+                partition_usage = "SPIFFS";
+                break;
             default:
                 partition_usage = "Unknown data";
                 break;
@@ -207,25 +210,17 @@ bool load_partition_table(bootloader_state_t* bs)
         }
 
         /* print partition type info */
-        ESP_LOGI(TAG, "%2d %-16s %-16s %02x %02x %08x %08x", i, partition->label, partition_usage,
+        ESP_LOGI(TAG, "%2d %-16s %-16s %02x %02x %08x %08x %08x",
+                 i, partition->label, partition_usage,
                  partition->type, partition->subtype,
-                 partition->pos.offset, partition->pos.size);
+                 partition->pos.offset, partition->pos.size,
+                 partition->flags);
     }
 
     bootloader_munmap(partitions);
 
     ESP_LOGI(TAG,"End of partition table");
     return true;
-}
-
-static uint32_t ota_select_crc(const esp_ota_select_entry_t *s)
-{
-  return crc32_le(UINT32_MAX, (uint8_t*)&s->ota_seq, 4);
-}
-
-static bool ota_select_valid(const esp_ota_select_entry_t *s)
-{
-  return s->ota_seq != UINT32_MAX && s->crc == ota_select_crc(s);
 }
 
 /**
@@ -246,8 +241,6 @@ void bootloader_main()
 #endif
     esp_image_header_t fhdr;
     bootloader_state_t bs;
-    esp_rom_spiflash_result_t spiRet1,spiRet2;
-    esp_ota_select_entry_t sa,sb;
     const esp_ota_select_entry_t *ota_select_map;
 
     memset(&bs, 0, sizeof(bs));
@@ -288,9 +281,10 @@ void bootloader_main()
         return;
     }
 
-    esp_partition_pos_t load_part_pos;
+    esp_partition_pos_t load_part_pos = { .offset = UINT32_MAX, .size = 0 };
 
     if (bs.ota_info.offset != 0) {              // check if partition table has OTA info partition
+        esp_ota_select_entry_t ss[2];
         //ESP_LOGE("OTA info sector handling is not implemented");
         if (bs.ota_info.size < 2 * SPI_SEC_SIZE) {
             ESP_LOGE(TAG, "ERROR: ota_info partition size %d is too small (minimum %d bytes)", bs.ota_info.size, sizeof(esp_ota_select_entry_t));
@@ -301,63 +295,70 @@ void bootloader_main()
             ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", bs.ota_info.offset, bs.ota_info.size);
             return;
         }
-        memcpy(&sa, ota_select_map, sizeof(esp_ota_select_entry_t));
-        memcpy(&sb, (uint8_t *)ota_select_map + SPI_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+        memcpy(&ss[0], ota_select_map, sizeof(ss[0]));
+        memcpy(&ss[1], (uint8_t *)ota_select_map + SPI_SEC_SIZE, sizeof(ss[1]));
         bootloader_munmap(ota_select_map);
-        ESP_LOGD(TAG, "OTA sequence values A 0x%08x B 0x%08x", sa.ota_seq, sb.ota_seq);
-        if(sa.ota_seq == 0xFFFFFFFF && sb.ota_seq == 0xFFFFFFFF) {
-            ESP_LOGD(TAG, "OTA sequence numbers both empty (all-0xFF");
-            // init status flash
-            if (bs.factory.offset != 0) {        // if have factory bin,boot factory bin
-                ESP_LOGD(TAG, "Defaulting to factory image");
-                load_part_pos = bs.factory;
-            } else {
-                ESP_LOGD(TAG, "No factory image, defaulting to OTA 0");
-                load_part_pos = bs.ota[0];
-                sa.ota_seq = 0x01;
-                sa.crc = ota_select_crc(&sa);
-                sb.ota_seq = 0x00;
-                sb.crc = ota_select_crc(&sb);
-
-                Cache_Read_Disable(0);
-                spiRet1 = esp_rom_spiflash_erase_sector(bs.ota_info.offset/0x1000);
-                spiRet2 = esp_rom_spiflash_erase_sector(bs.ota_info.offset/0x1000+1);
-                if (spiRet1 != ESP_ROM_SPIFLASH_RESULT_OK || spiRet2 != ESP_ROM_SPIFLASH_RESULT_OK ) {
-                    ESP_LOGE(TAG, SPI_ERROR_LOG);
-                    return;
+        if (ss[0].seq == UINT32_MAX && ss[1].seq == UINT32_MAX) {
+            esp_err_t r1 = ESP_OK, r2 = ESP_OK;
+            ESP_LOGI(TAG, "Initializing OTA info...");
+            memset(ss, 0, sizeof(ss));
+            /*
+             * If there is a factory default image, don't write any valid config and fall through.
+             * Otherwise, select the first OTA partition (if any).
+             */
+            if (bs.factory.size == 0) {
+                for (int i = 0; i < 16; i++) {
+                    if (bs.ota[i].size != 0) {
+                        ss[0].seq = 1;
+                        ss[0].boot_app_subtype = PART_SUBTYPE_OTA_MIN + i;
+                        ss[0].crc = esp_ota_select_crc(&ss[0]);
+                        break;
+                    }
                 }
-                spiRet1 = esp_rom_spiflash_write(bs.ota_info.offset,(uint32_t *)&sa,sizeof(esp_ota_select_entry_t));
-                spiRet2 = esp_rom_spiflash_write(bs.ota_info.offset + 0x1000,(uint32_t *)&sb,sizeof(esp_ota_select_entry_t));
-                if (spiRet1 != ESP_ROM_SPIFLASH_RESULT_OK || spiRet2 != ESP_ROM_SPIFLASH_RESULT_OK ) {
-                    ESP_LOGE(TAG, SPI_ERROR_LOG);
-                    return;
-                }
-                Cache_Read_Enable(0);
             }
-            //TODO:write data in ota info
-        } else  {
-            if(ota_select_valid(&sa) && ota_select_valid(&sb)) {
-                ESP_LOGD(TAG, "Both OTA sequence valid, using OTA slot %d", MAX(sa.ota_seq, sb.ota_seq)-1);
-                load_part_pos = bs.ota[(MAX(sa.ota_seq, sb.ota_seq) - 1)%bs.app_count];
-            } else if(ota_select_valid(&sa)) {
-                ESP_LOGD(TAG, "Only OTA sequence A is valid, using OTA slot %d", sa.ota_seq - 1);
-                load_part_pos = bs.ota[(sa.ota_seq - 1) % bs.app_count];
-            } else if(ota_select_valid(&sb)) {
-                ESP_LOGD(TAG, "Only OTA sequence B is valid, using OTA slot %d", sa.ota_seq - 1);
-                load_part_pos = bs.ota[(sb.ota_seq - 1) % bs.app_count];
-            } else if (bs.factory.offset != 0) {
-                ESP_LOGE(TAG, "ota data partition invalid, falling back to factory");
-                load_part_pos = bs.factory;
-            } else {
-                ESP_LOGE(TAG, "ota data partition invalid and no factory, can't boot");
-                return;
+            /* Not setting crc will keep selector(s) invalid. */
+            r1 = bootloader_flash_erase_range(bs.ota_info.offset, 2 * SPI_SEC_SIZE);
+            if (r1 == ESP_OK) {
+                bool encrypt = esp_flash_encryption_enabled();
+                r1 = bootloader_flash_write(bs.ota_info.offset, &ss[0], sizeof(ss[0]), encrypt);
+                r2 = bootloader_flash_write(bs.ota_info.offset + SPI_SEC_SIZE, &ss[1], sizeof(ss[1]), encrypt);
+            }
+            if (r1 != ESP_OK || r2 != ESP_OK) {
+                ESP_LOGE(TAG, SPI_ERROR_LOG);
+                /* Fall through, we may still boot successfully. */
             }
         }
-    } else if (bs.factory.offset != 0) {        // otherwise, look for factory app partition
-        load_part_pos = bs.factory;
-    } else if (bs.test.offset != 0) {           // otherwise, look for test app parition
-        load_part_pos = bs.test;
-    } else {                                    // nothing to load, bail out
+
+        for (int i = 0; i < 2; i++) {
+          ESP_LOGI(TAG, "OTA data %d: seq 0x%08x, st 0x%02x, CRC 0x%08x, valid? %d",
+                   i, ss[i].seq, ss[i].boot_app_subtype, ss[i].crc, esp_ota_select_valid(&ss[i]));
+        }
+
+        const esp_ota_select_entry_t *cs = esp_ota_choose_current(ss);
+        if (cs != NULL) {
+            if ((cs->boot_app_subtype & ~PART_SUBTYPE_OTA_MASK) == PART_SUBTYPE_OTA_MIN) {
+                load_part_pos = bs.ota[cs->boot_app_subtype & PART_SUBTYPE_OTA_MASK];
+            } else if (cs->boot_app_subtype == PART_SUBTYPE_FACTORY) {
+                load_part_pos = bs.factory;
+            } else if (cs->boot_app_subtype == PART_SUBTYPE_TEST) {
+                load_part_pos = bs.test;
+            }
+        } else {
+            ESP_LOGE(TAG, "No valid OTA images");
+        }
+    }
+
+    if (load_part_pos.size == 0) {
+        if (bs.factory.size != 0) {
+            ESP_LOGI(TAG, "Loading factory image");
+            load_part_pos = bs.factory;
+        } else if (bs.test.size != 0) {
+            ESP_LOGI(TAG, "Loading test image");
+            load_part_pos = bs.test;
+        }
+    }
+
+    if (load_part_pos.size == 0) {
         ESP_LOGE(TAG, "nothing to load");
         return;
     }
@@ -550,7 +551,8 @@ static void unpack_load_app(const esp_partition_pos_t* partition)
         irom_addr,
         irom_load_addr,
         irom_size,
-        image_header.entry_addr);
+        image_header.entry_addr,
+        partition->offset);
 }
 
 static void set_cache_and_start_app(
@@ -560,7 +562,8 @@ static void set_cache_and_start_app(
     uint32_t irom_addr,
     uint32_t irom_load_addr,
     uint32_t irom_size,
-    uint32_t entry_addr)
+    uint32_t entry_addr,
+    uint32_t image_flash_addr)
 {
     ESP_LOGD(TAG, "configure drom and irom and start");
     Cache_Read_Disable( 0 );
@@ -584,12 +587,10 @@ static void set_cache_and_start_app(
     // Application will need to do Cache_Flush(1) and Cache_Read_Enable(1)
 
     ESP_LOGD(TAG, "start: 0x%08x", entry_addr);
-    typedef void (*entry_t)(void);
-    entry_t entry = ((entry_t) entry_addr);
 
     // TODO: we have used quite a bit of stack at this point.
     // use "movsp" instruction to reset stack back to where ROM stack starts.
-    (*entry)();
+    ((void (*)(uint32_t)) entry_addr)(image_flash_addr);
 }
 
 static void update_flash_config(const esp_image_header_t* pfhdr)

--- a/components/bootloader_support/include/esp_ota_select.h
+++ b/components/bootloader_support/include/esp_ota_select.h
@@ -1,0 +1,42 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __ESP_OTA_SELECT_H
+#define __ESP_OTA_SELECT_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* OTA selection structure (two copies in the OTA data partition.)
+   Size of 32 bytes is friendly to flash encryption */
+typedef struct {
+    uint32_t seq;
+    uint32_t boot_app_subtype;
+    uint8_t  reserved[20];
+    uint32_t crc; /* CRC32 is computed with crc field set to 0. */
+} esp_ota_select_entry_t;
+
+uint32_t esp_ota_select_crc(const esp_ota_select_entry_t *s);
+bool esp_ota_select_valid(const esp_ota_select_entry_t *s);
+const esp_ota_select_entry_t *esp_ota_choose_current(const esp_ota_select_entry_t s[2]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ESP_OTA_SELECT_H */

--- a/components/bootloader_support/include_priv/bootloader_flash.h
+++ b/components/bootloader_support/include_priv/bootloader_flash.h
@@ -100,4 +100,6 @@ esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool 
  */
 esp_err_t bootloader_flash_erase_sector(size_t sector);
 
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size);
+
 #endif

--- a/components/bootloader_support/src/bootloader_flash.c
+++ b/components/bootloader_support/src/bootloader_flash.c
@@ -70,6 +70,10 @@ esp_err_t bootloader_flash_erase_sector(size_t sector)
     return spi_flash_erase_sector(sector);
 }
 
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size) {
+    return spi_flash_erase_range(start_addr, size);
+}
+
 #else
 /* Bootloader version, uses ROM functions only */
 #include <soc/dport_reg.h>
@@ -241,6 +245,11 @@ esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool 
 esp_err_t bootloader_flash_erase_sector(size_t sector)
 {
     return spi_to_esp_err(esp_rom_spiflash_erase_sector(sector));
+}
+
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size)
+{
+    return spi_to_esp_err(esp_rom_spiflash_erase_area(start_addr, size));
 }
 
 #endif

--- a/components/bootloader_support/src/esp_ota_select.c
+++ b/components/bootloader_support/src/esp_ota_select.c
@@ -1,0 +1,46 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#include "rom/crc.h"
+#include "esp_ota_select.h"
+
+uint32_t esp_ota_select_crc(const esp_ota_select_entry_t *s)
+{
+    esp_ota_select_entry_t tmp;
+    memcpy(&tmp, s, sizeof(tmp));
+    tmp.crc = 0;
+    return crc32_le(UINT32_MAX, (uint8_t *) &tmp, sizeof(tmp));
+}
+
+bool esp_ota_select_valid(const esp_ota_select_entry_t *s)
+{
+    return s->seq != UINT32_MAX && s->crc == esp_ota_select_crc(s);
+}
+
+const esp_ota_select_entry_t *esp_ota_choose_current(const esp_ota_select_entry_t s[2])
+{
+    const esp_ota_select_entry_t *cs = NULL;
+    bool s0_valid = esp_ota_select_valid(&s[0]);
+    bool s1_valid = esp_ota_select_valid(&s[1]);
+    if (s0_valid && s1_valid) {
+        cs = s[0].seq > s[1].seq ? &s[0] : &s[1];
+    } else if (s0_valid) {
+        cs = &s[0];
+    } else if (s1_valid) {
+        cs = &s[1];
+    }
+    return cs;
+}

--- a/components/bootloader_support/src/flash_encrypt.c
+++ b/components/bootloader_support/src/flash_encrypt.c
@@ -285,8 +285,8 @@ static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partit
         } else {
             should_encrypt = false;
         }
-    } else if (partition->type == PART_TYPE_DATA && partition->subtype == PART_SUBTYPE_DATA_OTA) {
-        /* check if we have ota data partition and the partition should be encrypted unconditionally */
+    } else if (partition->type == PART_TYPE_DATA &&
+               partition->subtype == PART_SUBTYPE_DATA_OTA) {
         should_encrypt = true;
     }
 
@@ -295,7 +295,8 @@ static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partit
     }
     else {
         /* should_encrypt */
-        ESP_LOGI(TAG, "Encrypting partition %d at offset 0x%x...", index, partition->pos.offset);
+        ESP_LOGI(TAG, "Encrypting partition %s (%d) at offset 0x%x...",
+                 partition->label, index, partition->pos.offset);
 
         err = esp_flash_encrypt_region(partition->pos.offset, partition->pos.size);
         if (err != ESP_OK) {

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -91,12 +91,15 @@ extern volatile int port_xSchedulerRunning[2];
 
 static const char* TAG = "cpu_start";
 
+uint32_t g_boot_image_flash_addr;
+
 /*
  * We arrive here after the bootloader finished loading the program from flash. The hardware is mostly uninitialized,
  * and the app CPU is in reset. We do have a stack, so we can do the initialization in C.
+ *
+ * Boot loader passes flash offset of our image so we can later know for sure which partition was used for boot.
  */
-
-void IRAM_ATTR call_start_cpu0()
+void IRAM_ATTR call_start_cpu0(uint32_t boot_image_flash_addr)
 {
 #if CONFIG_FREERTOS_UNICORE
     RESET_REASON rst_reas[1];
@@ -127,6 +130,8 @@ void IRAM_ATTR call_start_cpu0()
 
     //Clear BSS. Please do not attempt to do any complex stuff (like early logging) before this.
     memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
+
+    g_boot_image_flash_addr = boot_image_flash_addr;
 
     /* Unless waking from deep sleep (implying RTC memory is intact), clear RTC bss */
     if (rst_reas[0] != DEEPSLEEP_RESET) {

--- a/components/esp32/include/esp_flash_data_types.h
+++ b/components/esp32/include/esp_flash_data_types.h
@@ -24,15 +24,6 @@ extern "C"
 #define ESP_PARTITION_TABLE_ADDR 0x8000
 #define ESP_PARTITION_MAGIC 0x50AA
 
-/* OTA selection structure (two copies in the OTA data partition.)
-   Size of 32 bytes is friendly to flash encryption */
-typedef struct {
-    uint32_t ota_seq;
-    uint8_t  seq_label[24];
-    uint32_t crc; /* CRC32 of ota_seq field only */
-} esp_ota_select_entry_t;
-
-
 typedef struct {
     uint32_t offset;
     uint32_t size;
@@ -46,13 +37,13 @@ typedef struct {
 	uint8_t  type;
     uint8_t  subtype;
     esp_partition_pos_t pos;
-	uint8_t  label[16];
+    uint8_t  label[16];
     uint32_t flags;
 } esp_partition_info_t;
 
 #define PART_TYPE_APP 0x00
 #define PART_SUBTYPE_FACTORY  0x00
-#define PART_SUBTYPE_OTA_FLAG 0x10
+#define PART_SUBTYPE_OTA_MIN 0x10
 #define PART_SUBTYPE_OTA_MASK 0x0f
 #define PART_SUBTYPE_TEST     0x20
 
@@ -60,6 +51,7 @@ typedef struct {
 #define PART_SUBTYPE_DATA_OTA 0x00
 #define PART_SUBTYPE_DATA_RF  0x01
 #define PART_SUBTYPE_DATA_WIFI 0x02
+#define PART_SUBTYPE_DATA_SPIFFS 0x82
 
 #define PART_TYPE_END 0xff
 #define PART_SUBTYPE_END 0xff

--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -287,6 +287,16 @@ esp_err_t esp_partition_mmap(const esp_partition_t* partition, uint32_t offset, 
                              const void** out_ptr, spi_flash_mmap_handle_t* out_handle);
 
 
+/**
+ * @brief Get the partition that the device booted from.
+ *
+ * Returns partition that was used to boot the device.
+ *
+ * @return pointer to esp_partition_t structure, or NULL if no partition is found.
+ *         This pointer is valid for the lifetime of the application.
+ */
+const esp_partition_t *esp_partition_get_boot_partition(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -55,6 +55,8 @@ static SLIST_HEAD(partition_list_head_, partition_list_item_) s_partition_list =
         SLIST_HEAD_INITIALIZER(s_partition_list);
 static _lock_t s_partition_list_lock;
 
+/* From cpu_start.c */
+extern uint32_t g_boot_image_flash_addr;
 
 esp_partition_iterator_t esp_partition_find(esp_partition_type_t type,
         esp_partition_subtype_t subtype, const char* label)
@@ -321,4 +323,19 @@ esp_err_t esp_partition_mmap(const esp_partition_t* partition, uint32_t offset, 
         *out_ptr = (void*) (((ptrdiff_t) *out_ptr) + region_offset);
     }
     return rc;
+}
+
+const esp_partition_t *esp_partition_get_boot_partition(void)
+{
+    const esp_partition_t *p = NULL;
+    /* Boot partition must be an APP partition, but subtype can be any. */
+    esp_partition_iterator_t it = iterator_create(ESP_PARTITION_TYPE_APP, 0xff, NULL);
+    while ((it = esp_partition_next(it)) != NULL) {
+      p = esp_partition_get(it);
+      if (p->address == g_boot_image_flash_addr) {
+        esp_partition_iterator_release(it);
+        return p;
+      }
+    }
+    return NULL;
 }


### PR DESCRIPTION
Code is simplified: selector stores simple pointer to subpartition
instead of performing calculations based on sequence. Sequence now
serves as a simple tie-breaker.

Logic to determine boot partition is removed. Instead, boot loader now
passes the offset of the image used to boot, this means that logic used
to select image doesn't have to be in sync between boot loader and
library code.

Initial configuration now works with encrypted flash (encrypted write is
performed when needed).

Fixes espressif/esp-idf#253