### PR TITLE
Add RS-485 RTS line driver control to UART driver

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -636,6 +636,19 @@ esp_err_t uart_disable_pattern_det_intr(uart_port_t uart_num);
  *     - ESP_FAIL Parameter error
  */
 esp_err_t uart_enable_pattern_det_intr(uart_port_t uart_num, char pattern_chr, uint8_t chr_num, int chr_tout, int post_idle, int pre_idle);
+
+/**
+ * @brief   UART enable RS-485 mode and RS-485 hald-duplex line driver control using the RTS control line
+ *
+ * @param uart_num UART port number.
+ *
+ * @return
+ *     - ESP_OK Success
+ *     - ESP_FAIL Parameter error
+ */
+esp_err_t uart_set_rs485_hd_mode(uart_port_t uart_num, bool enable);
+
+
 /***************************EXAMPLE**********************************
  *
  *

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -696,8 +696,11 @@ static void uart_rx_intr_handler_default(void *param)
             UART_ENTER_CRITICAL_ISR(&uart_spinlock[uart_num]);
             uart_reg->int_ena.tx_done = 0;
             uart_reg->int_clr.tx_done = 1;
-            if(uart_reg->rs485_conf.en)
-                uart_reg->conf0.sw_rts = 1;
+            if(uart_reg->rs485_conf.en) {
+                uart_reg->conf0.rxfifo_rst = 1; // Workaround to clear phantom 00 characters
+                uart_reg->conf0.rxfifo_rst = 0; // received after TX.
+                uart_reg->conf0.sw_rts = 1;                
+            }
             UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
             xSemaphoreGiveFromISR(p_uart_obj[uart_num]->tx_done_sem, &HPTaskAwoken);
             if(HPTaskAwoken == pdTRUE) {

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1103,7 +1103,7 @@ esp_err_t uart_driver_delete(uart_port_t uart_num)
 esp_err_t uart_set_rs485_hd_mode(uart_port_t uart_num, bool enable)
 {
     UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
-    UART_CHECK((UART[uart_num]->conf1.rx_flow_en != 1), "disable hw flowctrl before using 485 half-duplex mode", ESP_FAIL);
+    UART_CHECK((!enable || !UART[uart_num]->conf1.rx_flow_en), "disable hw flowctrl before using 485 half-duplex mode", ESP_FAIL);
     UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
     if(enable) {
         UART[uart_num]->conf0.sw_rts = 1; // RTS = 1 generates a logic level of 0, which means DE starts as off

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -561,7 +561,7 @@ static void uart_rx_intr_handler_default(void *param)
                         int send_len = p_uart->tx_len_cur > tx_fifo_rem ? tx_fifo_rem : p_uart->tx_len_cur;
                         UART_ENTER_CRITICAL_ISR(&uart_spinlock[uart_num]);
                         if(uart_reg->rs485_conf.en) {
-                            uart_reg->conf0.sw_rts = 1;
+                            uart_reg->conf0.sw_rts = 0;
                             uart_reg->int_ena.tx_done = 1;
                         }
                         UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
@@ -697,7 +697,7 @@ static void uart_rx_intr_handler_default(void *param)
             uart_reg->int_ena.tx_done = 0;
             uart_reg->int_clr.tx_done = 1;
             if(uart_reg->rs485_conf.en)
-                uart_reg->conf0.sw_rts = 0;                     
+                uart_reg->conf0.sw_rts = 1;
             UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
             xSemaphoreGiveFromISR(p_uart_obj[uart_num]->tx_done_sem, &HPTaskAwoken);
             if(HPTaskAwoken == pdTRUE) {
@@ -769,7 +769,7 @@ static int uart_fill_fifo(uart_port_t uart_num, const char* buffer, uint32_t len
     uint8_t tx_remain_fifo_cnt = (UART_FIFO_LEN - tx_fifo_cnt);
     uint8_t copy_cnt = (len >= tx_remain_fifo_cnt ? tx_remain_fifo_cnt : len);
     if(UART[uart_num]->rs485_conf.en) {
-        UART[uart_num]->conf0.sw_rts = 1;
+        UART[uart_num]->conf0.sw_rts = 0;
         UART[uart_num]->int_ena.tx_done = 1;
     }
     for(i = 0; i < copy_cnt; i++) {
@@ -1100,9 +1100,13 @@ esp_err_t uart_driver_delete(uart_port_t uart_num)
 esp_err_t uart_set_rs485_hd_mode(uart_port_t uart_num, bool enable)
 {
     UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
+    UART_CHECK((UART[uart_num]->conf1.rx_flow_en != 1), "disable hw flowctrl before using 485 half-duplex mode", ESP_FAIL);
     UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
     if(enable) {
+        UART[uart_num]->conf0.sw_rts = 1; // RTS = 1 generates a logic level of 0, which means DE starts as off
         UART[uart_num]->rs485_conf.en = 1;
+        UART[uart_num]->rs485_conf.tx_rx_en = 0; // Must be set to 0  to automatically remove echo
+        UART[uart_num]->rs485_conf.rx_busy_tx_en = 1; // 0 = Allow collision, 1 = avoid collision
     } else {
         UART[uart_num]->rs485_conf.en = 0;
     }

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -424,7 +424,7 @@ esp_err_t uart_set_rts(uart_port_t uart_num, int level)
     UART_CHECK((UART[uart_num]->conf1.rx_flow_en != 1), "disable hw flowctrl before using sw control", ESP_FAIL);
     UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
     UART[uart_num]->conf0.sw_rts = level & 0x1;
-    UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
+    UART_EXIT_CRITICAL(&uart_spinlock[uart_num]);
     return ESP_OK;
 }
 
@@ -433,7 +433,7 @@ esp_err_t uart_set_dtr(uart_port_t uart_num, int level)
     UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
     UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
     UART[uart_num]->conf0.sw_dtr = level & 0x1;
-    UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
+    UART_EXIT_CRITICAL(&uart_spinlock[uart_num]);
     return ESP_OK;
 }
 
@@ -559,6 +559,12 @@ static void uart_rx_intr_handler_default(void *param)
                     if(p_uart->tx_len_tot > 0 && p_uart->tx_ptr && p_uart->tx_len_cur > 0) {
                         //To fill the TX FIFO.
                         int send_len = p_uart->tx_len_cur > tx_fifo_rem ? tx_fifo_rem : p_uart->tx_len_cur;
+                        UART_ENTER_CRITICAL_ISR(&uart_spinlock[uart_num]);
+                        if(uart_reg->rs485_conf.en) {
+                            uart_reg->conf0.sw_rts = 1;
+                            uart_reg->int_ena.tx_done = 1;
+                        }
+                        UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
                         for(buf_idx = 0; buf_idx < send_len; buf_idx++) {
                             WRITE_PERI_REG(UART_FIFO_AHB_REG(uart_num), *(p_uart->tx_ptr++) & 0xff);
                         }
@@ -690,6 +696,8 @@ static void uart_rx_intr_handler_default(void *param)
             UART_ENTER_CRITICAL_ISR(&uart_spinlock[uart_num]);
             uart_reg->int_ena.tx_done = 0;
             uart_reg->int_clr.tx_done = 1;
+            if(uart_reg->rs485_conf.en)
+                uart_reg->conf0.sw_rts = 0;                     
             UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
             xSemaphoreGiveFromISR(p_uart_obj[uart_num]->tx_done_sem, &HPTaskAwoken);
             if(HPTaskAwoken == pdTRUE) {
@@ -760,6 +768,10 @@ static int uart_fill_fifo(uart_port_t uart_num, const char* buffer, uint32_t len
     uint8_t tx_fifo_cnt = UART[uart_num]->status.txfifo_cnt;
     uint8_t tx_remain_fifo_cnt = (UART_FIFO_LEN - tx_fifo_cnt);
     uint8_t copy_cnt = (len >= tx_remain_fifo_cnt ? tx_remain_fifo_cnt : len);
+    if(UART[uart_num]->rs485_conf.en) {
+        UART[uart_num]->conf0.sw_rts = 1;
+        UART[uart_num]->int_ena.tx_done = 1;
+    }
     for(i = 0; i < copy_cnt; i++) {
         WRITE_PERI_REG(UART_FIFO_AHB_REG(uart_num), buffer[i]);
     }
@@ -1084,3 +1096,17 @@ esp_err_t uart_driver_delete(uart_port_t uart_num)
     p_uart_obj[uart_num] = NULL;
     return ESP_OK;
 }
+
+esp_err_t uart_set_rs485_hd_mode(uart_port_t uart_num, bool enable)
+{
+    UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
+    UART_ENTER_CRITICAL(&uart_spinlock[uart_num]);
+    if(enable) {
+        UART[uart_num]->rs485_conf.en = 1;
+    } else {
+        UART[uart_num]->rs485_conf.en = 0;
+    }
+    UART_EXIT_CRITICAL(&uart_spinlock[uart_num]);
+    return ESP_OK;
+}
+


### PR DESCRIPTION
This PR adds an initial implementation for RS-485 half-duplex line driver control using the RTS control line.

It uses the UART[uart_num]->rs485_conf.en bit to track that this mode is enabled.