### PR TITLE
I2S-driver: apll_predefine was ignored

### DIFF
--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -248,7 +248,7 @@ static esp_err_t i2s_apll_calculate(int rate, int bits_per_sample, int *sdm0, in
     //check pre-define apll parameters
     i = 0;
     while (apll_predefine[i][0]) {
-        if (apll_predefine[i][0] == bits_per_sample && apll_predefine[i][0] == rate) {
+        if (apll_predefine[i][0] == bits_per_sample && apll_predefine[i][1] == rate) {
             *sdm0 = apll_predefine[i][1];
             *sdm1 = apll_predefine[i][2];
             *sdm2 = apll_predefine[i][3];


### PR DESCRIPTION
In i2s.c, there are predefined values for audio PLL configuration in the `apll_predefine` array. In `i2s_apll_calculate`, the sampling rate supplied was compared to the bits_per_sample value in the array. This is a fix of this comparison.