### PR TITLE
Fix compilation warnings related to aliasing

### DIFF
--- a/components/bt/bluedroid/btc/profile/esp/blufi/blufi_prf.c
+++ b/components/bt/bluedroid/btc/profile/esp/blufi/blufi_prf.c
@@ -345,7 +345,7 @@ static void btc_blufi_send_notify(uint8_t *pkt, int pkt_len)
 static void btc_blufi_recv_handler(uint8_t *data, int len)
 {
     struct blufi_hdr *hdr = (struct blufi_hdr *)data;
-    uint16_t checksum;
+    uint16_t checksum, checksum_pkt;
     int ret;
 
     if (hdr->seq != blufi_env.recv_seq) {
@@ -369,8 +369,9 @@ static void btc_blufi_recv_handler(uint8_t *data, int len)
     if (BLUFI_FC_IS_CHECK(hdr->fc)
             && (blufi_env.cbs && blufi_env.cbs->checksum_func)) {
         checksum = blufi_env.cbs->checksum_func(hdr->seq, &hdr->seq, hdr->data_len + 2);
-        if (memcmp(&checksum, &hdr->data[hdr->data_len], 2) != 0) {
-            LOG_ERROR("%s checksum error %04x, pkt %04x\n", __func__, checksum, *(uint16_t *)&hdr->data[hdr->data_len]);
+        checksum_pkt = hdr->data[hdr->data_len] | (((uint16_t) hdr->data[hdr->data_len + 1]) << 8);
+        if (checksum != checksum_pkt) {
+            LOG_ERROR("%s checksum error %04x, pkt %04x\n", __func__, checksum, checksum_pkt);
             return;
         }
     }
@@ -381,7 +382,7 @@ static void btc_blufi_recv_handler(uint8_t *data, int len)
 
     if (BLUFI_FC_IS_FRAG(hdr->fc)) {
         if (blufi_env.offset == 0) {
-            blufi_env.total_len = *(uint16_t *)(hdr->data);
+            blufi_env.total_len = hdr->data[0] | (((uint16_t) hdr->data[1]) << 8);
             blufi_env.aggr_buf = GKI_getbuf(blufi_env.total_len);
             if (blufi_env.aggr_buf == NULL) {
                 LOG_ERROR("%s no mem, len %d\n", __func__, blufi_env.total_len);
@@ -420,7 +421,8 @@ void btc_blufi_send_encap(uint8_t type, uint8_t *data, int total_data_len)
             }
             hdr->fc = 0x0;
             hdr->data_len = blufi_env.frag_size + 2;
-            *(uint16_t *)hdr->data = remain_len;
+            hdr->data[0] = remain_len & 0xff;
+            hdr->data[1] = (remain_len >> 8) & 0xff;
             memcpy(hdr->data + 2, &data[total_data_len - remain_len], blufi_env.frag_size); //copy first, easy for check sum
             hdr->fc |= BLUFI_FC_FRAG;
         } else {

--- a/components/bt/bluedroid/stack/btu/btu_task.c
+++ b/components/bt/bluedroid/stack/btu/btu_task.c
@@ -223,8 +223,11 @@ static void btu_hci_msg_process(BT_HDR *p_msg)
     /* Determine the input message type. */
     switch (p_msg->event & BT_EVT_MASK) {
     case BTU_POST_TO_TASK_NO_GOOD_HORRIBLE_HACK: // TODO(zachoverflow): remove this
-        ((post_to_task_hack_t *)(&p_msg->data[0]))->callback(p_msg);
+      {
+        post_to_task_hack_t *ph = (post_to_task_hack_t *) &p_msg->data[0];
+        ph->callback(p_msg);
         break;
+      }
     case BT_EVT_TO_BTU_HCI_ACL:
         /* All Acl Data goes to L2CAP */
         l2c_rcv_acl_data (p_msg);


### PR DESCRIPTION
We compile with `-Werror` and a couple places in the bt component have aliasing issues.
This actually fixes two of them and at least shuts up the third one.