### PR TITLE
authenticate the correct key so bonds can endure across esp32 resets (IDFGH-2879)

### DIFF
--- a/components/bt/bluedroid/stack/btm/btm_ble.c
+++ b/components/bt/bluedroid/stack/btm/btm_ble.c
@@ -1225,7 +1225,7 @@ void btm_sec_save_le_key(BD_ADDR bd_addr, tBTM_LE_KEY_TYPE key_type, tBTM_LE_KEY
 
             /* Set that link key is known since this shares field with BTM_SEC_FLAG_LKEY_KNOWN flag in stack/btm_api.h*/
             p_rec->sec_flags |=  BTM_SEC_LE_LINK_KEY_KNOWN;
-            if ( p_keys->pcsrk_key.sec_level == SMP_SEC_AUTHENTICATED) {
+            if ( p_keys->lenc_key.sec_level == SMP_SEC_AUTHENTICATED) {
                 p_rec->sec_flags |= BTM_SEC_LE_LINK_KEY_AUTHED;
             } else {
                 p_rec->sec_flags &= ~BTM_SEC_LE_LINK_KEY_AUTHED;


### PR DESCRIPTION
Hi,
This is an attempt to resolve #2036 which caused a bonded esp32 to incorrectly set characteristic permissions with ENC_MITM set after a reset. The incorrect key sec_level was checked, so the BTM_SEC_LE_LINK_KEY_AUTHED bit was never set in the security flags. I had the same problem described in #2036 and this appeared to fix it.
Thanks,
Tom