### PR TITLE
bugfix esp-http-client: add username and password in esp_http_client_init()

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -535,6 +535,13 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
     client->parser->data = client;
     client->event.client = client;
 
+    if (config->username) {
+        client->connection_info.username = config->username;
+    }
+
+    if (config->password) {
+        client->connection_info.password = config->password;
+    }
     client->state = HTTP_STATE_INIT;
     return client;
 }


### PR DESCRIPTION
Username and password in the configuration parameter used for HTTP client initialization are not added to the HTTP client handle, thus, no authentication is sent into the HTTP header.