### PR TITLE
Memory corruptions and leaks

### DIFF
--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -435,7 +435,7 @@ static i2s_dma_t *i2s_create_dma_queue(i2s_port_t i2s_num, int dma_buf_count, in
     dma->buf = (char **)malloc(sizeof(char*) * dma_buf_count);
     if (dma->buf == NULL) {
         ESP_LOGE(I2S_TAG, "Error malloc dma buffer pointer");
-
+        free(dma);
         return NULL;
     }
     memset(dma->buf, 0, sizeof(char*) * dma_buf_count);

--- a/components/fatfs/src/vfs_fat_spiflash.c
+++ b/components/fatfs/src/vfs_fat_spiflash.c
@@ -83,6 +83,7 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
             goto fail;
         }
         free(workbuf);
+        workbuf = NULL;
         ESP_LOGI(TAG, "Mounting again");
         fresult = f_mount(fs, drv, 0);
         if (fresult != FR_OK) {
@@ -94,7 +95,9 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
     return ESP_OK;
 
 fail:
-    free(workbuf);
+    if (workbuf != NULL) {
+        free(workbuf);
+    }
     esp_vfs_fat_unregister_path(base_path);
     ff_diskio_unregister(pdrv);
     return result;

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -1689,6 +1689,7 @@ esp_err_t mdns_service_add(mdns_server_t * server, const char * service, const c
 
     item = (mdns_srv_item_t *)malloc(sizeof(mdns_srv_item_t));
     if (!item) {
+        free(s);
         return ESP_ERR_NO_MEM;
     }
 


### PR DESCRIPTION
Due to a coverity software pass, I saw those critical issues. Those patches fix tow "leaks" and one "memory corruption".