### PR TITLE
Add xPortGetHeapSize

### DIFF
--- a/components/esp32/include/esp_heap_alloc_caps.h
+++ b/components/esp32/include/esp_heap_alloc_caps.h
@@ -60,6 +60,19 @@ void heap_alloc_enable_nonos_stack_tag();
 void *pvPortMallocCaps(size_t xWantedSize, uint32_t caps);
 
 /**
+ * @brief Get the total size of all the regions that have the given capabilities
+ *
+ * This function takes all regions capable of having the given capabilities allocated in them
+ * and adds up their size.
+ *
+ * @param caps        Bitwise OR of MALLOC_CAP_* flags indicating the type
+ *                    of memory
+ *
+ * @return Number of bytes in the regions
+ */
+size_t xPortGetHeapSizeCaps( uint32_t caps );
+
+/**
  * @brief Get the total free size of all the regions that have the given capabilities
  *
  * This function takes all regions capable of having the given capabilities allocated in them
@@ -68,7 +81,7 @@ void *pvPortMallocCaps(size_t xWantedSize, uint32_t caps);
  * @param caps        Bitwise OR of MALLOC_CAP_* flags indicating the type
  *                    of memory
  *
- * @return Amount of free bytes in the regions
+ * @return Number of free bytes in the regions
  */
 size_t xPortGetFreeHeapSizeCaps( uint32_t caps );
 
@@ -81,11 +94,9 @@ size_t xPortGetFreeHeapSizeCaps( uint32_t caps );
  * @param caps        Bitwise OR of MALLOC_CAP_* flags indicating the type
  *                    of memory
  *
- * @return Amount of free bytes in the regions
+ * @return Number of free bytes in the regions
  */
 size_t xPortGetMinimumEverFreeHeapSizeCaps( uint32_t caps );
-
-
 
 /**
  * @brief Convenience function to check if a pointer is DMA-capable.
@@ -98,6 +109,5 @@ static inline bool  esp_ptr_dma_capable( const void *ptr )
 {
     return ( (int)ptr >= 0x3FFAE000 && (int)ptr < 0x40000000 );
 }
-
 
 #endif

--- a/components/freertos/heap_regions.c
+++ b/components/freertos/heap_regions.c
@@ -180,8 +180,8 @@ static const uint32_t uxHeapStructSize  = ( ( sizeof ( BlockLink_t ) + BLOCK_HEA
 /* Create a couple of list links to mark the start and end of the list. */
 static BlockLink_t xStart, *pxEnd = NULL;
 
-/* Keeps track of the number of free bytes remaining, but says nothing about
-fragmentation. */
+static size_t xRegionSize[HEAPREGIONS_MAX_TAGCOUNT] = {0};
+/* Keeps track of the number of free bytes remaining, but says nothing about fragmentation. */
 static size_t xFreeBytesRemaining[HEAPREGIONS_MAX_TAGCOUNT] = {0};
 static size_t xMinimumEverFreeBytesRemaining[HEAPREGIONS_MAX_TAGCOUNT] = {0};
 
@@ -398,6 +398,12 @@ BlockLink_t *pxLink;
 }
 /*-----------------------------------------------------------*/
 
+size_t xPortGetHeapSizeTagged( BaseType_t tag )
+{
+    return xRegionSize[ tag ];
+}
+/*-----------------------------------------------------------*/
+
 size_t xPortGetFreeHeapSizeTagged( BaseType_t tag )
 {
     return xFreeBytesRemaining[ tag ];
@@ -561,8 +567,9 @@ const HeapRegionTagged_t *pxHeapRegion;
         }
 
         xTotalHeapSize += pxFirstFreeBlockInRegion->xBlockSize;
-        xMinimumEverFreeBytesRemaining[ pxHeapRegion->xTag ] += pxFirstFreeBlockInRegion->xBlockSize;
+        xRegionSize[ pxHeapRegion->xTag ] += pxFirstFreeBlockInRegion->xBlockSize;
         xFreeBytesRemaining[ pxHeapRegion->xTag ] += pxFirstFreeBlockInRegion->xBlockSize;
+        xMinimumEverFreeBytesRemaining[ pxHeapRegion->xTag ] += pxFirstFreeBlockInRegion->xBlockSize;
 
         /* Move onto the next HeapRegionTagged_t structure. */
         xDefinedRegions++;

--- a/components/freertos/include/freertos/heap_regions.h
+++ b/components/freertos/include/freertos/heap_regions.h
@@ -68,11 +68,11 @@ void *pvPortMallocTagged( size_t xWantedSize, BaseType_t tag );
 void vPortFreeTagged( void *pv );
 
 /**
- * @brief Get the lowest amount of memory free for a certain tag
+ * @brief Get the lowest number of memory free for a certain tag
  *
  * This function allows the user to see what the least amount of
  * free memory for a certain tag is.
- * 
+ *
  * @param  tag Tag of the memory region
  *
  * @return Minimum amount of free bytes available in the runtime of
@@ -81,16 +81,24 @@ void vPortFreeTagged( void *pv );
 size_t xPortGetMinimumEverFreeHeapSizeTagged( BaseType_t tag );
 
 /**
- * @brief Get the amount of free bytes in a certain tagged region
+ * @brief Get the number of free bytes in a certain tagged region
  *
  * Works like xPortGetFreeHeapSize but allows the user to specify
  * a specific tag
- * 
+ *
  * @param  tag Tag of the memory region
  *
  * @return Remaining amount of free bytes in region
  */
 size_t xPortGetFreeHeapSizeTagged( BaseType_t tag );
 
+/**
+ * @brief Get the total number of bytes in a certain tagged region
+ *
+ * @param  tag Tag of the memory region
+ *
+ * @return Remaining amount of free bytes in region
+ */
+size_t xPortGetHeapSizeTagged( BaseType_t tag );
 
 #endif

--- a/components/freertos/include/freertos/portable.h
+++ b/components/freertos/include/freertos/portable.h
@@ -163,6 +163,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions );
 void *pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION;
 void vPortFree( void *pv ) PRIVILEGED_FUNCTION;
 void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION;
+size_t xPortGetHeapSize( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 

--- a/docs/api-reference/system/mem_alloc.rst
+++ b/docs/api-reference/system/mem_alloc.rst
@@ -68,10 +68,12 @@ Functions
 
 .. doxygenfunction:: heap_alloc_caps_init
 .. doxygenfunction:: pvPortMallocCaps
+.. doxygenfunction:: xPortGetHeapSizeCaps
 .. doxygenfunction:: xPortGetFreeHeapSizeCaps
 .. doxygenfunction:: xPortGetMinimumEverFreeHeapSizeCaps
 .. doxygenfunction:: vPortDefineHeapRegionsTagged
 .. doxygenfunction:: pvPortMallocTagged
 .. doxygenfunction:: vPortFreeTagged
-.. doxygenfunction:: xPortGetMinimumEverFreeHeapSizeTagged
+.. doxygenfunction:: xPortGetHeapSizeTagged
 .. doxygenfunction:: xPortGetFreeHeapSizeTagged
+.. doxygenfunction:: xPortGetMinimumEverFreeHeapSizeTagged


### PR DESCRIPTION
Provides a way to find out the size of the system heap, mostly informational.

Similar to xPortGetFreeHeapSize, xPortGetHeapSize returns the size of the byte-access-capable RAM,
but xPortGetHeapSizeCaps and xPortGetHeapSizetagged are provided as well.