### PR TITLE
comment out (#) to (//).

### DIFF
--- a/components/esp32/include/esp_wifi.h
+++ b/components/esp32/include/esp_wifi.h
@@ -135,7 +135,7 @@ typedef struct {
     .magic = WIFI_INIT_CONFIG_MAGIC\
 };
 #else
-#define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
+#define WIFI_INIT_CONFIG_DEFAULT // error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
 #endif
 
 /**


### PR DESCRIPTION
Can't compile idf when (# CONFIG_WIFI_ENABLED is not set) on make menuconfig, because of this comment out "#".