### PR TITLE
SPI: Document TIMEOUT return values

### DIFF
--- a/components/driver/include/driver/spi_master.h
+++ b/components/driver/include/driver/spi_master.h
@@ -172,6 +172,7 @@ esp_err_t spi_bus_remove_device(spi_device_handle_t handle);
  *                      never time out.
  * @return 
  *         - ESP_ERR_INVALID_ARG   if parameter is invalid
+ *         - ESP_ERR_TIMEOUT       if there was no room in the queue before ticks_to_wait expired
  *         - ESP_OK                on success
  */
 esp_err_t spi_device_queue_trans(spi_device_handle_t handle, spi_transaction_t *trans_desc, TickType_t ticks_to_wait);
@@ -193,6 +194,7 @@ esp_err_t spi_device_queue_trans(spi_device_handle_t handle, spi_transaction_t *
                         out.
  * @return 
  *         - ESP_ERR_INVALID_ARG   if parameter is invalid
+ *         - ESP_ERR_TIMEOUT       if there was no completed transaction before ticks_to_wait expired
  *         - ESP_OK                on success
  */
 esp_err_t spi_device_get_trans_result(spi_device_handle_t handle, spi_transaction_t **trans_desc, TickType_t ticks_to_wait);


### PR DESCRIPTION
`spi_device_queue_trans` and `spi_device_get_trans_result` can return `ESP_ERR_TIMEOUT` – but this had not been documented.