### PR TITLE
Fix component interdependencies, faster build time, smaller binary, fix #2571 (IDFGH-1793)

### DIFF
--- a/components/bt/host/bluedroid/btc/profile/std/spp/btc_spp.c
+++ b/components/bt/host/bluedroid/btc/profile/std/spp/btc_spp.c
@@ -22,7 +22,6 @@
 #include "osi/allocator.h"
 #include "esp_spp_api.h"
 #include "osi/list.h"
-#include "freertos/ringbuf.h"
 #include "osi/mutex.h"
 #include <sys/errno.h>
 #include <sys/lock.h>
@@ -31,6 +30,10 @@
 #include "esp_vfs_dev.h"
 
 #if (defined BTC_SPP_INCLUDED && BTC_SPP_INCLUDED == TRUE)
+#ifndef _DECL_esp_ringbuf
+#error "BTC_SPP_INCLUDED requires esp_ringbuf component"
+#endif
+#include "freertos/ringbuf.h"
 
 typedef struct {
     uint8_t serial;

--- a/components/driver/Kconfig
+++ b/components/driver/Kconfig
@@ -21,6 +21,27 @@ menu "Driver configurations"
 
     endmenu  # ADC Configuration
 
+    menu "I2C configuration"
+
+        config I2C_SLAVE_MODE
+            bool "Enable I2C slave mode"
+            default y
+            help
+                If this is set, the I2C driver will include support for being used as a slave I2C device.
+
+    endmenu # I2C Configuration
+
+    menu "RMT configuration"
+
+        config RMT_RECEIVE
+            bool "Enable RMT receive code"
+            default y
+            help
+                If this is set, the RMT driver will include support for receiving data.
+
+    endmenu # RMT Configuration
+
+
     menu "SPI configuration"
 
         config SPI_MASTER_IN_IRAM

--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -402,7 +402,6 @@ esp_err_t i2c_driver_delete(i2c_port_t i2c_num)
         p_i2c->tx_ring_buf = NULL;
         p_i2c->tx_buf_length = 0;
     }
-(??)
 #endif
 #if CONFIG_SPIRAM_USE_MALLOC
     if (p_i2c_obj[i2c_num]->evt_queue_storage) {

--- a/components/driver/include/driver/i2c.h
+++ b/components/driver/include/driver/i2c.h
@@ -27,7 +27,6 @@ extern "C" {
 #include "freertos/xtensa_api.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
-#include "freertos/ringbuf.h"
 #include "driver/gpio.h"
 
 #define I2C_APB_CLK_FREQ  APB_CLK_FREQ /*!< I2C source clock is APB clock, 80MHz */

--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -19,7 +19,9 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/xtensa_api.h"
+#ifdef _DECL_esp_ringbuf
 #include "freertos/ringbuf.h"
+#endif
 #include "driver/gpio.h"
 #include "driver/periph_ctrl.h"
 
@@ -717,6 +719,7 @@ esp_err_t rmt_write_items(rmt_channel_t channel, const rmt_item32_t* rmt_item, i
  */
 esp_err_t rmt_wait_tx_done(rmt_channel_t channel, TickType_t wait_time);
 
+#ifdef _DECL_esp_ringbuf
 /**
  * @brief Get ringbuffer from RMT.
  *
@@ -730,6 +733,7 @@ esp_err_t rmt_wait_tx_done(rmt_channel_t channel, TickType_t wait_time);
  *     - ESP_OK Success
  */
 esp_err_t rmt_get_ringbuf_handle(rmt_channel_t channel, RingbufHandle_t* buf_handle);
+#endif
 
 /**
  * @brief Init rmt translator and register user callback.

--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -28,7 +28,9 @@ extern "C" {
 #include "freertos/xtensa_api.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
+#ifdef _DECL_esp_ringbuf
 #include "freertos/ringbuf.h"
+#endif
 #include <esp_types.h>
 
 #define UART_FIFO_LEN           (128)        /*!< Length of the hardware FIFO buffers */

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -612,16 +612,12 @@ static void IRAM_ATTR rmt_driver_isr_default(void* arg)
                         } else {
 
                             }
-                        } else
-#else
-                            ESP_EARLY_LOGE(RMT_TAG, "RMT RX disabled in config\n");
-#endif 
-                        {
-                            ESP_EARLY_LOGE(RMT_TAG, "RMT RX BUFFER ERROR\n");
-                        }
                     } else {
                         ESP_EARLY_LOGE(RMT_TAG, "RMT RX BUFFER ERROR\n");
                     }
+#else
+                    ESP_EARLY_LOGE(RMT_TAG, "RMT RX disabled in config\n");
+#endif 
                     RMT.conf_ch[channel].conf1.mem_wr_rst = 1;
                     RMT.conf_ch[channel].conf1.mem_owner = RMT_MEM_OWNER_RX;
                     RMT.conf_ch[channel].conf1.rx_en = 1;

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -23,7 +23,12 @@
 #include "freertos/semphr.h"
 #include "freertos/xtensa_api.h"
 #include "freertos/task.h"
+
+#ifndef _DECL_esp_ringbuf
+#error "Missing component esp_ringbuf to build this component."
+#else
 #include "freertos/ringbuf.h"
+#endif
 #include "soc/uart_periph.h"
 #include "driver/uart.h"
 #include "driver/gpio.h"

