### PR TITLE
Fixed broken performance example (tcp_perf, udp_perf)

### DIFF
--- a/examples/performance/tcp_perf/main/tcp_main.c
+++ b/examples/performance/tcp_perf/main/tcp_main.c
@@ -33,6 +33,7 @@ step3:
 #include "freertos/event_groups.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include "nvs_flash.h"
 
 #include "tcp_perf.h"
 
@@ -123,6 +124,7 @@ static void tcp_conn(void *pvParameters)
 
 void app_main(void)
 {
+    nvs_flash_init();
 #if EXAMPLE_ESP_WIFI_MODE_AP
     ESP_LOGI(TAG, "EXAMPLE_ESP_WIFI_MODE_AP");
     wifi_init_softap();

--- a/examples/performance/udp_perf/main/udp_main.c
+++ b/examples/performance/udp_perf/main/udp_main.c
@@ -36,6 +36,7 @@ step3:
 #include "freertos/event_groups.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include "nvs_flash.h"
 
 #include "udp_perf.h"
 
@@ -102,6 +103,7 @@ static void udp_conn(void *pvParameters)
 
 void app_main(void)
 {
+    nvs_flash_init();
 #if EXAMPLE_ESP_WIFI_MODE_AP
     ESP_LOGI(TAG, "EXAMPLE_ESP_WIFI_MODE_AP");
     wifi_init_softap();


### PR DESCRIPTION
Both example needed nvs_flash_init to run successfully. Added function and required header file to both examples