### PR TITLE
lwip_close should free the socket for a new connection?

### DIFF
--- a/components/lwip/api/sockets.c
+++ b/components/lwip/api/sockets.c
@@ -864,9 +864,7 @@ lwip_close(int s)
     return -1;
   }
 
-#if !ESP_THREAD_SAFE
   free_socket(sock, is_tcp);
-#endif
 
   set_errno(0);
   return 0;


### PR DESCRIPTION
I'm building an HTTP server, and so obviously it does a lot of `lwip_accept` and `lwip_close`.

I found out pretty quickly that for some reason my httpd stopped working after a while. It turned out that `lwip_accept` was failing, but why? In `lwip_accept`, I had it print the state of each of the NUM_SOCKETS to figure out why it couldn't find a free socket. It turns out that none of the sockets were free, even though I know I only had maximum 4 simultaneous connections.

Looking further, it seems that you're supposed to call `free_socket` to make `conn == NULL` so that the socket is "free". But for me `ESP_THREAD_SAFE` is some truthy value, so `free_socket` was never called... why is the code like this?

I can't comment on whether or not the check on ESP_THREAD_SAFE should be there, but when I remove it, my httpd recycles sockets fine, and it works perfectly.

Note: if I had been using just `close` instead of `lwip_close`, I would not have had this problem since `#define close(s) lwip_close_r(s)`, and it calls `free_socket` as the result of some macro expansion. All the same, this seems like a bug.