### PR TITLE
idf_monitor: make Ctrl-] work when running on WSL (v3)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -97,7 +97,10 @@ if RUNNING_ON_WSL:
     import io
     enc = sys.stdin.encoding
     sys.stdin = io.open(sys.stdin.fileno(), mode='rb', buffering=0, closefd = False)
-    sys.stdin.encoding = enc
+    if sys.version_info >= (3, 0):
+        sys.stdin = codecs.getreader(enc)(sys.stdin)
+    else:
+        sys.stdin.encoding = enc
 
 class StoppableThread(object):
     """
@@ -195,7 +198,7 @@ class ConsoleReader(StoppableThread):
             # note that TIOCSTI is not implemented in WSL / bash-on-Windows.
             if self.cancelfd[1] is not None:
                 # unblock select()
-                os.write(self.cancelfd[1], "C")
+                os.write(self.cancelfd[1], b'C')
         elif os.name == 'posix':
             # this is the way cancel() is implemented in pyserial 3.3 or newer,
             # older pyserial (3.1+) has cancellation implemented via 'select',


### PR DESCRIPTION
Because the TIOCSTI termios ioctl is not supported on WSL (bash on
windows) at this time, another way for avoiding (or unblocking) a
blocking read on stdin is needed. Also, setting a timeout using
termios.c_cc[VMIN] = 0 with termios.c_cc[VTIME] = 1 does not currently
work for WSL.

A first approach to mimic the Windows kludge based on kbhit() by using
ioctl(TIOCINQ) for peeking at the input queue before calling read()
basically worked but failed badly for fast multi character input like
escape sequences sent back by the terminal. This can be easily
reproduced using the console example (examples/system/console). The root
cause was identified to be the buffering involved reading and decoding
stdin in python.

The second approach used pthread_kill() via ctypes (python 2) to unblock
getkey() in ConsoleReader which seemed to be working well.  However,
even in this case stdin must have been re-opened without buffering.
Otherwise, the read() may be restarted internally after seeing EINTR.
Additionally, the solution felt at least a bit unclean.

After having identified the importance of making stdin unbuffered, it
became clear that in this case select() (or other I/O completion
methods) should also work correctly. Therefore, the current solution was
implemented, which looks a lot cleaner. It should also work on other
POSIX systems (e.g., plain Linux), but this has not been tested, so far.

The change has been tested successfully on WSL with the console example,
escape sequences (UP, DOWN keys), Ctrl-] to leave the monitor and
Ctrl-T/Ctrl-A for re-flashing.