### PR TITLE
Fixed Undefined Reference Error by Changing Value of BTM_OOB_INCLUDED Macro

### DIFF
--- a/components/bt/bluedroid/common/include/common/bt_target.h
+++ b/components/bt/bluedroid/common/include/common/bt_target.h
@@ -735,7 +735,7 @@
 
 /* Include Out-of-Band implementation for Simple Pairing */
 #ifndef BTM_OOB_INCLUDED
-#define BTM_OOB_INCLUDED                FALSE//TRUE
+#define BTM_OOB_INCLUDED                TRUE
 #endif
 
 /* TRUE to include Sniff Subrating */


### PR DESCRIPTION
I have tried to build the `a2dp_sink` project from the examples, where the Hands Free/Handset Profile is enabled in `make menuconfig`. The resulting `sdkconfig` file that came out of this configuration can be [looked at here](https://pastebin.com/raw/XEwJjN5H). However, when I try to build the project, I get the following error:

```
LD build/a2dp_sink.elf
$BUILD_DIR_BASE/bt/libbt.a(btm_sco.o):(.literal.btm_send_connect_request+0x14): undefined reference to `BTM_BothEndsSupportSecureConnections'
$BUILD_DIR_BASE/bt/libbt.a(btm_sco.o): In function `btm_send_connect_request':
$IDF_PATH/components/bt/bluedroid/stack/btm/btm_sco.c:1642: undefined reference to `BTM_BothEndsSupportSecureConnections'
collect2: error: ld returned 1 exit status
make: *** [$BUILD_DIR_BASE/a2dp_sink.elf] Error 1
```

This error occurs because `BTM_BothEndsSupportSecureConnections` is not being included in the preprocessor output of `btm_sec.c`, so this symbol is never defined. It is not included in the preprocessor output because of the following `#if` directive from line 1601 of `btm_sec.c`:

```
#if BTM_OOB_INCLUDED == TRUE && SMP_INCLUDED == TRUE
```

This `#if` evaluates to false because `BTM_OOB_INCLUDED` is defined as `FALSE` on lines 736-739 of `bt_target.h`:

```
/* Include Out-of-Band implementation for Simple Pairing */
#ifndef BTM_OOB_INCLUDED
#define BTM_OOB_INCLUDED                FALSE//TRUE
#endif
```

Changing line 738 to `#define BTM_OOB_INCLUDED                TRUE` fixes the error above and allows me to build the `a2dp_sink.elf` file successfully. Therefore, I have made this pull request with that change in order to fix this bug. Perhaps there is a better way to fix this if `BTM_OOB_INCLUDED` is supposed to be defined in some other file, but this is the only way I could figure out how to fix the issue.