### PR TITLE
Initial support for uart RS485 half duplex

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -738,6 +738,20 @@ int uart_pattern_get_pos(uart_port_t uart_num);
  */
 esp_err_t uart_pattern_queue_reset(uart_port_t uart_num, int queue_length);
 
+/**
+ * @brief Enable or disables RS485 half duplex mode. Note, hardware flow control must be disabled to enable RS485.
+ *        We have the option to support a half-duplex transceiver by toggling the RTS pin to manually control
+          data direction. If using a Auto direction control transceiver then the RTS pin isn't required.
+ *        Currently the code enables collision detection interrupt and simply resets the RX FIFO on detection.
+ * @param uart_num UART port number.
+ * @param enable Enabled or disable RS485 mode.
+ * @param tx_rx_en Enable the transmitter’s output signal to be fed to the receiver’s input signal mainly.
+ * @param rx_busy_tx_en Enable the RS-485 transmitter to send data when the RS-485 receiver line is busy.
+ * @return
+ *     - ESP_OK Success
+ */
+esp_err_t uart_set_rs485(uart_port_t uart_num, bool enable, bool tx_rx_en, bool rx_busy_tx_en);
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/peripherals/uart_rs485_echo/Makefile
+++ b/examples/peripherals/uart_rs485_echo/Makefile
@@ -1,0 +1,9 @@
+#
+# This is a project Makefile. It is assumed the directory this Makefile resides in is a
+# project subdirectory.
+#
+
+PROJECT_NAME := uart_rs485_echo
+
+include $(IDF_PATH)/make/project.mk
+

--- a/examples/peripherals/uart_rs485_echo/README.md
+++ b/examples/peripherals/uart_rs485_echo/README.md
@@ -1,0 +1,25 @@
+# RS485 Half duplex UART Echo Example
+
+This is an example which echoes any data it receives on UART1 back to the sender.
+
+## Setup
+
+1. Connect an external serial RS485 transceiver (eg SparkFun Transceiver RS485 Breakout or XY-017 RS485 to TTL Module)
+   to an ESP32 board. Note the RTS pin is optional depending on whether the transceiver requires data direction control or not.
+   If using RTS ensure logic levels are correct way round for TX/RX.
+   The external interface needs to be 3.3V compatible. Default baud is 115200 and parity is even.
+
+  | ESP32 Interface | #define | ESP32 Pin | External UART Pin |
+  | --- | --- | --- | --- |
+  | Transmit Data (TxD) | ECHO_TEST_TXD | GPIO4 | RxD |
+  | Receive Data (RxD) | ECHO_TEST_RXD | GPIO5 | TxD |
+  | RTS (RTS) | ECHO_TEST_RTS | GPIO18 | RTS or direction control pin|
+  | Ground | n/a | GND | GND |
+
+2. Ensure baud rate and parity are correct, amend code as required.
+3. Compile and load the example to the ESP32 board.
+5. From a another node on the RS485 bus set up a serial terminal program to the same settings as of UART1 in ESP32
+6. Open the external serial interface in the terminal
+7. When typing any character in the terminal you should see it echoed back
+
+See the README.md file in the upper level 'examples' directory for more information about examples.

--- a/examples/peripherals/uart_rs485_echo/main/component.mk
+++ b/examples/peripherals/uart_rs485_echo/main/component.mk
@@ -1,0 +1,3 @@
+#
+# Main Makefile. This is basically the same as a component makefile.
+#

--- a/examples/peripherals/uart_rs485_echo/main/rs485_echo.c
+++ b/examples/peripherals/uart_rs485_echo/main/rs485_echo.c
@@ -1,0 +1,89 @@
+/*
+ *  @Copyright 2018 Jasbir Matharu
+ *  RS485 half duplex data direction control echo example using UART.
+ *
+ *  This example code is in the Public Domain (or CC0 licensed, at your option.)
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *  CONDITIONS OF ANY KIND, either express or implied.
+ */
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+
+/**
+ * This example was tested with a SP3485 RS485 breakout board (i.e SparkFun Transceiver Breakout) 
+ * which host a RTS pin for data direction control. In this example any data the UART receives is 
+ * sent back to the sender by toggling the RTS to set the direction. 
+ * It was also tested with a XY-017 RS485 to TTL Module (Auto Direction Transceiver) with the RTS 
+ * pin disabled and uart_set_rts commented out.
+ *
+ * - Port: UART1
+ * - Pin assignment: see defines below
+ */
+
+#define ECHO_TEST_TXD  (GPIO_NUM_4)
+#define ECHO_TEST_RXD  (GPIO_NUM_5)
+// Set ECHO_TEST_RTS to 'UART_PIN_NO_CHANGE' if using a Auto Direction Transceiver
+#define ECHO_TEST_RTS  (18)
+#define ECHO_TEST_CTS  (UART_PIN_NO_CHANGE)
+
+#define BUF_SIZE (1024)
+
+// Enable these to dump the contents received
+#define DEBUG_RX_DUMP 1
+#define DEBUG_RX_DUMP_HEX 0
+
+static void echo_task()
+{
+    /* Configure parameters of an UART driver,
+     * communication pins and install the driver */
+    uart_config_t uart_config = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity    = UART_PARITY_EVEN,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+    };
+    uart_param_config(UART_NUM_1, &uart_config);
+    // For RS485 disable tx/rx loopback and enable tx while rx is busy. 
+    uart_set_rs485(UART_NUM_1,true,false,true);
+    uart_set_pin(UART_NUM_1, ECHO_TEST_TXD, ECHO_TEST_RXD, ECHO_TEST_RTS, ECHO_TEST_CTS);
+    uart_driver_install(UART_NUM_1, BUF_SIZE * 2, 0, 0, NULL, 0);
+
+    // Configure a temporary buffer for the incoming data
+    uint8_t *data = (uint8_t *) malloc(BUF_SIZE);
+       
+    while (1) {
+        // Enabe RX by toggling RTS to high
+        uart_set_rts(UART_NUM_1,1);
+        int len = uart_read_bytes(UART_NUM_1, data, BUF_SIZE, 500 / portTICK_RATE_MS);
+        // Reset RTS to low for TX
+        uart_set_rts(UART_NUM_1,0);
+        if (len >0) {
+#if DEBUG_RX_DUMP == 1
+            int i=0;
+            for (i=0;i<len;i++) {
+#if DEBUG_RX_DUMP_HEX == 1
+                printf("%02X ",*(data+i));
+#else 
+                printf("%c",*(data+i));
+#endif // DEBUG_RX_DUMP_HEX 
+            }
+            printf(" %d \r\n",len);
+#endif // DEBUG_RX_DUMP
+
+            // Write data back to the UART
+            uart_write_bytes(UART_NUM_1, (const char *) data, len);
+            // Wait for tx fifo empty as we are in half duplex mode 
+            uart_wait_tx_done(UART_NUM_1,500 / portTICK_RATE_MS);
+        }
+    }
+}
+
+void app_main()
+{
+    xTaskCreate(echo_task, "rs485_echo_task", 2048, NULL, 10, NULL);
+}


### PR DESCRIPTION
This is my attempt at creating a cleaner fix for adding RS485 half duplex support. An simple echo example is also povided. 

Compared to a previous [PR 667](https://github.com/espressif/esp-idf/pull/667)  the benefits are:

1. Data direction control via the RTS pin can be done in the application code dependent on the RS485 transceiver code deployed.
2. Spurious break characters shouldn't occur in the RX FIFO.
3. The collision detection interrupt is handled. 