### PR TITLE
Bugfix GPIO_DIS_OUTPUT to work with pin 32 and up

### DIFF
--- a/components/esp32/include/rom/gpio.h
+++ b/components/esp32/include/rom/gpio.h
@@ -57,8 +57,8 @@ typedef enum {
 #define GPIO_OUTPUT_SET(gpio_no, bit_value) \
         ((gpio_no < 32) ? gpio_output_set(bit_value<<gpio_no, (bit_value ? 0 : 1)<<gpio_no, 1<<gpio_no,0) : \
                          gpio_output_set_high(bit_value<<(gpio_no - 32), (bit_value ? 0 : 1)<<(gpio_no - 32), 1<<(gpio_no -32),0))
-#define GPIO_DIS_OUTPUT(gpio_no)    ((gpio_no < 32) ? gpio_output_set(0,0,0, 1<<gpio_no) : gpio_output_set_high(0,0,0, 1<<gpio_no))
-#define GPIO_INPUT_GET(gpio_no)     ((gpio_no < 32)? ((gpio_input_get()>>gpio_no)&BIT0) : ((gpio_input_get_high()>>(gpio_no - 32))&BIT0))
+#define GPIO_DIS_OUTPUT(gpio_no)    ((gpio_no < 32) ? gpio_output_set(0,0,0, 1<<gpio_no) : gpio_output_set_high(0,0,0, 1<<(gpio_no - 32)))
+#define GPIO_INPUT_GET(gpio_no)     ((gpio_no < 32) ? ((gpio_input_get()>>gpio_no)&BIT0) : ((gpio_input_get_high()>>(gpio_no - 32))&BIT0))
 
 /* GPIO interrupt handler, registered through gpio_intr_handler_register */
 typedef void (* gpio_intr_handler_fn_t)(uint32_t intr_mask, bool high, void *arg);


### PR DESCRIPTION
gpio_output_set_high expect bit0 for pin32, therefore we need to shift value with 32 bits.