### PR TITLE
Position file stream at end of the file when fopen(file_name, 'a') is executed

### DIFF
--- a/components/fatfs/src/vfs_fat.c
+++ b/components/fatfs/src/vfs_fat.c
@@ -307,6 +307,16 @@ static int vfs_fat_open(void* ctx, const char * path, int flags, int mode)
         goto out;
     }
 out:
+    if ((fd >= 0) && (flags & O_APPEND)) {
+        res = f_lseek(&fat_ctx->files[fd], f_size(&fat_ctx->files[fd]));
+        if (res != FR_OK) {
+            ESP_LOGD(TAG, "%s: fresult=%d", __func__, res);
+            errno = fresult_to_errno(res);
+            res = f_close(&fat_ctx->files[fd]);
+            file_cleanup(fat_ctx, fd);
+            fd = -1;
+        }
+    }
     _lock_release(&fat_ctx->lock);
     return fd;
 }

--- a/components/fatfs/src/vfs_fat.c
+++ b/components/fatfs/src/vfs_fat.c
@@ -306,17 +306,17 @@ static int vfs_fat_open(void* ctx, const char * path, int flags, int mode)
         fd = -1;
         goto out;
     }
-out:
-    if ((fd >= 0) && (flags & O_APPEND)) {
+    if (flags & O_APPEND) {
         res = f_lseek(&fat_ctx->files[fd], f_size(&fat_ctx->files[fd]));
         if (res != FR_OK) {
             ESP_LOGD(TAG, "%s: fresult=%d", __func__, res);
             errno = fresult_to_errno(res);
-            res = f_close(&fat_ctx->files[fd]);
+            f_close(&fat_ctx->files[fd]);
             file_cleanup(fat_ctx, fd);
             fd = -1;
         }
     }
+out:
     _lock_release(&fat_ctx->lock);
     return fd;
 }


### PR DESCRIPTION
The file stream position should be set to the end of the file then `fopen("filename", 'a')` is executed.
>        a      Open for appending (writing at end of file).  The file is
>               created if it does not exist.  The stream is positioned at the
>               end of the file.
> 
[fopen](http://man7.org/linux/man-pages/man3/fopen.3.html)