### PR TITLE
components/driver: 'const' all config calls.

### DIFF
--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -270,7 +270,7 @@ esp_err_t gpio_set_direction(gpio_num_t gpio_num, gpio_mode_t mode)
     return ret;
 }
 
-esp_err_t gpio_config(gpio_config_t *pGPIOConfig)
+esp_err_t gpio_config(const gpio_config_t *pGPIOConfig)
 {
     uint64_t gpio_pin_mask = (pGPIOConfig->pin_bit_mask);
     uint32_t io_reg = 0;

--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -429,7 +429,7 @@ esp_err_t i2c_get_data_mode(i2c_port_t i2c_num, i2c_trans_mode_t *tx_trans_mode,
     return ESP_OK;
 }
 
-esp_err_t i2c_param_config(i2c_port_t i2c_num, i2c_config_t* i2c_conf)
+esp_err_t i2c_param_config(i2c_port_t i2c_num, const i2c_config_t* i2c_conf)
 {
     I2C_CHECK(i2c_num < I2C_NUM_MAX, I2C_NUM_ERROR_STR, ESP_ERR_INVALID_ARG);
     I2C_CHECK(i2c_conf != NULL, I2C_ADDR_ERROR_STR, ESP_ERR_INVALID_ARG);

--- a/components/driver/include/driver/gpio.h
+++ b/components/driver/include/driver/gpio.h
@@ -221,7 +221,7 @@ typedef intr_handle_t gpio_isr_handle_t;
  *     - ESP_ERR_INVALID_ARG Parameter error
  *
  */
-esp_err_t gpio_config(gpio_config_t *pGPIOConfig);
+esp_err_t gpio_config(const gpio_config_t *pGPIOConfig);
 
 
 /**

--- a/components/driver/include/driver/i2c.h
+++ b/components/driver/include/driver/i2c.h
@@ -135,7 +135,7 @@ esp_err_t i2c_driver_delete(i2c_port_t i2c_num);
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t i2c_param_config(i2c_port_t i2c_num, i2c_config_t* i2c_conf);
+esp_err_t i2c_param_config(i2c_port_t i2c_num, const i2c_config_t* i2c_conf);
 
 /**
  * @brief reset I2C tx hardware fifo

--- a/components/driver/include/driver/ledc.h
+++ b/components/driver/include/driver/ledc.h
@@ -115,7 +115,7 @@ typedef intr_handle_t ledc_isr_handle_t;
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t ledc_channel_config(ledc_channel_config_t* ledc_conf);
+esp_err_t ledc_channel_config(const ledc_channel_config_t* ledc_conf);
 
 /**
  * @brief LEDC timer configuration
@@ -128,7 +128,7 @@ esp_err_t ledc_channel_config(ledc_channel_config_t* ledc_conf);
  *     - ESP_ERR_INVALID_ARG Parameter error
  *     - ESP_FAIL Can not find a proper pre-divider number base on the given frequency and the current bit_num.
  */
-esp_err_t ledc_timer_config(ledc_timer_config_t* timer_conf);
+esp_err_t ledc_timer_config(const ledc_timer_config_t* timer_conf);
 
 /**
  * @brief LEDC update channel parameters

--- a/components/driver/include/driver/pcnt.h
+++ b/components/driver/include/driver/pcnt.h
@@ -88,7 +88,7 @@ typedef intr_handle_t pcnt_isr_handle_t;
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t pcnt_unit_config(pcnt_config_t *pcnt_config);
+esp_err_t pcnt_unit_config(const pcnt_config_t *pcnt_config);
 
 /**
  * @brief Get pulse counter value

--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -564,7 +564,7 @@ esp_err_t rmt_set_pin(rmt_channel_t channel, rmt_mode_t mode, gpio_num_t gpio_nu
  *     - ESP_ERR_INVALID_ARG Parameter error
  *     - ESP_OK Success
  */
-esp_err_t rmt_config(rmt_config_t* rmt_param);
+esp_err_t rmt_config(const rmt_config_t* rmt_param);
 
 /**
  * @brief   register RMT interrupt handler, the handler is an ISR.

--- a/components/driver/include/driver/sigmadelta.h
+++ b/components/driver/include/driver/sigmadelta.h
@@ -57,7 +57,7 @@ typedef struct {
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t sigmadelta_config(sigmadelta_config_t *config);
+esp_err_t sigmadelta_config(const sigmadelta_config_t *config);
 
 /**
  * @brief Set Sigma-delta channel duty.

--- a/components/driver/include/driver/spi_master.h
+++ b/components/driver/include/driver/spi_master.h
@@ -131,7 +131,7 @@ typedef struct spi_device_t* spi_device_handle_t;  ///< Handle for a device on a
  *         - ESP_ERR_NO_MEM        if out of memory
  *         - ESP_OK                on success
  */
-esp_err_t spi_bus_initialize(spi_host_device_t host, spi_bus_config_t *bus_config, int dma_chan);
+esp_err_t spi_bus_initialize(spi_host_device_t host, const spi_bus_config_t *bus_config, int dma_chan);
 
 /**
  * @brief Free a SPI bus

--- a/components/driver/include/driver/timer.h
+++ b/components/driver/include/driver/timer.h
@@ -287,7 +287,7 @@ esp_err_t timer_isr_register(timer_group_t group_num, timer_idx_t timer_num, voi
  *     - ESP_OK Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t timer_init(timer_group_t group_num, timer_idx_t timer_num, timer_config_t* config);
+esp_err_t timer_init(timer_group_t group_num, timer_idx_t timer_num, const timer_config_t* config);
 
 /** @brief Get timer configure value.
  *

--- a/components/driver/ledc.c
+++ b/components/driver/ledc.c
@@ -180,7 +180,7 @@ esp_err_t ledc_isr_register(void (*fn)(void*), void * arg, int intr_alloc_flags,
     return ret;
 }
 
-esp_err_t ledc_timer_config(ledc_timer_config_t* timer_conf)
+esp_err_t ledc_timer_config(const ledc_timer_config_t* timer_conf)
 {
     int freq_hz = timer_conf->freq_hz;
     int bit_num = timer_conf->bit_num;
@@ -245,7 +245,7 @@ esp_err_t ledc_set_pin(int gpio_num, ledc_mode_t speed_mode, ledc_channel_t ledc
     return ESP_OK;
 }
 
-esp_err_t ledc_channel_config(ledc_channel_config_t* ledc_conf)
+esp_err_t ledc_channel_config(const ledc_channel_config_t* ledc_conf)
 {
     uint32_t speed_mode = ledc_conf->speed_mode;
     uint32_t gpio_num = ledc_conf->gpio_num;

--- a/components/driver/pcnt.c
+++ b/components/driver/pcnt.c
@@ -39,7 +39,7 @@ static portMUX_TYPE pcnt_spinlock = portMUX_INITIALIZER_UNLOCKED;
 #define PCNT_ENTER_CRITICAL_ISR(mux)    portENTER_CRITICAL_ISR(mux)
 #define PCNT_EXIT_CRITICAL_ISR(mux)     portEXIT_CRITICAL_ISR(mux)
 
-esp_err_t pcnt_unit_config(pcnt_config_t *pcnt_config)
+esp_err_t pcnt_unit_config(const pcnt_config_t *pcnt_config)
 {
     uint8_t unit = pcnt_config->unit;
     uint8_t channel = pcnt_config->channel;

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -373,7 +373,7 @@ esp_err_t rmt_set_pin(rmt_channel_t channel, rmt_mode_t mode, gpio_num_t gpio_nu
     return ESP_OK;
 }
 
-esp_err_t rmt_config(rmt_config_t* rmt_param)
+esp_err_t rmt_config(const rmt_config_t* rmt_param)
 {
     uint8_t mode = rmt_param->rmt_mode;
     uint8_t channel = rmt_param->channel;

--- a/components/driver/sigmadelta.c
+++ b/components/driver/sigmadelta.c
@@ -25,7 +25,7 @@ static const char* SIGMADELTA_TAG = "SIGMADELTA";
 		return (ret_val); \
         }
 
-esp_err_t sigmadelta_config(sigmadelta_config_t *config)
+esp_err_t sigmadelta_config(const sigmadelta_config_t *config)
 {
     SIGMADELTA_CHECK(config->channel < SIGMADELTA_CHANNEL_MAX, SIGMADELTA_CHANNEL_ERR_STR, ESP_ERR_INVALID_ARG);
     SIGMADELTA_CHECK(GPIO_IS_VALID_OUTPUT_GPIO(config->sigmadelta_gpio), SIGMADELTA_IO_ERR_STR, ESP_ERR_INVALID_ARG);

--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -191,7 +191,7 @@ static const spi_signal_conn_t io_signal[3]={
 static void spi_intr(void *arg);
 
 
-esp_err_t spi_bus_initialize(spi_host_device_t host, spi_bus_config_t *bus_config, int dma_chan)
+esp_err_t spi_bus_initialize(spi_host_device_t host, const spi_bus_config_t *bus_config, int dma_chan)
 {
     bool native=true;
     /* ToDo: remove this when we have flash operations cooperating with this */

--- a/components/driver/timer.c
+++ b/components/driver/timer.c
@@ -204,7 +204,7 @@ esp_err_t timer_isr_register(timer_group_t group_num, timer_idx_t timer_num,
     return esp_intr_alloc_intrstatus(intr_source, intr_alloc_flags, status_reg, mask, fn, arg, handle);
 }
 
-esp_err_t timer_init(timer_group_t group_num, timer_idx_t timer_num, timer_config_t *config)
+esp_err_t timer_init(timer_group_t group_num, timer_idx_t timer_num, const timer_config_t *config)
 {
     TIMER_CHECK(group_num < TIMER_GROUP_MAX, TIMER_GROUP_NUM_ERROR, ESP_ERR_INVALID_ARG);
     TIMER_CHECK(timer_num < TIMER_MAX, TIMER_NUM_ERROR, ESP_ERR_INVALID_ARG);


### PR DESCRIPTION
Some were, some weren't. They all could/should be.

Signed-off-by: Michel Pollet <buserror@gmail.com>