### PR TITLE
Fix conflicting types in esp_aes_xts_setkey_enc et al., causing build errors

### DIFF
--- a/components/esp32/hwcrypto/aes.c
+++ b/components/esp32/hwcrypto/aes.c
@@ -431,7 +431,7 @@ static int esp_aes_xts_decode_keys( const unsigned char *key,
     return 0;
 }
 
-int esp_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
+int esp_aes_xts_setkey_enc( esp_aes_xts_context *ctx,
                                 const unsigned char *key,
                                 unsigned int keybits)
 {
@@ -453,7 +453,7 @@ int esp_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
     return esp_aes_setkey( &ctx->crypt, key1, key1bits );
 }
 
-int esp_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
+int esp_aes_xts_setkey_dec( esp_aes_xts_context *ctx,
                                 const unsigned char *key,
                                 unsigned int keybits)
 {
@@ -532,7 +532,7 @@ static void esp_gf128mul_x_ble( unsigned char r[16],
 /*
  * AES-XTS buffer encryption/decryption
  */
-int esp_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
+int esp_aes_crypt_xts( esp_aes_xts_context *ctx,
                            int mode,
                            size_t length,
                            const unsigned char data_unit[16],


### PR DESCRIPTION
Building without hw accelerated AES encryption generates build errors similar to this:

```
CC build/esp32/hwcrypto/aes.o
/home/esp-idf/components/esp32/hwcrypto/aes.c:434:5: error: conflicting types for 'esp_aes_xts_setkey_enc'
 int esp_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
     ^
In file included from /home/esp-idf/components/esp32/hwcrypto/aes.c:30:0:
/home/esp-idf/components/esp32/include/hwcrypto/aes.h:280:5: note: previous declaration of 'esp_aes_xts_setkey_enc' was here
 int esp_aes_xts_setkey_enc( esp_aes_xts_context *ctx,
...
``` 

Steps to reproduce:

1. Enter any exampel applications (e.g. examples/wifi/scan)
2. Run `make menuconfig`
3. Disable "Enable hardware accelerated AES encryption" (Component config -> mbedTLS)
4. Save and exit
5. Run `make`