### PR TITLE
Fix CDT GCC parser to correctly parse C++ commands

### DIFF
--- a/docs/get-started/eclipse-setup-windows.rst
+++ b/docs/get-started/eclipse-setup-windows.rst
@@ -58,7 +58,7 @@ Project Properties
 
      * In the list of providers, click "CDT GCC Built-in Compiler Settings Cygwin". Under "Command to get compiler specs", replace the text ``${COMMAND}`` at the beginning of the line with ``xtensa-esp32-elf-gcc``. This means the full "Command to get compiler specs" should be ``xtensa-esp32-elf-gcc ${FLAGS} -E -P -v -dD "${INPUTS}"``.
 
-     * In the list of providers, click "CDT GCC Build Output Parser" and type ``xtensa-esp32-elf-`` at the beginning of the Compiler command pattern. This means the full Compiler command pattern should be ``xtensa-esp32-elf-(g?cc)|([gc]\+\+)|(clang)``
+     * In the list of providers, click "CDT GCC Build Output Parser" and type ``xtensa-esp32-elf-`` at the beginning of the Compiler command pattern, and wrap remaining part with brackets. This means the full Compiler command pattern should be ``xtensa-esp32-elf-((g?cc)|([gc]\+\+)|(clang))``
 
 
 Building in Eclipse


### PR DESCRIPTION
Previously suggested parser command pattern:

xtensa-esp32-elf-(g?cc)|([gc]\+\+)|(clang)

was incorrect for compilation of c++ files, as it is expanded by Eclipse into or between:

xtensa-esp32-elf-(g?cc)
([gc]\+\+)
(clang)

Additional grouping around existing pattern solves that issue, and helps Eclipse to correctly find ESP-IDF includes for C++ files.