### PR TITLE
New I2c slave driver (IDFGH-2501)

### DIFF
--- a/components/driver/include/driver/i2c.h
+++ b/components/driver/include/driver/i2c.h
@@ -1,4 +1,5 @@
 // Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+// Copyright (c) 2018 LoBo (https://github.com/loboris)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,7 +110,6 @@ typedef struct {
     uint16_t txptr;       /*!< slave buffer tx pointer */
     uint16_t rxovf;       /*!< slave buffer rx overflow count */
     uint16_t txovf;       /*!< slave buffer tx overflow count */
-    uint16_t bufflen;     /*!< slave buffer length */
     uint16_t ro_len;      /*!< slave buffer read-only area length */
     uint8_t  status;      /*!< slave transaction status */
 } i2c_slave_state_t;
@@ -393,6 +393,21 @@ esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, 
  *     - Others(>=0) The number of data bytes that was pushed to the I2C slave buffer.
  */
 int i2c_slave_write_buffer(i2c_port_t i2c_num, uint8_t* data, int addr, int size, TickType_t ticks_to_wait);
+
+/**
+ * @brief Fill slave buffer
+ *        @note
+ *        Only call this function in I2C slave mode
+ *
+ * @param i2c_num I2C port number
+ * @param val value to fill the buffer with
+ * @param ticks_to_wait Maximum waiting ticks
+ *
+ * @return
+ *     - ESP_FAIL(-1) Parameter error
+ *     - Others(>=0) The number of data bytes that was pushed to the I2C slave buffer.
+ */
+int i2c_slave_set_buffer(i2c_port_t i2c_num, uint8_t val, TickType_t ticks_to_wait);
 
 /**
  * @brief Read data from the slave buffer

--- a/docs/en/api-reference/peripherals/i2c.rst
+++ b/docs/en/api-reference/peripherals/i2c.rst
@@ -265,11 +265,13 @@ By similar token the command link to read from the slave looks as follows::
 Slave Mode
 """"""""""
 
-In **slave mode** i2c device with 128-4096 memory is emulated.
+In **slave mode** i2c device with 128-4096 memory is emulated.<br>
+All master's read/write requests for data are handled by the driver's interrupt routine. The user only needs to provide the initial buffer content and, optionally, to handle the master's request from the slave task.
 
-Master can read from or write to the ESP32 i2c device, providing the memory address to read from or write to.
 
-For buffer sizes 128-265 bytes, 8-bit addressing is used, for buffer sizes >265 bytes, 16-bit addressing is used.
+Master can read from or write to the ESP32 i2c device, providing the memory (buffer) address to read from or write to.
+
+For buffer sizes 128-256 bytes, 8-bit addressing is used, for buffer sizes >256 bytes, 16-bit addressing is used.
 
 .. blockdiag::
     :scale: 100
@@ -407,16 +409,15 @@ For buffer sizes 128-265 bytes, 8-bit addressing is used, for buffer sizes >265 
     }
 
 
-Optional **read only** area at the end of the slave buffer can be set. Master can only read from that area, writting to it will be ignored.
-
-It is up to the user to organize the slave buffer in a way most appropriate for the application.<br>
-Writting to some addresses can, for example, be treated by the slave task as commands with optional arguments.<br>
-Read only area can contain the slave ID, revision number, sensor data etc.
-
+Optional **read only** area at the end of the slave buffer can be set. Master can only read from that area, writting to it by the master will be ignored.
 
 The API provides functions to read and write data from/to the slave buffer at any time - * :cpp:func:`i2c_slave_read_buffer` and :cpp:func:`i2c_slave_write_buffer`.
-I2C slave **task** can be created which receives notifications from the i2c driver about the slave events: **address set**, **data sent to master**, **data received from master**.
+I2C **slave task** can be created which receives notifications from the i2c driver about the slave events: **address set**, **data sent to master**, **data received from master**.
  Slave buffer address, number of bytes sent or received and overflow status are available to the slave task to take some action an slave events.
+
+It is up to the user to organize the slave buffer in a way most appropriate for the application.<br>
+Writting to some addresses can, for example, be treated by the **slave task** as commands with optional arguments.<br>
+Read only area can contain the slave ID, revision number, sensor data etc.
 
 An example of using these functions is provided in :example:`peripherals/i2c`.
 

--- a/examples/peripherals/i2c/main/i2c_example_main.c
+++ b/examples/peripherals/i2c/main/i2c_example_main.c
@@ -10,6 +10,7 @@
    CONDITIONS OF ANY KIND, either express or implied.
 */
 #include <stdio.h>
