### PR TITLE
Replace to strncmp from strcmp on examples/bluetoot/gatt_client

### DIFF
--- a/examples/bluetooth/gatt_client/main/gattc_demo.c
+++ b/examples/bluetooth/gatt_client/main/gattc_demo.c
@@ -317,7 +317,7 @@ static void esp_gap_cb(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *par
             }
 
             if (adv_name != NULL) {
-                if (strcmp((char *)adv_name, device_name) == 0) {
+                if (strncmp((char *)adv_name, device_name, adv_name_len) == 0) {
                     ESP_LOGI(GATTC_TAG, "Searched device %s\n", device_name);
                     if (connect == false) {
                         connect = true;


### PR DESCRIPTION
Thanks for useful example projects.

I tried to use GATT client project but I cannot establish connection between server and the client.
I found that `strcmp` does not return expected result on my environment so I changed the value.

My environment
- OS: Ubuntu16.10 64bit
- GCC: version 6.2.0 20161005 (Ubuntu 6.2.0-5ubuntu12)

After this modification, GATT client proceed connection to found server device.

Thanks.