### PR TITLE
bt: pointer does not point to adress member of struct but to struct

### DIFF
--- a/components/bt/bluedroid/bta/dm/bta_dm_act.c
+++ b/components/bt/bluedroid/bta/dm/bta_dm_act.c
@@ -4467,7 +4467,7 @@ void bta_dm_ble_update_conn_params (tBTA_DM_MSG *p_data)
 *******************************************************************************/
 void bta_dm_ble_set_rand_address(tBTA_DM_MSG *p_data)
 {
-    UINT8 len = sizeof(p_data->set_addr);
+    UINT8 len = sizeof(p_data->set_addr.address);
     if (len != BD_ADDR_LEN) {
         APPL_TRACE_ERROR("Invalid random adress");
         return;


### PR DESCRIPTION
[BD_ADDR_LEN](https://github.com/espressif/esp-idf/blob/master/components/bt/bluedroid/stack/include/bt_types.h#L303)
[p_data->set_addr](https://github.com/espressif/esp-idf/blob/master/components/bt/bluedroid/bta/dm/bta_dm_int.h#L734)
[BD_ADDR address](https://github.com/espressif/esp-idf/blob/master/components/bt/bluedroid/bta/dm/bta_dm_int.h#L489)
[BD_ADDR](https://github.com/espressif/esp-idf/blob/master/components/bt/bluedroid/stack/include/bt_types.h#L304)

[esp32 forum: Need to Change line 4470 in bta_dm_act.c ](https://esp32.com/viewtopic.php?f=2&t=1557&p=7176#p7175)

best wishs
rudi ;-)
