### PR TITLE
openssl: add support for CN / hostname verification

### DIFF
--- a/components/openssl/include/openssl/ssl.h
+++ b/components/openssl/include/openssl/ssl.h
@@ -1512,6 +1512,15 @@ long SSL_get_timeout(const SSL *ssl);
 int SSL_get_verify_mode(const SSL *ssl);
 
 /**
+ * @brief get SSL verify parameters
+ *
+ * @param ssl - SSL point
+ *
+ * @return verify parameters
+ */
+X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl);
+
+/**
  * @brief get SSL write only IO handle
  *
  * @param ssl - SSL point

--- a/components/openssl/include/openssl/ssl.h
+++ b/components/openssl/include/openssl/ssl.h
@@ -1521,6 +1521,20 @@ int SSL_get_verify_mode(const SSL *ssl);
 X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl);
 
 /**
+ * @brief set expected hostname the peer cert CN should have
+ *
+ * @param param - verify parameters from SSL_get0_param()
+ *
+ * @param name - the expected hostname
+ *
+ * @param namelen - the length of the hostname, or 0 if NUL terminated
+ *
+ * @return verify parameters
+ */
+int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
+                                const char *name, size_t namelen);
+
+/**
  * @brief get SSL write only IO handle
  *
  * @param ssl - SSL point

--- a/components/openssl/include/openssl/ssl.h
+++ b/components/openssl/include/openssl/ssl.h
@@ -26,6 +26,14 @@
 {
 */
 
+#define SSL_CB_ALERT 0x4000
+
+#define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT		(1 << 0)
+#define X509_CHECK_FLAG_NO_WILDCARDS			(1 << 1)
+#define X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS		(1 << 2)
+#define X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS		(1 << 3)
+#define X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS		(1 << 4)
+
 /**
  * @brief create a SSL context
  *
@@ -1533,6 +1541,30 @@ X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl);
  */
 int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
                                 const char *name, size_t namelen);
+
+/**
+ * @brief set parameters for X509 host verify action
+ *
+ * @param param -verify parameters from SSL_get0_param()
+ *
+ * @param flags - bitfield of X509_CHECK_FLAG_... parameters to set
+ *
+ * @return 1 for success, 0 for failure
+ */
+int X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
+				    unsigned long flags);
+
+/**
+ * @brief clear parameters for X509 host verify action
+ *
+ * @param param -verify parameters from SSL_get0_param()
+ *
+ * @param flags - bitfield of X509_CHECK_FLAG_... parameters to clear
+ *
+ * @return 1 for success, 0 for failure
+ */
+int X509_VERIFY_PARAM_clear_hostflags(X509_VERIFY_PARAM *param,
+				      unsigned long flags);
 
 /**
  * @brief get SSL write only IO handle

--- a/components/openssl/library/ssl_x509.c
+++ b/components/openssl/library/ssl_x509.c
@@ -118,6 +118,15 @@ failed1:
 }
 
 /**
+ * @brief return SSL X509 verify parameters
+ */
+
+X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl)
+{
+	return &ssl->param;
+}
+
+/**
  * @brief set SSL context client CA certification
  */
 int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)

--- a/components/openssl/library/ssl_x509.c
+++ b/components/openssl/library/ssl_x509.c
@@ -127,6 +127,28 @@ X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl)
 }
 
 /**
+ * @brief set X509 host verification flags
+ */
+
+int X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param,
+				    unsigned long flags)
+{
+	/* flags not supported yet */
+	return 0;
+}
+
+/**
+ * @brief clear X509 host verification flags
+ */
+
+int X509_VERIFY_PARAM_clear_hostflags(X509_VERIFY_PARAM *param,
+				      unsigned long flags)
+{
+	/* flags not supported yet */
+	return 0;
+}
+
+/**
  * @brief set SSL context client CA certification
  */
 int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)

--- a/components/openssl/platform/ssl_pm.c
+++ b/components/openssl/platform/ssl_pm.c
@@ -659,3 +659,31 @@ long ssl_pm_get_verify_result(const SSL *ssl)
 
     return verify_result;
 }
+
+/**
+ * @brief set expected hostname on peer cert CN
+ */
+
+int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param,
+                                const char *name, size_t namelen)
+{
+	SSL *ssl = (SSL *)((char *)param - offsetof(SSL, param));
+	struct ssl_pm *ssl_pm = (struct ssl_pm *)ssl->ssl_pm;
+	char *name_cstr = NULL;
+
+	if (namelen) {
+		name_cstr = malloc(namelen + 1);
+		if (!name_cstr)
+			return 0;
+		memcpy(name_cstr, name, namelen);
+		name_cstr[namelen] = '\0';
+		name = name_cstr;
+	}
+
+	mbedtls_ssl_set_hostname(&ssl_pm->ssl, name);
+
+	if (namelen)
+		free(name_cstr);
+
+	return 1;
+}


### PR DESCRIPTION
This series of three patches adds support to the openssl wrapper for OpenSSL APIs related to setting the expected hostname in the CN field of the peer cert, using mbedtls `mbedtls_ssl_set_hostname()`.  That cannot be done at the moment because the necessary mbedtls ssl ctx is private to the wrapper.  This makes it available to the user using only additional related OpenSSL apis.