### PR TITLE
Correct Content-Length in openssl_server example

### DIFF
--- a/examples/protocols/openssl_server/main/openssl_server_example_main.c
+++ b/examples/protocols/openssl_server/main/openssl_server_example_main.c
@@ -37,7 +37,7 @@ const static char *TAG = "Openssl_example";
 
 #define OPENSSL_EXAMPLE_SERVER_ACK "HTTP/1.1 200 OK\r\n" \
                                 "Content-Type: text/html\r\n" \
-                                "Content-Length: 98\r\n\r\n" \
+                                "Content-Length: 106\r\n\r\n" \
                                 "<html>\r\n" \
                                 "<head>\r\n" \
                                 "<title>OpenSSL example</title></head><body>\r\n" \


### PR DESCRIPTION
Before this fix it didn't send all of the response, ending with `</h`