### PR TITLE
fixing http_request_example request content

### DIFF
--- a/examples/protocols/http_request/main/http_request_example_main.c
+++ b/examples/protocols/http_request/main/http_request_example_main.c
@@ -46,10 +46,10 @@ const int CONNECTED_BIT = BIT0;
 
 static const char *TAG = "example";
 
-static const char *REQUEST = "GET " WEB_URL " HTTP/1.1\n"
-    "Host: "WEB_SERVER"\n"
-    "User-Agent: esp-idf/1.0 esp32\n"
-    "\n";
+static const char *REQUEST = "GET " WEB_URL " HTTP/1.0\r\n"
+    "Host: "WEB_SERVER"\r\n"
+    "User-Agent: esp-idf/1.0 esp32\r\n"
+    "\r\n";
 
 static esp_err_t event_handler(void *ctx, system_event_t *event)
 {


### PR DESCRIPTION
request new lines must be `\r\n` as specified in the HTTP RFC.
Also the following logic checks for the socket to be closed by the server. This only happens with HTTP/1.0 not HTTP/1.1. So I have adjusted the protocol in the request, too.