### PR TITLE
Updated missing includes file.  Fixes  #271.

### DIFF
--- a/components/newlib/include/regex.h
+++ b/components/newlib/include/regex.h
@@ -38,6 +38,7 @@
 #define	_REGEX_H_
 
 #include <sys/cdefs.h>
+#include <sys/stat.h>
 
 /* types */
 typedef off_t regoff_t;


### PR DESCRIPTION
`#include <sys/stat.h>` was missing.  When compiling without this include you would get the `error: unknown type name 'off_t'` message.

Fixes  #271.