### PR TITLE
rmt: Adds a simple handler that can be called when transmission ends.

### DIFF
--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -119,6 +119,8 @@ typedef struct {
 
 typedef intr_handle_t rmt_isr_handle_t;
 
+typedef void (*rmt_tx_end_t)(rmt_channel_t channel);
+
 /**
  * @brief Set RMT clock divider, channel clock is divided from source clock.
  *
@@ -701,6 +703,19 @@ esp_err_t rmt_wait_tx_done(rmt_channel_t channel, TickType_t wait_time);
  *     - ESP_OK Success
  */
 esp_err_t rmt_get_ringbuf_handle(rmt_channel_t channel, RingbufHandle_t* buf_handle);
+
+/**
+ * @brief Registers a callback that will be called when transmission ends.
+ *
+ *        Called by rmt_driver_isr_default in interrupt context.
+ *
+ * @note Requires rmt_driver_install to install the default ISR handler.
+ *
+ * @param fn Function to be called from the default interrupt handler or NULL.
+ *
+ * @return the previous handler (or NULL if there was none)
+ */
+rmt_tx_end_t rmt_register_tx_end_callback(rmt_tx_end_t fn);
 
 /***************************EXAMPLE**********************************
  *


### PR DESCRIPTION
Adds an easy way to know when RMT has finished transmitting, by adding a handler that will be executed in interrupt context.

Also removes a debug message that might spam the logs when TX has finished (see #1167), but only if the new functionality is used - because you can easily add this log using the newly added handle.