### PR TITLE
Compile heap_task_info.c conditionally on CONFIG_HEAP_TASK_TRACKING

### DIFF
--- a/components/heap/CMakeLists.txt
+++ b/components/heap/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT CONFIG_HEAP_POISONING_DISABLED)
     list(APPEND COMPONENT_SRCS "multi_heap_poisoning.c")
 endif()
 
+if(CONFIG_HEAP_TASK_TRACKING)
+    list(APPEND COMPONENT_SRCS "heap_task_info.c")
+endif()
+
 set(COMPONENT_ADD_INCLUDEDIRS "include")
 
 set(COMPONENT_REQUIRES "")


### PR DESCRIPTION
"heap_task_info.c" file was missing in `COMPONENT_SRCS` in heap component's `CMakeLists.txt`.