### PR TITLE
Added Reason-Phrase to status line

### DIFF
--- a/examples/system/ota/main/ota_example_main.c
+++ b/examples/system/ota/main/ota_example_main.c
@@ -256,7 +256,7 @@ static void ota_example_task(void *pvParameter)
             task_fatal_error();
         } else if (buff_len > 0 && !resp_body_start) {  /*deal with response header*/
             // only start ota when server response 200 state code
-            if (strstr(text, "200") == NULL && !http_200_flag) {
+            if (strstr(text, "200 OK") == NULL && !http_200_flag) {
                 ESP_LOGE(TAG, "ota url is invalid or bin is not exist");
                 task_fatal_error();
             }


### PR DESCRIPTION
Just checking for the string "200" can lead to false-positives. For example my server responded with a 404 but included the following header:
Strict-Transport-Security: max-age=63072000; includeSubdomains
Which lead to a false-positive.
Adding the Reason-Phrase seems like a solution.