### PR TITLE
Revisit: mbedtls port: Fix detection of EWOULDBLOCK/EAGAIN with non-blocking sockets

### DIFF
--- a/components/mbedtls/port/net.c
+++ b/components/mbedtls/port/net.c
@@ -205,7 +205,7 @@ static int net_would_block( const mbedtls_net_context *ctx, int *errout )
 {
     int error = mbedtls_net_errno(ctx->fd);
 
-    if ( errout ) *errout = error;
+    if ( errout ) *errout = error; 
 
     /*
      * Never return 'WOULD BLOCK' on a non-blocking socket

--- a/components/mbedtls/port/net.c
+++ b/components/mbedtls/port/net.c
@@ -201,9 +201,11 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *
  * Note: on a blocking socket this function always returns 0!
  */
-static int net_would_block( const mbedtls_net_context *ctx )
+static int net_would_block( const mbedtls_net_context *ctx, int *errout )
 {
     int error = mbedtls_net_errno(ctx->fd);
+
+    if ( errout ) *errout = error;
 
     /*
      * Never return 'WOULD BLOCK' on a non-blocking socket
@@ -260,7 +262,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
     }
 
     if ( ret < 0 ) {
-        if ( net_would_block( bind_ctx ) != 0 ) {
+        if ( net_would_block( bind_ctx, NULL ) != 0 ) {
             return ( MBEDTLS_ERR_SSL_WANT_READ );
         }
 
@@ -349,11 +351,10 @@ int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
     ret = (int) read( fd, buf, len );
 
     if ( ret < 0 ) {
-        if ( net_would_block( ctx ) != 0 ) {
+        if ( net_would_block( ctx, &error ) != 0 ) {
             return ( MBEDTLS_ERR_SSL_WANT_READ );
         }
 
-        error = mbedtls_net_errno(fd);
         if ( error == EPIPE || error == ECONNRESET ) {
             return ( MBEDTLS_ERR_NET_CONN_RESET );
         }
@@ -425,11 +426,10 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
     ret = (int) write( fd, buf, len );
 
     if ( ret < 0 ) {
-        if ( net_would_block( ctx ) != 0 ) {
+        if ( net_would_block( ctx, &error ) != 0 ) {
             return ( MBEDTLS_ERR_SSL_WANT_WRITE );
         }
 
-        error = mbedtls_net_errno(fd);
         if ( error == EPIPE || error == ECONNRESET ) {
             return ( MBEDTLS_ERR_NET_CONN_RESET );
         }


### PR DESCRIPTION
Since mbedtls_net_errno is reset by fcntl, it is reset after calling
net_would_block, so the call to mbedtls_net_errno in mbedtls_net_recv
and mbedtls_net_send will always get back 0. This change propagates
the value returned by mbedtls_net_errno up through net_would_block,
to allow the correct error value to be used and avoid a redundant
call to mbedtls_net_errno.