### PR TITLE
Enable subprojects (make bootloader case more generic)

### DIFF
--- a/components/bootloader/subproject/Makefile
+++ b/components/bootloader/subproject/Makefile
@@ -22,11 +22,13 @@ CFLAGS += -I $(IDF_PATH)/components/esp32/include
 # IS_BOOTLOADER_BUILD tells the component Makefile.projbuild to be a no-op
 IS_BOOTLOADER_BUILD := 1
 export IS_BOOTLOADER_BUILD
+IS_SUBPROJECT_BUILD := 1
+export IS_SUBPROJECT_BUILD
 
 # BOOTLOADER_BUILD macro is the same, for source file changes
-CFLAGS += -D BOOTLOADER_BUILD=1
+CPPFLAGS += -DBOOTLOADER_BUILD=1
 
 # include the top-level "project" include directory, for sdkconfig.h
-CFLAGS += -I$(BUILD_DIR_BASE)/../include
+CPPFLAGS += -I$(BUILD_DIR_BASE)/../include
 
 include $(IDF_PATH)/make/project.mk

--- a/components/esp32/component.mk
+++ b/components/esp32/component.mk
@@ -55,8 +55,9 @@ COMPONENT_ADD_LINKER_DEPS := $(ALL_LIB_FILES) $(addprefix ld/,$(LINKER_SCRIPTS))
 # saves us from having to add the target to a Makefile.projbuild
 $(COMPONENT_LIBRARY): esp32_out.ld
 
-esp32_out.ld: $(COMPONENT_PATH)/ld/esp32.ld ../include/sdkconfig.h
-	$(CC) -I ../include -C -P -x c -E $< -o $@
+# below we skipped $(BUILD_DIR_BASE)/include/sdkconfig.h
+esp32_out.ld: $(COMPONENT_PATH)/ld/esp32.ld 
+	$(CC) $(CPPFLAGS) -I $(BUILD_DIR_BASE)/include -C -P -x c -E $< -o $@
 
 COMPONENT_EXTRA_CLEAN := esp32_out.ld
 

--- a/make/project.mk
+++ b/make/project.mk
@@ -392,7 +392,7 @@ $(foreach componentpath,$(COMPONENT_PATHS), \
 # once we know component paths, we can include the config generation targets
 #
 # (bootloader build doesn't need this, config is exported from top-level)
-ifndef IS_BOOTLOADER_BUILD
+ifndef IS_SUBPROJECT_BUILD
 include $(IDF_PATH)/make/project_config.mk
 endif
 


### PR DESCRIPTION
This allows practical usage of the "subproject" idea as introduced for bootloader to deliver other subprojects. My use case is OTA, where OTA_0 is a simple application that allows re-programming only and OTA_1 is the actual application. This allows to have a fallback if programming fails, and then have a significantly large actual application, as it is larger than 50% of the flash size. As defining `IS_BOOTLOADER_BUILD` both enables subproject in project.mk and at the same time disables multiple needed functions in spi_flash, it makes sense to split this to be controlled thru different variables. So `IS_SUBPROJECT_BUILD` controls the skip of building configuration in project.mk to enable subproject, and `IS_BOOTLOADER_BUILD` remains to control the rest. This then requires setting of `IS_SUBPROJECT_BUILD`  in bootloader Makefile.