### PR TITLE
Change python-future req to 0.15.2 (again)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ setuptools
 # Please keep it as the first item of this list.
 #
 pyserial>=3.0
-future>=0.16.0
+future>=0.15.2
 cryptography


### PR DESCRIPTION
I suspect the change made in https://github.com/espressif/esp-idf/pull/2428 was stomped on unintentionally