### PR TITLE
Add option to disable server side SSL session tickets as well as client

### DIFF
--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -285,12 +285,21 @@ config MBEDTLS_SSL_ALPN
    help
        Disabling this option will save some code size if it is not needed.
 
-config MBEDTLS_SSL_SESSION_TICKETS
-   bool "TLS: Support RFC 5077 SSL session tickets"
+config MBEDTLS_CLIENT_SSL_SESSION_TICKETS
+   bool "TLS: Client Support for RFC 5077 SSL session tickets"
    default y
    depends on MBEDTLS_TLS_ENABLED
    help
-       Support RFC 5077 session tickets. See mbedTLS documentation for more details.
+       Client support for RFC 5077 session tickets. See mbedTLS documentation for more details.
+
+       Disabling this option will save some code size.
+
+config MBEDTLS_SERVER_SSL_SESSION_TICKETS
+   bool "TLS: Server Support for RFC 5077 SSL session tickets"
+   default y
+   depends on MBEDTLS_TLS_ENABLED
+   help
+       Server support for RFC 5077 session tickets. See mbedTLS documentation for more details.
 
        Disabling this option will save some code size.
 

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -1303,7 +1303,7 @@
  *
  * Comment this macro to disable support for SSL session tickets
  */
-#ifdef CONFIG_MBEDTLS_SSL_SESSION_TICKETS
+#ifdef CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS
 #define MBEDTLS_SSL_SESSION_TICKETS
 #endif
 
@@ -2335,7 +2335,9 @@
  *
  * Requires: MBEDTLS_CIPHER_C
  */
+#ifdef CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS
 #define MBEDTLS_SSL_TICKET_C
+#endif
 
 /**
  * \def MBEDTLS_SSL_CLI_C


### PR DESCRIPTION
When trying to slim down my image size I started removing ciphers that i didn't intend to use in my application. I found that after removing `CONFIG_MBEDTLS_CCM_C` that mbed no longer compiled properly with ssl_tickets.c

Turns out, disabling `CONFIG_MBEDTLS_SSL_SESSION_TICKETS` does not disable session tickets for a TLS server implementation (which rely on ciphers) 

This ticket breaks out CONFIG_MBEDTLS_SSL_SESSION_TICKETS into:

CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS
and CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS

so that the user has control to decide which they want to enable. 


