### PR TITLE
Use closesocket instead of close

### DIFF
--- a/components/esp32/smartconfig.c
+++ b/components/esp32/smartconfig.c
@@ -100,7 +100,7 @@ static void sc_ack_send_task(void *pvParameters)
                         if (ack->cb) {
                             ack->cb(SC_STATUS_LINK_OVER, remote_ip);
                         }
-                        close(send_sock);
+                        closesocket(send_sock);
                         free(ack);
                         vTaskDelete(NULL);
                     }
@@ -112,7 +112,7 @@ static void sc_ack_send_task(void *pvParameters)
                         continue;
                     }
                     ESP_LOGE(TAG, "send failed, errno %d", err);
-                    close(send_sock);
+                    closesocket(send_sock);
                     free(ack);
                     vTaskDelete(NULL);
                 }


### PR DESCRIPTION
Prevents conflict with close() when it's not provided by lwip.