### PR TITLE
Converting URLs from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ ESP-IDF is the official development framework for the [ESP32](https://espressif.
 
 See setup guides for detailed instructions to set up the ESP-IDF:
 
-* [Windows Setup Guide](http://esp-idf.readthedocs.io/en/latest/get-started/windows-setup.html)
-* [Mac OS Setup Guide](http://esp-idf.readthedocs.io/en/latest/get-started/macos-setup.html)
-* [Linux Setup Guide](http://esp-idf.readthedocs.io/en/latest/get-started/linux-setup.html)
+* [Windows Setup Guide](https://esp-idf.readthedocs.io/en/latest/get-started/windows-setup.html)
+* [Mac OS Setup Guide](https://esp-idf.readthedocs.io/en/latest/get-started/macos-setup.html)
+* [Linux Setup Guide](https://esp-idf.readthedocs.io/en/latest/get-started/linux-setup.html)
 
 ## Finding a Project
 
@@ -52,7 +52,7 @@ You don't need to run `make all` before running `make flash`, `make flash` will 
 
 ## Viewing Serial Output
 
-The `make monitor` target uses the [idf_monitor tool](http://esp-idf.readthedocs.io/en/latest/idf-monitor.html) to display serial output from the ESP32. idf_monitor also has a range of features to decode crash output and interact with the device. [Check the documentation page for details](http://esp-idf.readthedocs.io/en/latest/idf-monitor.html).
+The `make monitor` target uses the [idf_monitor tool](https://esp-idf.readthedocs.io/en/latest/idf-monitor.html) to display serial output from the ESP32. idf_monitor also has a range of features to decode crash output and interact with the device. [Check the documentation page for details](https://esp-idf.readthedocs.io/en/latest/idf-monitor.html).
 
 Exit the monitor by typing Ctrl-].
 
@@ -108,9 +108,9 @@ This can be combined with other targets, ie `make erase_flash flash` will erase 
 
 * Documentation for the latest version: http://esp-idf.readthedocs.io/. This documentation is built from the [docs directory](docs) of this repository.
 
-* The [esp32.com forum](http://esp32.com/) is a place to ask questions and find community resources.
+* The [esp32.com forum](https://esp32.com/) is a place to ask questions and find community resources.
 
 * [Check the Issues section on github](https://github.com/espressif/esp-idf/issues) if you find a bug or have a feature request. Please check existing Issues before opening a new one.
 
-* If you're interested in contributing to ESP-IDF, please check the [Contributions Guide](http://esp-idf.readthedocs.io/en/latest/contributing.html>).
+* If you're interested in contributing to ESP-IDF, please check the [Contributions Guide](https://esp-idf.readthedocs.io/en/latest/contributing.html>).
 


### PR DESCRIPTION
URLs in `README` are unsafe. Modifying to HTTPS; I manually checked that all of these URLs are hosted on servers with SSL/TLS support.