### PR TITLE
Potential variable shadowing in ESP_ERROR_CHECK

### DIFF
--- a/components/esp32/include/esp_err.h
+++ b/components/esp32/include/esp_err.h
@@ -64,14 +64,14 @@ void _esp_error_check_failed(esp_err_t rc, const char *file, int line, const cha
  */
 #ifdef NDEBUG
 #define ESP_ERROR_CHECK(x) do {                                         \
-        esp_err_t rc = (x);                                             \
-        (void) sizeof(rc);                                              \
+        esp_err_t __err_rc = (x);                                       \
+        (void) sizeof(__err_rc);                                        \
     } while(0);
 #else
 #define ESP_ERROR_CHECK(x) do {                                         \
-        esp_err_t rc = (x);                                             \
-        if (rc != ESP_OK) {                                             \
-            _esp_error_check_failed(rc, __FILE__, __LINE__,             \
+        esp_err_t __err_rc = (x);                                       \
+        if (__err_rc != ESP_OK) {                                       \
+            _esp_error_check_failed(__err_rc, __FILE__, __LINE__,       \
                                     __ASSERT_FUNC, #x);                 \
         }                                                               \
     } while(0);


### PR DESCRIPTION
Renamed the internal rc to __err_rc to avoid clashes with local variables.
This code would not do the expected thing with the original ESP_ERROR_CHECK macro:

esp_err_t my_func(esp_err_t x)
{
  assert(x == 23);
}

esp_err_t rc = 23; //some value that is important fo the user
ESP_ERROR_CHECK(my_func(rc));

The macro will expand to:
esp_err_t rc = (my_func(rc));

And the code will assert, as my_func will receive a random value - whatever is in the internal macro rc temp variable. This is due to the C weirdness of allowing this code:

int x = x; //x has a random value.