### PR TITLE
Place libc gettimeofday function in IRAM

### DIFF
--- a/components/esp32/ld/esp32.spiram.rom-functions-iram.ld
+++ b/components/esp32/ld/esp32.spiram.rom-functions-iram.ld
@@ -142,3 +142,4 @@
     *lib_a-strdup_r.o(.literal .text .literal.* .text.*)
     *lib_a-system.o(.literal .text .literal.* .text.*)
     *lib_a-strndup_r.o(.literal .text .literal.* .text.*)
+    *lib_a-sysgettod.o(.literal .text .literal.* .text.*)


### PR DESCRIPTION
When calling ``gettimeofday()`` from the IDF, the whole call chain resides in IRAM, except for gettimeofday from libc which makes impossible to use this functionality inside interrupt context when the cache is disabled. Adding this line in the ld script fixes the problem.