### PR TITLE
Allow custom types as suggested by the partition table documentation (IDFGH-2882)

### DIFF
--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -96,7 +96,7 @@ typedef struct esp_partition_iterator_opaque_* esp_partition_iterator_t;
  * However, this is the format used by this API.
  */
 typedef struct {
-    esp_partition_type_t type;          /*!< partition type (app/data) */
+    uint8_t type;			            /*!< partition type (app/data) */
     esp_partition_subtype_t subtype;    /*!< partition subtype */
     uint32_t address;                   /*!< starting address of the partition in flash */
     uint32_t size;                      /*!< size of the partition, in bytes */
@@ -119,7 +119,7 @@ typedef struct {
  *         Iterator obtained through this function has to be released
  *         using esp_partition_iterator_release when not used any more.
  */
-esp_partition_iterator_t esp_partition_find(esp_partition_type_t type, esp_partition_subtype_t subtype, const char* label);
+esp_partition_iterator_t esp_partition_find(uint8_t type, esp_partition_subtype_t subtype, const char* label);
 
 /**
  * @brief Find first partition based on one or more parameters
@@ -134,7 +134,7 @@ esp_partition_iterator_t esp_partition_find(esp_partition_type_t type, esp_parti
  * @return pointer to esp_partition_t structure, or NULL if no partition is found.
  *         This pointer is valid for the lifetime of the application.
  */
-const esp_partition_t* esp_partition_find_first(esp_partition_type_t type, esp_partition_subtype_t subtype, const char* label);
+const esp_partition_t* esp_partition_find_first(uint8_t type, esp_partition_subtype_t subtype, const char* label);
 
 /**
  * @brief Get esp_partition_t structure for given partition

--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -96,7 +96,7 @@ typedef struct esp_partition_iterator_opaque_* esp_partition_iterator_t;
  * However, this is the format used by this API.
  */
 typedef struct {
-    uint8_t type;			            /*!< partition type (app/data) */
+    uint8_t type;                       /*!< partition type (app/data) */
     esp_partition_subtype_t subtype;    /*!< partition subtype */
     uint32_t address;                   /*!< starting address of the partition in flash */
     uint32_t size;                      /*!< size of the partition, in bytes */

--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -58,7 +58,7 @@ static SLIST_HEAD(partition_list_head_, partition_list_item_) s_partition_list =
 static _lock_t s_partition_list_lock;
 
 
-esp_partition_iterator_t esp_partition_find(esp_partition_type_t type,
+esp_partition_iterator_t esp_partition_find(uint8_t type,
         esp_partition_subtype_t subtype, const char* label)
 {
     if (SLIST_EMPTY(&s_partition_list)) {
@@ -115,7 +115,7 @@ esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t it)
     return it;
 }
 
-const esp_partition_t* esp_partition_find_first(esp_partition_type_t type,
+const esp_partition_t* esp_partition_find_first(uint8_t type,
         esp_partition_subtype_t subtype, const char* label)
 {
     esp_partition_iterator_t it = esp_partition_find(type, subtype, label);


### PR DESCRIPTION
The [partition table documentation](http://esp-idf.readthedocs.io/en/latest/api-guides/partition-tables.html#type-field) explicitly recommends defining custom partition types:

> If your application needs to store data, please add a custom partition type in the range 0x40-0xFE.

But there’s _no way_ to use these custom partition types with the partition API. Both `esp_partition_find(…)` and `esp_partition_find_first(…)` demand a `esp_partition_type_t` specifying the partition type.

This PR changes the `type` parameters of these two functions to `uint8_t` to allow custom types.