### PR TITLE
Add option to enable/disable ble service change registration

### DIFF
--- a/components/bt/Kconfig
+++ b/components/bt/Kconfig
@@ -34,7 +34,7 @@ choice BTDM_CONTROLLER_HCI_MODE_CHOICE
 
 config BTDM_CONTROLLER_HCI_MODE_VHCI
     bool "VHCI"
-    help 
+    help
         Normal option. Mostly, choose this VHCI when bluetooth host run on ESP32, too.
 
 config BTDM_CONTROLLER_HCI_MODE_UART_H4
@@ -119,7 +119,7 @@ config A2DP_ENABLE
     default n
     help
         Advanced Audio Distrubution Profile
-    
+
 choice A2DP_ROLE
     prompt "A2DP ROLE config"
     depends on A2DP_ENABLE
@@ -150,7 +150,7 @@ config BT_SPP_ENABLED
 config GATTS_ENABLE
     bool "Include GATT server module(GATTS)"
     depends on BLUEDROID_ENABLED
-    default y 
+    default y
     help
         This option can be disabled when the app work only on gatt client mode
 
@@ -168,6 +168,15 @@ config BLE_SMP_ENABLE
    help
        This option can be close when the app not used the ble security connect.
 
+config BLE_ENABLE_SRVCHG_REG
+    bool "Enable automatic service change notify registration"
+    depends on BLUEDROID_ENABLED
+    default y
+    help
+        This option enables automatic registration of service change notification
+        after connect. Be careful, it can may collide with your command sequences
+        and lead to GATT_BUSY.
+
 config BT_STACK_NO_LOG
     bool "Close the bluedroid bt stack log print"
     depends on BLUEDROID_ENABLED
@@ -180,7 +189,7 @@ config BT_ACL_CONNECTIONS
     depends on BLUEDROID_ENABLED
     range 1 7
     default 4
-    help 
+    help
         Maximum BT/BLE connection count
 
 config BT_ALLOCATION_FROM_SPIRAM_FIRST
@@ -201,7 +210,7 @@ config SMP_ENABLE
    bool
    depends on BLUEDROID_ENABLED
    default CLASSIC_BT_ENABLED || BLE_SMP_ENABLE
-   
+
 # Memory reserved at start of DRAM for Bluetooth stack
 config BT_RESERVE_DRAM
     hex

--- a/components/bt/bluedroid/bta/gatt/bta_gattc_act.c
+++ b/components/bt/bluedroid/bta/gatt/bta_gattc_act.c
@@ -1233,7 +1233,7 @@ void bta_gattc_read_cmpl(tBTA_GATTC_CLCB *p_clcb, tBTA_GATTC_OP_CMPL *p_data)
     } else {
         cb_data.read.handle = p_clcb->p_q_cmd->api_read.handle;
     }
-    
+
     if (p_clcb->p_q_cmd->hdr.event != BTA_GATTC_API_READ_MULTI_EVT) {
         event = p_clcb->p_q_cmd->api_read.cmpl_evt;
     } else {
@@ -1625,7 +1625,9 @@ static void bta_gattc_conn_cback(tGATT_IF gattc_if, BD_ADDR bda, UINT16 conn_id,
 
     if ((transport == BT_TRANSPORT_LE) && (connected == TRUE) && (p_conn != NULL) \
          && (p_conn->service_change_ccc_written == FALSE) && (p_conn->ccc_timer_used == FALSE)) {
+#ifdef CONFIG_BLE_ENABLE_SRVCHG_REG
         result = bta_gattc_register_service_change_notify(conn_id, bda, &start_ccc_timer);
+#endif
         if (start_ccc_timer == TRUE) {
             TIMER_LIST_ENT *ccc_timer = &(p_conn->service_change_ccc_timer);
             /* start a 1000ms timer to wait for service discovery finished */


### PR DESCRIPTION
Add option to enable/disable automatic registration of BLE Gattc
service change notify. Which sends in paralel
(with user message flow) commands to BLE server which
sometime leads to GATT_BUSY.

Solving Issue 1575