### PR TITLE
Widening 'ss' variable type in f_mkfs()

### DIFF
--- a/components/fatfs/src/ff.c
+++ b/components/fatfs/src/ff.c
@@ -5223,7 +5223,7 @@ FRESULT f_mkfs (
 	static const WORD cst[] = {1, 4, 16, 64, 256, 512, 0};	/* Cluster size boundary for FAT12/16 volume (4Ks unit) */
 	static const WORD cst32[] = {1, 2, 4, 8, 16, 32, 0};	/* Cluster size boundary for FAT32 volume (128Ks unit) */
 	BYTE fmt, sys, *buf, *pte, pdrv, part;
-	WORD ss;
+	DWORD ss;
 	DWORD szb_buf, sz_buf, sz_blk, n_clst, pau, sect, nsect, n;
 	DWORD b_vol, b_fat, b_data;				/* Base LBA for volume, fat, data */
 	DWORD sz_vol, sz_rsv, sz_fat, sz_dir;	/* Size for volume, fat, dir, data */


### PR DESCRIPTION
Type of variable 'ss' should be widen from WORD to DWORD in function f_mkfs() defined in ff.c. The variable is passed to disk_ioctl() by reference and get the value by assigning to (*uint32_t).
Send the reference to 'ss':
if (disk_ioctl(pdrv, GET_SECTOR_SIZE, &ss) != RES_OK) return FR_DISK_ERR;
Assign the value to 'ss' by reference:
in ff_wl_ioctl():
    case GET_SECTOR_SIZE:
        *((uint32_t *) buff) = wl_sector_size(wl_handle);
ff_sdmmc_ioctl():
        case GET_SECTOR_SIZE:
            *((uint32_t*) buff) = card->csd.sector_size;
