### PR TITLE
Add the possibility to include a custom config file in FreeRTOSConfig.h

### DIFF
--- a/components/freertos/include/freertos/FreeRTOSConfig.h
+++ b/components/freertos/include/freertos/FreeRTOSConfig.h
@@ -268,6 +268,10 @@
 #define configENABLE_TASK_SNAPSHOT			1
 #endif
 
+#if defined(FREERTOSPORTCONFIG_H)
+#include FREERTOSPORTCONFIG_H
+#endif
+
 
 #endif /* FREERTOS_CONFIG_H */
 


### PR DESCRIPTION
This allows to add and change config values by simply adding a definition of FREERTOSPORTCONFIG_H inside sdkconfig.h.

For instance, in **sdkconfig.h**:

```c
#define FREERTOSPORTCONFIG_H         "FreeRTOSPortConfig.h"
```

Inside **FreeRTOSPortConfig.h**:

```c
// Enable support for both dynamic and static allocation
#define configSUPPORT_STATIC_ALLOCATION       1
#define configSUPPORT_DYNAMIC_ALLOCATION      1

#undef configTIMER_TASK_STACK_DEPTH
#define configTIMER_TASK_STACK_DEPTH          4096
```

This is needed by the ESP32 port of MicroPython: https://github.com/micropython/micropython-esp32