### PR TITLE
components: i2c: fix erroneous sanity check

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -1005,7 +1005,7 @@ esp_err_t i2c_master_read(i2c_cmd_handle_t cmd_handle, uint8_t* data, size_t dat
     I2C_CHECK((data != NULL), I2C_ADDR_ERROR_STR, ESP_ERR_INVALID_ARG);
     I2C_CHECK(cmd_handle != NULL, I2C_CMD_LINK_INIT_ERR_STR, ESP_ERR_INVALID_ARG);
     I2C_CHECK(ack < I2C_MASTER_ACK_MAX, I2C_ACK_TYPE_ERR_STR, ESP_ERR_INVALID_ARG);
-    I2C_CHECK(data_len < 1, I2C_DATA_LEN_ERR_STR, ESP_ERR_INVALID_ARG);
+    I2C_CHECK(data_len, I2C_DATA_LEN_ERR_STR, ESP_ERR_INVALID_ARG);
 
     if(ack != I2C_MASTER_LAST_NACK) {
         return i2c_master_read_static(cmd_handle, data, data_len, ack);


### PR DESCRIPTION
The predicate for the I2C_CHECK macro describes what you expect to be true.
i2c_master_read used this macro in the wrong way. Fix that.

Signed-off-by: Thomas Basler <github.thomas@familie-basler.net>
Signed-off-by: Ralf Ramsauer <ralf@ramses-pyramidenbau.de>