### PR TITLE
components/driver: Add width field to the slot config.

### DIFF
--- a/components/driver/include/driver/sdmmc_host.h
+++ b/components/driver/include/driver/sdmmc_host.h
@@ -50,6 +50,7 @@ extern "C" {
 typedef struct {
     gpio_num_t gpio_cd;     ///< GPIO number of card detect signal
     gpio_num_t gpio_wp;     ///< GPIO number of write protect signal
+    uint8_t width;          ///< Bus width used by the slot (might be less than the max width supported)
 } sdmmc_slot_config_t;
 
 #define SDMMC_SLOT_NO_CD      ((gpio_num_t) -1)     ///< indicates that card detect line is not used
@@ -61,6 +62,7 @@ typedef struct {
 #define SDMMC_SLOT_CONFIG_DEFAULT() {\
     .gpio_cd = SDMMC_SLOT_NO_CD, \
     .gpio_wp = SDMMC_SLOT_NO_WP, \
+    .width   = 4, \
 }
 
 /**

--- a/components/driver/sdmmc_host.c
+++ b/components/driver/sdmmc_host.c
@@ -302,17 +302,24 @@ esp_err_t sdmmc_host_init_slot(int slot, const sdmmc_slot_config_t* slot_config)
 
     // Configure pins
     const sdmmc_slot_info_t* pslot = &s_slot_info[slot];
+
+    if (slot_config->width > pslot->width) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
     configure_pin(pslot->clk);
     configure_pin(pslot->cmd);
     configure_pin(pslot->d0);
-    configure_pin(pslot->d1);
-    configure_pin(pslot->d2);
-    configure_pin(pslot->d3);
-    if (pslot->width == 8) {
-        configure_pin(pslot->d4);
-        configure_pin(pslot->d5);
-        configure_pin(pslot->d6);
-        configure_pin(pslot->d7);
+    if (slot_config->width >= 4) {
+        configure_pin(pslot->d1);
+        configure_pin(pslot->d2);
+        configure_pin(pslot->d3);
+        if (slot_config->width == 8) {
+            configure_pin(pslot->d4);
+            configure_pin(pslot->d5);
+            configure_pin(pslot->d6);
+            configure_pin(pslot->d7);
+        }
     }
     if (gpio_cd != -1) {
         gpio_set_direction(gpio_cd, GPIO_MODE_INPUT);


### PR DESCRIPTION
Therefore if the width is set to 1, you can choose to only
configure the CLK, DAT0 and CMD pins.