### PR TITLE
ESP_ERR_NVS_VALUE_TOO_LONG had conflicting value.

### DIFF
--- a/components/nvs_flash/include/nvs.h
+++ b/components/nvs_flash/include/nvs.h
@@ -42,7 +42,7 @@ typedef uint32_t nvs_handle;
 #define ESP_ERR_NVS_INVALID_STATE       (ESP_ERR_NVS_BASE + 0x0b)  /*!< NVS is in an inconsistent state due to a previous error. Call nvs_flash_init and nvs_open again, then retry. */
 #define ESP_ERR_NVS_INVALID_LENGTH      (ESP_ERR_NVS_BASE + 0x0c)  /*!< String or blob length is not sufficient to store data */
 #define ESP_ERR_NVS_NO_FREE_PAGES       (ESP_ERR_NVS_BASE + 0x0d)  /*!< NVS partition doesn't contain any empty pages. This may happen if NVS partition was truncated. Erase the whole partition and call nvs_flash_init again. */
-#define ESP_ERR_NVS_VALUE_TOO_LONG      (ESP_ERR_NVS_BASE + 0x0c)  /*!< String or blob length is longer than supported by the implementation */
+#define ESP_ERR_NVS_VALUE_TOO_LONG      (ESP_ERR_NVS_BASE + 0x0e)  /*!< String or blob length is longer than supported by the implementation */
 
 /**
  * @brief Mode of opening the non-volatile storage


### PR DESCRIPTION
`ESP_ERR_NVS_VALUE_TOO_LONG` had conflicting value, its original value was `0x0c`, which is the same as `ESP_ERR_NVS_INVALID_LENGTH`