### PR TITLE
components/lwip: Expose TCP_MSL in menuconfig.

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -93,6 +93,12 @@ config TCP_MSS
 
         Can be set lower to save RAM, the default value 1436 will give best throughput.
 
+config TCP_MSL
+    int "Maximum segment lifetime (MSL)"
+    default 60000
+    help
+        Set maximum segment lifetime in in milliseconds.
+
 config TCP_SND_BUF_DEFAULT
     int "Default send buffer size"
     default 5744  # 4 * default MSS

--- a/components/lwip/include/lwip/port/lwipopts.h
+++ b/components/lwip/include/lwip/port/lwipopts.h
@@ -295,6 +295,11 @@
 #define TCP_MSS                         CONFIG_TCP_MSS
 
 /**
+ * TCP_MSL: The maximum segment lifetime in milliseconds
+ */
+#define TCP_MSL                         CONFIG_TCP_MSL
+
+/**
  * TCP_MAXRTX: Maximum number of retransmissions of data segments.
  */
 #define TCP_MAXRTX                      CONFIG_TCP_MAXRTX


### PR DESCRIPTION
Closed sockets that remain in state TIME_WAIT will consume heap and eventually block the server port until they are finally freed. The timeout is defined with 2*TCP_MSL (defaults to 60s).

This PR adds a menuconfig item to adjust the timeout to application requirements.
