### PR TITLE
Hardware MPI loses sign when multiplying by -1

### DIFF
--- a/components/mbedtls/port/esp_bignum.c
+++ b/components/mbedtls/port/esp_bignum.c
@@ -497,10 +497,14 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi
         return 0;
     }
     if (bits_x == 1) {
-        return mbedtls_mpi_copy(Z, Y);
+        ret = mbedtls_mpi_copy(Z, Y);
+        Z->s *= X->s;
+        return ret;
     }
     if (bits_y == 1) {
-        return mbedtls_mpi_copy(Z, X);
+        ret = mbedtls_mpi_copy(Z, X);
+        Z->s *= Y->s;
+        return ret;
     }
 
     words_mult = (words_x > words_y ? words_x : words_y);


### PR DESCRIPTION
Test case:
```c
mbedtls_mpi x, y, z;
mbedtls_mpi_init(&x); mbedtls_mpi_init(&y); mbedtls_mpi_init(&z);

mbedtls_mpi_lset(&x, 12345);
mbedtls_mpi_lset(&y, -1);
mbedtls_mpi_mul_mpi(&z, &x, &y);

mbedtls_mpi_write_file(NULL, &z, 10, NULL);
```

Expected: -12345
Actual: 12345