### PR TITLE
Typo fixes

### DIFF
--- a/components/esp32/include/esp_intr_alloc.h
+++ b/components/esp32/include/esp_intr_alloc.h
@@ -104,7 +104,7 @@ typedef intr_handle_data_t* intr_handle_t ;
 esp_err_t esp_intr_mark_shared(int intno, int cpu, bool is_in_iram);
 
 /**
- * @brief Reserve an interrupt to be used outside of this framewoek
+ * @brief Reserve an interrupt to be used outside of this framework
  * 
  * This will mark a certain interrupt on the specified CPU as
  * reserved, not to be allocated for any reason.

--- a/docs/api-reference/system/intr_alloc.rst
+++ b/docs/api-reference/system/intr_alloc.rst
@@ -15,7 +15,7 @@ install the given interrupt handler and ISR to it.
 
 This code has two different types of interrupts it handles differently: Shared interrupts and non-shared interrupts. The simplest
 of the two are non-shared interrupts: a separate interrupt is allocated per esp_intr_alloc call and this interrupt is solely used for
-the peripheral attached to it, with only one ISR that will get called. Non-shared interrupts can have multiple peripherals triggering 
+the peripheral attached to it, with only one ISR that will get called. Shared interrupts can have multiple peripherals triggering
 it, with multiple ISRs being called when one of the peripherals attached signals an interrupt. Thus, ISRs that are intended for shared
 interrupts should check the interrupt status of the peripheral they service in order to see if any action is required.
 


### PR DESCRIPTION
The second typo of "shared" vs. "non-shared"... I'm 90% sure on that one, but it's pretty confusing