### PR TITLE
doc/wifi: small fix

### DIFF
--- a/docs/en/api-guides/wifi.rst
+++ b/docs/en/api-guides/wifi.rst
@@ -699,7 +699,7 @@ Scenario:
         EVENT_TASK <-  WIFI_TASK [label="4.6 > SYSTEM_EVENT_STA_DISCONNECTED"];
         WIFI_TASK  ->  AP        [label="4.7 > 4/4 EAPOL"];
         EVENT_TASK <-  WIFI_TASK [label="4.8 > SYSTEM_EVENT_STA_DISCONNECTED"];
-        EVENT_TASK <-  WIFI_TASK [label="4.9 > SYSTEM_EVENT_STA_DISCONNECTED"];
+        EVENT_TASK <-  WIFI_TASK [label="4.9 > SYSTEM_EVENT_STA_CONNECTED"];
     }
 
 


### PR DESCRIPTION
The WiFi station connect sequence diagram does not have any "successful" ending.
It looks like a copy-paste error, because there are two consequent `SYSTEM_EVENT_STA_DISCONNECTED` events firing with nothing happening in between.

I think the original meaning was that the last event should be `SYSTEM_EVENT_STA_CONNECTED` to signify that if all goes well, that is the event that will be fired.