### PR TITLE
Porting recvmsg() from upstream LwIP

### DIFF
--- a/components/coap/port/coap_io_socket.c
+++ b/components/coap/port/coap_io_socket.c
@@ -213,7 +213,7 @@ coap_free_endpoint(coap_endpoint_t *ep) {
 
 #ifdef CUSTOM_COAP_NETWORK_SEND
 
-#if defined(WITH_POSIX) != defined(HAVE_NETINET_IN_H)
+#if !defined(WITH_POSIX) && !defined(HAVE_NETINET_IN_H)
 /* define struct in6_pktinfo and struct in_pktinfo if not available
    FIXME: check with configure
 */

--- a/components/coap/port/include/coap_config_posix.h
+++ b/components/coap/port/include/coap_config_posix.h
@@ -26,7 +26,10 @@
 #define HAVE_MALLOC
 #define HAVE_ARPA_INET_H
 
+#ifndef IP_PKTINFO
 #define IP_PKTINFO   IP_MULTICAST_IF
+#endif
+
 #define IPV6_PKTINFO IPV6_V6ONLY
 
 #define PACKAGE_NAME "libcoap-posix"

--- a/components/lwip/api/api_lib.c
+++ b/components/lwip/api/api_lib.c
@@ -559,6 +559,26 @@ netconn_recv_tcp_pbuf(struct netconn *conn, struct pbuf **new_buf)
 }
 
 /**
+ * Receive data (in form of a netbuf) from a UDP or RAW netconn
+ *
+ * @param conn the netconn from which to receive data
+ * @param new_buf pointer where a new netbuf is stored when received data
+ * @param apiflags flags that control function behaviour. For now only:
+ * - NETCONN_DONTBLOCK: only read data that is available now, don't wait for more data
+ * @return ERR_OK if data has been received, an error code otherwise (timeout,
+ *                memory error or another error)
+ *         ERR_ARG if conn is not a UDP/RAW netconn
+ */
+err_t
+netconn_recv_udp_raw_netbuf_flags(struct netconn *conn, struct netbuf **new_buf, u8_t apiflags)
+{
+  LWIP_ERROR("netconn_recv_udp_raw_netbuf: invalid conn", (conn != NULL) &&
+                                                          NETCONNTYPE_GROUP(netconn_type(conn)) != NETCONN_TCP, return ERR_ARG;);
+
+  return netconn_recv_data(conn, (void **)new_buf);
+}
+
+/**
  * Receive data (in form of a netbuf containing a packet buffer) from a netconn
  *
  * @param conn the netconn from which to receive data

--- a/components/lwip/api/api_msg.c
+++ b/components/lwip/api/api_msg.c
@@ -212,12 +212,10 @@ recv_udp(void *arg, struct udp_pcb *pcb, struct pbuf *p,
     ip_addr_set(&buf->addr, addr);
     buf->port = port;
 #if LWIP_NETBUF_RECVINFO
-    {
+    if (conn->flags & NETCONN_FLAG_PKTINFO) {
       /* get the UDP header - always in the first pbuf, ensured by udp_input */
-      const struct udp_hdr* udphdr = (const struct udp_hdr*)ip_next_header_ptr();
-#if LWIP_CHECKSUM_ON_COPY
+      const struct udp_hdr *udphdr = (const struct udp_hdr *)ip_next_header_ptr();
       buf->flags = NETBUF_FLAG_DESTADDR;
-#endif /* LWIP_CHECKSUM_ON_COPY */
       ip_addr_set(&buf->toaddr, ip_current_dest_addr());
       buf->toport_chksum = udphdr->dest;
     }

