### PR TITLE
This is a fix for the esp_log_level_set function. The problem is when…

### DIFF
--- a/components/log/log.c
+++ b/components/log/log.c
@@ -164,7 +164,7 @@ void esp_log_level_set(const char* tag, esp_log_level_t level)
 #ifdef LOG_BUILTIN_CHECKS
         assert(i == 0 || s_log_cache[(i - 1) / 2].generation < s_log_cache[i].generation);
 #endif
-        if (s_log_cache[i].tag == tag) {
+        if (strcmp(s_log_cache[i].tag,tag) == 0) {
             s_log_cache[i].level = level;
             break;
         }


### PR DESCRIPTION
… this

function is called but NOT withe the same 'c' string constant that the LOG*
calls used in each module, the cache check doesn't match, so the cached
entry won't get updated. There's no point in optimizing this function
anyway because it is only called rarely.