### PR TITLE
freertos: enable use of pxTaskGetStackStart

### DIFF
--- a/components/freertos/include/freertos/FreeRTOSConfig.h
+++ b/components/freertos/include/freertos/FreeRTOSConfig.h
@@ -253,6 +253,7 @@ int xt_clock_freq(void) __attribute__((deprecated));
 #define INCLUDE_uxTaskGetStackHighWaterMark	1
 #define INCLUDE_pcTaskGetTaskName			1
 #define INCLUDE_xTaskGetIdleTaskHandle      1
+#define INCLUDE_pxTaskGetStackStart			1
 
 #define INCLUDE_xSemaphoreGetMutexHolder    1
 

--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3814,14 +3814,17 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 /*-----------------------------------------------------------*/
 
 #if (INCLUDE_pxTaskGetStackStart == 1)
-   uint8_t* pxTaskGetStackStart( TaskHandle_t xTask)
-   {
-   TCB_t *pxTCB;
-   UBaseType_t uxReturn;
 
-       pxTCB = prvGetTCBFromHandle( xTask );
-       return ( uint8_t * ) pxTCB->pxStack;
-   }
+	uint8_t* pxTaskGetStackStart( TaskHandle_t xTask)
+	{
+		TCB_t *pxTCB;
+		uint8_t* uxReturn;
+
+		pxTCB = prvGetTCBFromHandle( xTask );
+		uxReturn = (uint8_t*)pxTCB->pxStack;
+
+		return uxReturn;
+	}
 
 #endif /* INCLUDE_pxTaskGetStackStart */
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Having `pxTaskGetStackStart` allows for measuring of free stack space - not only the high water mark (the lowest amount ever), but also for current stack use. On a platform where you can so easily run into low memory, having a more precise way to measure how much of it is left is a must.

As a use case, here is a screenshot of my tool for measuring stack using `pxTaskGetStackStart` for stack start and `uxTaskGetSnapshotAll` for stack end and current position.
![image](https://user-images.githubusercontent.com/697605/33066618-1cc917e4-ceac-11e7-8da9-7213cf4a75f0.png)

