### PR TITLE
Function for obtain current log handler before redirect

### DIFF
--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -55,22 +55,14 @@ void esp_log_level_set(const char* tag, esp_log_level_t level);
  * @brief Set function used to output log entries
  *
  * By default, log output goes to UART0. This function can be used to redirect log
- * output to some other destination, such as file or network.
+ * output to some other destination, such as file or network. Returns the original
+ * log handler, which may be necessary to return output to the previous destination.
  *
- * @param func Function used for output. Must have same signature as vprintf.
+ * @param func new Function used for output. Must have same signature as vprintf.
+ *
+ * @return func old Function used for output.
  */
-void esp_log_set_vprintf(vprintf_like_t func);
-
-/**
- * @brief Get function used to current output log handler
- *
- * This function can be used to obtain current log handler before redirect 
- * log output to other destination, with later time return output to the 
- * previous destination.
- *
- * @return func Function used for output.
- */
-vprintf_like_t esp_log_get_vprintf(void);
+vprintf_like_t esp_log_set_vprintf(vprintf_like_t func);
 
 /**
  * @brief Function which returns timestamp to be used in log output

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -62,6 +62,17 @@ void esp_log_level_set(const char* tag, esp_log_level_t level);
 void esp_log_set_vprintf(vprintf_like_t func);
 
 /**
+ * @brief Get function used to current output log handler
+ *
+ * This function can be used to obtain current log handler before redirect 
+ * log output to other destination, with later time return output to the 
+ * previous destination.
+ *
+ * @return func Function used for output.
+ */
+vprintf_like_t esp_log_get_vprintf(void);
+
+/**
  * @brief Function which returns timestamp to be used in log output
  *
  * This function is used in expansion of ESP_LOGx macros.

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -111,6 +111,11 @@ void esp_log_set_vprintf(vprintf_like_t func)
     s_log_print_func = func;
 }
 
+vprintf_like_t esp_log_get_vprintf(void)
+{
+    return s_log_print_func;
+}
+
 void esp_log_level_set(const char* tag, esp_log_level_t level)
 {
     if (!s_log_mutex) {

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -106,14 +106,18 @@ static inline void heap_swap(int i, int j);
 static inline bool should_output(esp_log_level_t level_for_message, esp_log_level_t level_for_tag);
 static inline void clear_log_level_list();
 
-void esp_log_set_vprintf(vprintf_like_t func)
+vprintf_like_t esp_log_set_vprintf(vprintf_like_t func)
 {
-    s_log_print_func = func;
-}
+    if (!s_log_mutex) {
+        s_log_mutex = xSemaphoreCreateMutex();
+    }
+    xSemaphoreTake(s_log_mutex, portMAX_DELAY);
 
-vprintf_like_t esp_log_get_vprintf(void)
-{
-    return s_log_print_func;
+    vprintf_like_t orig_func = s_log_print_func;
+    s_log_print_func = func;
+
+    xSemaphoreGive(s_log_mutex);
+    return orig_func;
 }
 
 void esp_log_level_set(const char* tag, esp_log_level_t level)


### PR DESCRIPTION
Please add simple function esp_log_get_vprintf() to get context of the current log output function in order to return the output to the current handler, because variable s_log_print_function is static.