+#include <string.h>
 #include "driver/i2c.h"
 
 /**
@@ -43,21 +44,19 @@
  * - i2c master(ESP32) will read data from i2c slave(ESP32).
  */
 
-#define DATA_LENGTH                        512              /*!<Data buffer length for test buffer*/
-#define RW_TEST_LENGTH                     129              /*!<Data length for r/w test, any value from 0-DATA_LENGTH*/
-#define DELAY_TIME_BETWEEN_ITEMS_MS        1234             /*!< delay time between different test items */
+#define DELAY_TIME_BETWEEN_ITEMS_MS        3000             /*!< delay time between different test items in ms */
 
 #define I2C_EXAMPLE_SLAVE_SCL_IO           26               /*!<gpio number for i2c slave clock  */
 #define I2C_EXAMPLE_SLAVE_SDA_IO           25               /*!<gpio number for i2c slave data */
 #define I2C_EXAMPLE_SLAVE_NUM              I2C_NUM_0        /*!<I2C port number for slave dev */
-#define I2C_EXAMPLE_SLAVE_TX_BUF_LEN       (2*DATA_LENGTH)  /*!<I2C slave tx buffer size */
-#define I2C_EXAMPLE_SLAVE_RX_BUF_LEN       (2*DATA_LENGTH)  /*!<I2C slave rx buffer size */
+#define I2C_EXAMPLE_SLAVE_BUF_LEN          256              /*!<I2C slave buffer size, 128-4096 bytes */
+#define I2C_EXAMPLE_SLAVE_RO_LEN           16               /*!<I2C slave read-only size */
 
 #define I2C_EXAMPLE_MASTER_SCL_IO          19               /*!< gpio number for I2C master clock */
 #define I2C_EXAMPLE_MASTER_SDA_IO          18               /*!< gpio number for I2C master data  */
 #define I2C_EXAMPLE_MASTER_NUM             I2C_NUM_1        /*!< I2C port number for master dev */
-#define I2C_EXAMPLE_MASTER_TX_BUF_DISABLE  0                /*!< I2C master do not need buffer */
-#define I2C_EXAMPLE_MASTER_RX_BUF_DISABLE  0                /*!< I2C master do not need buffer */
+#define I2C_EXAMPLE_MASTER_BUF_DISABLE     0                /*!< I2C master do not need buffer */
+#define I2C_EXAMPLE_MASTER_RO_DISABLE      0                /*!< I2C master do not need buffer */
 #define I2C_EXAMPLE_MASTER_FREQ_HZ         100000           /*!< I2C master clock frequency */
 
 #define BH1750_SENSOR_ADDR                 0x23             /*!< slave address for BH1750 sensor */
@@ -71,24 +70,131 @@
 #define NACK_VAL                           0x1              /*!< I2C nack value */
 
 SemaphoreHandle_t print_mux = NULL;
