### PR TITLE
Adding anti name mandling definition

### DIFF
--- a/components/freertos/include/freertos/ringbuf.h
+++ b/components/freertos/include/freertos/ringbuf.h
@@ -1,6 +1,10 @@
 #ifndef FREERTOS_RINGBUF_H
 #define FREERTOS_RINGBUF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 Header definitions for a FreeRTOS ringbuffer object
 
@@ -242,5 +246,8 @@ BaseType_t xRingbufferRemoveFromQueueSetWrite(RingbufHandle_t ringbuf, QueueSetH
  */
 void xRingbufferPrintInfo(RingbufHandle_t ringbuf);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
When using CPP and C combination this particular file threw error on linking.

```
/root/esp/project/main/./wifi/client.c:116: undefined reference to `xRingbufferReceive(void*, unsigned int*, unsigned int)'
/root/esp/project/main/./wifi/client.c:116: undefined reference to `vRingbufferReturnItem(void*, void*)'
```