### PR TITLE
Fix esp_bt_controller_mem_release()

### DIFF
--- a/components/bt/bt.c
+++ b/components/bt/bt.c
@@ -37,6 +37,7 @@
 #include "esp_pm.h"
 #include "esp_ipc.h"
 #include "driver/periph_ctrl.h"
+#include "soc/soc_memory_layout.h"
 
 #if CONFIG_BT_ENABLED
 
@@ -397,6 +398,7 @@ esp_err_t esp_bt_controller_mem_release(esp_bt_mode_t mode)
 {
     bool update = true;
     intptr_t mem_start, mem_end;
+    const uint32_t *dram_caps = soc_memory_types[SOC_MEMORY_TYPE_DRAM].caps;
 
     //get the mode which can be released, skip the mode which is running
     mode &= ~btdm_controller_get_mode();
@@ -434,14 +436,14 @@ esp_err_t esp_bt_controller_mem_release(esp_bt_mode_t mode)
                     && mem_end == btdm_dram_available_region[i+1].start) {
                 continue;
             } else {
-                ESP_LOGD(BTDM_LOG_TAG, "Release DRAM [0x%08x] - [0x%08x]\n", mem_start, mem_end);
-                ESP_ERROR_CHECK( heap_caps_add_region(mem_start, mem_end));
+                ESP_LOGD(BTDM_LOG_TAG, "Release DRAM [0x%08x] - [0x%08x]", mem_start, mem_end);
+                ESP_ERROR_CHECK(heap_caps_add_region_with_caps(dram_caps, mem_start, mem_end));
                 update = true;
             }
         } else {
             mem_end = btdm_dram_available_region[i].end;
-            ESP_LOGD(BTDM_LOG_TAG, "Release DRAM [0x%08x] - [0x%08x]\n", mem_start, mem_end);
-            ESP_ERROR_CHECK( heap_caps_add_region(mem_start, mem_end));
+            ESP_LOGD(BTDM_LOG_TAG, "Release DRAM [0x%08x] - [0x%08x]", mem_start, mem_end);
+            ESP_ERROR_CHECK(heap_caps_add_region_with_caps(dram_caps, mem_start, mem_end));
             update = true;
         }
     }

--- a/components/heap/heap_caps_init.c
+++ b/components/heap/heap_caps_init.c
@@ -234,8 +234,7 @@ esp_err_t heap_caps_add_region_with_caps(const uint32_t caps[], intptr_t start, 
     //region is invalid (or maybe added twice)
     heap_t *heap;
     SLIST_FOREACH(heap, &registered_heaps, next) {
-        if ( start <= heap->start &&  heap->start <=end ) return ESP_FAIL;
-        if ( start <= heap->end &&  heap->end <=end ) return ESP_FAIL;
+        if (start < heap->end && end > heap->start) return ESP_FAIL;
     }
 
     heap_t *p_new = malloc(sizeof(heap_t));

--- a/components/soc/include/soc/soc_memory_layout.h
+++ b/components/soc/include/soc/soc_memory_layout.h
@@ -20,6 +20,7 @@
 #include "sdkconfig.h"
 #include "esp_attr.h"
 
+#define SOC_MEMORY_TYPE_DRAM 0
 #define SOC_MEMORY_TYPE_NO_PRIOS 3
 
 /* Type descriptor holds a description for a particular type of memory on a particular SoC.


### PR DESCRIPTION
Region boundaries may not exactly match the regions defined in soc_memory_regions.
We know we're releasing DRAM, so use DRAM caps directly.

Fix boundary checks in heap_caps_add_region_with_caps.

Fixes https://github.com/espressif/esp-idf/issues/1277