+static TaskHandle_t i2c_slave_task_handle = NULL;
+static i2c_slave_state_t slave_state;
+
+
+static void i2c_slave_task(void* arg)
+{
+    uint32_t notify_val = 0;
+    int notify_res = 0;
+    int rdlen;
+    uint8_t *data;
+
+    printf("[SLV_TASK] Started\n");
+    if (i2c_slave_add_task(I2C_EXAMPLE_SLAVE_NUM, &i2c_slave_task_handle, &slave_state) != ESP_OK) {
+        printf("[SLV_TASK] Error registering slave task\n");
+        goto exit;
+    }
+
+    while (1) {
+        // === Wait for notification from I2C interrupt routine ===
+        notify_val = 0;
+        notify_res = xTaskNotifyWait(0, ULONG_MAX, &notify_val, 1000 / portTICK_RATE_MS);
+        if (notify_res != pdPASS) continue;
+
+        // notification received
+        // Check if task exit requested
+        if (notify_val == I2C_SLAVE_DRIVER_DELETED) {
+            printf("[SLV_TASK] i2c driver deleted\n");
+            break;
+        }
+
+        data = NULL;
+        rdlen = 0;
+        if ((slave_state.rxptr == 0) && (slave_state.txptr == 0)) {
+            // address received from master
+            printf("[SLV_TASK] Address set by master: %d\n", slave_state.rxaddr);
+        }
+        else if (slave_state.status & 0x02) {
+            // read transaction, data sent to master
+            if (slave_state.txptr) {
+                data = malloc(slave_state.txptr+1);
+                if (data) {
+                    rdlen = i2c_slave_read_buffer(I2C_EXAMPLE_SLAVE_NUM, data, slave_state.txaddr, slave_state.txptr, 200 / portTICK_RATE_MS);
+                    if (rdlen != slave_state.txptr) {
+                        free(data);
+                        data = NULL;
+                    }
+                    data[slave_state.txptr] = 0;
+                }
+            }
+            printf("[SLV_TASK] Data sent to master: address=%d, length=%d, overflow=%d\n", slave_state.txaddr, slave_state.txptr, slave_state.txovf);
+            if (data) {
+                printf("  Data: [%s]\n", data);
+                free(data);
+            }
+            else printf("  [No data]\n");
+        }
+        else {
+            // write transaction, data received from master
+            if (slave_state.rxptr) {
+                data = malloc(slave_state.rxptr+1);
+                if (data) {
+                    rdlen = i2c_slave_read_buffer(I2C_EXAMPLE_SLAVE_NUM, data, slave_state.rxaddr, slave_state.rxptr, 200 / portTICK_RATE_MS);
+                    if (rdlen != slave_state.rxptr) {
+                        free(data);
+                        data = NULL;
+                    }
+                    data[slave_state.rxptr] = 0;
+                }
+            }
+            printf("[SLV_TASK] Data received from master: address=%d, length=%d, overflow=%d\n", slave_state.rxaddr, slave_state.rxptr, slave_state.rxovf);
+            if (data) {
+                printf("  Data: [%s]\n", data);
+                free(data);
+            }
+            else printf("  [No data]\n");
+        }
+    }
+
+exit:
+    i2c_slave_remove_task(I2C_EXAMPLE_SLAVE_NUM);
+    printf("[SLV_TASK] Deleted\n");
+    i2c_slave_task_handle = NULL;
+    vTaskDelete(NULL);
+}
+
 
 /**
- * @brief test code to read esp-i2c-slave
- *        We need to fill the buffer of esp slave device, then master can read them out.
+ * @brief test code to read from esp-i2c-slave
+ *        Master device reads data from slave(both esp32),
+ *        the data will be read from slave buffer at given address.
+ *        We can set the slave buffer data using i2c_slave_write_buffer() function.
  *
- * _______________________________________________________________________________________
- * | start | slave_addr + rd_bit +ack | read n-1 bytes + ack | read 1 byte + nack | stop |
- * --------|--------------------------|----------------------|--------------------|------|
+ * For slave buffer size <= 256 8-bit addressing is used
+ * _________________________________________________________________________________________________________________________________________________
+ * | start | slave_addr + wr_bit + ack | buff_addr + ack | start | slave_addr + rd_bit + ack | read n-1 bytes + ack | read n-th byte + nack | stop |
+ * --------|---------------------------|-----------------|-------|---------------------------|----------------------|-----------------------|------|
+ *
+ * For slave buffer size > 256 16-bit addressing is used
+ * _________________________________________________________________________________________________________________________________________________________________________
+ * | start | slave_addr + wr_bit + ack | buff_addr_hi + ack | buff_addr_lo + ack | start | slave_addr + rd_bit + ack | read n-1 bytes + ack | read n-th byte + nack | stop |
+ * --------|---------------------------|--------------------|--------------------|-------|---------------------------|---------  -----------|-----------------------|------|
  *
  */
-static esp_err_t i2c_example_master_read_slave(i2c_port_t i2c_num, uint8_t* data_rd, size_t size)
+static esp_err_t i2c_example_master_read_slave(i2c_port_t i2c_num, uint16_t addr, uint8_t* data_rd, size_t size)
 {
     if (size == 0) {
         return ESP_OK;
     }
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, ( ESP_SLAVE_ADDR << 1 ) | WRITE_BIT, ACK_CHECK_EN);
+    // send slave buffer address, 1 or 2 bytes
+    if (I2C_EXAMPLE_SLAVE_BUF_LEN > 256) {
+        // use 16-bit addressing, send MSByte first
+        i2c_master_write_byte(cmd, (uint8_t)(addr>>8), ACK_CHECK_EN);
+        i2c_master_write_byte(cmd, (uint8_t)addr, ACK_CHECK_EN);
+    }
+    else {
+        // use 8-bit addressing
+        i2c_master_write_byte(cmd, (uint8_t)addr, ACK_CHECK_EN);
+    }
+    // repeated-start, switch to read mode
+    i2c_master_start(cmd);
     i2c_master_write_byte(cmd, ( ESP_SLAVE_ADDR << 1 ) | READ_BIT, ACK_CHECK_EN);
