### PR TITLE
Set direction of SMI pins MDC and MDIO correctly.

### DIFF
--- a/components/ethernet/eth_phy/phy_common.c
+++ b/components/ethernet/eth_phy/phy_common.c
@@ -40,8 +40,12 @@ void phy_rmii_configure_data_interface_pins(void)
 
 void phy_rmii_smi_configure_pins(uint8_t mdc_gpio, uint8_t mdio_gpio)
 {
+    // setup SMI MDC pin
+    gpio_set_direction(mdc_gpio, GPIO_MODE_OUTPUT);
     gpio_matrix_out(mdc_gpio, EMAC_MDC_O_IDX, 0, 0);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[mdc_gpio], PIN_FUNC_GPIO);
+    // setup SMI MDIO pin
+    gpio_set_direction(mdio_gpio, GPIO_MODE_INPUT_OUTPUT);
     gpio_matrix_out(mdio_gpio, EMAC_MDO_O_IDX, 0, 0);
     gpio_matrix_in(mdio_gpio, EMAC_MDI_I_IDX, 0);
     PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[mdio_gpio], PIN_FUNC_GPIO);


### PR DESCRIPTION
Some `GPIOs` do not have the correct default settings for `SMI`.
This PR solves a problem with e.g. `MDIO` on `GPIO32` https://github.com/espressif/arduino-esp32/issues/744#issuecomment-363797043