### PR TITLE
Fix compile error using asm

### DIFF
--- a/components/freertos/include/freertos/portable.h
+++ b/components/freertos/include/freertos/portable.h
@@ -205,7 +205,7 @@ BaseType_t xPortInterruptedFromISRContext();
 /* Multi-core: get current core ID */
 static inline uint32_t IRAM_ATTR xPortGetCoreID() {
     int id;
-    asm (
+    __asm__ (
         "rsr.prid %0\n"
         " extui %0,%0,13,1"
         :"=r"(id));


### PR DESCRIPTION
In function 'xPortGetCoreID':
error: expected ')' before ':' token
         :"=r"(id));

It is recommended to use `__asm__` instead of `asm`

See:
https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html#Alternate-Keywords