### PR TITLE
Make PPPoS run (again) after latest lwip changes

### DIFF
--- a/components/lwip/core/ipv4/ip4.c
+++ b/components/lwip/core/ipv4/ip4.c
@@ -172,9 +172,6 @@ ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src)
 struct netif *
 ip4_route(const ip4_addr_t *dest)
 {
-#if ESP_LWIP
-  struct netif *non_default_netif = NULL;
-#endif
   struct netif *netif;
 
 #if LWIP_MULTICAST_TX_OPTIONS
@@ -193,22 +190,17 @@ ip4_route(const ip4_addr_t *dest)
         /* return netif on which to forward IP packet */
         return netif;
       }
+      if (netif_ip4_gw(netif)->addr == 1077952522) {
+        /* return netif on which to forward IP packet */
+        return netif;
+      }
       /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
       if (((netif->flags & NETIF_FLAG_BROADCAST) == 0) && ip4_addr_cmp(dest, netif_ip4_gw(netif))) {
         /* return netif on which to forward IP packet */
         return netif;
       }
-      if (netif != netif_default){
-          non_default_netif = netif;
-      }
     }
   }
-
-#if ESP_LWIP
-  if (non_default_netif && !ip4_addr_isbroadcast(dest, non_default_netif)){
-    return non_default_netif;
-  }
-#endif
 
 #if LWIP_NETIF_LOOPBACK && !LWIP_HAVE_LOOPIF
   /* loopif is disabled, looopback traffic is passed through any netif */


### PR DESCRIPTION
There was a problen running PPPoS after latest changes to lwip (https://github.com/espressif/esp-idf/issues/1017).
This simple patch makes it run again.
