### PR TITLE
Clean-up the TCB at the right time.

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3740,11 +3740,6 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 
 	static void prvDeleteTCB( TCB_t *pxTCB )
 	{
-		/* This call is required specifically for the TriCore port.  It must be
-		above the vPortFree() calls.  The call is also used by ports/demos that
-		want to allocate and clean RAM statically. */
-		portCLEAN_UP_TCB( pxTCB );
-
 		/* Free up the memory allocated by the scheduler for the task.  It is up
 		to the task to free any memory allocated at the application level. */
 		#if ( configUSE_NEWLIB_REENTRANT == 1 )
@@ -3783,6 +3778,7 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 				/* Neither the stack nor the TCB were allocated dynamically, so
 				nothing needs to be freed. */
 				configASSERT( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB	)
+				portCLEAN_UP_TCB( pxTCB );
 				mtCOVERAGE_TEST_MARKER();
 			}
 		}


### PR DESCRIPTION
In the ESP32 port the current statement about clean-up TCB does not apply:

```c
/* This call is required specifically for the TriCore port.  It must be
above the vPortFree() calls.  The call is also used by ports/demos that
want to allocate and clean RAM statically. */
portCLEAN_UP_TCB( pxTCB );
```

Because it's not a tri-core port. What is actually useful is the ability to "release" an statically allocated TCB when a task is deleted. In order to do so, ```portCLEAN_UP_TCB``` can be used, but it needs to be called after all the accesses to the TCB are performed. In the current location, releasing the TCB causes a crash because the TCB is accessed by FreeRTOS several times afterwards. The proposed patch moves the call to the end and inside the check for a statically allocated TCB (where it makes sense).