--- a/components/lwip/include/lwip/lwip/api.h
+++ b/components/lwip/include/lwip/lwip/api.h
@@ -61,6 +61,8 @@ extern "C" {
 #define NETCONN_DONTBLOCK 0x04
 
 /* Flags for struct netconn.flags (u8_t) */
+/** This netconn had an error, don't block on recvmbox/acceptmbox any more */
+#define NETCONN_FLAG_MBOXCLOSED               0x01
 /** Should this netconn avoid blocking? */
 #define NETCONN_FLAG_NON_BLOCKING             0x02
 /** Was the last connect action a non-blocking one? */

--- a/components/lwip/include/lwip/lwip/api.h
+++ b/components/lwip/include/lwip/lwip/api.h
@@ -77,6 +77,10 @@ extern "C" {
     dual-stack usage by default. */
 #define NETCONN_FLAG_IPV6_V6ONLY              0x20
 #endif /* LWIP_IPV6 */
+#if LWIP_NETBUF_RECVINFO
+/** Received packet info will be recorded for this netconn */
+#define NETCONN_FLAG_PKTINFO                  0x40
+#endif /* LWIP_NETBUF_RECVINFO */
 
 
     /* Helpers to process several netconn_types by the same code */
@@ -272,6 +276,7 @@ err_t   netconn_disconnect (struct netconn *conn);
 err_t   netconn_listen_with_backlog(struct netconn *conn, u8_t backlog);
 #define netconn_listen(conn) netconn_listen_with_backlog(conn, TCP_DEFAULT_LISTEN_BACKLOG)
 err_t   netconn_accept(struct netconn *conn, struct netconn **new_conn);
+err_t   netconn_recv_udp_raw_netbuf_flags(struct netconn *conn, struct netbuf **new_buf, u8_t apiflags);
 err_t   netconn_recv(struct netconn *conn, struct netbuf **new_buf);
 err_t   netconn_recv_tcp_pbuf(struct netconn *conn, struct pbuf **new_buf);
 void    netconn_recved(struct netconn *conn, u32_t length);

--- a/components/lwip/include/lwip/lwip/ip_addr.h
+++ b/components/lwip/include/lwip/lwip/ip_addr.h
@@ -67,6 +67,9 @@ extern const ip_addr_t ip_addr_any_type;
 #define IP_IS_ANY_TYPE_VAL(ipaddr)    (IP_GET_TYPE(&ipaddr) == IPADDR_TYPE_ANY)
 #define IPADDR_ANY_TYPE_INIT          { { { { 0ul, 0ul, 0ul, 0ul } } }, IPADDR_TYPE_ANY }
 
+#define IP_IS_V4_VAL(ipaddr)          (IP_GET_TYPE(&ipaddr) == IPADDR_TYPE_V4)
+#define IP_IS_V4(ipaddr)              (((ipaddr) == NULL) || IP_IS_V4_VAL(*(ipaddr)))
+
 #define IP_IS_V6_VAL(ipaddr)          (IP_GET_TYPE(&ipaddr) == IPADDR_TYPE_V6)
 #define IP_IS_V6(ipaddr)              (((ipaddr) != NULL) && IP_IS_V6_VAL(*(ipaddr)))
 

--- a/components/lwip/include/lwip/lwip/netbuf.h
+++ b/components/lwip/include/lwip/lwip/netbuf.h
@@ -56,9 +56,7 @@ struct netbuf {
   ip_addr_t addr;
   u16_t port;
 #if LWIP_NETBUF_RECVINFO || LWIP_CHECKSUM_ON_COPY
-#if LWIP_CHECKSUM_ON_COPY
   u8_t flags;
-#endif /* LWIP_CHECKSUM_ON_COPY */
   u16_t toport_chksum;
 #if LWIP_NETBUF_RECVINFO
   ip_addr_t toaddr;

--- a/components/lwip/include/lwip/lwip/opt.h
+++ b/components/lwip/include/lwip/lwip/opt.h
@@ -975,7 +975,7 @@
  * LWIP_NETBUF_RECVINFO==1: append destination addr and port to every netbuf.
  */
 #ifndef LWIP_NETBUF_RECVINFO
-#define LWIP_NETBUF_RECVINFO            0
+#define LWIP_NETBUF_RECVINFO            1
 #endif
 
 /*

--- a/components/lwip/include/lwip/lwip/pbuf.h
+++ b/components/lwip/include/lwip/lwip/pbuf.h
@@ -137,6 +137,9 @@ struct pbuf {
    */
   u16_t ref;
 
+  /** For incoming packets, this contains the input netif's index */
+  u8_t if_idx;
+
 #if ESP_LWIP
   struct netif *l2_owner;
   void *l2_buf;

--- a/components/lwip/include/lwip/port/lwipopts.h
+++ b/components/lwip/include/lwip/port/lwipopts.h
@@ -770,6 +770,7 @@ enum {
 #define CHECKSUM_CHECK_IP               0
 
 #define LWIP_NETCONN_FULLDUPLEX         1
+#define LWIP_NETBUF_RECVINFO            1
 #define LWIP_NETCONN_SEM_PER_THREAD     1
 
 #define LWIP_DHCP_MAX_NTP_SERVERS       CONFIG_LWIP_DHCP_MAX_NTP_SERVERS


### PR DESCRIPTION
Hi guys, as discussed in issue #1460, this is updating LwIP with the latest changes to support recvmsg(). There are no automatic unit tests for this, so I have only done some manual regression testing and it did not seem to break anything. Also the recvmsg() functionality is working as intended. Just to be clear this is not my code, but rather directly taken from upstream LwIP, so all the licenses apply. Unfortunately the esp-idf implementation is customised extensively, so a bona-fide patch did not work and I had to copy specific parts manually. 

There are some dodgy bits that I did not know what to do with (i.e. coap). These are generally annotated with a FIXME.

Looking for feedback at the moment more than an actual merge. Happy to donate time to this, i.e. for writing up some unit tests.