### PR TITLE
add: esp_log_vwrite(), supports va_list parameter forwarding (IDFGH-1794)

### DIFF
--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -106,6 +106,17 @@ uint32_t esp_log_early_timestamp(void);
  */
 void esp_log_write(esp_log_level_t level, const char* tag, const char* format, ...) __attribute__ ((format (printf, 3, 4)));
 
+/**
+ * @brief Write message into the log, va_list variant
+ *
+ * @see esp_log_write()
+ *
+ * This function is provided to ease integration toward other logging framework,
+ * so that esp_log can be used as a log sink.
+ */
+void esp_log_vwrite(esp_log_level_t level, const char* tag, const char* format, va_list args);
+
+
 /** @cond */
 
 #include "esp_log_internal.h"

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -184,9 +184,10 @@ void clear_log_level_list()
 #endif
 }
 
-void IRAM_ATTR esp_log_write(esp_log_level_t level,
+void IRAM_ATTR esp_log_vwrite(esp_log_level_t level,
         const char* tag,
-        const char* format, ...)
+        const char* format,
+        va_list args)
 {
     if (!s_log_mutex) {
         s_log_mutex = xSemaphoreCreateMutex();
@@ -210,9 +211,16 @@ void IRAM_ATTR esp_log_write(esp_log_level_t level,
         return;
     }
 
+    (*s_log_print_func)(format, args);
+}
+
+void IRAM_ATTR esp_log_write(esp_log_level_t level,
+        const char* tag,
+        const char* format, ...)
+{
     va_list list;
     va_start(list, format);
-    (*s_log_print_func)(format, list);
+    esp_log_vwrite(level, tag, format, list);
     va_end(list);
 }
 


### PR DESCRIPTION
Rework esp_log_write() to introduce esp_log_vwrite(), a variant that accepts va_list parameters.

Trivial, but important to have in case other logging frameworks are already in place in the codebase; they can easily funnel data to esp_log_vwrite(), and use esp_log as a sink.
