### PR TITLE
Make spi_master structures available to user application (IDFGH-2504)

### DIFF
--- a/components/driver/include/driver/spi_master.h
+++ b/components/driver/include/driver/spi_master.h
@@ -105,42 +105,6 @@ typedef struct {
 
 typedef struct spi_device_t* spi_device_handle_t;  ///< Handle for a device on a SPI bus
 
-typedef struct spi_device_t spi_device_t;
-
-#define NO_CS 3     //Number of CS pins per SPI host
-
-
-/// struct to hold private transaction data (like tx and rx buffer for DMA).
-typedef struct {        
-    spi_transaction_t   *trans; 
-    uint32_t *buffer_to_send;   //equals to tx_data, if SPI_TRANS_USE_RXDATA is applied; otherwise if original buffer wasn't in DMA-capable memory, this gets the address of a temporary buffer that is;
-                                //otherwise sets to the original buffer or NULL if no buffer is assigned.
-    uint32_t *buffer_to_rcv;    // similar to buffer_to_send
-} spi_trans_priv;
-
-typedef struct {
-    spi_device_t *device[NO_CS];
-    intr_handle_t intr;
-    spi_dev_t *hw;
-    spi_trans_priv cur_trans_buf;
-    int cur_cs;
-    lldesc_t *dmadesc_tx;
-    lldesc_t *dmadesc_rx;
-    bool no_gpio_matrix;
-    int dma_chan;
-    int max_transfer_sz;
-#ifdef CONFIG_PM_ENABLE
-    esp_pm_lock_handle_t pm_lock;
-#endif
-} spi_host_t;
-
-struct spi_device_t {
-    QueueHandle_t trans_queue;
-    QueueHandle_t ret_queue;
-    spi_device_interface_config_t cfg;
-    spi_host_t *host;
-};
-
 /**
  * @brief Initialize a SPI bus
  *
@@ -264,21 +228,6 @@ esp_err_t spi_device_get_trans_result(spi_device_handle_t handle, spi_transactio
  */
 esp_err_t spi_device_transmit(spi_device_handle_t handle, spi_transaction_t *trans_desc);
 
-
-/**
- * @brief Set the SPI clock to a certain frequency
- *
- * Set the SPI clock to a certain frequency. Returns the effective frequency set, which may be slightly
- * different from the requested frequency.
- * 
- * @param hw SPI host device structure pointer
- * @param fapb APB clock frequency
- * @param hz desired SPI clock frequency in HZ
- * @param duty_cycle SPI clock duty cycle
- * @return 
- *         - the effective frequency set
- */
-int spi_set_clock(spi_dev_t *hw, int fapb, int hz, int duty_cycle);
 
 #ifdef __cplusplus
 }

--- a/components/driver/include/driver/spi_master.h
+++ b/components/driver/include/driver/spi_master.h
@@ -105,6 +105,42 @@ typedef struct {
 
 typedef struct spi_device_t* spi_device_handle_t;  ///< Handle for a device on a SPI bus
 
+typedef struct spi_device_t spi_device_t;
+
+#define NO_CS 3     //Number of CS pins per SPI host
+
+
+/// struct to hold private transaction data (like tx and rx buffer for DMA).
+typedef struct {        
+    spi_transaction_t   *trans; 
+    uint32_t *buffer_to_send;   //equals to tx_data, if SPI_TRANS_USE_RXDATA is applied; otherwise if original buffer wasn't in DMA-capable memory, this gets the address of a temporary buffer that is;
+                                //otherwise sets to the original buffer or NULL if no buffer is assigned.
+    uint32_t *buffer_to_rcv;    // similar to buffer_to_send
+} spi_trans_priv;
+
+typedef struct {
+    spi_device_t *device[NO_CS];
+    intr_handle_t intr;
+    spi_dev_t *hw;
+    spi_trans_priv cur_trans_buf;
+    int cur_cs;
+    lldesc_t *dmadesc_tx;
+    lldesc_t *dmadesc_rx;
+    bool no_gpio_matrix;
+    int dma_chan;
+    int max_transfer_sz;
+#ifdef CONFIG_PM_ENABLE
+    esp_pm_lock_handle_t pm_lock;
+#endif
+} spi_host_t;
+
+struct spi_device_t {
+    QueueHandle_t trans_queue;
+    QueueHandle_t ret_queue;
+    spi_device_interface_config_t cfg;
+    spi_host_t *host;
+};
+
 /**
  * @brief Initialize a SPI bus
  *
@@ -228,6 +264,21 @@ esp_err_t spi_device_get_trans_result(spi_device_handle_t handle, spi_transactio
  */
 esp_err_t spi_device_transmit(spi_device_handle_t handle, spi_transaction_t *trans_desc);
 
+
+/**
+ * @brief Set the SPI clock to a certain frequency
+ *
+ * Set the SPI clock to a certain frequency. Returns the effective frequency set, which may be slightly
+ * different from the requested frequency.
+ * 
+ * @param hw SPI host device structure pointer
+ * @param fapb APB clock frequency
+ * @param hz desired SPI clock frequency in HZ
+ * @param duty_cycle SPI clock duty cycle
+ * @return 
+ *         - the effective frequency set
+ */
+int spi_set_clock(spi_dev_t *hw, int fapb, int hz, int duty_cycle);
 
 #ifdef __cplusplus
 }

