### PR TITLE
Fix SPI read edges in spi_intr

### DIFF
--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -625,9 +625,9 @@ static void IRAM_ATTR spi_intr(void *arg)
             } else {
                 data=(uint32_t *)trans->tx_buffer;
             }
-            if (trans->rxlength < 8*32) {
+            if (trans->length < 8*32) {
                 //No need for DMA.
-                for (int x=0; x < trans->rxlength; x+=32) {
+                for (int x=0; x < trans->length; x+=32) {
                     //Use memcpy to get around alignment issues for txdata
                     uint32_t word;
                     memcpy(&word, &data[x/32], 4);
@@ -656,7 +656,7 @@ static void IRAM_ATTR spi_intr(void *arg)
             host->hw->addr=trans->address & 0xffffffff;
         }
         host->hw->user.usr_mosi=(trans->tx_buffer==NULL)?0:1;
-        host->hw->user.usr_miso=(trans->tx_buffer==NULL)?0:1;
+        host->hw->user.usr_miso=(trans->rx_buffer==NULL)?0:1;
 
         //Call pre-transmission callback, if any
         if (dev->cfg.pre_cb) dev->cfg.pre_cb(trans);


### PR DESCRIPTION
References debugging work done by @xiangjunhuang  and @negativekelvin in https://github.com/espressif/esp-idf/issues/287

Without this diff I couldn't get esp32 + the SPI interface with a Semtech `sx1272` going.

@igrr 