### PR TITLE
Fix bootloader's OTA partition selection after some OTA flashing

### DIFF
--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -328,7 +328,7 @@ static int get_selected_boot_partition(const bootloader_state_t *bs)
             }
         } else  {
             if(ota_select_valid(&sa) && ota_select_valid(&sb)) {
-                ESP_LOGD(TAG, "Both OTA sequence valid, using OTA slot %d", MAX(sa.ota_seq, sb.ota_seq)-1);
+                ESP_LOGD(TAG, "Both OTA sequence valid, using OTA slot %d", (MAX(sa.ota_seq, sb.ota_seq)-1) % bs->app_count);
                 return MAX(sa.ota_seq, sb.ota_seq) - 1;
             } else if(ota_select_valid(&sa)) {
                 ESP_LOGD(TAG, "Only OTA sequence A is valid, using OTA slot %d", sa.ota_seq - 1);

--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -262,8 +262,8 @@ static esp_partition_pos_t index_to_partition(const bootloader_state_t *bs, int 
         return bs->test;
     }
 
-    if (index >= 0 && index < MAX_OTA_SLOTS && index < bs->app_count) {
-        return bs->ota[index];
+    if (bs->app_count > 0) {
+        return bs->ota[index % bs->app_count];
     }
 
     esp_partition_pos_t invalid = { 0 };


### PR DESCRIPTION
## Problem
With [default two OTA partitions](https://github.com/espressif/esp-idf/blob/master/components/partition_table/partitions_two_ota.csv), according to the algorithm of esp_rewrite_ota_data(...) in [latest esp_ota_ops.c](https://github.com/espressif/esp-idf/blob/17adb40ca8d9159e28c3666cf46085eb16ddc7f6/components/app_update/esp_ota_ops.c#L308-L322), boot partition should be alternated after every OTA flashing. The problem happens after third one.

#### Initial (flash via USB-UART)
```
D (1659) boot: OTA sequence values A 0xffffffff B 0xffffffff
D (1712) boot: OTA sequence numbers both empty (all-0xFF)
```
#### After first OTA 
```
D (1665) boot: OTA sequence values A 0x00000001 B 0xffffffff
D (1717) boot: Only OTA sequence A is valid, using OTA slot 0
```

#### After second OTA 
```
D (1665) boot: OTA sequence values A 0x00000001 B 0x00000002
D (1717) boot: Both OTA sequence valid, using OTA slot 1
``````

#### After third OTA (wrong behavior)

```
D (1665) boot: OTA sequence values A 0x00000003 B 0x00000002
D (1717) boot: Both OTA sequence valid, using OTA slot 2 # WRONG! only slot 0 and 1 are available
```

In boot process after third OTA, app boot from OTA slot 1 actually. As there are only two (slot 0 and 1) OTA partitions, OTA slot 2 (i.e. third OTA parttiion) not exists. Nevertheless, bootloader automatically fallbacks to earlier partition (slot 1).

This problem can be reproduced with [offical OTA excample](https://github.com/espressif/esp-idf/tree/master/examples/system/ota) too.

After third OTA, bootloader repeatedly boot from OTA slot 1 (second OTA partition) only. It refuses further OTA flashed onto OTA slot 0.

This happens because [get_selected_boot_partition(...)](
https://github.com/yanbe/esp-idf/blob/fe8eee9e0d60117824b23089b5cc4a290fd12b43/components/bootloader/subproject/main/bootloader_start.c#L332) returns auto-incremented ota_seq based value, *NOT* OTA app partition index, and it is passed to `index_to_partition(...)` via `load_boot_image(...)` without special care.

Consequently, developers cannot try updated program via OTA after second one.

## Solution 

To fix this, referring the algorithm of esp_rewrite_ota_data(...) in [esp_ota_ops.c](https://github.com/espressif/esp-idf/blob/17adb40ca8d9159e28c3666cf46085eb16ddc7f6/components/app_update/esp_ota_ops.c#L308-L322), I modified `index_to_partition(...)` to point latest (most recently flashed) OTA slot correctly.

 In my opinion, modifying `get_selected_boot_partition(...)` ([around here](https://github.com/yanbe/esp-idf/blob/fe8eee9e0d60117824b23089b5cc4a290fd12b43/components/bootloader/subproject/main/bootloader_start.c#L330-L332)) is not good idea in terms of fallback ordering of partitions.