### PR TITLE
Fix compile error when using timer in C++

### DIFF
--- a/components/soc/esp32/include/soc/gpio_sd_struct.h
+++ b/components/soc/esp32/include/soc/gpio_sd_struct.h
@@ -44,5 +44,11 @@ typedef volatile struct {
         uint32_t val;
     } version;
 } gpio_sd_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern gpio_sd_dev_t SIGMADELTA;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_GPIO_SD_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/gpio_struct.h
+++ b/components/soc/esp32/include/soc/gpio_struct.h
@@ -200,5 +200,11 @@ typedef volatile struct {
         uint32_t val;
     } func_out_sel_cfg[40];
 } gpio_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern gpio_dev_t GPIO;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_GPIO_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/i2c_struct.h
+++ b/components/soc/esp32/include/soc/i2c_struct.h
@@ -284,6 +284,12 @@ typedef volatile struct {
     uint32_t reserved_fc;
     uint32_t ram_data[32];                          /*This the start address for ram when use apb nonfifo access.*/
 } i2c_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern i2c_dev_t I2C0;
 extern i2c_dev_t I2C1;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_I2C_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/i2s_struct.h
+++ b/components/soc/esp32/include/soc/i2s_struct.h
@@ -455,7 +455,13 @@ typedef volatile struct {
     uint32_t reserved_f8;
     uint32_t date;                                        /**/
 } i2s_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern i2s_dev_t I2S0;
 extern i2s_dev_t I2S1;
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _SOC_I2S_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/ledc_struct.h
+++ b/components/soc/esp32/include/soc/ledc_struct.h
@@ -242,5 +242,11 @@ typedef volatile struct {
     uint32_t reserved_1f8;
     uint32_t date;                                     /*This register represents the version .*/
 } ledc_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern ledc_dev_t LEDC;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_LEDC_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/mcpwm_struct.h
+++ b/components/soc/esp32/include/soc/mcpwm_struct.h
@@ -447,6 +447,12 @@ typedef volatile struct {
         uint32_t val;
     }version;
 } mcpwm_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern mcpwm_dev_t MCPWM0;
 extern mcpwm_dev_t MCPWM1;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_MCPWM_STRUCT_H__ */

--- a/components/soc/esp32/include/soc/pcnt_struct.h
+++ b/components/soc/esp32/include/soc/pcnt_struct.h
@@ -168,5 +168,11 @@ typedef volatile struct {
     uint32_t reserved_f8;
     uint32_t date;                                  /**/
 } pcnt_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern pcnt_dev_t PCNT;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_PCNT_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/rmt_struct.h
+++ b/components/soc/esp32/include/soc/rmt_struct.h
@@ -224,7 +224,13 @@ typedef volatile struct {
     uint32_t reserved_f8;
     uint32_t date;                                      /*This is the version register.*/
 } rmt_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern rmt_dev_t RMT;
+#ifdef __cplusplus
+}
+#endif
 
 typedef struct {
     union {
@@ -257,6 +263,12 @@ typedef volatile struct {
         };
     } chan[8];
 } rmt_mem_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern rmt_mem_t RMTMEM;
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _SOC_RMT_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/sdmmc_struct.h
+++ b/components/soc/esp32/include/soc/sdmmc_struct.h
@@ -362,7 +362,13 @@ typedef volatile struct {
         uint32_t val;
     } clock;
 } sdmmc_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern sdmmc_dev_t SDMMC;
+#ifdef __cplusplus
+}
+#endif
 
 _Static_assert(sizeof(sdmmc_dev_t) == 0x804, "invalid size of sdmmc_dev_t structure");
 

--- a/components/soc/esp32/include/soc/spi_struct.h
+++ b/components/soc/esp32/include/soc/spi_struct.h
@@ -669,8 +669,14 @@ typedef volatile struct {
         uint32_t val;
     } date;
 } spi_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern spi_dev_t SPI0;                                      /* SPI0 IS FOR INTERNAL USE*/
 extern spi_dev_t SPI1;
 extern spi_dev_t SPI2;
 extern spi_dev_t SPI3;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_SPI_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/timer_group_struct.h
+++ b/components/soc/esp32/include/soc/timer_group_struct.h
@@ -190,6 +190,12 @@ typedef volatile struct {
         uint32_t val;
     } clk;
 } timg_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern timg_dev_t TIMERG0;
 extern timg_dev_t TIMERG1;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_TIMG_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/uart_struct.h
+++ b/components/soc/esp32/include/soc/uart_struct.h
@@ -359,7 +359,13 @@ typedef volatile struct {
     uint32_t date;                                    /**/
     uint32_t id;                                      /**/
 } uart_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern uart_dev_t UART0;
 extern uart_dev_t UART1;
 extern uart_dev_t UART2;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_UART_STRUCT_H_ */

--- a/components/soc/esp32/include/soc/uhci_struct.h
+++ b/components/soc/esp32/include/soc/uhci_struct.h
@@ -332,6 +332,12 @@ typedef volatile struct {
     uint32_t reserved_f8;
     uint32_t date;                                         /*version information*/
 } uhci_dev_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern uhci_dev_t UHCI0;
 extern uhci_dev_t UHCI1;
+#ifdef __cplusplus
+}
+#endif
 #endif  /* _SOC_UHCI_STRUCT_H_ */


### PR DESCRIPTION
In file included from E:/timer_test/main/main.cpp:11:0:
E:/esp-idf/components/soc/esp32/include/soc/timer_group_struct.h: At global scope:
E:/esp-idf/components/soc/esp32/include/soc/timer_group_struct.h:193:19: error: 'timg_dev_t TIMERG0', declared using anonymous type, is used but never defined [-fpermissive]
 extern timg_dev_t TIMERG0;
                   ^
E:/esp-idf/components/soc/esp32/include/soc/timer_group_struct.h:192:3: note: 'typedef volatile struct<anonymous> timg_dev_t' does not refer to the unqualified type, so it is not used for linkage
 } timg_dev_t;