### PR TITLE
Extension to lwip sntp to provide a weak callback notifying us the ti…

### DIFF
--- a/components/lwip/apps/sntp/sntp.c
+++ b/components/lwip/apps/sntp/sntp.c
@@ -199,6 +199,19 @@ static u32_t sntp_last_timestamp_sent[2];
 #endif /* SNTP_CHECK_RESPONSE >= 2 */
 
 /**
+ * Weak callbacks to implement setting system time
+ */
+extern void __attribute__((weak)) sntp_setsystemtime_us(u32_t t, u32_t us)
+{
+  SNTP_SET_SYSTEM_TIME_US(t, us);
+}
+
+extern void __attribute__((weak)) sntp_setsystemtime(u32_t t)
+{
+  SNTP_SET_SYSTEM_TIME(t);
+}
+
+/**
  * SNTP processing of received timestamp
  */
 static void
@@ -214,14 +227,14 @@ sntp_process(u32_t *receive_timestamp)
 
 #if SNTP_CALC_TIME_US
   u32_t us = ntohl(receive_timestamp[1]) / 4295;
-  SNTP_SET_SYSTEM_TIME_US(t, us);
+  sntp_setsystemtime_us(t, us);
   /* display local time from GMT time */
   LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp_process: %s, %"U32_F" us", ctime(&tim), us));
 
 #else /* SNTP_CALC_TIME_US */
 
   /* change system time and/or the update the RTC clock */
-  SNTP_SET_SYSTEM_TIME(t);
+  sntp_setsystemtime(t);
   /* display local time from GMT time */
 
   LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp_process: %s", ctime(&tim)));


### PR DESCRIPTION
Regarding:

https://www.esp32.com/viewtopic.php?f=13&t=4833
and
https://www.esp32.com/viewtopic.php?f=2&t=4695

A few users (vonnieda, loboris, and myself) have asked for a way of overriding, or getting notified of, the SNTP time being set. The use case here is to be able to delay the main application code until we have an accurate clock. The application flow then becomes:

1] Wait for network to come up
- sntp_setoperatingmode(SNTP_OPMODE_POLL);
- sntp_setservername(0, (char*)"pool.ntp.org");
- sntp_init();

2] Wait for SNTP time to be set
- Continue with application code

Following forum discussions with ESP_Sprite, and ESP_Angus, this patch implements a mechanism for [2], using weak linked overridable functions.

User code can then override
  void sntp_setsystemtime_us(u32_t t, u32_t us)
to be notified of, and set, system time.

For compatibility and completeness, we have also provided a void sntp_setsystemtime(u32_t t), although this does not seem to be required for the standard ESP32 environment.