### PR TITLE
cmakelists: move spi_flash to COMPONENT_REQUIRES

### DIFF
--- a/components/app_update/CMakeLists.txt
+++ b/components/app_update/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(COMPONENT_SRCDIRS ".")
 set(COMPONENT_ADD_INCLUDEDIRS "include")
 
-set(COMPONENT_REQUIRES "")
-set(COMPONENT_PRIV_REQUIRES bootloader_support spi_flash)
+set(COMPONENT_REQUIRES spi_flash)
+set(COMPONENT_PRIV_REQUIRES bootloader_support)
 
 register_component()


### PR DESCRIPTION
in the include file esp_ota_ops.h "esp_partition.h" is included.
This is from spi_flash so component that requires app_update also will need that

this fixes this error:

  In file included from ../components/esp32-homie/ota.c:11:0:
  /esp-idf/components/app_update/include/esp_ota_ops.h:22:27: fatal error: esp_partition.h: No such file or directory

Signed-off-by: Nicola Lunghi <25422924+nicola-lunghi@users.noreply.github.com>