### PR TITLE
Add checks to for CONFIG_MBEDTLS_SSL_ALPN

### DIFF
--- a/components/aws_iot/port/network_mbedtls_wrapper.c
+++ b/components/aws_iot/port/network_mbedtls_wrapper.c
@@ -236,6 +236,7 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
 
     mbedtls_ssl_conf_read_timeout(&(tlsDataParams->conf), pNetwork->tlsConnectParams.timeout_ms);
 
+#ifdef CONFIG_MBEDTLS_SSL_ALPN
     /* Use the AWS IoT ALPN extension for MQTT, if port 443 is requested */
     if (pNetwork->tlsConnectParams.DestinationPort == 443) {
         const char *alpnProtocols[] = { "x-amzn-mqtt-ca", NULL };
@@ -244,6 +245,7 @@ IoT_Error_t iot_tls_connect(Network *pNetwork, TLSConnectParams *params) {
             return SSL_CONNECTION_ERROR;
         }
     }
+#endif
 
     if((ret = mbedtls_ssl_setup(&(tlsDataParams->ssl), &(tlsDataParams->conf))) != 0) {
         ESP_LOGE(TAG, "failed! mbedtls_ssl_setup returned -0x%x", -ret);

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -205,9 +205,11 @@ static int create_ssl_handle(esp_tls_t *tls, const char *hostname, size_t hostle
         goto exit;
     }
 
+#ifdef CONFIG_MBEDTLS_SSL_ALPN
     if (cfg->alpn_protos) {
         mbedtls_ssl_conf_alpn_protocols(&tls->conf, cfg->alpn_protos);
     }
+#endif
 
     if (cfg->cacert_pem_buf != NULL) {
         mbedtls_x509_crt_init(&tls->cacert);


### PR DESCRIPTION
Some components need to know if CONFIG_MBEDTLS_SSL_ALPN is disabled in order to compile.