### PR TITLE
esp_ping - Document that timeout units are in milliseconds

### DIFF
--- a/components/lwip/apps/ping/esp_ping.c
+++ b/components/lwip/apps/ping/esp_ping.c
@@ -49,11 +49,11 @@ esp_err_t esp_ping_set_target(ping_target_id_t opt_id, void *opt_val, uint32_t o
         break;
     case PING_TARGET_RCV_TIMEO:
         ESP_PING_CHECK_OPTLEN(opt_len, uint32_t);
-        ping_option_info->ping_rcv_timeout = (*(uint32_t *)opt_val) * 1000;
+        ping_option_info->ping_rcv_timeout = (*(uint32_t *)opt_val);
         break;
     case PING_TARGET_DELAY_TIME:
         ESP_PING_CHECK_OPTLEN(opt_len, uint32_t);
-        ping_option_info->ping_delay = (*(uint32_t *)opt_val) * 1000;
+        ping_option_info->ping_delay = (*(uint32_t *)opt_val);
         break;
     case PING_TARGET_ID:
         ESP_PING_CHECK_OPTLEN(opt_len, uint16_t);

--- a/components/lwip/apps/ping/esp_ping.h
+++ b/components/lwip/apps/ping/esp_ping.h
@@ -45,8 +45,8 @@ typedef struct _ping_found {
 typedef enum {
     PING_TARGET_IP_ADDRESS          = 50,   /**< target IP address */
     PING_TARGET_IP_ADDRESS_COUNT    = 51,   /**< target IP address total counter */
-    PING_TARGET_RCV_TIMEO           = 52,   /**< receive timeout */
-    PING_TARGET_DELAY_TIME          = 53,   /**< delay time */
+    PING_TARGET_RCV_TIMEO           = 52,   /**< receive timeout in milliseconds */
+    PING_TARGET_DELAY_TIME          = 53,   /**< delay time in milliseconds */
     PING_TARGET_ID                  = 54,   /**< identifier */
     PING_TARGET_RES_FN              = 55,   /**< ping result callback function */
     PING_TARGET_RES_RESET           = 56    /**< ping result statistic reset */


### PR DESCRIPTION
Remove 1000 multiplier from esp_ping_set_target() parameters that define time