### PR TITLE
When pressing a special key in idf_monitor, the monitor crashes

### DIFF
--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -119,6 +119,8 @@ typedef struct {
 
 typedef intr_handle_t rmt_isr_handle_t;
 
+typedef void (*rmt_on_tx_end_t)(rmt_channel_t channel);
+
 /**
  * @brief Set RMT clock divider, channel clock is divided from source clock.
  *
@@ -701,6 +703,22 @@ esp_err_t rmt_wait_tx_done(rmt_channel_t channel, TickType_t wait_time);
  *     - ESP_OK Success
  */
 esp_err_t rmt_get_ringbuf_handle(rmt_channel_t channel, RingbufHandle_t* buf_handle);
+
+/**
+ * @brief Registers a handler that will be called when transmission ends.
+ *
+ *        Called by rmt_driver_isr_default in interrupt context.
+ *
+ *        When used, disables printing of debug message "RMT INTR : TX END"
+ *        at end of transmission.
+ * 
+ * @note Requires rmt_driver_install to install the default ISR handler.
+ *
+ * @param fn Function to be called from the default interrupt handler or NULL.
+ *
+ * @return the previous handler (or NULL if there was none)
+ */
+rmt_on_tx_end_t rmt_on_tx_end(rmt_on_tx_end_t fn);
 
 /***************************EXAMPLE**********************************
  *

--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -292,6 +292,8 @@ class Monitor(object):
                 self.serial.write(codecs.encode(key))
             except serial.SerialException:
                 pass # this shouldn't happen, but sometimes port has closed in serial thread
+            except UnicodeEncodeError:
+                pass # this can happen if a non-ascii character was passed, ignoring
 
     def handle_serial_input(self, data):
         # this may need to be made more efficient, as it pushes out a byte


### PR DESCRIPTION
When running `make monitor` and pressing a key that doesn't translate to ASCII well (for example up arrow), `idf_monitor.py` exits with an exception:

```
Traceback (most recent call last):
  File "(...)/tools/idf_monitor.py", line 568, in <module>
    main()
  File "(...)/tools/idf_monitor.py", line 502, in main
    monitor.main_loop()
  File "(...)/tools/idf_monitor.py", line 267, in main_loop
    self.handle_key(data)
  File "(...)/tools/idf_monitor.py", line 292, in handle_key
    self.serial.write(codecs.encode(key))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe0' in position 0: ordinal not in range(128)
make: *** [(...)/components/esptool_py/Makefile.projbuild:96: monitor] Error 1
```

Added pull request fixing the issue.

Windows 10, msys32 from latest Espressif's bundle.