### PR TITLE
component/bt: allow to use alternative Bluetooth stack by disabling Bluedroid

### DIFF
--- a/components/bt/Kconfig
+++ b/components/bt/Kconfig
@@ -1,7 +1,14 @@
 menuconfig BT_ENABLED
     bool "Bluetooth"
     help
-        Select this option to enable Bluetooth stack and show the submenu with Bluetooth configuration choices.
+        Select this option to enable Bluetooth and show the submenu with Bluetooth configuration choices.
+
+config BLUEDROID_ENABLED
+	bool "Bluedroid Bluetooth stack enabled"
+    depends on BT_ENABLED
+	default y
+	help
+		This enables the default Bluedroid Bluetooth stack
 
 config BTC_TASK_STACK_SIZE
 	int "Bluetooth event (callback to application) task stack size"

--- a/components/bt/component.mk
+++ b/components/bt/component.mk
@@ -3,7 +3,26 @@
 #
 ifdef CONFIG_BT_ENABLED
 
-COMPONENT_ADD_INCLUDEDIRS :=	bluedroid/bta/include			\
+COMPONENT_SRCDIRS := .
+
+COMPONENT_ADD_INCLUDEDIRS := include
+
+LIBS := btdm_app
+
+COMPONENT_ADD_LDFLAGS     := -lbt -L $(COMPONENT_PATH)/lib \
+                           $(addprefix -l,$(LIBS))
+
+# re-link program if BT binary libs change
+COMPONENT_ADD_LINKER_DEPS := $(patsubst %,$(COMPONENT_PATH)/lib/lib%.a,$(LIBS))
+
+COMPONENT_SUBMODULES += lib
+
+endif
+
+
+ifdef CONFIG_BLUEDROID_ENABLED
+
+COMPONENT_ADD_INCLUDEDIRS +=	bluedroid/bta/include			\
 				bluedroid/bta/sys/include		\
 				bluedroid/btcore/include		\
 				bluedroid/device/include		\
@@ -29,17 +48,8 @@ COMPONENT_ADD_INCLUDEDIRS :=	bluedroid/bta/include			\
 				bluedroid/stack/include			\
 				bluedroid/api/include		\
 				bluedroid/include			\
-				include	
 
-LIBS := btdm_app
-
-COMPONENT_ADD_LDFLAGS := -lbt -L $(COMPONENT_PATH)/lib \
-                           $(addprefix -l,$(LIBS))
-
-# re-link program if BT binary libs change
-COMPONENT_ADD_LINKER_DEPS := $(patsubst %,$(COMPONENT_PATH)/lib/lib%.a,$(LIBS))
-
-COMPONENT_SRCDIRS := 	bluedroid/bta/dm			\
+COMPONENT_SRCDIRS += 	bluedroid/bta/dm			\
 			bluedroid/bta/gatt			\
 			bluedroid/bta/hh			\
 			bluedroid/bta/sdp			\
@@ -69,8 +79,5 @@ COMPONENT_SRCDIRS := 	bluedroid/bta/dm			\
 			bluedroid/stack				\
 			bluedroid/api			\
 			bluedroid				\
-			.
-
-COMPONENT_SUBMODULES += lib
 
 endif


### PR DESCRIPTION
To allow for alternative Bluetooth stacks, the Bluedroid part of component/bt should be made optional. By this, the VHCI layer (and the rest of the system that depends on CONFIG_BT_ENABLED) becomes available to other stacks. 

This pull request adds a new 'CONFIG_BLUEDROID_ENABLE' option to allow for that.

You can now try [BTstack on esp32](https://github.com/bluekitchen/btstack/tree/esp32-freertos/port/esp32)
