### PR TITLE
Fix: Use ESP_LOGI instead of ESP_LOGE to log the start of scanning process

### DIFF
--- a/examples/bluetooth/ble_spp_client/main/spp_client_demo.c
+++ b/examples/bluetooth/ble_spp_client/main/spp_client_demo.c
@@ -601,7 +601,7 @@ static void esp_gap_cb(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *par
         }
         //the unit of the duration is second
         uint32_t duration = 0xFFFF;
-        ESP_LOGE(GATTC_TAG, "Enable Ble Scan:during time 0x%04X minutes.",duration);
+        ESP_LOGI(GATTC_TAG, "Enable Ble Scan:during time 0x%04X minutes.",duration);
         esp_ble_gap_start_scanning(duration);
         break;
     }


### PR DESCRIPTION
In the `spp_client_demo` example, the information about the start of scanning process was incorrectly logged as an error.