### PR TITLE
BLE SM Security Flags not set in all situations

### DIFF
--- a/components/bt/bluedroid/btif/bta_dm_co.c
+++ b/components/bt/bluedroid/btif/bta_dm_co.c
@@ -492,7 +492,7 @@ void bta_dm_co_ble_set_rsp_key_req(UINT8 rsp_key)
 {
 #if (SMP_INCLUDED == TRUE)
    rsp_key &= 0x0f;  // 4~7bit reservd, only used the 0~3bit
-   bte_appl_cfg.ble_init_key &= rsp_key;
+   bte_appl_cfg.ble_resp_key &= rsp_key;
 #endif  ///SMP_INCLUDED == TRUE
 }
 

--- a/components/bt/bluedroid/stack/btm/btm_ble.c
+++ b/components/bt/bluedroid/stack/btm/btm_ble.c
@@ -1221,6 +1221,14 @@ void btm_sec_save_le_key(BD_ADDR bd_addr, tBTM_LE_KEY_TYPE key_type, tBTM_LE_KEY
             p_rec->ble.keys.key_size = p_keys->lenc_key.key_size;
             p_rec->ble.key_type |= BTM_LE_KEY_LENC;
 
+            /* Set that link key is known since this shares field with BTM_SEC_FLAG_LKEY_KNOWN flag in btm_api.h*/
+            p_rec->sec_flags |=  BTM_SEC_LE_LINK_KEY_KNOWN;
+            if ( p_keys->pcsrk_key.sec_level == SMP_SEC_AUTHENTICATED) {
+                p_rec->sec_flags |= BTM_SEC_LE_LINK_KEY_AUTHED;
+            } else {
+                p_rec->sec_flags &= ~BTM_SEC_LE_LINK_KEY_AUTHED;
+            }
+
             BTM_TRACE_DEBUG("BTM_LE_KEY_LENC key_type=0x%x DIV=0x%x key_size=0x%x sec_level=0x%x",
                             p_rec->ble.key_type,
                             p_rec->ble.keys.div,


### PR DESCRIPTION
I found a situation where the proper BLE security flags were not set in all pairing situations.   In the scenario I found the ESP was acting as Slave to a remote Win 10 master.  In this scenario during SM pairing only the slave exchanges the LTK (master doesn't send an LTK).   Because of this the BLE security flags for the link were not properly set to indicate that a link key was known (and if MITM was used if applicable).   This caused a ATT write request from the Master to be improperly rejected to an attribute that requires encrypted writes.