--- a/components/esp32/clk.c
+++ b/components/esp32/clk.c
@@ -32,8 +32,10 @@
 #include "soc/i2s_periph.h"
 #include "driver/periph_ctrl.h"
 #include "xtensa/core-macros.h"
+#ifdef _DECL_bootloader_support
 #include "bootloader_clock.h"
 #include "driver/spi_common.h"
+#endif
 
 /* Number of cycles to wait from the 32k XTAL oscillator to consider it running.
  * Larger values increase startup delay. Smaller values may cause false positive

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -62,6 +62,7 @@
 #endif
 #include "esp_app_trace.h"
 #include "esp_private/dbg_stubs.h"
+#include "esp_flash_encrypt.h"
 #ifdef _DECL_esp_event
 #include "esp_event.h"
 #endif

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -60,9 +60,17 @@
 #include "esp_coexist_internal.h"
 #include "esp_core_dump.h"
 #include "esp_app_trace.h"
+<<<<<<< HEAD
 #include "esp_private/dbg_stubs.h"
 #include "esp_flash_encrypt.h"
 #include "esp32/spiram.h"
+=======
+#include "esp_dbg_stubs.h"
+#ifdef _DECL_bootloader_support
+#include "esp_efuse.h"
+#endif
+#include "esp_spiram.h"
+>>>>>>> Step 2: Fix inter-component dependencies errors so it can be build faster and smaller without useless components
 #include "esp_clk_internal.h"
 #include "esp_timer.h"
 #include "esp_pm.h"

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -45,7 +45,6 @@
 #include "esp_spi_flash.h"
 #include "esp_flash.h"
 #include "nvs_flash.h"
-#include "esp_event.h"
 #include "esp_spi_flash.h"
 #include "esp_private/crosscore_int.h"
 #include "esp_log.h"
@@ -66,6 +65,9 @@
 #include "esp32/spiram.h"
 =======
 #include "esp_dbg_stubs.h"
+#ifdef _DECL_esp_event
+#include "esp_event.h"
+#endif
 #ifdef _DECL_bootloader_support
 #include "esp_efuse.h"
 #endif

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -57,22 +57,15 @@
 #include "esp_phy_init.h"
 #include "esp32/cache_err_int.h"
 #include "esp_coexist_internal.h"
+#ifdef _DECL_espcoredump
 #include "esp_core_dump.h"
+#endif
 #include "esp_app_trace.h"
-<<<<<<< HEAD
 #include "esp_private/dbg_stubs.h"
-#include "esp_flash_encrypt.h"
-#include "esp32/spiram.h"
-=======
-#include "esp_dbg_stubs.h"
 #ifdef _DECL_esp_event
 #include "esp_event.h"
 #endif
-#ifdef _DECL_bootloader_support
-#include "esp_efuse.h"
-#endif
-#include "esp_spiram.h"
->>>>>>> Step 2: Fix inter-component dependencies errors so it can be build faster and smaller without useless components
+#include "esp32/spiram.h"
 #include "esp_clk_internal.h"
 #include "esp_timer.h"
 #include "esp_pm.h"
@@ -439,6 +432,7 @@ void start_cpu0_default(void)
 #endif //CONFIG_PM_DFS_INIT_AUTO
 #endif //CONFIG_PM_ENABLE
 
+#ifdef _DECL_espcoredump
 #if CONFIG_ESP32_ENABLE_COREDUMP
     esp_core_dump_init();
     size_t core_data_sz = 0;
@@ -446,6 +440,7 @@ void start_cpu0_default(void)
     if (esp_core_dump_image_get(&core_data_addr, &core_data_sz) == ESP_OK && core_data_sz > 0) {
         ESP_LOGI(TAG, "Found core dump %d bytes in flash @ 0x%x", core_data_sz, core_data_addr);
     }
+#endif
 #endif
 
 #if CONFIG_ESP32_WIFI_SW_COEXIST_ENABLE

--- a/components/esp32/include/esp_attr.h
+++ b/components/esp32/include/esp_attr.h
@@ -80,18 +80,19 @@
 // Format: FLAG_ATTR(flag_enum_t)
 #ifdef __cplusplus
 
+// Inline is required here to avoid multiple definition error in linker
 #define FLAG_ATTR_IMPL(TYPE, INT_TYPE) \
-constexpr TYPE operator~ (TYPE a) { return (TYPE)~(INT_TYPE)a; } \
-constexpr TYPE operator| (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a | (INT_TYPE)b); } \
-constexpr TYPE operator& (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a & (INT_TYPE)b); } \
-constexpr TYPE operator^ (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a ^ (INT_TYPE)b); } \
-constexpr TYPE operator>> (TYPE a, int b) { return (TYPE)((INT_TYPE)a >> b); } \
-constexpr TYPE operator<< (TYPE a, int b) { return (TYPE)((INT_TYPE)a << b); } \
-TYPE& operator|=(TYPE& a, TYPE b) { a = a | b; return a; } \
-TYPE& operator&=(TYPE& a, TYPE b) { a = a & b; return a; } \
-TYPE& operator^=(TYPE& a, TYPE b) { a = a ^ b; return a; } \
-TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
-TYPE& operator<<=(TYPE& a, int b) { a <<= b; return a; }
+inline constexpr TYPE operator~ (TYPE a) { return (TYPE)~(INT_TYPE)a; } \
+inline constexpr TYPE operator| (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a | (INT_TYPE)b); } \
+inline constexpr TYPE operator& (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a & (INT_TYPE)b); } \
+inline constexpr TYPE operator^ (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a ^ (INT_TYPE)b); } \
+inline constexpr TYPE operator>> (TYPE a, int b) { return (TYPE)((INT_TYPE)a >> b); } \
+inline constexpr TYPE operator<< (TYPE a, int b) { return (TYPE)((INT_TYPE)a << b); } \
+inline TYPE& operator|=(TYPE& a, TYPE b) { a = a | b; return a; } \
+inline TYPE& operator&=(TYPE& a, TYPE b) { a = a & b; return a; } \
+inline TYPE& operator^=(TYPE& a, TYPE b) { a = a ^ b; return a; } \
+inline TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
+inline TYPE& operator<<=(TYPE& a, int b) { a <<= b; return a; }
 
 #define FLAG_ATTR_U32(TYPE) FLAG_ATTR_IMPL(TYPE, uint32_t)
 #define FLAG_ATTR FLAG_ATTR_U32

--- a/components/esp32/panic.c
+++ b/components/esp32/panic.c
@@ -37,7 +37,9 @@
 #include "esp_private/panic_reason.h"
 #include "esp_attr.h"
 #include "esp_err.h"
+#ifdef _DECL_espcoredump
 #include "esp_core_dump.h"
+#endif
 #include "esp_spi_flash.h"
 #include "esp32/cache_err_int.h"
 #include "esp_app_trace.h"
@@ -614,6 +616,7 @@ static __attribute__((noreturn)) void commonErrorHandler(XtExcFrame *frame)
     panicPutStr("Entering gdb stub now.\r\n");
     esp_gdbstub_panic_handler(frame);
 #else
+#ifdef _DECL_espcoredump
 #if CONFIG_ESP32_ENABLE_COREDUMP
     static bool s_dumping_core;
     if (s_dumping_core) {
@@ -631,6 +634,7 @@ static __attribute__((noreturn)) void commonErrorHandler(XtExcFrame *frame)
         reconfigureAllWdts();
     }
 #endif /* CONFIG_ESP32_ENABLE_COREDUMP */
