### PR TITLE
Change I2C Bus Reset to handle interrupted READ sequences.

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -543,16 +543,21 @@ static esp_err_t i2c_master_clear_bus(i2c_port_t i2c_num)
     // period. If the slave is sending a stream of ZERO bytes, it will only release SDA during the ACK bit period.
     // So, this reset code needs to synchronize the bit stream with, Either, the ACK bit, Or a 1 bit to correctly generate
     // a STOP condition.
+    int scl_half_period = 5; // use standard 100kHz data rate
     gpio_set_level(scl_io, 0);
     gpio_set_level(sda_io, 1);
+    ets_delay_us(scl_half_period);
     int i=0;
     while( !gpio_get_level(sda_id) && (i<9)){ // cycle SCL until SDA is HIGH
         gpio_set_level(scl_io, 1);
+        ets_delay_us(scl_half_period);
         gpio_set_level(scl_io, 0);
+        ets_delay_us(scl_half_period);
         i++;
     }
     gpio_set_level(sda_io,0); // setup for STOP
     gpio_set_level(scl_io,1);
+    ets_delay_us(scl_half_period);
     gpio_set_level(sda_io, 1); // STOP, SDA low -> high while SCL is HIGH
     i2c_set_pin(i2c_num, sda_io, scl_io, 1, 1, I2C_MODE_MASTER);
     return ESP_OK;

--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -548,7 +548,7 @@ static esp_err_t i2c_master_clear_bus(i2c_port_t i2c_num)
     gpio_set_level(sda_io, 1);
     ets_delay_us(scl_half_period);
     int i=0;
-    while( !gpio_get_level(sda_id) && (i<9)){ // cycle SCL until SDA is HIGH
+    while( !gpio_get_level(sda_io) && (i<9)){ // cycle SCL until SDA is HIGH
         gpio_set_level(scl_io, 1);
         ets_delay_us(scl_half_period);
         gpio_set_level(scl_io, 0);


### PR DESCRIPTION
The current bus reset code does not handle interrupted READ cycles.

 If a SLAVE device was in a READ operation when the bus was interrupted, the SLAVE device is controlling SDA.

The only bit during the 9 clock cycles of a byte READ the MASTER(ESP32) is guaranteed control over, is during the ACK bit period. 

If the SLAVE is sending a stream of ZERO bytes, it will only release SDA during the ACK bit period. The master(ESP32) cannot generate a STOP unless SDA is HIGH.

So, this reset code synchronizes the bit stream with, Either, the ACK bit, Or a 1 bit.