### PR TITLE
Fix bracket warning in BT stack

### DIFF
--- a/components/bt/bluedroid/stack/gatt/gatt_utils.c
+++ b/components/bt/bluedroid/stack/gatt/gatt_utils.c
@@ -2192,9 +2192,10 @@ void gatt_end_operation(tGATT_CLCB *p_clcb, tGATT_STATUS status, void *p_data)
         (*p_disc_cmpl_cb)(conn_id, disc_type, status);
     } else if (p_cmpl_cb && op) {
         (*p_cmpl_cb)(conn_id, op, status, &cb_data);
-    } else
+    } else {
         GATT_TRACE_WARNING ("gatt_end_operation not sent out op=%d p_disc_cmpl_cb:%p p_cmpl_cb:%p",
                             operation, p_disc_cmpl_cb, p_cmpl_cb);
+    }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
With -Werror turned on and CONFIG_BT_STACK_NO_LOG enabled, this line throws an error.