### PR TITLE
Make sure LD -L option is calculated correctly with complex SRCDIRS.

### DIFF
--- a/make/project.mk
+++ b/make/project.mk
@@ -189,9 +189,9 @@ endif
 IDF_VER := $(shell git -C $(IDF_PATH) describe --always --tags --dirty)
 
 # Set default LDFLAGS
-
+SRCDIRS_COMPONENT_NAMES := $(sort $(foreach comp,$(SRCDIRS),$(lastword $(subst /, ,$(comp)))))
 LDFLAGS ?= -nostdlib \
-	$(addprefix -L$(BUILD_DIR_BASE)/,$(COMPONENTS) $(TEST_COMPONENT_NAMES) $(SRCDIRS) ) \
+	$(addprefix -L$(BUILD_DIR_BASE)/,$(COMPONENTS) $(TEST_COMPONENT_NAMES) $(SRCDIRS_COMPONENT_NAMES) ) \
 	-u call_user_start_cpu0	\
 	$(EXTRA_LDFLAGS) \
 	-Wl,--gc-sections	\


### PR DESCRIPTION
When the project Makefile has specified SRCDIRS components that are not directly below Makefile folder level, the LD -L option is not calculated correctly.

For example,
SRCDIRS = comp_a happy/comp_b /c/dev/comp_c

Then the following are built:

    build/comp_a/libcomp_a.a
    build/comp_b/libcomp_b.a
    build/comp_c/libcomp_c.a

But when LD is run, the -L is calculated as follows

    -L build/comp_a
    -L build/happy/comp_b
    -L build//c/dev/comp_c

This means libcomp_b.a and libcomp_c.a are not found by LD. With this change set, -L is calculated correctly for comp_b and comp_c