### PR TITLE
linux-setup.rst: Add note about adding key

### DIFF
--- a/docs/get-started/linux-setup.rst
+++ b/docs/get-started/linux-setup.rst
@@ -80,6 +80,10 @@ Backwards compatibility libraries are available in AUR_ for native and lib32 con
 - https://aur.archlinux.org/packages/ncurses5-compat-libs/
 - https://aur.archlinux.org/packages/lib32-ncurses5-compat-libs/
 
+Before installing these packages you might need to add the author's public key to your keyring::
+
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys 702353E0F7E48EDB
+
 Alternatively, use crosstool-NG to compile a gdb that links against ncurses 6.
 
 


### PR DESCRIPTION
for me it was necessary to add the key manually to the key ring. Otherwise I could not have installed the packages