+#endif
     rtc_wdt_disable();
 #if CONFIG_ESP32_PANIC_PRINT_REBOOT || CONFIG_ESP32_PANIC_SILENT_REBOOT
     panicPutStr("Rebooting...\r\n");

--- a/components/esp_event/event_send.c
+++ b/components/esp_event/event_send.c
@@ -103,8 +103,10 @@ static system_event_id_t esp_event_legacy_ip_event_id(int32_t event_id)
     case IP_EVENT_GOT_IP6:
         return SYSTEM_EVENT_GOT_IP6;
 
+#ifdef _DECL_ethernet
     case IP_EVENT_ETH_GOT_IP:
         return SYSTEM_EVENT_ETH_GOT_IP;
+#endif
 
     default:
         ESP_LOGE(TAG, "invalid ip event id %d", event_id);

--- a/components/esp_event/event_send_compat.inc
+++ b/components/esp_event/event_send_compat.inc
@@ -17,7 +17,9 @@
 #include "esp_event_legacy.h"
 #include "esp_wifi_types.h"
 #include "tcpip_adapter.h"
+#ifdef _DECL_ethernet
 #include "esp_eth.h"
+#endif
 
 /**
  * The purpose of this file is to provide an "esp_event_send_to_default_loop"
@@ -91,6 +93,7 @@ esp_err_t esp_event_send_to_default_loop(system_event_t *event)
 
         /* Ethernet events */
         /* Some extra defines to fit the old naming scheme... */
+#ifdef _DECL_ethernet
 #define ETH_EVENT_ETH_START ETHERNET_EVENT_START
 #define ETH_EVENT_ETH_STOP ETHERNET_EVENT_STOP
 #define ETH_EVENT_ETH_CONNECTED ETHERNET_EVENT_CONNECTED
@@ -102,8 +105,9 @@ esp_err_t esp_event_send_to_default_loop(system_event_t *event)
         HANDLE_SYS_EVENT(ETH, ETH_DISCONNECTED);
 
         /* IP events */
-        HANDLE_SYS_EVENT_ARG(IP, STA_GOT_IP, got_ip);
         HANDLE_SYS_EVENT_ARG(IP, ETH_GOT_IP, got_ip);
+#endif
+        HANDLE_SYS_EVENT_ARG(IP, STA_GOT_IP, got_ip);
         HANDLE_SYS_EVENT(IP, STA_LOST_IP);
         HANDLE_SYS_EVENT_ARG(IP, GOT_IP6, got_ip6);
         HANDLE_SYS_EVENT(IP, AP_STAIPASSIGNED);
@@ -282,6 +286,7 @@ static void esp_system_event_debug(const system_event_t* event)
                      IP6_ADDR_BLOCK8(addr));
             break;
         }
+#ifdef _DECL_ethernet
         case SYSTEM_EVENT_ETH_START: {
             ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_START");
             break;
@@ -306,6 +311,7 @@ static void esp_system_event_debug(const system_event_t* event)
                 IP2STR(&got_ip->ip_info.gw));
             break;
         }