+    // read data
     if (size > 1) {
         i2c_master_read(cmd, data_rd, size - 1, ACK_VAL);
     }
@@ -100,21 +206,38 @@ static esp_err_t i2c_example_master_read_slave(i2c_port_t i2c_num, uint8_t* data
 }
 
 /**
- * @brief Test code to write esp-i2c-slave
- *        Master device write data to slave(both esp32),
- *        the data will be stored in slave buffer.
+ * @brief Test code to write to esp-i2c-slave
+ *        Master device writes data to slave(both esp32),
+ *        the data will be stored in slave buffer at given address.
  *        We can read them out from slave buffer.
  *
- * ___________________________________________________________________
- * | start | slave_addr + wr_bit + ack | write n bytes + ack  | stop |
- * --------|---------------------------|----------------------|------|
+ * For slave buffer size <= 256 8-bit addressing is used
+ * _____________________________________________________________________________________
+ * | start | slave_addr + wr_bit + ack | buff_addr + ack | write n bytes + ack  | stop |
+ * --------|---------------------------|-----------------|----------------------|------|
+ *
+ * For slave buffer size > 256 16-bit addressing is used
+ * _____________________________________________________________________________________________________________
+ * | start | slave_addr + wr_bit + ack | buff_addr_hi + ack | buff_addr_lo + ack | write n bytes + ack  | stop |
+ * --------|---------------------------|--------------------|--------------------|----------------------|------|
  *
  */
-static esp_err_t i2c_example_master_write_slave(i2c_port_t i2c_num, uint8_t* data_wr, size_t size)
+static esp_err_t i2c_example_master_write_slave(i2c_port_t i2c_num, uint16_t addr, uint8_t* data_wr, size_t size)
 {
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, ( ESP_SLAVE_ADDR << 1 ) | WRITE_BIT, ACK_CHECK_EN);
+    // send slave buffer address
+    if (I2C_EXAMPLE_SLAVE_BUF_LEN > 256) {
+        // use 16-bit addressing, send MSByte first
+        i2c_master_write_byte(cmd, (uint8_t)(addr>>8), ACK_CHECK_EN);
+        i2c_master_write_byte(cmd, (uint8_t)addr, ACK_CHECK_EN);
+    }
+    else {
+        // use 8-bit addressing
+        i2c_master_write_byte(cmd, (uint8_t)addr, ACK_CHECK_EN);
+    }
+    // send data
     i2c_master_write(cmd, data_wr, size, ACK_CHECK_EN);
     i2c_master_stop(cmd);
     esp_err_t ret = i2c_master_cmd_begin(i2c_num, cmd, 1000 / portTICK_RATE_MS);
