### PR TITLE
[api-guides] Remove the THEN keyword from IF

### DIFF
--- a/docs/api-guides/romconsole.rst
+++ b/docs/api-guides/romconsole.rst
@@ -44,7 +44,7 @@ Expressions, Math
 Control
 -------
 
-- IF expression THEN statement - *perform statement if expression is true*
+- IF expression statement - *perform statement if expression is true*
 - FOR variable = start TO end	- *start for block*
 - FOR variable = start TO end STEP value - *start for block with step*
 - NEXT - *end of for block*


### PR DESCRIPTION
Neither the TinyBasicPlus nor the ESP32 variant use the THEN keyword in a IF statement

<img width="377" alt="screen shot 2018-02-09 at 18 03 15" src="https://user-images.githubusercontent.com/325326/36039698-918cdfc4-0dc3-11e8-8950-dce97dcc9264.png">

