### PR TITLE
bugfix: incorrect divider setting in rtc_clk_cpu_freq_to_config()

### DIFF
--- a/components/soc/esp32/rtc_clk.c
+++ b/components/soc/esp32/rtc_clk.c
@@ -546,7 +546,7 @@ void rtc_clk_cpu_freq_to_config(rtc_cpu_freq_t cpu_freq, rtc_cpu_freq_config_t* 
             source = RTC_CPU_FREQ_SRC_XTAL;
             if (cpu_freq == RTC_CPU_FREQ_2M) {
                 freq_mhz = 2;
-                divider = out_config->source_freq_mhz / 2;
+                divider = source_freq_mhz / 2;
             } else {
                 freq_mhz = source_freq_mhz;
                 divider = 1;


### PR DESCRIPTION
Fix a bug where `out_config->source_freq_mhz` is undefined

`rtc_clk_cpu_freq_set()` now can set cpu to 2MHz
