### PR TITLE
Fix pppapi_set_default()

### DIFF
--- a/components/lwip/api/pppapi.c
+++ b/components/lwip/api/pppapi.c
@@ -48,9 +48,9 @@
 static err_t
 pppapi_do_ppp_set_default(struct tcpip_api_call *m)
 {
-  struct pppapi_msg_msg *msg = (struct pppapi_msg_msg *)m;
-  
-  ppp_set_default(msg->ppp);
+  struct pppapi_msg *msg = (struct pppapi_msg *)m;
+
+  ppp_set_default(msg->msg.ppp);
   return ERR_OK;
 }
 


### PR DESCRIPTION
Most of the calls were fixed in 47c722d6742265c2c0260eca7ef17e71000f39ea, except this one.