### PR TITLE
Pass assigned IP in SYSTEM_EVENT_AP_STAIPASSIGNED event

### DIFF
--- a/components/esp32/include/esp_event_legacy.h
+++ b/components/esp32/include/esp_event_legacy.h
@@ -120,6 +120,10 @@ typedef struct {
     uint8_t mac[6];           /**< MAC address of the station which send probe request */
 } system_event_ap_probe_req_rx_t;
 
+typedef struct {
+    uint8_t ip[4];            /**< IP address assigned to client */
+} system_event_ap_staipassigned_t;
+
 typedef union {
     system_event_sta_connected_t               connected;          /**< ESP32 station connected to AP */
     system_event_sta_disconnected_t            disconnected;       /**< ESP32 station disconnected to AP */
@@ -131,6 +135,7 @@ typedef union {
     system_event_ap_staconnected_t             sta_connected;      /**< a station connected to ESP32 soft-AP */
     system_event_ap_stadisconnected_t          sta_disconnected;   /**< a station disconnected to ESP32 soft-AP */
     system_event_ap_probe_req_rx_t             ap_probereqrecved;  /**< ESP32 soft-AP receive probe request packet */
+    system_event_ap_staipassigned_t            ap_ipassigned    ;  /**< ESP32 soft-AP assigned IP to station */
     system_event_got_ip6_t                     got_ip6;            /**< ESP32 station　or ap or ethernet ipv6 addr state change to preferred */
 } system_event_info_t;
 

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -92,6 +92,7 @@ static void tcpip_adapter_dhcps_cb(u8_t client_ip[4])
                 client_ip[0],client_ip[1],client_ip[2],client_ip[3]);
     system_event_t evt;
     evt.event_id = SYSTEM_EVENT_AP_STAIPASSIGNED;
+    memcpy(evt.event_info.ap_ipassigned.ip, client_ip, 4);
     esp_event_send(&evt);
 }
 


### PR DESCRIPTION
Passes assigned IP from DHCP callback up to the WiFi event handler