--- a/components/driver/include/driver/spi_master_internal.h
+++ b/components/driver/include/driver/spi_master_internal.h
@@ -1,0 +1,83 @@
+// Copyright 2010-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef _DRIVER_SPI_MASTER_INTERNAL_H_
+#define _DRIVER_SPI_MASTER_INTERNAL_H_
+
+#include "driver/spi_master.h"
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct spi_device_t spi_device_t;
+
+#define NO_CS 3     //Number of CS pins per SPI host
+
+
+/// struct to hold private transaction data (like tx and rx buffer for DMA).
+typedef struct {        
+    spi_transaction_t   *trans; 
+    uint32_t *buffer_to_send;   //equals to tx_data, if SPI_TRANS_USE_RXDATA is applied; otherwise if original buffer wasn't in DMA-capable memory, this gets the address of a temporary buffer that is;
+                                //otherwise sets to the original buffer or NULL if no buffer is assigned.
+    uint32_t *buffer_to_rcv;    // similar to buffer_to_send
+} spi_trans_priv;
+
+typedef struct {
+    spi_device_t *device[NO_CS];
+    intr_handle_t intr;
+    spi_dev_t *hw;
+    spi_trans_priv cur_trans_buf;
+    int cur_cs;
+    lldesc_t *dmadesc_tx;
+    lldesc_t *dmadesc_rx;
+    bool no_gpio_matrix;
+    int dma_chan;
+    int max_transfer_sz;
+#ifdef CONFIG_PM_ENABLE
+    esp_pm_lock_handle_t pm_lock;
+#endif
+} spi_host_t;
+
+struct spi_device_t {
+    QueueHandle_t trans_queue;
+    QueueHandle_t ret_queue;
+    spi_device_interface_config_t cfg;
+    spi_host_t *host;
+};
+
+
+/**
+ * @brief Set the SPI clock to a certain frequency
+ *
+ * Set the SPI clock to a certain frequency. Returns the effective frequency set, which may be slightly
+ * different from the requested frequency.
+ * 
+ * @param hw SPI host device structure pointer
+ * @param fapb APB clock frequency
+ * @param hz desired SPI clock frequency in HZ
+ * @param duty_cycle SPI clock duty cycle
+ * @return 
+ *         - the effective frequency set
+ */
+int spi_set_clock(spi_dev_t *hw, int fapb, int hz, int duty_cycle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/components/driver/include/driver/spi_master_internal.h
+++ b/components/driver/include/driver/spi_master_internal.h
@@ -26,7 +26,8 @@ extern "C"
 
 typedef struct spi_device_t spi_device_t;
 
-#define NO_CS 3     //Number of CS pins per SPI host
+#define NO_CS 6     //Number of CS pins per SPI host including software handled
+#define NO_HWCS 3   //Number of hardware handled CS pins per SPI host
 
 
 /// struct to hold private transaction data (like tx and rx buffer for DMA).

--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -36,6 +36,7 @@ queue and re-enabling the interrupt will trigger the interrupt again, which can 
 #include <string.h>
 #include "driver/spi_common.h"
 #include "driver/spi_master.h"
+#include "driver/spi_master_internal.h"
 #include "soc/gpio_sig_map.h"
 #include "soc/spi_reg.h"
 #include "soc/dport_reg.h"

--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -61,42 +61,6 @@ queue and re-enabling the interrupt will trigger the interrupt again, which can 
 #include "driver/periph_ctrl.h"
 #include "esp_heap_caps.h"
 
-typedef struct spi_device_t spi_device_t;
-
-#define NO_CS 3     //Number of CS pins per SPI host
-
-
-/// struct to hold private transaction data (like tx and rx buffer for DMA).
-typedef struct {        
-    spi_transaction_t   *trans; 
-    uint32_t *buffer_to_send;   //equals to tx_data, if SPI_TRANS_USE_RXDATA is applied; otherwise if original buffer wasn't in DMA-capable memory, this gets the address of a temporary buffer that is;
-                                //otherwise sets to the original buffer or NULL if no buffer is assigned.
-    uint32_t *buffer_to_rcv;    // similar to buffer_to_send
-} spi_trans_priv;
-
-typedef struct {
-    spi_device_t *device[NO_CS];
-    intr_handle_t intr;
-    spi_dev_t *hw;
-    spi_trans_priv cur_trans_buf;
-    int cur_cs;
-    lldesc_t *dmadesc_tx;
-    lldesc_t *dmadesc_rx;
-    bool no_gpio_matrix;
-    int dma_chan;
-    int max_transfer_sz;
-#ifdef CONFIG_PM_ENABLE
-    esp_pm_lock_handle_t pm_lock;
-#endif
-} spi_host_t;
-
-struct spi_device_t {
-    QueueHandle_t trans_queue;
-    QueueHandle_t ret_queue;
-    spi_device_interface_config_t cfg;
-    spi_host_t *host;
-};
-
 static spi_host_t *spihost[3];
 
 
@@ -325,7 +289,7 @@ static int spi_freq_for_pre_n(int fapb, int pre, int n) {
  * Set the SPI clock to a certain frequency. Returns the effective frequency set, which may be slightly
  * different from the requested frequency.
  */
-static int spi_set_clock(spi_dev_t *hw, int fapb, int hz, int duty_cycle) {
+int spi_set_clock(spi_dev_t *hw, int fapb, int hz, int duty_cycle) {
     int pre, n, h, l, eff_clk;
 
     //In hw, n, h and l are 1-64, pre is 1-8K. Value written to register is one lower than used value.


### PR DESCRIPTION
This simple PR enables some of spi_master structures to be visible from the user application.

This makes it possible to use the spi_master driver to initialize the bus, add devices, and then use the returned _spi_device_handle_t_ variable for some lower level functions.

This way it is possible to create some spi functions which don't use the transactions and/or DMA.
For example, setting large amount  individual pixels on spi display using the transactions is **very** slow. Using direct transfer which is possible with this changes, the transfer can be up to 10x faster.
