### PR TITLE
Add support for SSL mutual auth

### DIFF
--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -204,6 +204,9 @@ static void mbedtls_cleanup(esp_tls_t *tls)
         mbedtls_x509_crt_free(tls->cacert_ptr);
     }
     tls->cacert_ptr = NULL;
+    mbedtls_x509_crt_free(&tls->cacert);
+    mbedtls_x509_crt_free(&tls->clientcert);
+    mbedtls_pk_free(&tls->clientkey);
     mbedtls_entropy_free(&tls->entropy);
     mbedtls_ssl_config_free(&tls->conf);
     mbedtls_ctr_drbg_free(&tls->ctr_drbg);
@@ -274,7 +277,34 @@ static int create_ssl_handle(esp_tls_t *tls, const char *hostname, size_t hostle
     } else {
         mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
     }
-    
+
+    if (cfg->clientcert_pem_buf != NULL && cfg->clientkey_pem_buf != NULL) {
+        mbedtls_x509_crt_init(&tls->clientcert);
+        mbedtls_pk_init(&tls->clientkey);
+
+        ret = mbedtls_x509_crt_parse(&tls->clientcert, cfg->clientcert_pem_buf, cfg->clientcert_pem_bytes);
+        if (ret < 0) {
+            ESP_LOGE(TAG, "mbedtls_x509_crt_parse returned -0x%x\n\n", -ret);
+            goto exit;
+        }
+
+        ret = mbedtls_pk_parse_key(&tls->clientkey, cfg->clientkey_pem_buf, cfg->clientkey_pem_bytes,
+                  cfg->clientkey_password, cfg->clientkey_password_len);
+        if (ret < 0) {
+            ESP_LOGE(TAG, "mbedtls_pk_parse_keyfile returned -0x%x\n\n", -ret);
+            goto exit;
+        }
+
+        ret = mbedtls_ssl_conf_own_cert(&tls->conf, &tls->clientcert, &tls->clientkey);
+        if (ret < 0) {
+            ESP_LOGE(TAG, "mbedtls_ssl_conf_own_cert returned -0x%x\n\n", -ret);
+            goto exit;
+        }
+    } else if (cfg->clientcert_pem_buf != NULL || cfg->clientkey_pem_buf != NULL) {
+        ESP_LOGE(TAG, "You have to provide both clientcert_pem_buf and clientkey_pem_buf for mutual authentication\n\n");
+        goto exit;
+    }
+
     mbedtls_ssl_conf_rng(&tls->conf, mbedtls_ctr_drbg_random, &tls->ctr_drbg);
 
 #ifdef CONFIG_MBEDTLS_DEBUG

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -60,7 +60,22 @@ typedef struct esp_tls_cfg {
  
     unsigned int cacert_pem_bytes;          /*!< Size of Certificate Authority certificate
                                                  pointed to by cacert_pem_buf */
+
+    const unsigned char *clientcert_pem_buf;/*!< Client certificate in a buffer */
  
+    unsigned int clientcert_pem_bytes;      /*!< Size of client certificate pointed to by
+                                                 clientcert_pem_buf */
+
+    const unsigned char *clientkey_pem_buf; /*!< Client key in a buffer */
+
+    unsigned int clientkey_pem_bytes;       /*!< Size of client key pointed to by
+                                                 clientkey_pem_buf */
+
+    const unsigned char *clientkey_password;/*!< Client key decryption password string */
+
+    unsigned int clientkey_password_len;    /*!< String length of the password pointed to by
+                                                 clientkey_password */
+
     bool non_block;                         /*!< Configure non-blocking mode. If set to true the 
                                                  underneath socket will be configured in non 
                                                  blocking mode after tls session is established */
@@ -89,7 +104,12 @@ typedef struct esp_tls {
  
     mbedtls_net_context server_fd;                                              /*!< mbedTLS wrapper type for sockets */
  
-    mbedtls_x509_crt cacert;                                                    /*!< Container for an X.509 certificate */
+    mbedtls_x509_crt cacert;                                                    /*!< Container for the X.509 CA certificate */
+
+    mbedtls_x509_crt clientcert;                                                /*!< Container for the X.509 client certificate */
+
+    mbedtls_pk_context clientkey;                                               /*!< Container for the private key of the client
+                                                                                     certificate */
  
     mbedtls_x509_crt *cacert_ptr;                                               /*!< Pointer to the cacert being used. */
 

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -40,6 +40,27 @@ esp_transport_handle_t esp_transport_ssl_init();
  */
 void esp_transport_ssl_set_cert_data(esp_transport_handle_t t, const char *data, int len);
 
+/**
+ * @brief      Set SSL client certificate data for mutual authentication (as PEM format).
+ *             Note that, this function stores the pointer to data, rather than making a copy.
+ *             So we need to make sure to keep the data lifetime before cleanup the connection
+ *
+ * @param      t     ssl transport
+ * @param[in]  data  The pem data
+ * @param[in]  len   The length
+ */
+void esp_transport_ssl_set_client_cert_data(esp_transport_handle_t t, const char *data, int len);
+
+/**
+ * @brief      Set SSL client key data for mutual authentication (as PEM format).
+ *             Note that, this function stores the pointer to data, rather than making a copy.
+ *             So we need to make sure to keep the data lifetime before cleanup the connection
+ *
+ * @param      t     ssl transport
+ * @param[in]  data  The pem data
+ * @param[in]  len   The length
+ */
+void esp_transport_ssl_set_client_key_data(esp_transport_handle_t t, const char *data, int len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This makes it possible to port esp-mqtt mutual auth support to the idf version.

Tested and working with the esp-mqtt mutual auth example.