### PR TITLE
Enable usage of escape char '\' in string values

### DIFF
--- a/tools/kconfig/confdata.c
+++ b/tools/kconfig/confdata.c
@@ -161,18 +161,12 @@ static int conf_set_sym_val(struct symbol *sym, int def, int def_flags, char *p)
 	case S_STRING:
 		if (*p++ != '"')
 			break;
-		for (p2 = p; (p2 = strpbrk(p2, "\"\\")); p2++) {
-			if (*p2 == '"') {
-				*p2 = 0;
-				break;
-			}
-			memmove(p2, p2 + 1, strlen(p2));
-		}
-		if (!p2) {
+		if(p[strlen(p)-1]!='"') {
 			if (def != S_DEF_AUTO)
 				conf_warning("invalid string found");
 			return 1;
 		}
+		p[strlen(p)-1]=0;
 		/* fall through */
 	case S_INT:
 	case S_HEX:
@@ -623,6 +617,7 @@ static void conf_write_symbol(FILE *fp, struct symbol *sym,
 			      struct conf_printer *printer, void *printer_arg)
 {
 	const char *str;
+	char *str2;
 
 	switch (sym->type) {
 	case S_OTHER:
@@ -630,9 +625,10 @@ static void conf_write_symbol(FILE *fp, struct symbol *sym,
 		break;
 	case S_STRING:
 		str = sym_get_string_value(sym);
-		str = sym_escape_string_value(str);
-		printer->print_symbol(fp, sym, str, printer_arg);
-		free((void *)str);
+		str2 = xmalloc(strlen(str)+2);
+		sprintf(str2, "\"%s\"", str);
+		printer->print_symbol(fp, sym, str2, printer_arg);
+		free((void *)str2);
 		break;
 	default:
 		str = sym_get_string_value(sym);

--- a/tools/kconfig/symbol.c
+++ b/tools/kconfig/symbol.c
@@ -911,49 +911,6 @@ const char *sym_expand_string_value(const char *in)
 	return res;
 }
 
-const char *sym_escape_string_value(const char *in)
-{
-	const char *p;
-	size_t reslen;
-	char *res;
-	size_t l;
-
-	reslen = strlen(in) + strlen("\"\"") + 1;
-
-	p = in;
-	for (;;) {
-		l = strcspn(p, "\"\\");
-		p += l;
-
-		if (p[0] == '\0')
-			break;
-
-		reslen++;
-		p++;
-	}
-
-	res = xmalloc(reslen);
-	res[0] = '\0';
-
-	strcat(res, "\"");
-
-	p = in;
-	for (;;) {
-		l = strcspn(p, "\"\\");
-		strncat(res, p, l);
-		p += l;
-
-		if (p[0] == '\0')
-			break;
-
-		strcat(res, "\\");
-		strncat(res, p++, 1);
-	}
-
-	strcat(res, "\"");
-	return res;
-}
-
 struct sym_match {
 	struct symbol	*sym;
 	off_t		so, eo;


### PR DESCRIPTION
Allows the use of escape characters in kconfig and sdkconfig string values, allowing the use of unicode characters, etc.