### PR TITLE
add FATFS_TINY menuconfig item

### DIFF
--- a/components/fatfs/Kconfig
+++ b/components/fatfs/Kconfig
@@ -105,4 +105,19 @@ config FATFS_MAX_LFN
    help
       Maximum long filename length. Can be reduced to save RAM.
 
+choice FATFS_TINY
+   prompt "Use per-file caches"
+   default FATFS_TINY_NO
+   help
+      By default, FatFs keeps a 4096-byte (sector size) cache per open file to
+      reduce reads and writes to the underlying media. Disabling this forces
+      FatFs to use a single, common cache across all open files, which conserves
+      heap but will cause more wear on the media.
+
+config FATFS_TINY_NO
+   bool "Yes - heap penality is 4096 * max_files"
+config FATFS_TINY_YES
+   bool "No - slower, and more wear on the Flash"
+endchoice
+
 endmenu

--- a/components/fatfs/src/ffconf.h
+++ b/components/fatfs/src/ffconf.h
@@ -211,7 +211,7 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define	_FS_TINY	0
+#define	_FS_TINY	CONFIG_FATFS_TINY_YES
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector


### PR DESCRIPTION
Enabling `_FS_TINY` saves `4096 bytes * max_files` of heap. This makes a big difference for us!