### PR TITLE
check that the contents of partitions will fit into the partitions (IDFGH-2503)

### DIFF
--- a/components/esptool_py/Makefile.projbuild
+++ b/components/esptool_py/Makefile.projbuild
@@ -14,6 +14,7 @@ PYTHON ?= $(call dequote,$(CONFIG_PYTHON))
 ESPTOOLPY_SRC := $(COMPONENT_PATH)/esptool/esptool.py
 ESPTOOLPY := $(PYTHON) $(ESPTOOLPY_SRC) --chip esp32
 ESPTOOLPY_SERIAL := $(ESPTOOLPY) --port $(ESPPORT) --baud $(ESPBAUD) --before $(CONFIG_ESPTOOLPY_BEFORE) --after $(CONFIG_ESPTOOLPY_AFTER)
+CHECK_ESP32PART := $(COMPONENT_PATH)/../partition_table/check_esp32part.py
 
 # Supporting esptool command line tools
 ESPEFUSEPY := $(PYTHON) $(COMPONENT_PATH)/esptool/espefuse.py
@@ -49,6 +50,7 @@ $(APP_BIN_UNSIGNED): $(APP_ELF) $(ESPTOOLPY_SRC)
 	$(ESPTOOLPY) elf2image $(ESPTOOL_FLASH_OPTIONS) $(ESPTOOL_ELF2IMAGE_OPTIONS) -o $@ $<
 
 flash: all_binaries $(ESPTOOLPY_SRC) $(call prereq_if_explicit,erase_flash)
+	$(PYTHON) $(CHECK_ESP32PART) $(PARTITION_TABLE_CSV_PATH) $(ESPTOOL_ALL_FLASH_ARGS)
 	@echo "Flashing binaries to serial port $(ESPPORT) (app at offset $(CONFIG_APP_OFFSET))..."
 ifdef CONFIG_SECURE_BOOT_ENABLED
 	@echo "(Secure boot enabled, so bootloader not flashed automatically. See 'make bootloader' output)"

--- a/components/partition_table/check_esp32part.py
+++ b/components/partition_table/check_esp32part.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import os.path
+import sys
+
+import gen_esp32part
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+
+    if len(args) % 2 == 0:
+        print 'expected odd number of arguments'
+        sys.exit(1);
+
+    table = gen_esp32part.PartitionTable.from_csv(open(args[0]).read())
+
+    # For each of the images that we want to write into the flash at a certain offset,
+    for i in range(1, len(args) - 1, 2):
+        offset = gen_esp32part.parse_int(args[i])
+        image = args[i + 1]
+        image_size = os.path.getsize(image)
+
+        # .. find the corresponding partition in the table. `partition` may be
+        # None in e.g. the case of the bootloader.bin.
+        partition = None
+        for p in table:
+            if p.offset == offset:
+                partition = p
+                break
+
+        # If we did find the partition, make sure that this image will fit in
+        # that partition.
+        if partition is not None:
+            if partition.size < image_size:
+                print '%s (sz=%i) will not fit in partition (sz=%i) starting at %i' % (image, image_size, partition.size, offset)
+                sys.exit(1)
+        else:
+            # Otherwise, it's only an error if the image is overlapping a
+            # partition (starting at a different offset).
+            for p in table:
+                if (offset >= p.offset and offset < p.offset + p.size) \
+                    or (offset + image_size >= p.offset and offset + image_size < p.offset + p.size):
+                    print '%s is not in a partition, but it overlaps a partition!'
+                    sys.exit(1)


### PR DESCRIPTION
(I expect changes to be requested. Opening this to start a discussion!)

I was looking to tweak the flash partition sizes, and I realized that apparently esp-idf isn't checking that the images will fit into their given partitions before flashing them in.

For example, I used the following `partitions.csv`:
```
nvs,      data, nvs,     0x9000,  0x3000
otadata,  data, ota,     0xd000,  0x2000
phy_init, data, phy,     0xf000,  0x1000
factory,  app,  factory, 0x10000,  1K
ota_0,    app,  ota_0,   ,         1M
ota_1,    app,  ota_1,   ,         1M
```
to successfully flash a device. (The device booted, did all the stuff it's supposed to in the program, etc.) Note the `factory` partition size: 1K. My app is 1.2MB, so I guess in fact esptool happily spilled the app image over into the `ota_0` partition.

In this pull request I'm adding a little Python script to check whether the images will fit into their partitions. This caught my error (I tested that much).

A caveat: for this to be entirely correct, it should be rounding sizes (and offsets) to dword boundaries.