### PR TITLE
components/openssl: Add support for SNI with SSL_set_tlsext_host_name

### DIFF
--- a/components/openssl/include/internal/ssl_methods.h
+++ b/components/openssl/include/internal/ssl_methods.h
@@ -31,7 +31,8 @@
                     set_fd, get_fd, \
                     set_bufflen, \
                     get_verify_result, \
-                    get_state) \
+                    get_state, \
+                    set_hostname) \
         static const SSL_METHOD_FUNC func_name LOCAL_ATRR = { \
                 new, \
                 free, \
@@ -45,7 +46,8 @@
                 get_fd, \
                 set_bufflen, \
                 get_verify_result, \
-                get_state \
+                get_state, \
+                set_hostname \
         };
 
 #define IMPLEMENT_TLS_METHOD(ver, mode, fun, func_name) \

--- a/components/openssl/include/internal/ssl_types.h
+++ b/components/openssl/include/internal/ssl_types.h
@@ -255,6 +255,8 @@ struct ssl_method_func_st {
     long (*ssl_get_verify_result)(const SSL *ssl);
 
     OSSL_HANDSHAKE_STATE (*ssl_get_state)(const SSL *ssl);
+
+    int (*ssl_set_hostname)(const SSL* ssl, const char* hostname);
 };
 
 struct x509_method_st {

--- a/components/openssl/include/openssl/ssl.h
+++ b/components/openssl/include/openssl/ssl.h
@@ -146,6 +146,16 @@ int SSL_shutdown(SSL *ssl);
 int SSL_set_fd(SSL *ssl, int fd);
 
 /**
+ * @brief set the host name for use with SNI
+ * @param ssl  - the SSL point
+ * @param name - host name
+ * @return result
+ *     1 : OK
+ *     0 : failed
+ */
+int SSL_set_tlsext_host_name(const SSL *s, const char *name);
+
+/**
  * @brief These functions load the private key into the SSL_CTX or SSL object
  *
  * @param ctx  - the SSL context point

--- a/components/openssl/include/platform/ssl_pm.h
+++ b/components/openssl/include/platform/ssl_pm.h
@@ -40,6 +40,7 @@ void ssl_pm_set_fd(SSL *ssl, int fd, int mode);
 int ssl_pm_get_fd(const SSL *ssl, int mode);
 
 OSSL_HANDSHAKE_STATE ssl_pm_get_state(const SSL *ssl);
+int ssl_pm_set_hostname(const SSL* ssl, const char* hostname);
 
 void ssl_pm_set_bufflen(SSL *ssl, int len);
 

--- a/components/openssl/library/ssl_lib.c
+++ b/components/openssl/library/ssl_lib.c
@@ -166,6 +166,15 @@ OSSL_HANDSHAKE_STATE SSL_get_state(const SSL *ssl)
 }
 
 /**
+ * @brief set hostname for SNI
+ */
+int SSL_set_tlsext_host_name(const SSL *ssl, const char *name) {
+    SSL_ASSERT1(ssl);
+
+    return SSL_METHOD_CALL(set_hostname, ssl, name);
+}
+
+/**
  * @brief create a SSL context
  */
 SSL_CTX* SSL_CTX_new(const SSL_METHOD *method)

--- a/components/openssl/library/ssl_methods.c
+++ b/components/openssl/library/ssl_methods.c
@@ -25,7 +25,8 @@ IMPLEMENT_TLS_METHOD_FUNC(TLS_method_func,
         ssl_pm_set_fd, ssl_pm_get_fd,
         ssl_pm_set_bufflen,
         ssl_pm_get_verify_result,
-        ssl_pm_get_state);
+        ssl_pm_get_state,
+        ssl_pm_set_hostname);
 
 /**
  * TLS or SSL client method collection

--- a/components/openssl/platform/ssl_pm.c
+++ b/components/openssl/platform/ssl_pm.c
@@ -429,6 +429,12 @@ OSSL_HANDSHAKE_STATE ssl_pm_get_state(const SSL *ssl)
     return state;
 }
 
+int ssl_pm_set_hostname(const SSL* ssl, const char* hostname) {
+    struct ssl_pm *ssl_pm = (struct ssl_pm *)ssl->ssl_pm;
+
+    return mbedtls_ssl_set_hostname(&ssl_pm->ssl, hostname);
+}
+
 int x509_pm_show_info(X509 *x)
 {
     int ret;


### PR DESCRIPTION
I'm not very familiar with this project and its codebase (yet), but I tried sending some API requests with esp-request, which did not work, as the server required SNI, so I added it.