### PR TITLE
Bugfix: Use bit_num instead of duty_resolution

### DIFF
--- a/examples/peripherals/ledc/main/ledc_example_main.c
+++ b/examples/peripherals/ledc/main/ledc_example_main.c
@@ -60,7 +60,7 @@ void app_main()
      * that will be used by LED Controller
      */
     ledc_timer_config_t ledc_timer = {
-        .duty_resolution = LEDC_TIMER_13_BIT, // resolution of PWM duty
+        .bit_num = LEDC_TIMER_13_BIT, // resolution of PWM duty
         .freq_hz = 5000,                      // frequency of PWM signal
         .speed_mode = LEDC_HS_MODE,           // timer mode
         .timer_num = LEDC_HS_TIMER            // timer index


### PR DESCRIPTION
ledc_timer_config_t no longer has a member duty_resolution.
Instead it is now called bit_num.

Signed-off-by: Simon Egli <deadolus@gmail.com>