### PR TITLE
Add esp_tls_init_global_ca_store function to esp-tls

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -258,10 +258,24 @@ void esp_tls_conn_delete(esp_tls_t *tls);
 size_t esp_tls_get_bytes_avail(esp_tls_t *tls);
 
 /**
+ * @brief      Create a global CA store, initially empty
+ *
+ * This function should be called if the application wants to use the same CA store for
+ * multiple connections, and to manage the certificates directly via mbedTLS APIs.
+ * The application must call this function before calling esp_tls_conn_new().
+ *
+ * @return
+ *             - ESP_OK  if creating global CA store was successful.
+ *             - ESP_ERR_NO_MEM if an error occured when allocating the mbedTLS resources.
+ */
+esp_err_t esp_tls_init_global_ca_store();
+
+/**
  * @brief      Create a global CA store with the buffer provided in cfg.
  *
  * This function should be called if the application wants to use the same CA store for
- * multiple connections. The application must call this function before calling esp_tls_conn_new().
+ * multiple connections, initializing it with a certificate chain in the provided buffer.
+ * The application must call this function before calling esp_tls_conn_new().
  *
  * @param[in]  cacert_pem_buf    Buffer which has certificates in pem format. This buffer
  *                               is used for creating a global CA store, which can be used
@@ -269,7 +283,7 @@ size_t esp_tls_get_bytes_avail(esp_tls_t *tls);
  * @param[in]  cacert_pem_bytes  Length of the buffer.
  *
  * @return
- *             - ESP_OK  if creating global CA store was successful.
+ *             - ESP_OK  if adding initial certificates was successful.
  *             - Other   if an error occured or an action must be taken by the calling process.
  */
 esp_err_t esp_tls_set_global_ca_store(const unsigned char *cacert_pem_buf, const unsigned int cacert_pem_bytes);


### PR DESCRIPTION
called from `esp_tls_set_global_ca_store`. (if `global_cacert` has already been initialized, re-initialize it -- same behaviour as before).

Having `esp_tls_init_global_ca_store` function allows allocating the mbedTLS certificate chain, but to manage it directly with mbedTLS APIs (in my use case, I only have der format certs, but I still need the cert chain initialized first, before adding them).