@@ -123,7 +246,7 @@ static esp_err_t i2c_example_master_write_slave(i2c_port_t i2c_num, uint8_t* dat
 }
 
 /**
- * @brief test code to write esp-i2c-slave
+ * @brief test code to read from esp-i2c-slave
  *
  * 1. set mode
  * _________________________________________________________________
@@ -175,8 +298,8 @@ static void i2c_example_master_init()
     conf.master.clk_speed = I2C_EXAMPLE_MASTER_FREQ_HZ;
     i2c_param_config(i2c_master_port, &conf);
     i2c_driver_install(i2c_master_port, conf.mode,
-                       I2C_EXAMPLE_MASTER_RX_BUF_DISABLE,
-                       I2C_EXAMPLE_MASTER_TX_BUF_DISABLE, 0);
+                       I2C_EXAMPLE_MASTER_BUF_DISABLE,
+                       I2C_EXAMPLE_MASTER_RO_DISABLE, 0);
 }
 
 /**
@@ -195,107 +318,125 @@ static void i2c_example_slave_init()
     conf_slave.slave.slave_addr = ESP_SLAVE_ADDR;
     i2c_param_config(i2c_slave_port, &conf_slave);
     i2c_driver_install(i2c_slave_port, conf_slave.mode,
-                       I2C_EXAMPLE_SLAVE_RX_BUF_LEN,
-                       I2C_EXAMPLE_SLAVE_TX_BUF_LEN, 0);
-}
-
-/**
- * @brief test function to show buffer
- */
-static void disp_buf(uint8_t* buf, int len)
-{
-    int i;
-    for (i = 0; i < len; i++) {
-        printf("%02x ", buf[i]);
-        if (( i + 1 ) % 16 == 0) {
-            printf("\n");
-        }
-    }
-    printf("\n");
+                       I2C_EXAMPLE_SLAVE_BUF_LEN,
+                       I2C_EXAMPLE_SLAVE_RO_LEN, 0);
+    // Create the slave task
+    xTaskCreate(i2c_slave_task, "i2c_slave_task", 1024 * 2, (void* ) 0, 12, &i2c_slave_task_handle);
 }
 
 static void i2c_test_task(void* arg)
 {
-    int i = 0;
     int ret;
     uint32_t task_idx = (uint32_t) arg;
-    uint8_t* data = (uint8_t*) malloc(DATA_LENGTH);
-    uint8_t* data_wr = (uint8_t*) malloc(DATA_LENGTH);
-    uint8_t* data_rd = (uint8_t*) malloc(DATA_LENGTH);
+    char data[128] = {'\0'};
     uint8_t sensor_data_h, sensor_data_l;
     int cnt = 0;
     while (1) {
-        printf("test cnt: %d\n", cnt++);
+        cnt++;
+
+        //=== Sensor test ===========================
         ret = i2c_example_master_sensor_test( I2C_EXAMPLE_MASTER_NUM, &sensor_data_h, &sensor_data_l);
         xSemaphoreTake(print_mux, portMAX_DELAY);
+        printf("*************************************\n");
+
+        printf("TASK[%d]  MASTER READ SENSOR( BH1750 )\n", task_idx);
+        printf("*************************************\n");
         if(ret == ESP_ERR_TIMEOUT) {
             printf("I2C timeout\n");
+            printf("*************************************\n");
         } else if(ret == ESP_OK) {
-            printf("*******************\n");
-            printf("TASK[%d]  MASTER READ SENSOR( BH1750 )\n", task_idx);
-            printf("*******************\n");
             printf("data_h: %02x\n", sensor_data_h);
             printf("data_l: %02x\n", sensor_data_l);
             printf("sensor val: %f\n", (sensor_data_h << 8 | sensor_data_l) / 1.2);
         } else {
             printf("%s: No ack, sensor not connected...skip...\n", esp_err_to_name(ret));
         }
+        printf("*************************************\n\n");
         xSemaphoreGive(print_mux);
+
         vTaskDelay(( DELAY_TIME_BETWEEN_ITEMS_MS * ( task_idx + 1 ) ) / portTICK_RATE_MS);
-        //---------------------------------------------------
-        for (i = 0; i < DATA_LENGTH; i++) {
-            data[i] = i;
-        }
+
+        //=== Slave read test ===========================
+        i2c_slave_set_buffer(I2C_EXAMPLE_SLAVE_NUM, 0, 500 / portTICK_RATE_MS);
+        // Set some data for master to read
+        sprintf(data, "Master read: count=%d, task_id=%d", cnt, task_idx);
+        i2c_slave_write_buffer(I2C_EXAMPLE_SLAVE_NUM, (uint8_t *)data, 0, strlen(data)+1, 500 / portTICK_RATE_MS);
+
         xSemaphoreTake(print_mux, portMAX_DELAY);
-        size_t d_size = i2c_slave_write_buffer(I2C_EXAMPLE_SLAVE_NUM, data, RW_TEST_LENGTH, 1000 / portTICK_RATE_MS);
-        if (d_size == 0) {
-            printf("i2c slave tx buffer full\n");
-            ret = i2c_example_master_read_slave(I2C_EXAMPLE_MASTER_NUM, data_rd, DATA_LENGTH);
-        } else {
-            ret = i2c_example_master_read_slave(I2C_EXAMPLE_MASTER_NUM, data_rd, RW_TEST_LENGTH);
-        }
+        printf("*******************************\n");
+        printf("TASK[%d]  MASTER READ FROM SLAVE\n", task_idx);
+        printf("*******************************\n");
+        ret = i2c_example_master_read_slave(I2C_EXAMPLE_MASTER_NUM, 0, (uint8_t *)data, strlen(data)+1);
+        vTaskDelay(100 / portTICK_RATE_MS);
 
         if (ret == ESP_ERR_TIMEOUT) {
-            printf("I2C timeout\n");
-            printf("*********\n");
+            printf("Master read timeout\n");
         } else if (ret == ESP_OK) {
-            printf("*******************\n");
-            printf("TASK[%d]  MASTER READ FROM SLAVE\n", task_idx);
-            printf("*******************\n");
-            printf("====TASK[%d] Slave buffer data ====\n", task_idx);
-            disp_buf(data, d_size);
-            printf("====TASK[%d] Master read ====\n", task_idx);
-            disp_buf(data_rd, d_size);
+            printf("Master read OK\n  data: [");
+            for (int i=0; i<strlen(data)+1; i++) {
+                if (i>0) printf(" ");
+                printf("%2X", data[i]);
+            }
+            printf("]\n");
         } else {
             printf("%s: Master read slave error, IO not connected...\n", esp_err_to_name(ret));
         }
+        printf("*******************************\n\n");
         xSemaphoreGive(print_mux);
+
         vTaskDelay(( DELAY_TIME_BETWEEN_ITEMS_MS * ( task_idx + 1 ) ) / portTICK_RATE_MS);
-        //---------------------------------------------------
-        int size;
-        for (i = 0; i < DATA_LENGTH; i++) {
-            data_wr[i] = i + 10;
-        }
+
+        //=== Slave read test (with overflow) ===========
+        i2c_slave_set_buffer(I2C_EXAMPLE_SLAVE_NUM, 0, 500 / portTICK_RATE_MS);
+        i2c_slave_write_buffer(I2C_EXAMPLE_SLAVE_NUM, (uint8_t *)"1234567890abcdef", I2C_EXAMPLE_SLAVE_BUF_LEN-16, 16, 500 / portTICK_RATE_MS);
+
         xSemaphoreTake(print_mux, portMAX_DELAY);
-        //we need to fill the slave buffer so that master can read later
-        ret = i2c_example_master_write_slave( I2C_EXAMPLE_MASTER_NUM, data_wr, RW_TEST_LENGTH);
-        if (ret == ESP_OK) {
-            size = i2c_slave_read_buffer( I2C_EXAMPLE_SLAVE_NUM, data, RW_TEST_LENGTH, 1000 / portTICK_RATE_MS);
-        }
+        printf("******************************************\n");
+        printf("TASK[%d]  MASTER READ FROM SLAVE (OVERFLOW)\n", task_idx);
+        printf("******************************************\n");
+        ret = i2c_example_master_read_slave(I2C_EXAMPLE_MASTER_NUM, I2C_EXAMPLE_SLAVE_BUF_LEN-16, (uint8_t *)data, 32);
+        vTaskDelay(100 / portTICK_RATE_MS);
+
         if (ret == ESP_ERR_TIMEOUT) {
-            printf("I2C timeout\n");
+            printf("Master read timeout\n");
         } else if (ret == ESP_OK) {
-            printf("*******************\n");
-            printf("TASK[%d]  MASTER WRITE TO SLAVE\n", task_idx);
-            printf("*******************\n");
-            printf("----TASK[%d] Master write ----\n", task_idx);
-            disp_buf(data_wr, RW_TEST_LENGTH);
-            printf("----TASK[%d] Slave read: [%d] bytes ----\n", task_idx, size);
-            disp_buf(data, size);
+            printf("Master read OK\n  data: [");
+            for (int i=0; i<32; i++) {
+                if (i>0) printf(" ");
+                printf("%2X", data[i]);
+            }
+            printf("]\n");
         } else {
-            printf("TASK[%d] %s: Master write slave error, IO not connected....\n", task_idx, esp_err_to_name(ret));
+            printf("%s: Master read slave error, IO not connected...\n", esp_err_to_name(ret));
         }
+        printf("******************************************\n\n");
         xSemaphoreGive(print_mux);
+
+        vTaskDelay(( DELAY_TIME_BETWEEN_ITEMS_MS * ( task_idx + 1 ) ) / portTICK_RATE_MS);
+
+        //=== Slave write test ===========================
+        // Set the data to be sent to the slave by master
+        sprintf(data, "Master write: count=%d, task_id=%d", cnt, task_idx);
+        i2c_slave_write_buffer(I2C_EXAMPLE_SLAVE_NUM, (uint8_t *)data, 128, strlen(data)+1, 500 / portTICK_RATE_MS);
+
+        xSemaphoreTake(print_mux, portMAX_DELAY);
+        printf("******************************\n");
+        printf("TASK[%d]  MASTER WRITE TO SLAVE\n", task_idx);
+        printf("******************************\n");
+
+        ret = i2c_example_master_write_slave( I2C_EXAMPLE_MASTER_NUM, 128, (uint8_t *)data, strlen(data)+1);
+        vTaskDelay(100 / portTICK_RATE_MS);
+
+        if (ret == ESP_ERR_TIMEOUT) {
+            printf("Master write timeout\n");
+        } else if (ret == ESP_OK) {
+            printf("Master write OK\n");
+        } else {
+            printf("%s: Master write slave error, IO not connected....\n", esp_err_to_name(ret));
+        }
+        printf("******************************\n\n");
+        xSemaphoreGive(print_mux);
+
         vTaskDelay(( DELAY_TIME_BETWEEN_ITEMS_MS * ( task_idx + 1 ) ) / portTICK_RATE_MS);
     }
 }


