### PR TITLE
Update toolchain version in windows prerequisites install script

### DIFF
--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -30,7 +30,7 @@ python -m pip install --upgrade pip
 pip install pyserial
 
 # TODO: automatically download precompiled toolchain, unpack at /opt/xtensa-esp32-elf/
-TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-59.zip
+TOOLCHAIN_ZIP=xtensa-esp32-elf-win32-1.22.0-61-gab8375a-5.2.0.zip
 echo "Downloading precompiled toolchain ${TOOLCHAIN_ZIP}..."
 cd ~
 curl -LO --retry 10 http://dl.espressif.com/dl/${TOOLCHAIN_ZIP}


### PR DESCRIPTION
This pull request updates the toolchain version in the windows prerequisites installation script by providing the latest toolchain download URL that has been provided in `docs/windows-setup.rst`