### PR TITLE
Improved documentation for /dev/ttyUSB0 issues

### DIFF
--- a/docs/get-started/linux-setup.rst
+++ b/docs/get-started/linux-setup.rst
@@ -70,6 +70,15 @@ ESP32 toolchain for Linux is available for download from Espressif website:
     Instead of ``/home/user-name`` there should be a home path specific to your installation.
 
 
+Permission issues /dev/ttyUSB0
+------------------------------
+
+With some Linux distributions you may get the ``Failed to open port /dev/ttyUSB0`` error message when flashing the ESP32.  This can be solved by adding the current user to the ``dialout`` group, such as running the following command::
+
+        sudo adduser $USER dialout
+
+
+
 Arch Linux Users
 ----------------
 


### PR DESCRIPTION
Improved documentation for /dev/ttyUSB0 issues.  This occurred in Ubuntu, but I'm sure is applies to most distributions.