### PR TITLE
Add task tracking option for heap usage monitoring

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -87,6 +87,7 @@ task.h is included from an application file. */
 #include "StackMacros.h"
 #include "portmacro.h"
 #include "semphr.h"
+#include "multi_heap_poisoning.h"
 
 /* Lint e961 and e750 are suppressed as a MISRA exception justified because the
 MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be defined for the
@@ -3749,6 +3750,12 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 				pxTaskStatusArray[ uxTask ].xTaskNumber = pxNextTCB->uxTCBNumber;
 				pxTaskStatusArray[ uxTask ].eCurrentState = eState;
 				pxTaskStatusArray[ uxTask ].uxCurrentPriority = pxNextTCB->uxPriority;
+#ifndef CONFIG_HEAP_POISONING_DISABLED
+				poison_head_t* stackblk = (poison_head_t*)(pxNextTCB->pxStack - sizeof(poison_head_t));
+				uint32_t stackinfo = stackblk->alloc_size << 16;
+				stackinfo |= pxNextTCB->pxTopOfStack - pxNextTCB->pxStack;
+				pxTaskStatusArray[ uxTask ].pxStackBase = (StackType_t*)stackinfo;
+#endif
 
 				#if ( INCLUDE_vTaskSuspend == 1 )
 				{

--- a/components/heap/Kconfig
+++ b/components/heap/Kconfig
@@ -37,4 +37,13 @@ config HEAP_TRACING_STACK_DEPTH
         More stack frames uses more memory in the heap trace buffer (and slows down allocation), but
         can provide useful information.
 
+config HEAP_TASK_TRACKING
+    bool "Enable heap task tracking"
+    depends on !HEAP_POISONING_DISABLED
+    help
+        Enables tracking the task responsible for each heap allocation.
+
+        This function depends on heap poisoning being enabled and adds four more bytes of overhead for each block
+        allocated.
+
 endmenu

--- a/components/heap/component.mk
+++ b/components/heap/component.mk
@@ -6,6 +6,10 @@ COMPONENT_OBJS := heap_caps_init.o heap_caps.o multi_heap.o heap_trace.o
 
 ifndef CONFIG_HEAP_POISONING_DISABLED
 COMPONENT_OBJS += multi_heap_poisoning.o
+
+ifdef CONFIG_HEAP_TASK_TRACKING
+COMPONENT_OBJS += esp_heap_debug.o
+endif
 endif
 
 ifdef CONFIG_HEAP_TRACING

--- a/components/heap/esp_heap_debug.c
+++ b/components/heap/esp_heap_debug.c
@@ -1,0 +1,104 @@
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <multi_heap.h>
+#include "multi_heap_internal.h"
+#include "multi_heap_poisoning.h"
+#include "heap_private.h"
+#include "esp_heap_debug.h"
+
+#ifdef CONFIG_HEAP_TASK_TRACKING
+
+// return all possible capabilities (across all priorities) for a given heap
+
+inline static uint32_t get_all_caps(const heap_t *heap)
+{
+    uint32_t all_caps = 0;
+    for (int prio = 0; prio < SOC_MEMORY_TYPE_NO_PRIOS; prio++) {
+        all_caps |= heap->caps[prio];
+    }
+    return all_caps;
+}
+
+// For each task that has allocated memory from the heap, return totals for
+// allocations of each type of heap region (8-bit DRAM, 8-bit D/IRAM, 32-bit
+// IRAM) into provided array of heap_dump_totals_t structs 'totals'.
+
+// If one or more task handles is provided in array 'tasks', for each block
+// allocated by one of the tasks a heap_dump_block_t struct is written into
+// provided array 'buffer' to give the task, address, size and region type for
+// the block.
+
+size_t esp_heap_debug_dump_totals(heap_dump_totals_t* totals, size_t* ntotal, size_t max,
+				  TaskHandle_t* tasks, size_t ntasks,
+				  heap_dump_block_t* buffer, size_t size)
+{
+    heap_t *heap;
+    heap_block_t *b;
+    poison_head_t *d;
+    TaskHandle_t btask;
+    size_t count = *ntotal;
+    size_t remaining = size;
+    size_t i;
+
+    SLIST_FOREACH(heap, &registered_heaps, next) {
+	heap_metadata_t *meta = heap->heap;
+	if (meta == NULL) {
+	    continue;
+	}
+	uint32_t caps = get_all_caps(heap);
+	int type = 0;
+	if (caps & MALLOC_CAP_EXEC)
+	    ++type;
+	if (!(caps & MALLOC_CAP_8BIT))
+	    ++type;
+	b = &meta->first_block;
+	multi_heap_internal_lock(meta);
+	while (b && remaining > 0) {
+	    if (b->header & BLOCK_FREE_FLAG) {
+		b = (heap_block_t*)(b->header & NEXT_BLOCK_MASK);
+		continue;
+	    }
+	    d = (poison_head_t*)b->data;
+	    btask = d->task;
+	    size_t index;
+	    for (index = 0; index < count; ++index) {
+		if (totals[index].task == btask)
+		    break;
+	    }
+	    if (index < count)
+		totals[index].after[type] += d->alloc_size;
+	    else {
+		if (count < max) {
+		    totals[count].task = btask;
+		    for (i = 0; i < NUM_USED_TYPES; ++i) {
+			totals[count].before[i] = 0;
+			totals[count].after[i] = 0;
+		    }
+		    totals[count].after[type] = d->alloc_size;
+		    ++count;
+		}
+	    }
+	    if (tasks) {
+		for (i = 0; i < ntasks; ++i) {
+		    if (btask == tasks[i])
+			break;
+		}
+		if (i == ntasks) {
+		    b = (heap_block_t*)(b->header & NEXT_BLOCK_MASK);
+		    continue;
+		}
+	    }
+	    buffer->task = btask;
+	    buffer->address = (void*)d + sizeof(poison_head_t);
+	    buffer->size = d->alloc_size;
+	    buffer->type = type;
+	    ++buffer;
+	    --remaining;
+	    b = (heap_block_t*)(b->header & NEXT_BLOCK_MASK);
+	}
+	multi_heap_internal_unlock(meta);
+    }
+    *ntotal = count;
+    return size - remaining;
+}
+#endif

--- a/components/heap/esp_heap_debug.c
+++ b/components/heap/esp_heap_debug.c
@@ -51,6 +51,8 @@ size_t esp_heap_debug_dump_totals(heap_dump_totals_t* totals, size_t* ntotal, si
 	    ++type;
 	if (!(caps & MALLOC_CAP_8BIT))
 	    ++type;
+	if (caps & MALLOC_CAP_SPIRAM)
+	    type = 3;
 	b = &meta->first_block;
 	multi_heap_internal_lock(meta);
 	while (b && remaining > 0) {

--- a/components/heap/include/esp_heap_debug.h
+++ b/components/heap/include/esp_heap_debug.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#define NUM_USED_TYPES 3
+#define NUM_USED_TYPES 4
 
 typedef struct {
     TaskHandle_t task;

--- a/components/heap/include/esp_heap_debug.h
+++ b/components/heap/include/esp_heap_debug.h
@@ -1,0 +1,34 @@
+#ifndef _ESP_HEAP_DEBUG_H
+#define _ESP_HEAP_DEBUG_H
+
+#ifdef CONFIG_HEAP_TASK_TRACKING
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NUM_USED_TYPES 3
+
+typedef struct {
+    TaskHandle_t task;
+    int before[NUM_USED_TYPES];
+    int after[NUM_USED_TYPES];
+} heap_dump_totals_t;
+
+typedef struct {
+    TaskHandle_t task;
+    void* address;
+    int size: 24;                   // The size of the allocated block.
+    int type: 7;                    // Type of block's region
+    int unused: 1;                  // (forces 32-bit access for type)
+} heap_dump_block_t;
+
+extern size_t esp_heap_debug_dump_totals(heap_dump_totals_t* totals, size_t* ntotal, size_t max,
+					 TaskHandle_t* tasks, size_t ntasks,
+					 heap_dump_block_t* buffer, size_t size);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif // _ESP_HEAP_DEBUG_H

--- a/components/heap/include/multi_heap.h
+++ b/components/heap/include/multi_heap.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /** @brief Opaque handle to a registered heap */
-typedef struct multi_heap_info *multi_heap_handle_t;
+typedef struct multi_heap_metadata *multi_heap_handle_t;
 
 /** @brief malloc() a buffer in a given heap
  *

--- a/components/heap/include/multi_heap_poisoning.h
+++ b/components/heap/include/multi_heap_poisoning.h
@@ -1,0 +1,13 @@
+#pragma once
+
+typedef struct {
+    uint32_t head_canary;
+#ifdef CONFIG_HEAP_TASK_TRACKING
+    TaskHandle_t task;
+#endif
+    size_t alloc_size;
+} poison_head_t;
+
+typedef struct {
+    uint32_t tail_canary;
+} poison_tail_t;


### PR DESCRIPTION
Add back a feature that was available in the old heap implementation
in release/v2.1 and earlier: keep track of which task allocates each
block from the heap.  The task handle is conditionally added as
another word in the heap poisoning header under this configuration
option CONFIG_HEAP_TASK_TRACKING.

To allow custom monitoring and debugging code to be added, move data
structure declarations from multi_heap.c and multi_heap_poisoning.c
into multi_heap_internal.h and a new file multi_heap_poisoning.h,
respectively.

As a result, the struct multi_heap_info with typename heap_t conflicts
with heap_t declared in heap_private.h for code that needs both
headers.  Also, it might be confusing to have this struct named
multi_heap_info when there is a different struct in multi_heap.h with
the typename multi_heap_info_t.  Therefore struct multi_heap_info was
renamed multi_heap_metadata with typename heap_metadata_t.