### PR TITLE
Add missing debug log message for out-of-sockets case

### DIFF
--- a/components/lwip/api/sockets.c
+++ b/components/lwip/api/sockets.c
@@ -1501,6 +1501,7 @@ lwip_socket(int domain, int type, int protocol)
   i = alloc_socket(conn, 0);
 
   if (i == -1) {
+    LWIP_DEBUGF(SOCKETS_DEBUG, ("-1 / ENFILE (could not allocate socket)\n"));
     netconn_delete(conn);
     set_errno(ENFILE);
     return -1;


### PR DESCRIPTION
This log message is printed in two parts.  For the case of  not being able to allocate a socket because they are all used, the second part of the message was missing.