### PR TITLE
python3 default support & solving python3 buffer migration problems

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -14,7 +14,7 @@ config TOOLPREFIX
         a crosstool-ng gcc setup that is in your PATH.
 
 config PYTHON
-    string "Python 2 interpreter"
+    string "Python interpreter"
     default "python"
     help
         The executable name/path that is used to run python. On some systems Python 2.x

--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -252,7 +252,7 @@ class LineMatcher:
             self._dict[s[0]] = lev
     def match(self, line):
         try:
-            m = self._re.search(line)
+            m = self._re.search(str(line))
             if m:
                 lev = self.level[m.group(1)]
                 if m.group(2) in self._dict:
@@ -303,9 +303,9 @@ class Monitor(object):
         self.exit_key = CTRL_RBRACKET
 
         self.translate_eol = {
-            "CRLF": lambda c: c.replace(b"\n", b"\r\n"),
-            "CR":   lambda c: c.replace(b"\n", b"\r"),
-            "LF":   lambda c: c.replace(b"\r", b"\n"),
+            "CRLF": lambda c: c.replace("\n", "\r\n"),
+            "CR":   lambda c: c.replace("\n", "\r"),
+            "LF":   lambda c: c.replace("\r", "\n"),
         }[eol]
 
         # internal state
@@ -414,7 +414,7 @@ class Monitor(object):
         # handle_serial_input is invoked
 
     def handle_possible_pc_address_in_line(self, line):
-        line = self._pc_address_buffer + line
+        line = str(self._pc_address_buffer + line)
         self._pc_address_buffer = b""
         for m in re.finditer(MATCH_PCADDR, line):
             self.lookup_pc_address(m.group())
@@ -525,7 +525,7 @@ class Monitor(object):
             ["%saddr2line" % self.toolchain_prefix,
              "-pfiaC", "-e", self.elf_file, pc_addr],
             cwd=".")
-        if not "?? ??:0" in translation:
+        if not "?? ??:0" in str(translation):
             yellow_print(translation)
 
     def check_gdbstub_trigger(self, line):


### PR DESCRIPTION
python3 support has problems to buffer migration issues.
By following this official guide: http://python3porting.com/problems.html#bytes-strings-and-unicode
problems with byte and str buffers like the example below are solved.

Before doing these changes the hello world example would have produced errors while monitoring like the one below:
```
▶ make monitor
MONITOR
--- idf_monitor on /dev/ttyUSB0 115200 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
ets Jun  8 2016 00:22:57

rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0018,len:4
load:0x3fff001c,len:5552
ho 0 tail 12 room 4
load:0x40078000,len:0

Traceback (most recent call last):
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 571, in <module>
    main()
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 505, in main
    monitor.main_loop()
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 269, in main_loop
    self.handle_serial_input(data)
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 305, in handle_serial_input
    self.handle_serial_input_line(self._read_line.strip())
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 313, in handle_serial_input_line
    self.lookup_pc_address(str(m.group()))
  File "/home/sniper/esp/esp-idf/tools/idf_monitor.py", line 403, in lookup_pc_address
    if not "?? ??:0" in translation:
TypeError: 'str' does not support the buffer interface
make: *** [monitor] Error 1
```

Also, since all buffers are figured out for python3, I think python3 should be the default interpreter for monitoring.
