### PR TITLE
Fix markdown and format of GPIO example README

### DIFF
--- a/examples/peripherals/gpio/README.md
+++ b/examples/peripherals/gpio/README.md
@@ -1,20 +1,15 @@
 # Example: GPIO
 
-###This test code shows how to configure gpio and how to use gpio interrupt.
+This test code shows how to configure gpio and how to use gpio interrupt.
 
- 
-####GPIO functions:
+## GPIO functions:
 
  * GPIO18: output
  * GPIO19: output
  * GPIO4:  input, pulled up, interrupt from rising edge and falling edge
  * GPIO5:  input, pulled up, interrupt from rising edge.
- 
-####Test:
+
+## Test:
  * Connect GPIO18 with GPIO4
  * Connect GPIO19 with GPIO5
  * Generate pulses on GPIO18/19, that triggers interrupt on GPIO4/5
- 
-
-
-


### PR DESCRIPTION
Fixed headers so they work (requires space between hash and text) and have a sensible structure and removed trailing spaces.