### PR TITLE
gpio: Bitmask overflow fix in gpio_reset_pin

### DIFF
--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -316,7 +316,7 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
 {
     assert(gpio_num >= 0 && GPIO_IS_VALID_GPIO(gpio_num));
     gpio_config_t cfg = {
-        .pin_bit_mask = BIT(gpio_num),
+        .pin_bit_mask = BIT64(gpio_num),
         .mode = GPIO_MODE_DISABLE,
         //for powersave reasons, the GPIO should not be floating, select pullup
         .pull_up_en = true,

--- a/components/soc/esp32/include/soc/soc.h
+++ b/components/soc/esp32/include/soc/soc.h
@@ -134,6 +134,7 @@
 
 #ifndef __ASSEMBLER__
 #define BIT(nr)                 (1UL << (nr))
+#define BIT64(nr)               (1ULL << (nr))
 #else
 #define BIT(nr)                 (1 << (nr))
 #endif


### PR DESCRIPTION
For pins 32 and up the BIT(nr) macro used here overflowed,
causing undetermined GPIO pins to be reset.
Example: freeing SPI device/bus where CS is on pin 33
caused debug UART to cease communication, TXD0 was
disabled.

Fixed as BIT64(nr) macro, to be used elsewhere as needed.
For example in definitions like GPIO_SEL_32..GPIO_SEL_39.