### PR TITLE
Fix infinite loop on esp_http_client_fetch_headers

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -894,7 +894,7 @@ int esp_http_client_fetch_headers(esp_http_client_handle_t client)
 
     while (client->state < HTTP_STATE_RES_COMPLETE_HEADER) {
         buffer->len = esp_transport_read(client->transport, buffer->data, client->buffer_size, client->timeout_ms);
-        if (buffer->len < 0) {
+        if (buffer->len <= 0) {
             return ESP_FAIL;
         }
         http_parser_execute(client->parser, client->parser_settings, buffer->data, buffer->len);


### PR DESCRIPTION
error must also be returned if esp_tls_conn_read return 0 because socket  was closed