+#endif
         default: {
             ESP_LOGW(TAG, "unexpected system event %d!", event->event_id);
             break;

--- a/components/esp_http_client/lib/include/http_utils.h
+++ b/components/esp_http_client/lib/include/http_utils.h
@@ -16,6 +16,9 @@
 #ifndef _HTTP_UTILS_H_
 #define _HTTP_UTILS_H_
 #include <sys/time.h>
+#ifndef _DECL_tcp_transport
+#error "This component requires tcp_transport to be enabled"
+#endif
 
 /**
  * @brief      Assign new_str to *str pointer, and realloc *str if it not NULL

--- a/components/esp_wifi/include/esp_wifi.h
+++ b/components/esp_wifi/include/esp_wifi.h
@@ -61,6 +61,9 @@
 #include <stdbool.h>
 #include "esp_err.h"
 #include "esp_wifi_types.h"
+#ifndef _DECL_esp_event
+  #error "WIFI component usually needs you to enable esp_event component. You can not use WIFI_INIT_CONFIG_DEFAULT (C code only) without this."
+#endif
 #include "esp_event.h"
 #include "esp_private/esp_wifi_private.h"
 

--- a/components/lwip/port/esp32/include/netif/nettestif.h
+++ b/components/lwip/port/esp32/include/netif/nettestif.h
@@ -22,9 +22,13 @@
 extern "C" {
 #endif
 
+#if CONFIG_NETIF_USE_TEST_IF
+
 err_t nettestif_init(struct netif *netif);
 
 void nettestif_input(void *buffer, u16_t len);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/components/lwip/port/esp32/netif/dhcp_state.c
+++ b/components/lwip/port/esp32/netif/dhcp_state.c
@@ -33,7 +33,9 @@ static const char *interface_key[] =
 #ifdef _DECL_ethernet
     "IF_ETH",
 #endif
+#if CONFIG_NETIF_USE_TEST_IF
     "IF_TEST",
+#endif
 };
 
 _Static_assert(sizeof(interface_key) / sizeof(char*) == TCPIP_ADAPTER_IF_MAX,

--- a/components/lwip/port/esp32/netif/dhcp_state.c
+++ b/components/lwip/port/esp32/netif/dhcp_state.c
@@ -26,7 +26,15 @@
 #define VALID_NETIF_ID(id) ((id < ESP_IF_MAX) && (id != ESP_IF_WIFI_AP))
 
 static uint32_t restored_ip_addr[TCPIP_ADAPTER_IF_MAX];
-static const char *interface_key[] = {"IF_STA", "IF_AP", "IF_ETH", "IF_TEST"};
+static const char *interface_key[] = 
+{
+    "IF_STA", 
+    "IF_AP",
+#ifdef _DECL_ethernet
+    "IF_ETH",
+#endif
+    "IF_TEST",
+};
 
 _Static_assert(sizeof(interface_key) / sizeof(char*) == TCPIP_ADAPTER_IF_MAX,
                "Number interface keys differs from number of interfaces");

--- a/components/lwip/port/esp32/netif/ethernetif.c
+++ b/components/lwip/port/esp32/netif/ethernetif.c
@@ -48,6 +48,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef _DECL_ethernet
 #include "esp_eth.h"
 #include "tcpip_adapter.h"
 
@@ -227,3 +228,5 @@ err_t ethernetif_init(struct netif *netif)
 
     return ERR_OK;
 }
+#endif
+

--- a/components/lwip/port/esp32/netif/nettestif.c
+++ b/components/lwip/port/esp32/netif/nettestif.c
@@ -15,6 +15,7 @@
 
 #include "tcpip_adapter.h"
 
+#if CONFIG_NETIF_USE_TEST_IF
 static struct netif *g_last_netif = NULL;
 
 
@@ -103,3 +104,5 @@ void nettestif_input(void *buffer, u16_t len)
   }
 
 }
+
+#endif

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -4181,9 +4181,11 @@ esp_err_t mdns_init(void)
     if ((err = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL)) != ESP_OK) {
         goto free_event_handlers;
     }
+#ifdef _DECL_ethernet
     if ((err = esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL)) != ESP_OK) {
         goto free_event_handlers;
     }
+#endif
 
     uint8_t i;
     ip6_addr_t tmp_addr6;
@@ -4214,7 +4216,9 @@ free_all_and_disable_pcbs:
 free_event_handlers:
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler);
     esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, &event_handler);
+#ifdef _DECL_ethernet
     esp_event_handler_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, &event_handler);
+#endif
     vQueueDelete(_mdns_server->action_queue);
 free_lock:
     vSemaphoreDelete(_mdns_server->lock);
@@ -4262,7 +4266,9 @@ void mdns_free(void)
     vSemaphoreDelete(_mdns_server->lock);
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler);
     esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, &event_handler);
+#ifdef _DECL_ethernet
     esp_event_handler_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, &event_handler);
+#endif
     free(_mdns_server);
     _mdns_server = NULL;
 }

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -783,11 +783,13 @@ static uint16_t _mdns_append_question(uint8_t * packet, uint16_t * index, mdns_o
  */
 static tcpip_adapter_if_t _mdns_get_other_if (tcpip_adapter_if_t tcpip_if)
 {
+#ifdef _DECL_ethernet
     if (tcpip_if == TCPIP_ADAPTER_IF_STA) {
         return TCPIP_ADAPTER_IF_ETH;
     } else if (tcpip_if == TCPIP_ADAPTER_IF_ETH) {
         return TCPIP_ADAPTER_IF_STA;
     }
+#endif
     return TCPIP_ADAPTER_IF_MAX;
 }
 
@@ -3077,6 +3079,7 @@ static void _mdns_handle_system_event(esp_event_base_t event_base,
             default:
                 break;
         }
+#ifdef _DECL_ethernet
     } else if (event_base == ETH_EVENT) {
         switch (event_id) {
             case ETHERNET_EVENT_CONNECTED:
@@ -3093,15 +3096,18 @@ static void _mdns_handle_system_event(esp_event_base_t event_base,
             default:
                 break;
         }
+#endif
     } else if (event_base == IP_EVENT) {
         switch (event_id) {
             case IP_EVENT_STA_GOT_IP:
                 _mdns_enable_pcb(TCPIP_ADAPTER_IF_STA, MDNS_IP_PROTOCOL_V4);
                 _mdns_announce_pcb(TCPIP_ADAPTER_IF_STA, MDNS_IP_PROTOCOL_V6, NULL, 0, true);
                 break;
+#ifdef _DECL_ethernet
             case IP_EVENT_ETH_GOT_IP:
                 _mdns_enable_pcb(TCPIP_ADAPTER_IF_ETH, MDNS_IP_PROTOCOL_V4);
                 break;
+#endif
             case IP_EVENT_GOT_IP6:
                 _mdns_enable_pcb(interface, MDNS_IP_PROTOCOL_V6);
                 _mdns_announce_pcb(interface, MDNS_IP_PROTOCOL_V4, NULL, 0, true);

--- a/components/mdns/mdns_console.c
+++ b/components/mdns/mdns_console.c
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#ifdef _DECL_console
 #include <stdio.h>
 #include <string.h>
 #include "esp_console.h"
@@ -1058,3 +1059,4 @@ void mdns_console_register(void)
     register_mdns_query_svc();
 }
 
+#endif /* _DECL_console */

--- a/components/mdns/private_include/mdns_networking.h
+++ b/components/mdns/private_include/mdns_networking.h
@@ -21,7 +21,9 @@
 #include "esp_system.h"
 #include "esp_timer.h"
 #include "esp_event.h"
+#ifdef _DECL_ethernet
 #include "esp_eth.h"
+#endif
 
 
 /**

--- a/components/newlib/syscalls.c
+++ b/components/newlib/syscalls.c
@@ -27,6 +27,7 @@ int _system_r(struct _reent *r, const char *str)
     return -1;
 }
 
+int _raise_r(struct _reent *r, int sig) __attribute__((weak));
 int _raise_r(struct _reent *r, int sig)
 {
     abort();

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -29,7 +29,9 @@
 #include "esp_ipc.h"
 #include "esp_attr.h"
 #include "esp_spi_flash.h"
+#ifdef _DECL_bootloader_support
 #include "esp_flash_encrypt.h"
+#endif
 #include "esp_log.h"
 #include "cache_utils.h"
 #include "esp32/spiram.h"

--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -131,6 +131,9 @@ static __attribute__((unused)) bool is_safe_write_address(size_t addr, size_t si
         UNSAFE_WRITE_ADDRESS;
     }
     return true;
+#else
+    UNSAFE_WRITE_ADDRESS;
+#endif
 }
 
 

--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -32,9 +32,19 @@
 #include "esp_spi_flash.h"
 #include "esp_log.h"
 #include "esp32/clk.h"
+#ifdef _DECL_bootloader_support
 #include "esp_flash_partitions.h"
+#else
+  #pragma message "Not using bootloader_support component disable SPI flash write operations"
+#endif
+#ifdef _DECL_app_update
+#include "esp_ota_ops.h"
+#else
+  #pragma message "Not using app_update component disable OTA operations"
+#endif
 #include "cache_utils.h"
 #include "esp_flash.h"
+
 
 /* bytes erased by SPIEraseBlock() ROM function */
 #define BLOCK_ERASE_SIZE 65536
@@ -116,6 +126,7 @@ static const spi_flash_guard_funcs_t *s_flash_guard_ops;
 
 static __attribute__((unused)) bool is_safe_write_address(size_t addr, size_t size)
 {
+#if defined(_DECL_bootloader_support) && defined(_DECL_app_update)
     if (!esp_partition_main_flash_region_safe(addr, size)) {
         UNSAFE_WRITE_ADDRESS;
     }

--- a/components/tcpip_adapter/Kconfig
+++ b/components/tcpip_adapter/Kconfig
@@ -24,4 +24,10 @@ menu "TCP/IP Adapter"
                 lwIP is a small independent implementation of the TCP/IP protocol suite.
     endchoice
 
+    config NETIF_USE_TEST_IF
+        bool "Enable TCP adapter for Lwip Test interface"
+        default y
+        help
+            If this is set, the test interface will be implemented. This is not required usually.
+
 endmenu

--- a/components/tcpip_adapter/event_handlers.c
+++ b/components/tcpip_adapter/event_handlers.c
@@ -17,7 +17,9 @@
 #include "esp_event.h"
 #include "esp_wifi.h"
 #include "esp_private/wifi.h"
+#ifdef _DECL_ethernet
 #include "esp_eth.h"
+#endif
 #include "esp_err.h"
 #include "esp_log.h"
 
@@ -46,6 +48,7 @@ static void handle_eth_connected(void *arg, esp_event_base_t base, int32_t event
 static void handle_eth_disconnected(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_eth_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 
+#ifdef _DECL_ethernet
 static void handle_eth_start(void *arg, esp_event_base_t base, int32_t event_id, void *data)
 {
     tcpip_adapter_ip_info_t eth_ip;
@@ -94,21 +97,23 @@ static void handle_eth_disconnected(void *arg, esp_event_base_t base, int32_t ev
     tcpip_adapter_down(TCPIP_ADAPTER_IF_ETH);
 }
 
-static void handle_sta_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data)
+static void handle_eth_got_ip(void* arg, esp_event_base_t base, int32_t event_id, void* data)
 {
-    API_CALL_CHECK("esp_wifi_internal_set_sta_ip", esp_wifi_internal_set_sta_ip(), ESP_OK);
-
     const ip_event_got_ip_t *event = (const ip_event_got_ip_t *) data;
-    ESP_LOGI(TAG, "sta ip: " IPSTR ", mask: " IPSTR ", gw: " IPSTR,
+    ESP_LOGI(TAG, "eth ip: " IPSTR ", mask: " IPSTR ", gw: " IPSTR,
              IP2STR(&event->ip_info.ip),
              IP2STR(&event->ip_info.netmask),
              IP2STR(&event->ip_info.gw));
 }
 
-static void handle_eth_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data)
+#endif
+
+static void handle_sta_got_ip(void* arg, esp_event_base_t base, int32_t event_id, void* data)
 {
+    API_CALL_CHECK("esp_wifi_internal_set_sta_ip", esp_wifi_internal_set_sta_ip(), ESP_OK);
+
     const ip_event_got_ip_t *event = (const ip_event_got_ip_t *) data;
-    ESP_LOGI(TAG, "eth ip: " IPSTR ", mask: " IPSTR ", gw: " IPSTR,
+    ESP_LOGI(TAG, "sta ip: " IPSTR ", mask: " IPSTR ", gw: " IPSTR,
              IP2STR(&event->ip_info.ip),
              IP2STR(&event->ip_info.netmask),
              IP2STR(&event->ip_info.gw));
@@ -260,6 +265,7 @@ esp_err_t tcpip_adapter_clear_default_wifi_handlers(void)
     return ESP_OK;
 }
 
+#ifdef _DECL_ethernet
 esp_err_t tcpip_adapter_set_default_eth_handlers(void)
 {
     esp_err_t err;
@@ -304,3 +310,4 @@ esp_err_t tcpip_adapter_clear_default_eth_handlers(void)
     esp_event_handler_unregister(IP_EVENT, IP_EVENT_ETH_GOT_IP, handle_eth_got_ip);
     return ESP_OK;
 }
+#endif

--- a/components/tcpip_adapter/event_handlers.c
+++ b/components/tcpip_adapter/event_handlers.c
@@ -42,13 +42,13 @@ static void handle_sta_connected(void *arg, esp_event_base_t base, int32_t event
 static void handle_sta_disconnected(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_sta_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 
+#ifdef _DECL_ethernet
 static void handle_eth_start(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_eth_stop(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_eth_connected(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_eth_disconnected(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 static void handle_eth_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data);
 
-#ifdef _DECL_ethernet
 static void handle_eth_start(void *arg, esp_event_base_t base, int32_t event_id, void *data)
 {
     tcpip_adapter_ip_info_t eth_ip;

--- a/components/tcpip_adapter/include/tcpip_adapter.h
+++ b/components/tcpip_adapter/include/tcpip_adapter.h
@@ -98,7 +98,9 @@ typedef enum {
 #ifdef _DECL_ethernet
     TCPIP_ADAPTER_IF_ETH,         /**< Ethernet interface */
 #endif
+#if CONFIG_NETIF_USE_TEST_IF
     TCPIP_ADAPTER_IF_TEST,        /**< tcpip stack test interface */
+#endif
     TCPIP_ADAPTER_IF_MAX
 } tcpip_adapter_if_t;
 
@@ -152,7 +154,9 @@ typedef enum {
     IP_EVENT_STA_LOST_IP,              /*!< ESP32 station lost IP and the IP is reset to 0 */
     IP_EVENT_AP_STAIPASSIGNED,         /*!< ESP32 soft-AP assign an IP to a connected station */
     IP_EVENT_GOT_IP6,                  /*!< ESP32 station or ap or ethernet interface v6IP addr is preferred */
+#ifdef _DECL_ethernet
     IP_EVENT_ETH_GOT_IP,               /*!< ESP32 ethernet got IP from connected AP */
+#endif
 } ip_event_t;
 
 /** @brief IP event base declaration */
@@ -700,6 +704,7 @@ esp_err_t tcpip_adapter_get_netif(tcpip_adapter_if_t tcpip_if, void ** netif);
  */
 bool tcpip_adapter_is_netif_up(tcpip_adapter_if_t tcpip_if);
 
+#if CONFIG_NETIF_USE_TEST_IF
 /**
  * @brief  Cause the TCP/IP stack to start the test interface with specified MAC and IP.
  * Test interface is used to exercise network stack with injected packets from SW.
@@ -713,7 +718,9 @@ bool tcpip_adapter_is_netif_up(tcpip_adapter_if_t tcpip_if);
  *         - ESP_ERR_NO_MEM
  */
 esp_err_t tcpip_adapter_test_start(uint8_t *mac, tcpip_adapter_ip_info_t *ip_info);
+#endif
 
+#ifdef _DECL_ethernet
 /**
  * @brief  Install default event handlers for Ethernet interface
  * @return
@@ -729,6 +736,7 @@ esp_err_t tcpip_adapter_set_default_eth_handlers(void);
  *      - one of the errors from esp_event on failure
  */
 esp_err_t tcpip_adapter_clear_default_eth_handlers(void);
+#endif
 
 /**
  * @brief  Install default event handlers for Wi-Fi interfaces (station and AP)

--- a/components/tcpip_adapter/include/tcpip_adapter.h
+++ b/components/tcpip_adapter/include/tcpip_adapter.h
@@ -95,7 +95,9 @@ typedef struct {
 typedef enum {
     TCPIP_ADAPTER_IF_STA = 0,     /**< Wi-Fi STA (station) interface */
     TCPIP_ADAPTER_IF_AP,          /**< Wi-Fi soft-AP interface */
+#ifdef _DECL_ethernet
     TCPIP_ADAPTER_IF_ETH,         /**< Ethernet interface */
+#endif
     TCPIP_ADAPTER_IF_TEST,        /**< tcpip stack test interface */
     TCPIP_ADAPTER_IF_MAX
 } tcpip_adapter_if_t;
@@ -182,6 +184,7 @@ typedef struct {
  */
 void tcpip_adapter_init(void);
 
+#ifdef _DECL_ethernet
 /**
  * @brief  Cause the TCP/IP stack to start the Ethernet interface with specified MAC and IP
  *
@@ -197,6 +200,7 @@ void tcpip_adapter_init(void);
  *         - ESP_ERR_NO_MEM
  */
 esp_err_t tcpip_adapter_eth_start(uint8_t *mac, tcpip_adapter_ip_info_t *ip_info, void *args);
+#endif
 
 /**
  * @brief  Cause the TCP/IP stack to start the Wi-Fi station interface with specified MAC and IP
@@ -561,6 +565,7 @@ esp_err_t tcpip_adapter_dhcpc_start(tcpip_adapter_if_t tcpip_if);
  */
 esp_err_t tcpip_adapter_dhcpc_stop(tcpip_adapter_if_t tcpip_if);
 
+#ifdef _DECL_ethernet
 /**
  * @brief  Receive an Ethernet frame from the Ethernet interface
  *
@@ -576,6 +581,7 @@ esp_err_t tcpip_adapter_dhcpc_stop(tcpip_adapter_if_t tcpip_if);
  *         - ESP_OK
  */
 esp_err_t tcpip_adapter_eth_input(void *buffer, uint16_t len, void *eb);
+#endif
 
 /**
  * @brief  Receive an 802.11 data frame from the Wi-Fi Station interface

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -205,7 +205,11 @@ static esp_err_t tcpip_adapter_start(tcpip_adapter_if_t tcpip_if, uint8_t *mac, 
         netif_add(esp_netif[tcpip_if], &ip_info->ip, &ip_info->netmask, &ip_info->gw, args, netif_init, tcpip_input);
        
 #if ESP_GRATUITOUS_ARP
-        if (tcpip_if == TCPIP_ADAPTER_IF_STA || tcpip_if == TCPIP_ADAPTER_IF_ETH) {
+        if (tcpip_if == TCPIP_ADAPTER_IF_STA
+#if _DECL_ethernet
+         || tcpip_if == TCPIP_ADAPTER_IF_ETH
+#endif
+           ) {
             netif_set_garp_flag(esp_netif[tcpip_if]);
         }
 #endif

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -35,7 +35,9 @@
 #ifdef _DECL_ethernet
 #include "netif/ethernetif.h"
 #endif
+#if CONFIG_NETIF_USE_TEST_IF
 #include "netif/nettestif.h"
+#endif
 
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"
@@ -173,8 +175,10 @@ static esp_err_t tcpip_adapter_update_default_netif(void)
 #endif
     } else if (esp_netif[TCPIP_ADAPTER_IF_AP] != NULL && netif_is_up(esp_netif[TCPIP_ADAPTER_IF_AP])) {
         netif_set_default(esp_netif[TCPIP_ADAPTER_IF_AP]);
+#if CONFIG_NETIF_USE_TEST_IF
     } else if(esp_netif[TCPIP_ADAPTER_IF_TEST] != NULL && netif_is_up(esp_netif[TCPIP_ADAPTER_IF_TEST])) {
         netif_set_default(esp_netif[TCPIP_ADAPTER_IF_TEST]);
+#endif
     }
 
     return ESP_OK;
@@ -229,8 +233,10 @@ static esp_err_t tcpip_adapter_start(tcpip_adapter_if_t tcpip_if, uint8_t *mac, 
 
             dhcps_status = TCPIP_ADAPTER_DHCP_STARTED;
         }
+#if CONFIG_NETIF_USE_TEST_IF
     } else if (tcpip_if == TCPIP_ADAPTER_IF_TEST) {
         netif_set_up(esp_netif[tcpip_if]);
+#endif
     }
 
     tcpip_adapter_update_default_netif();
@@ -252,12 +258,13 @@ esp_err_t tcpip_adapter_sta_start(uint8_t *mac, tcpip_adapter_ip_info_t *ip_info
     return tcpip_adapter_start(TCPIP_ADAPTER_IF_STA, mac, ip_info, NULL);
 }
 
+#if CONFIG_NETIF_USE_TEST_IF
 esp_err_t tcpip_adapter_test_start(uint8_t *mac, tcpip_adapter_ip_info_t *ip_info)
 {
     esp_netif_init_fn[TCPIP_ADAPTER_IF_TEST] = nettestif_init;
     return tcpip_adapter_start(TCPIP_ADAPTER_IF_TEST, mac, ip_info, NULL);
 }
-
+#endif
 
 esp_err_t tcpip_adapter_ap_start(uint8_t *mac, tcpip_adapter_ip_info_t *ip_info)
 {

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -34,8 +34,8 @@
 #include "netif/wlanif.h"
 #ifdef _DECL_ethernet
 #include "netif/ethernetif.h"
-#include "netif/nettestif.h"
 #endif
+#include "netif/nettestif.h"
 
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"

--- a/make/project.mk
+++ b/make/project.mk
@@ -312,7 +312,7 @@ export COMPONENT_INCLUDES
 
 # Create the component list preprocessor definition
 COMPONENT_DECLARATION := 
-COMPONENT_DECLARATION += $(addprefix -D_DECL_, $(COMPONENT_LIBRARIES))
+COMPONENT_DECLARATION += $(addprefix -D_DECL_, $(subst -,_,$(COMPONENT_LIBRARIES)))
 export COMPONENT_DECLARATION
  
 

--- a/make/project.mk
+++ b/make/project.mk
@@ -310,6 +310,15 @@ COMPONENT_INCLUDES += $(abspath $(BUILD_DIR_BASE)/include/)
 
 export COMPONENT_INCLUDES
 
+# Create the component list preprocessor definition
+COMPONENT_DECLARATION := 
+COMPONENT_DECLARATION += $(addprefix -D_DECL_, $(COMPONENT_LIBRARIES))
+export COMPONENT_DECLARATION
+ 
+
+# Set variables common to both project & component
+include $(IDF_PATH)/make/common.mk
+
 all:
 ifdef CONFIG_SECURE_BOOT_ENABLED
 	@echo "(Secure boot enabled, so bootloader not flashed automatically. See 'make bootloader' output)"
@@ -444,6 +453,7 @@ CFLAGS := $(strip \
 	$(COMMON_FLAGS) \
 	$(COMMON_WARNING_FLAGS) -Wno-old-style-declaration \
 	$(CFLAGS) \
+	$(COMPONENT_DECLARATION) \
 	$(EXTRA_CFLAGS))
 
 # List of flags to pass to C++ compiler
@@ -457,6 +467,7 @@ CXXFLAGS := $(strip \
 	$(COMMON_FLAGS) \
 	$(COMMON_WARNING_FLAGS) \
 	$(CXXFLAGS) \
+	$(COMPONENT_DECLARATION) \
 	$(EXTRA_CXXFLAGS))
 
 ifdef CONFIG_COMPILER_CXX_EXCEPTIONS

--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -810,7 +810,7 @@ def get_python_env_path():
         with open(version_file_path, "r") as version_file:
             idf_version_str = version_file.read()
     else:
-        idf_version_str = subprocess.check_output(['git', '-C', global_idf_path, 'describe', '--tags'], cwd=global_idf_path, env=os.environ).decode()
+        idf_version_str = subprocess.check_output(['git', '--work-tree=' + global_idf_path, 'describe', '--tags'], cwd=global_idf_path, env=os.environ).decode()
     match = re.match(r'^v([0-9]+\.[0-9]+).*', idf_version_str)
     idf_version = match.group(1)
 


### PR DESCRIPTION
This fixes #2571.
Basically, it's a 2 step process. First, the project_common.mk is modified to add a vector of `-D_DECL_component_name` to the C and CXX flags, so each component is aware of the other selected components in the main makefile.
Typically, this does not change anything for default build, but make build considerably faster and produce a smaller binary when you specify only the components you need in the Makefile.
In my case, in minimalist build, I have:
```
COMPONENTS=freertos esp32 soc heap newlib esptool_py nvs_flash spi_flash log tcpip_adapter lwip main xtensa-debug-module driver bt vfs micro-ecc nghttp wpa_supplicant smartconfig_ack app_trace mbedtls libesphttpd esp_http_client esp-tls pthread cxx
 ```

Then, I've fixed all the dependencies that were cross-linked between components so we don't build useless stuff. 
I've added a I2C_SLAVE_MODE option in Kconfig of driver component to disable I2C slave code.
I've also added a RMT_RECEIVE option to disable RMT receive.

Here are my results:
# Without specifying any components in main makefile (usual default):
```
Complete (no component specifications)
Bin size: 591168
Build time: 4m52
```

# Without app_update, ethernet, bootloader_support
```
Bin size: 579872
Build time: 3m12
```

# Without app_update, bootloader_support
```
Bin size: 580176
Build time: 3m22
```

# Without ethernet, I2C slave, RMT receive
```
Bin size: 585632
Build time: 3m30
```

Please notice that binary size saving is usually 3x larger since you've a factory plus 2 OTA partitions (so 3 times the binary size). So in the end, the change gives 33kB of flash saving.