### PR TITLE
Fix late argument verification in emac-main

### DIFF
--- a/components/ethernet/emac_main.c
+++ b/components/ethernet/emac_main.c
@@ -948,13 +948,13 @@ esp_err_t esp_eth_init(eth_config_t *config)
         emac_set_user_config_data(config);
     }
 
-    emac_config.emac_phy_power_enable(true);    
-
     ret = emac_verify_args();
 
     if (ret != ESP_OK) {
         goto _exit;
     }
+
+    emac_config.emac_phy_power_enable(true);    
 
     //before set emac reg must enable clk
     emac_enable_clk(true);


### PR DESCRIPTION
Prevent crash when emac_phy_power_enable is not set.