### PR TITLE
give the AP and STA netifs different names for ease of debugging lwip

### DIFF
--- a/components/lwip/include/lwip/port/netif/wlanif.h
+++ b/components/lwip/include/lwip/port/netif/wlanif.h
@@ -26,7 +26,8 @@
 extern "C" {
 #endif
 
-err_t wlanif_init(struct netif *netif);
+err_t wlanif_init_ap(struct netif *netif);
+err_t wlanif_init_sta(struct netif *netif);
 
 void wlanif_input(struct netif *netif, void *buffer, u16_t len, void* eb);
 

--- a/components/lwip/port/netif/wlanif.c
+++ b/components/lwip/port/netif/wlanif.c
@@ -52,9 +52,6 @@
 
 #include "tcpip_adapter.h"
 
-/* Define those to better describe your network interface. */
-#define IFNAME0 'e'
-#define IFNAME1 'n'
 
 /**
  * In this function, the hardware should be initialized.
@@ -216,8 +213,6 @@ wlanif_init(struct netif *netif)
    */
   NETIF_INIT_SNMP(netif, snmp_ifType_ethernet_csmacd, 100);
 
-  netif->name[0] = IFNAME0;
-  netif->name[1] = IFNAME1;
   /* We directly use etharp_output() here to save a function call.
    * You can instead declare your own function an call etharp_output()
    * from it if you have to do some checks before sending (e.g. if link
@@ -233,3 +228,17 @@ wlanif_init(struct netif *netif)
 
   return ERR_OK;
 }
+
+err_t wlanif_init_sta(struct netif *netif) {
+  netif->name[0] = 's';
+  netif->name[1] = 't';
+  return wlanif_init(netif);
+}
+
+err_t wlanif_init_ap(struct netif *netif) {
+  netif->name[0] = 'a';
+  netif->name[1] = 'p';
+  return wlanif_init(netif);
+}
+
+

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -65,8 +65,9 @@ static netif_init_fn tcpip_if_to_netif_init_fn(tcpip_adapter_if_t tcpip_if)
     switch(tcpip_if) {
 #ifdef CONFIG_WIFI_ENABLED
     case TCPIP_ADAPTER_IF_AP:
+        return wlanif_init_ap;
     case TCPIP_ADAPTER_IF_STA:
-        return wlanif_init;
+        return wlanif_init_sta;
 #endif
 #ifdef CONFIG_ETHERNET
         case TCPIP_ADAPTER_IF_ETH:


### PR DESCRIPTION
lwip debugging while in AP+STA mode was not great since both netifs were named the same, "en". This changes the AP netif to be called "ap" and the STA netif to be called "st".