### PR TITLE
Update rmt.c - Fixes exceptions LoadProhibited in RMT driver

### DIFF
--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -540,6 +540,10 @@ static void IRAM_ATTR rmt_driver_isr_default(void* arg)
             if(intr_st & BIT(i)) {
                 channel = i / 3;
                 rmt_obj_t* p_rmt = p_rmt_obj[channel];
+                if(NULL == p_rmt) {
+                    RMT.int_clr.val = BIT(i);
+                    continue;
+                }
                 switch(i % 3) {
                     //TX END
                     case 0:


### PR DESCRIPTION
Fixes exceptions LoadProhibited, when rmt tries read variable p_rmt on RX END which can be 0.
It happens after esp_reset()  (OTA) and the rmt is not probably stopped by it.
In other words the routine rmt_driver_isr_default was called before second rx channel was registered.

scenario:
register tx channel
register rx channel
reboot
register tx channel
-> exception (because rx channel is accessed)