### PR TITLE
Updated command to get compiler specs.

### DIFF
--- a/docs/en/get-started/eclipse-setup.rst
+++ b/docs/en/get-started/eclipse-setup.rst
@@ -59,7 +59,7 @@ Navigate to "C/C++ General" -> "Preprocessor Include Paths" property page:
 
 * Click the "Providers" tab
 
-* In the list of providers, click "CDT Cross GCC Built-in Compiler Settings". Change "Command to get compiler specs" to ``xtensa-esp32-elf-gcc ${FLAGS} -E -P -v -dD "${INPUTS}"``.
+* In the list of providers, click "CDT Cross GCC Built-in Compiler Settings". Change "Command to get compiler specs" to ``xtensa-esp32-elf-gcc ${FLAGS} -std=c++11 -E -P -v -dD "${INPUTS}"``.
 
 * In the list of providers, click "CDT GCC Build Output Parser" and change the "Compiler command pattern" to ``xtensa-esp32-elf-(gcc|g\+\+|c\+\+|cc|cpp|clang)``
 


### PR DESCRIPTION
Eclipse was unable to resolve the std::mutex type eventhough the mutex header file was succesfully included. By adding this modification, the issues was resolved.