### PR TITLE
Spelling 'talse' => 'false'

### DIFF
--- a/components/driver/include/driver/rtc_io.h
+++ b/components/driver/include/driver/rtc_io.h
@@ -35,7 +35,7 @@ typedef enum {
  * @brief Determine if the specified GPIO is a valid RTC GPIO.
  *
  * @param gpio_num GPIO number
- * @return true if GPIO is valid for RTC GPIO use. talse otherwise.
+ * @return true if GPIO is valid for RTC GPIO use. False otherwise.
  */
 inline static bool rtc_gpio_is_valid_gpio(gpio_num_t gpio_num)
 {


### PR DESCRIPTION
Trivial change "talse" => "False"