### PR TITLE
reduce speed of I2C master bus reset routine and release SDA

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -540,14 +540,23 @@ static esp_err_t i2c_master_clear_bus(i2c_port_t i2c_num)
     // because after some serious interference, the bus may keep high all the time and the i2c bus is out of service.
     gpio_set_direction(scl_io, GPIO_MODE_OUTPUT_OD);
     gpio_set_direction(sda_io, GPIO_MODE_OUTPUT_OD);
-    gpio_set_level(scl_io, 1);
+
+    int scl_half_period = 5; // use standard 100kHz data rate
     gpio_set_level(sda_io, 1);
-    gpio_set_level(sda_io, 0);
+    ets_delay_us(scl_half_period);
+    gpio_set_level(scl_io, 1);
+    ets_delay_us(scl_half_period);
     for (int i = 0; i < 9; i++) {
         gpio_set_level(scl_io, 0);
+        ets_delay_us(scl_half_period);
         gpio_set_level(scl_io, 1);
+        ets_delay_us(scl_half_period);
     }
-    gpio_set_level(sda_io, 1);
+    gpio_set_level(sda_io, 0); // setup stop condition (this is an implicit start condition)
+    ets_delay_us(scl_half_period);
+    gpio_set_level(sda_io, 1); // generate stop condition
+    ets_delay_us(scl_half_period);
+
     i2c_set_pin(i2c_num, sda_io, scl_io, 1, 1, I2C_MODE_MASTER);
     return ESP_OK;
 }


### PR DESCRIPTION
The I2C master reset has two major issues I have discovered:

1. The clock rate of the SCL line is at the maximum speed possible (many MHz), which is likely not a valid I2C data rate. In my case, the bus had too much capacitance and also the slave device could not use a clock rate that fast.
2. The SDA line is driven low during the reset sequence. This is not correct because a stuck/desynced slave will recognise this as an ACK and may continue to hold the bus. Instead, the SDA line should be released before the clocks.

This pull request sets the clock rate to 100kHz (the standard "slow" I2C clock rate) and releases the SDA line during the reset. At this stage, it is not possible to use the clock rate that the user has provided when configuring the I2C port, because this variable is lost when the I2C controller is reset on `i2c.c` line 582.