### PR TITLE
Add #include guards and __cplusplus guards to esp_debug.h

### DIFF
--- a/components/mbedtls/port/include/mbedtls/esp_debug.h
+++ b/components/mbedtls/port/include/mbedtls/esp_debug.h
@@ -11,6 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#ifndef _ESP_DEBUG_H_
+#define _ESP_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "sdkconfig.h"
 #ifdef CONFIG_MBEDTLS_DEBUG
@@ -43,3 +49,9 @@ void mbedtls_esp_disable_debug_log(mbedtls_ssl_config *conf);
 
 
 #endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ESP_DEBUG_H__ */


### PR DESCRIPTION
I found this was needed when `CONFIG_MBEDTLS_DEBUG=y` and `#include "esp_debug.h"` used from within a C++ file.