### PR TITLE
Fix impossible check in uart_set_line_inverse

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -191,7 +191,7 @@ esp_err_t uart_get_baudrate(uart_port_t uart_num, uint32_t* baudrate)
 esp_err_t uart_set_line_inverse(uart_port_t uart_num, uint32_t inverse_mask)
 {
     UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
-    UART_CHECK((((inverse_mask & UART_LINE_INV_MASK) == 0) && (inverse_mask != 0)), "inverse_mask error", ESP_FAIL);
+    UART_CHECK((((inverse_mask & ~UART_LINE_INV_MASK) == 0) && (inverse_mask != 0)), "inverse_mask error", ESP_FAIL);
     UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
     CLEAR_PERI_REG_MASK(UART_CONF0_REG(uart_num), UART_LINE_INV_MASK);
     SET_PERI_REG_MASK(UART_CONF0_REG(uart_num), inverse_mask);


### PR DESCRIPTION
uart_set_line_inverse had an impossible check which would fail regardless of the desired mask. Fix now checks for any bits set outside of the mask, in addition to the desired mask not being 0.

If the inverse mask should be able to set to 0 (ie to undo an inverse line), I'd be willing to throw in a fix for that as well. Uncertain if not being able to unset inverse lines is desired or not.