### PR TITLE
Ethernet: Let applications specify DMA buffers (IDFGH-2876)

### DIFF
--- a/components/ethernet/emac_common.h
+++ b/components/ethernet/emac_common.h
@@ -103,12 +103,7 @@ struct emac_close_cmd {
     int8_t err;
 };
 
-#define DMA_RX_BUF_NUM CONFIG_DMA_RX_BUF_NUM
-#define DMA_TX_BUF_NUM CONFIG_DMA_TX_BUF_NUM
 #define EMAC_TASK_PRIORITY CONFIG_EMAC_TASK_PRIORITY
-
-#define DMA_RX_BUF_SIZE 1600
-#define DMA_TX_BUF_SIZE 1600
 
 //rest buf num
 #define FLOW_CONTROL_HIGH_WATERMARK 3

--- a/components/ethernet/include/esp_eth.h
+++ b/components/ethernet/include/esp_eth.h
@@ -45,6 +45,11 @@ typedef enum {
     ETH_MODE_FULLDUPLEX,
 } eth_duplex_mode_t;
 
+#define ETH_DMA_RX_BUF_NUM CONFIG_DMA_RX_BUF_NUM
+#define ETH_DMA_TX_BUF_NUM CONFIG_DMA_TX_BUF_NUM
+#define ETH_DMA_RX_BUF_SIZE 1600
+#define ETH_DMA_TX_BUF_SIZE 1600
+
 typedef enum {
     PHY0 = 0,
     PHY1,
@@ -108,6 +113,8 @@ typedef struct {
     bool flow_ctrl_enable;                      /*!< flag of flow ctrl enable */
     eth_phy_get_partner_pause_enable_func  phy_get_partner_pause_enable; /*!< get partner pause enable */
     eth_phy_power_enable_func  phy_power_enable;  /*!< enable or disable phy power */
+    uint8_t *dma_rx_buf;                        /*!< DMA-capable buffer of size ETH_DMA_RX_BUF_SIZE * ETH_DMA_RX_BUF_NUM, may be NULL */
+    uint8_t *dma_tx_buf;                        /*!< DMA-capable buffer of size ETH_DMA_TX_BUF_SIZE * ETH_DMA_TX_BUF_NUM, may be NULL */
 
 } eth_config_t;
 


### PR DESCRIPTION
By default, ethernet requires 2x 16kB of statically allocated RAM for the DMA buffers, whether ethernet is actually used by the application or not.

This pull request enables applications to specify the buffer manually. They can either specify it as a statically allocated buffer (just like it was before) or allocate it dynamically when needed.

See: https://github.com/micropython/micropython-esp32/issues/222#issuecomment-350582604