### PR TITLE
freertos: minor issue in documentation snippet of queue.

### DIFF
--- a/components/freertos/include/freertos/queue.h
+++ b/components/freertos/include/freertos/queue.h
@@ -1106,7 +1106,7 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 	// Now the buffer is empty we can switch context if necessary.
 	if( xHigherPriorityTaskWoken )
 	{
-		taskYIELD ();
+		portYIELD_FROM_ISR ();
 	}
  }
  </pre>
@@ -1177,7 +1177,7 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 	// Now the buffer is empty we can switch context if necessary.
 	if( xHigherPriorityTaskWoken )
 	{
-		taskYIELD ();
+		portYIELD_FROM_ISR ();
 	}
  }
  </pre>


### PR DESCRIPTION
`taskYIELD` was used in ISR context, but `portYIELD_FROM_ISR` should instead.