### PR TITLE
Downgrade python-future required version to 0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ setuptools
 # Please keep it as the first item of this list.
 #
 pyserial>=3.0
-future>=0.16.0
+future>=0.15.2


### PR DESCRIPTION
It works fine and this way python-future from Ubuntu Bionic can be used.