### PR TITLE
Fix PartitionDefinition comparison in Python 3.6

### DIFF
--- a/components/partition_table/gen_esp32part.py
+++ b/components/partition_table/gen_esp32part.py
@@ -250,6 +250,18 @@ class PartitionDefinition(object):
     def __cmp__(self, other):
         return self.offset - other.offset
 
+    def __lt__(self, other):
+        return self.offset < other.offset
+
+    def __gt__(self, other):
+        return self.offset > other.offset
+
+    def __le__(self, other):
+        return self.offset <= other.offset
+
+    def __ge__(self, other):
+        return self.offset >= other.offset
+
     def parse_type(self, strval):
         if strval == "":
             raise InputError("Field 'type' can't be left empty.")


### PR DESCRIPTION
Even though the #577 has been merged last year, there's still a problem with comparison of `PartitionDefinition` objects. The comparison protocol requires all `__lt__`, `__le__`, `__gt__` and `__ge__` methods to be implemented.