### PR TITLE
Feature: Makefile EXCLUDE_COMPONENTS

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -123,6 +123,7 @@ These variables all have default values that can be overridden for custom behavi
 - ``COMPONENT_DIRS``: Directories to search for components. Defaults to `$(IDF_PATH)/components`, `$(PROJECT_PATH)/components`, ``$(PROJECT_PATH)/main`` and ``EXTRA_COMPONENT_DIRS``. Override this variable if you don't want to search for components in these places.
 - ``EXTRA_COMPONENT_DIRS``: Optional list of additional directories to search for components.
 - ``COMPONENTS``: A list of component names to build into the project. Defaults to all components found in the COMPONENT_DIRS directories.
+- ``EXCLUDE_COMPONENTS``: Optional list of component names to exclude during the build process. Note that this decreases build time, but not binary size.
 
 Any paths in these Makefile variables should be absolute paths. You can convert relative paths using ``$(PROJECT_PATH)/xxx``, ``$(IDF_PATH)/xxx``, or use the Make function ``$(abspath xxx)``.
 

--- a/make/project.mk
+++ b/make/project.mk
@@ -150,6 +150,10 @@ COMPONENTS := $(dir $(foreach cd,$(COMPONENT_DIRS),                           \
 				))
 COMPONENTS := $(sort $(foreach comp,$(COMPONENTS),$(lastword $(subst /, ,$(comp)))))
 endif
+# After a full manifest of component names is determined, subtract the ones explicitly omitted by the project Makefile.
+ifdef EXCLUDE_COMPONENTS
+COMPONENTS := $(filter-out $(EXCLUDE_COMPONENTS), $(COMPONENTS))
+endif
 export COMPONENTS
 
 # Resolve all of COMPONENTS into absolute paths in COMPONENT_PATHS.
@@ -511,6 +515,9 @@ list-components:
 	$(info $(call dequote,$(SEPARATOR)))
 	$(info COMPONENTS (list of component names))
 	$(info $(COMPONENTS))
+	$(info $(call dequote,$(SEPARATOR)))
+	$(info EXCLUDE_COMPONENTS (list of excluded names))
+	$(info $(if $(EXCLUDE_COMPONENTS),$(EXCLUDE_COMPONENTS),(none provided)))	
 	$(info $(call dequote,$(SEPARATOR)))
 	$(info COMPONENT_PATHS (paths to all components):)
 	$(foreach cp,$(COMPONENT_PATHS),$(info $(cp)))


### PR DESCRIPTION
Add project build variable, readthedocs.io documentation for EXCLUDE_COMPONENTS

Target audience: CI/team build environments, VM/ARM/legacy users, component developers