### PR TITLE
pass more arguments to git describe so that it always works even if d…

### DIFF
--- a/make/project.mk
+++ b/make/project.mk
@@ -186,8 +186,7 @@ endif
 	@echo $(ESPTOOLPY_WRITE_FLASH) $(ESPTOOL_ALL_FLASH_ARGS)
 
 
-# Git version of ESP-IDF (of the form v1.0-285-g5c4f707)
-IDF_VER := $(shell git -C $(IDF_PATH) describe)
+IDF_VER := $(shell git -C $(IDF_PATH) describe --always --tags --dirty)
 
 # Set default LDFLAGS
 


### PR DESCRIPTION
…etached branch, etc

Without this patch, if your `$IDF_PATH` is in a detached head state, you get a bunch of `fatal: No names found, cannot describe anything.` during make and `$IDF_VER` is empty.

This change keeps the behavior of `git describe` the same when you're in a branch/tag, but also allows `git describe` to do something reasonable when in a detached head. Additionally, `--dirty` makes `git describe` make a note if the git repo had uncommitted changes.