### PR TITLE
Remove Content-Length from chunked encoding

### DIFF
--- a/components/http_server/src/httpd_txrx.c
+++ b/components/http_server/src/httpd_txrx.c
@@ -296,7 +296,7 @@ esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, size_t buf_len)
     }
 
     struct httpd_req_aux *ra = r->aux;
-    const char *httpd_chunked_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n";
+    const char *httpd_chunked_hdr_str = "HTTP/1.1 %s\r\nContent-Type: %s\r\nTransfer-Encoding: chunked\r\n";
     const char *colon_separator = ": ";
     const char *cr_lf_seperator = "\r\n";
 


### PR DESCRIPTION
Content-Length header should not be included when using chunked encoding.
Some browsers will close the socket after seeing the 0 sized response instead of
reading the chunks.

Safari on iOS will not display pages sent with chunked encoding and Wireshark also marks the HTTP response as malformed.