### PR TITLE
Fixed: ble_adv data truncation

### DIFF
--- a/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
+++ b/components/bt/bluedroid/btc/profile/std/gap/btc_gap_ble.c
@@ -477,7 +477,7 @@ static void btc_search_callback(tBTA_DM_SEARCH_EVT event, tBTA_DM_SEARCH *p_data
 		param.scan_rst.ble_evt_type = p_data->inq_res.ble_evt_type;
         param.scan_rst.flag = p_data->inq_res.flag;
         memcpy(param.scan_rst.ble_adv, p_data->inq_res.p_eir,
-               ESP_BLE_ADV_DATA_LEN_MAX);
+               ESP_BLE_ADV_DATA_LEN_MAX + ESP_BLE_SCAN_RSP_DATA_LEN_MAX);
         break;
     }
     case BTA_DM_INQ_CMPL_EVT: {


### PR DESCRIPTION
Fixed issue with ble_adv data being truncated after the 31st octet due to an incorrect length passed in a memcpy.

Fixes: #369