### PR TITLE
Bugfix I_DELAY macro

### DIFF
--- a/components/ulp/include/esp32/ulp.h
+++ b/components/ulp/include/esp32/ulp.h
@@ -266,9 +266,9 @@ _Static_assert(sizeof(ulp_insn_t) == 4, "ULP coprocessor instruction size should
  * Delay (nop) for a given number of cycles
  */
 #define I_DELAY(cycles_) { .delay = {\
-    .opcode = OPCODE_DELAY, \
+    .cycles = cycles_, \
     .unused = 0, \
-    .cycles = cycles_ } }
+    .opcode = OPCODE_DELAY } }
 
 /**
  * Halt the coprocessor.


### PR DESCRIPTION
When compiling 

> const ulp_insn_t program[] = {
> I_DELAY(1)
> };

with the xtensa-esp32-elf-g++ compiler i always got the error:

> sorry, unimplemented: non-trivial designated initializers not supported
> 
>        };

This was due to the different order in the macro and the struct. The struct has another order of the fields (opcode, unused, cycles) vs (cycles, unused, opcode):
>    struct {
>        uint32_t cycles : 16;       /*!< Number of cycles to sleep */
>        uint32_t unused : 12;       /*!< Unused */
>        uint32_t opcode : 4;        /*!< Opcode (OPCODE_DELAY) */
>    } delay;                        /*!< Format of DELAY instruction */

After updating the order in the macro it is possible to compile with the g++ compiler.