### PR DESCRIPTION
This PR proposes a different, in my opinion better and more convinient, way of handling ESP32 I2C slave device.

In **slave mode** i2c device with 128-4096 memory is emulated, via the **slave buffer**.
All master's read/write requests for data are handled by the driver's interrupt routine. The user only needs to provide the initial buffer content and, optionally, to handle the master's request from the slave task.

Master can read from or write to the **ESP32 i2c device**, providing the memory (buffer) address to read from or write to.

For buffer sizes 128-256 bytes, 8-bit addressing is used, for buffer sizes >256 bytes, 16-bit addressing is used.

***

**_Typical master write sequence is as follows:_**

_For slave buffer size <= 256 8-bit addressing is used_
```
_____________________________________________________________________________________
| start | slave_addr + wr_bit + ack | buff_addr + ack | write n bytes + ack  | stop |
--------|---------------------------|-----------------|----------------------|------|
```
_For slave buffer size > 256 16-bit addressing is used_
```
_____________________________________________________________________________________________________________
| start | slave_addr + wr_bit + ack | buff_addr_hi + ack | buff_addr_lo + ack | write n bytes + ack  | stop |
--------|---------------------------|--------------------|--------------------|----------------------|------|
```

**_Typical master read sequence is as follows:_**

_For slave buffer size <= 256 8-bit addressing is used_
```
_________________________________________________________________________________________________________________________________________________
| start | slave_addr + wr_bit + ack | buff_addr + ack | start | slave_addr + rd_bit + ack | read n-1 bytes + ack | read n-th byte + nack | stop |
--------|---------------------------|-----------------|-------|---------------------------|----------------------|-----------------------|------|
```
_For slave buffer size > 256 16-bit addressing is used_
```
_________________________________________________________________________________________________________________________________________________________________________
| start | slave_addr + wr_bit + ack | buff_addr_hi + ack | buff_addr_lo + ack | start | slave_addr + rd_bit + ack | read n-1 bytes + ack | read n-th byte + nack | stop |
--------|---------------------------|--------------------|--------------------|-------|---------------------------|---------  -----------|-----------------------|------|
```
***

Optional **read only** area at the end of the slave buffer can be set. Master can only read from that area, writing to it by the master will be ignored.

The API provides functions to read and write data from/to the **slave buffer** at any time: `i2c_slave_read_buffer()` and `i2c_slave_write_buffer`.

I2C **slave task** can be created which receives notifications from the i2c driver about the slave events: **_address set_**, **_data sent to master_**, **_data received from master_**.
Slave buffer address, number of bytes sent or received and overflow status are available to the slave task to take some action on slave events.

It is up to the user to organize the slave buffer in a way most appropriate for the application.
Writting to some addresses can, for example, be treated by the **slave task** as commands with optional arguments and some action taken.
Read only area can contain the slave ID, revision number, sensor data etc.

***
I2C example and documentation are updated for the new driver.
***

The driver was extensively tested with ESP32 i2c master (on the same and different board), STM32F4 hardware and software I2C driver and Atmel xmega chip's i2c driver with clock frequencies of 100000 and 400000.

