### PR TITLE
CMake Auto App Signing Support (IDFGH-1792)

### DIFF
--- a/components/esptool_py/project_include.cmake
+++ b/components/esptool_py/project_include.cmake
@@ -1,8 +1,8 @@
 # Set some global esptool.py variables
 #
 # Many of these are read when generating flash_app_args & flash_project_args
-set(ESPTOOLPY "${PYTHON}" "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip esp32)
-set(ESPSECUREPY "${PYTHON}" "${CMAKE_CURRENT_LIST_DIR}/esptool/espsecure.py")
+set(ESPTOOLPY "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip esp32)
+set(ESPSECUREPY "${CMAKE_CURRENT_LIST_DIR}/esptool/espsecure.py")
 
 set(ESPFLASHMODE ${CONFIG_ESPTOOLPY_FLASHMODE})
 set(ESPFLASHFREQ ${CONFIG_ESPTOOLPY_FLASHFREQ})


### PR DESCRIPTION
This fixes the previous issue with partition table signing (was making file not found errors). It also adds support for automatic signing of the app.bin using the key specified from menuconfig.

## Steps to test

1. Run make menuconfig
2. Enable 'Require signed app images'
3. Enable 'Sign binaries during builds'
4. Set signing key to yours.
5. Attempt a build using cmake.
6. verify signature is present at end of partiton table and binary.


A somewhat related unsolved issue is enabling bootloader checks causes an error.


Example console outputs...
[944/945] Generating UNSIGNED_proj.bin
esptool.py v2.5.1
[945/945] Generating proj.bin
espsecure.py v2.5.1
Signed 1008624 bytes of data from UNSIGNED_proj.bin with key /Users/snipesy/CLionProjects/proj/secure_boot_signing_key.pem`