### PR TITLE
gen_esp32part.py changes and fixes (IDFGH-1429)

### DIFF
--- a/components/partition_table/gen_esp32part.py
+++ b/components/partition_table/gen_esp32part.py
@@ -57,6 +57,7 @@ SUBTYPES = {
         "esphttpd" : 0x80,
         "fat" : 0x81,
         "spiffs" : 0x82,
+        "default" : 0xFE,
     },
 }
 
@@ -143,14 +144,14 @@ class PartitionTable(list):
             ptype = TYPES[ptype]
         except KeyError:
             try:
-                ptypes = int(ptype, 0)
+                ptype = int(ptype, 0)
             except TypeError:
                 pass
         try:
             subtype = SUBTYPES[int(ptype)][subtype]
         except KeyError:
             try:
-                ptypes = int(ptype, 0)
+                subtype = int(subtype, 0)
             except TypeError:
                 pass
 
@@ -310,7 +311,7 @@ class PartitionDefinition(object):
 
     def parse_subtype(self, strval):
         if strval == "":
-            return 0 # default
+            return  SUBTYPES.get(self.type, {}).get("default", 0) # default
         return parse_int(strval, SUBTYPES.get(self.type, {}))
 
     def parse_address(self, strval):

--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -74,6 +74,7 @@ typedef enum {
     ESP_PARTITION_SUBTYPE_DATA_ESPHTTPD = 0x80,                               //!< ESPHTTPD partition
     ESP_PARTITION_SUBTYPE_DATA_FAT = 0x81,                                    //!< FAT partition
     ESP_PARTITION_SUBTYPE_DATA_SPIFFS = 0x82,                                 //!< SPIFFS partition
+    ESP_PARTITION_SUBTYPE_DATA_DEFAULT = 0xfe,                                 //!< default (or unspecified) data partition
 
     ESP_PARTITION_SUBTYPE_ANY = 0xff,                                         //!< Used to search for partitions with any subtype
 } esp_partition_subtype_t;


### PR DESCRIPTION
Allow non-zero default subtypes, create non-zero default subtype for type data, fixes