### PR TITLE
Add uart api call to use xon/xoff flow control

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -269,6 +269,20 @@ esp_err_t uart_set_line_inverse(uart_port_t uart_num, uint32_t inverse_mask);
 esp_err_t uart_set_hw_flow_ctrl(uart_port_t uart_num, uart_hw_flowcontrol_t flow_ctrl, uint8_t rx_thresh);
 
 /**
+ * @brief Set software flow control.
+ *
+ * @param uart_num   UART_NUM_0, UART_NUM_1 or UART_NUM_2
+ * @param enable     switch on or off
+ * @param rx_thresh_xon  low water mark
+ * @param rx_thresh_xoff high water mark
+ *
+ * @return
+ *     - ESP_OK   Success
+ *     - ESP_FAIL Parameter error
+ */
+ esp_err_t uart_set_sw_flow_ctrl(uart_port_t uart_num, bool enable, uint8_t rx_thresh_xon,  uint8_t rx_thresh_xoff);
+
+/**
  * @brief Get hardware flow control mode
  *
  * @param uart_num UART_NUM_0, UART_NUM_1 or UART_NUM_2


### PR DESCRIPTION
The uart driver has support for hardware flow control, but we (Kano Computing) are using a flow control pin to control device reset, which I guess is a common use case. We'd therefore like to use software flow control. Since the hardware has this build in, I've made this PR to switch it on. 

We are not especially attached to this API and would be fine with anything which does the same job.