### PR TITLE
Fix missing typedef on enum defintion.

### DIFF
--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -36,7 +36,7 @@ typedef enum {
 } esp_image_spi_mode_t;
 
 /* SPI flash clock frequency */
-enum {
+typedef enum {
     ESP_IMAGE_SPI_SPEED_40M,
     ESP_IMAGE_SPI_SPEED_26M,
     ESP_IMAGE_SPI_SPEED_20M,


### PR DESCRIPTION
Related https://github.com/espressif/esp-idf/issues/2136

I believe when we create new enum data type, then we should use typedef. The reason not showing any trouble till this time, we did not use esp_image_spi_freq_t directly. But we need to fix this for future use. 