### PR TITLE
if esp-idf is a submodule, then everything except this check works

### DIFF
--- a/make/project.mk
+++ b/make/project.mk
@@ -410,7 +410,7 @@ define GenerateSubmoduleCheckTarget
 check-submodules: $(IDF_PATH)/$(1)/.git
 $(IDF_PATH)/$(1)/.git:
 	@echo "WARNING: Missing submodule $(1)..."
-	[ -d ${IDF_PATH}/.git ] || ( echo "ERROR: esp-idf must be cloned from git to work."; exit 1)
+	[ -e ${IDF_PATH}/.git ] || ( echo "ERROR: esp-idf must be cloned from git to work."; exit 1)
 	[ -x $(which git) ] || ( echo "ERROR: Need to run 'git submodule init $(1)' in esp-idf root directory."; exit 1)
 	@echo "Attempting 'git submodule update --init $(1)' in esp-idf root directory..."
 	cd ${IDF_PATH} && git submodule update --init $(1)


### PR DESCRIPTION
Instead of forking this repo, and then customizing on top of it, (and then later having to reconcile changes), I have a root repo with all my goodies and then an esp-idf submodule.

It just works! Except that esp-idf's make process does a check for `${IDF_PATH}/.git` -- which doesn't exist when esp-idf is a submodule. I don't really see the point of this check, since if esp-idf cannot be manipulated by git, any number of git commands in the makefile will fail and the build will stop.