### PR TITLE
bugfix/sdspi_host.c: wrong CD/WP pin configuration

### DIFF
--- a/components/driver/sdspi_host.c
+++ b/components/driver/sdspi_host.c
@@ -316,16 +316,16 @@ esp_err_t sdspi_host_init_slot(int slot, const sdspi_slot_config_t* slot_config)
     };
     if (slot_config->gpio_cd != SDSPI_SLOT_NO_CD) {
         io_conf.pin_bit_mask |= (1 << slot_config->gpio_cd);
-        s_slots[slot].gpio_wp = slot_config->gpio_wp;
+        s_slots[slot].gpio_cd = slot_config->gpio_cp;
     } else {
-        s_slots[slot].gpio_wp = GPIO_UNUSED;
+        s_slots[slot].gpio_cd = GPIO_UNUSED;
     }
 
     if (slot_config->gpio_wp != SDSPI_SLOT_NO_WP) {
         io_conf.pin_bit_mask |= (1 << slot_config->gpio_wp);
-        s_slots[slot].gpio_cd = slot_config->gpio_cd;
+        s_slots[slot].gpio_wp = slot_config->gpio_wp;
     } else {
-        s_slots[slot].gpio_cd = GPIO_UNUSED;
+        s_slots[slot].gpio_wp = GPIO_UNUSED;
     }
 
     if (io_conf.pin_bit_mask != 0) {


### PR DESCRIPTION
Looks like the configuration of CP and WP pins are wrong, since the check for `gpio_cd` and `gpio_wp` in `slot_config` seems to be swapped.