### PR TITLE
RMT API: Add missing get function: rmt_get_idle_level().  Suppress … (IDFGH-18291)

### DIFF
--- a/components/driver/include/driver/ledc.h
+++ b/components/driver/include/driver/ledc.h
@@ -171,6 +171,8 @@ esp_err_t ledc_timer_config(const ledc_timer_config_t* timer_conf);
  */
 esp_err_t ledc_update_duty(ledc_mode_t speed_mode, ledc_channel_t channel);
 
+esp_err_t ledc_set_pin(int gpio_num, ledc_mode_t speed_mode, ledc_channel_t ledc_channel);
+
 /**
  * @brief LEDC stop.
  *        Disable LEDC output, and set idle level

--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -491,6 +491,21 @@ esp_err_t rmt_get_source_clk(rmt_channel_t channel, rmt_source_clk_t* src_clk);
 esp_err_t rmt_set_idle_level(rmt_channel_t channel, bool idle_out_en, rmt_idle_level_t level);
 
 /**
+ * @brief Get RMT idle output level for transmitter
+ *
+ * @param channel RMT channel (0-7)
+ *
+ * @param idle_out_en Pointer to accept value of enable idle.
+ *
+ * @param level Pointer to accept value of output signal's level in idle state for specified channel.
+ *
+ * @return
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ *     - ESP_OK Success
+ */
+esp_err_t rmt_get_idle_level(rmt_channel_t channel, bool* idle_out_en, rmt_idle_level_t* level);
+
+/**
  * @brief Get RMT status
  *
  * @param channel RMT channel (0-7)
@@ -715,7 +730,7 @@ esp_err_t rmt_write_items(rmt_channel_t channel, const rmt_item32_t* rmt_item, i
  *
  * @param channel RMT channel (0 - 7)
  *
- * @param wait_time Maximum time in ticks to wait for transmission to be complete 
+ * @param wait_time Maximum time in ticks to wait for transmission to be complete.  If set 0, return immediately with ESP_ERR_TIMEOUT if TX is busy (polling).
  *
  * @return
  *     - ESP_OK RMT Tx done successfully

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -306,6 +306,14 @@ esp_err_t rmt_set_idle_level(rmt_channel_t channel, bool idle_out_en, rmt_idle_l
     return ESP_OK;
 }
 
+esp_err_t rmt_get_idle_level(rmt_channel_t channel, bool* idle_out_en, rmt_idle_level_t* level)
+{
+    RMT_CHECK(channel < RMT_CHANNEL_MAX, RMT_CHANNEL_ERROR_STR, ESP_ERR_INVALID_ARG);
+    *idle_out_en = (bool) (RMT.conf_ch[channel].conf1.idle_out_en);
+    *level = (rmt_idle_level_t) (RMT.conf_ch[channel].conf1.idle_out_lv);
+    return ESP_OK;
+}
+
 esp_err_t rmt_get_status(rmt_channel_t channel, uint32_t* status)
 {
     RMT_CHECK(channel < RMT_CHANNEL_MAX, RMT_CHANNEL_ERROR_STR, ESP_ERR_INVALID_ARG);
@@ -837,7 +845,9 @@ esp_err_t rmt_wait_tx_done(rmt_channel_t channel, TickType_t wait_time)
         return ESP_OK;
     }
     else {
-        ESP_LOGE(RMT_TAG, "Timeout on wait_tx_done");
+        if (wait_time != 0) {  // Don't emit error message if just polling.
+            ESP_LOGE(RMT_TAG, "Timeout on wait_tx_done");
+        }
         return ESP_ERR_TIMEOUT;
     }
 }


### PR DESCRIPTION
Contributing some improvements I required for my project.

1. Add missing get function to RMT API: rmt_get_idle_level(). 

2. Suppress error message from rmt_wait_tx_done() if wait_time==0 (allows for polling).

Here's my justification for the changes: https://github.com/espressif/esp-idf/issues/1175#issuecomment-423984281
