### PR TITLE
add_path.sh: cmake: add tools folder to the path

### DIFF
--- a/add_path.sh
+++ b/add_path.sh
@@ -9,7 +9,10 @@
 if [ -z ${IDF_PATH} ]; then
 	echo "IDF_PATH must be set before including this script."
 else
-	IDF_ADD_PATHS_EXTRAS="${IDF_PATH}/components/esptool_py/esptool:${IDF_PATH}/components/espcoredump:${IDF_PATH}/components/partition_table/"
+	IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/esptool_py/esptool"
+	IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/espcoredump"
+	IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/partition_table/"
+	IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/tools/"
 	export PATH="${PATH}:${IDF_ADD_PATHS_EXTRAS}"
 	echo "Added to PATH: ${IDF_ADD_PATHS_EXTRAS}"
 fi


### PR DESCRIPTION
the ${IDF_PATH}/tools/" is needed for cmake to work. add it to the add_path.sh script