### PR TITLE
Add directory handling to spiffs driver

### DIFF
--- a/components/spiffs/include/spiffs_config.h
+++ b/components/spiffs/include/spiffs_config.h
@@ -158,7 +158,8 @@ extern void spiffs_api_unlock(struct spiffs_t *fs);
 // This is derived from following:
 // logical_page_size - (SPIFFS_OBJ_NAME_LEN + sizeof(spiffs_page_header) +
 // spiffs_object_ix_header fields + at least some LUT entries)
-#define SPIFFS_OBJ_META_LEN             (CONFIG_SPIFFS_META_LENGTH)
+// We are using at least 1 byte of metadata (for directory handling)
+#define SPIFFS_OBJ_META_LEN             (CONFIG_SPIFFS_META_LENGTH+1)
 
 // Size of buffer allocated on stack used when copying data.
 // Lower value generates more read/writes. No meaning having it bigger


### PR DESCRIPTION
This PR adds directory support to spiffs driver.
The directories are handled by adding obe byte to spiffs file metadata.
Tested and no problem found so far.
The example application will be pushed to my GitHub repository.