### PR TITLE
bugfix: switching from lower xtal freq to 40MHz doesn't have effect

### DIFF
--- a/components/soc/esp32/rtc_clk.c
+++ b/components/soc/esp32/rtc_clk.c
@@ -641,9 +641,7 @@ void rtc_clk_cpu_freq_set_config(const rtc_cpu_freq_config_t* config)
         rtc_clk_bbpll_disable();
     }
     if (config->source == RTC_CPU_FREQ_SRC_XTAL) {
-        if (config->div > 1) {
             rtc_clk_cpu_freq_to_xtal(config->freq_mhz, config->div);
-        }
     } else if (config->source == RTC_CPU_FREQ_SRC_PLL) {
         rtc_clk_bbpll_enable();
         rtc_clk_wait_for_slow_cycle();


### PR DESCRIPTION
The if-statement prevents XTAL freq from being set back to 40MHz.
If the CPU runs on a ultra low frequency set by the XTAL divider, say 2MHz, then it won't be able to get back to 40Mhz.

Please advise because I'm not sure if this is a design decision to not allow xtal-driven CPU to switch below 40Mhz.
