### PR TITLE
Avoid writing to file under critical section in esp_pm_dump_locks

### DIFF
--- a/components/esp32/pm_locks.c
+++ b/components/esp32/pm_locks.c
@@ -174,26 +174,29 @@ esp_err_t esp_pm_dump_locks(FILE* stream)
 
     fprintf(stream, "Lock stats:\n");
     esp_pm_lock_t* it;
+    esp_pm_lock_t lock;
     SLIST_FOREACH(it, &s_list, next) {
         portENTER_CRITICAL(&it->spinlock);
-        if (it->name == NULL) {
+        lock = *it;
+        portEXIT_CRITICAL(&it->spinlock);
+        if (lock.name == NULL) {
             fprintf(stream, "lock@%p ", it);
         } else {
-            fprintf(stream, "%-15s ", it->name);
+            fprintf(stream, "%-15s ", lock.name);
         }
 #ifdef WITH_PROFILING
-        pm_time_t time_held = it->time_held;
-        if (it->count > 0) {
-            time_held += cur_time - it->last_taken;
+        pm_time_t time_held = lock.time_held;
+        if (lock.count > 0) {
+            time_held += cur_time - lock.last_taken;
         }
         fprintf(stream, "%10s  %3d  %3d  %9d  %9lld  %3lld%%\n",
-                s_lock_type_names[it->type], it->arg,
-                it->count, it->times_taken, time_held,
+                s_lock_type_names[lock.type], lock.arg,
+                lock.count, lock.times_taken, time_held,
                 (time_held + cur_time_d100 - 1) / cur_time_d100);
 #else
-        fprintf(stream, "%10s  %3d  %3d\n", s_lock_type_names[it->type], it->arg, it->count);
+        fprintf(stream, "%10s  %3d  %3d\n",
+                s_lock_type_names[lock.type], lock.arg, lock.count);
 #endif // WITH_PROFILING
-        portEXIT_CRITICAL(&it->spinlock);
     }
     _lock_release(&s_list_lock);
 #ifdef WITH_PROFILING


### PR DESCRIPTION
Function esp_pm_dump_locks writes to a file descriptor under critical section.
This results in an interrupt watchdog timeout if the underlying FS driver is
interrupt based. An example where this problem is seen is when calling the function
with stdout file descriptor and stdout being registered to a UART with
esp_vfs_dev_uart_use_driver.

Fix the problem by only copying needed data under critical section and do the
actual file writing with interrupts enabled.

Fixes https://github.com/espressif/esp-idf/issues/1917

Signed-off-by: Mikael Kanstrup <mikael.kanstrup@sony.com>