### PR TITLE
components/mdns: wrong Message compression detect

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -555,7 +555,7 @@ static const uint8_t * _mdns_read_fqdn(const uint8_t * packet, const uint8_t * s
             return NULL;
         }
         uint8_t len = start[index++];
-        if ((len >= 192) {
+        if ((len < 192) {
             if (len > 63) {
                 //length can not be more than 63
                 return NULL;

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -555,9 +555,9 @@ static const uint8_t * _mdns_read_fqdn(const uint8_t * packet, const uint8_t * s
             return NULL;
         }
         uint8_t len = start[index++];
-        if ((len & 0xC0) == 0) {
-            if (len > 64) {
-                //length can not be more than 64
+        if ((len >= 192) {
+            if (len > 63) {
+                //length can not be more than 63
                 return NULL;
             }
             uint8_t i;


### PR DESCRIPTION
This patch fix wrong Message compression detection.

Old behavior assumes message compressed when any of 2 most significant bits are set,
But in fact Message compressed only when both those bits are set to 1.

Also there fixed maximal label length check (see https://tools.ietf.org/html/rfc6762#appendix-C).