### PR TITLE
Add missing support for C++ exceptions

### DIFF
--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -92,6 +92,10 @@ extern volatile int port_xSchedulerRunning[2];
 
 static const char* TAG = "cpu_start";
 
+struct object { long placeholder[ 10 ]; };
+void __register_frame_info (const void *begin, struct object *ob);
+extern char __eh_frame[];
+
 /*
  * We arrive here after the bootloader finished loading the program from flash. The hardware is mostly uninitialized,
  * and the app CPU is in reset. We do have a stack, so we can do the initialization in C.
@@ -176,7 +180,7 @@ void IRAM_ATTR call_start_cpu1()
                   "wsr    %0, vecbase\n" \
                   ::"r"(&_init_start));
 
-    ets_set_appcpu_boot_addr(0); 
+    ets_set_appcpu_boot_addr(0);
     cpu_configure_region_protection();
 
 #if CONFIG_CONSOLE_UART_NONE
@@ -290,6 +294,9 @@ void start_cpu1_default(void)
 
 static void do_global_ctors(void)
 {
+    static struct object ob;
+    __register_frame_info( __eh_frame, &ob );
+
     void (**p)(void);
     for (p = &__init_array_end - 1; p >= &__init_array_start; --p) {
         (*p)();

--- a/components/esp32/ld/esp32.common.ld
+++ b/components/esp32/ld/esp32.common.ld
@@ -151,7 +151,7 @@ SECTIONS
     *(.rodata1)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
-    *(.gcc_except_table.*)
+    *(.gcc_except_table .gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
     . = (. + 3) & ~ 3;

--- a/components/esp32/ld/esp32.common.ld
+++ b/components/esp32/ld/esp32.common.ld
@@ -151,11 +151,13 @@ SECTIONS
     *(.rodata1)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
-    *(.gcc_except_table)
+    *(.gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
-    *(.eh_frame)
     . = (. + 3) & ~ 3;
+    __eh_frame = ABSOLUTE(.);
+    KEEP(*(.eh_frame))
+    . = (. + 7) & ~ 3;
     /*  C++ constructor and destructor tables, properly ordered:  */
     __init_array_start = ABSOLUTE(.);
     KEEP (*crtbegin.o(.ctors))


### PR DESCRIPTION
Specifying -fexceptions for the compiler is not enough.

- add necessary zero padding after .eh_frame section
- link .gcc_except_table_table in a way flash script does not complain
- call __registrer_frame_info before global constructors

Kudos jcmvbkbc for the necessary help.

This (partially) solves #459 