### PR TITLE
replace a non-working #error statement with a working _Static_assert statement

### DIFF
--- a/components/esp32/include/esp_wifi.h
+++ b/components/esp32/include/esp_wifi.h
@@ -135,7 +135,7 @@ typedef struct {
     .magic = WIFI_INIT_CONFIG_MAGIC\
 };
 #else
-#define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
+#define WIFI_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable wifi in menuconfig to use esp_wifi.h");
 #endif
 
 /**


### PR DESCRIPTION
The following doesn't work like the author intended:

`#define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work`

Instead of making the compiler print "Wifi is disabled in config,.." and exit, it causes a long confusing error like:

```
$DELETED/esp-idf/components/esp32/include/esp_wifi.h:138:34: error: stray '#' in program
 #define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
                                  ^
$DELETED/main/./wifi_task.c:37:43: note: in expansion of macro 'WIFI_INIT_CONFIG_DEFAULT'
     wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();
                                           ^
$DELETED/esp-idf/components/esp32/include/esp_wifi.h:138:35: error: 'error' undeclared (first use in this function)
 #define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
                                   ^
$DELETED/main/./wifi_task.c:37:43: note: in expansion of macro 'WIFI_INIT_CONFIG_DEFAULT'
     wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();
                                           ^
$DELETED/esp-idf/components/esp32/include/esp_wifi.h:138:35: note: each undeclared identifier is reported only once for each function it appears in
 #define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
                                   ^
$DELETED/main/./wifi_task.c:37:43: note: in expansion of macro 'WIFI_INIT_CONFIG_DEFAULT'
     wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();
                                           ^
$DELETED/esp-idf/components/esp32/include/esp_wifi.h:138:41: error: expected ',' or ';' before 'Wif'
 #define WIFI_INIT_CONFIG_DEFAULT #error Wifi is disabled in config, WIFI_INIT_CONFIG_DEFAULT will not work
                                         ^
$DELETED/main/./wifi_task.c:37:43: note: in expansion of macro 'WIFI_INIT_CONFIG_DEFAULT'
     wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();
```

To me, it seems that if anyone includes `esp_wifi.h` without enabling wifi in the config, then that is an error. I can't imagine a situation where someone wants wifi struct definitions without intending to use wifi, but it's a possibility. Does anyone do that?