### PR TITLE
Add dynamic deleted timer list to freertos timer loop (IDFGH-2497)

### DIFF
--- a/components/freertos/timers.c
+++ b/components/freertos/timers.c
@@ -700,7 +700,6 @@ TickType_t xTimeNow;
 
 List_t* xDeletedTimerList = NULL;
 
-int deleted_timer_count = 0;
 	while( xQueueReceive( xTimerQueue, &xMessage, tmrNO_DELAY ) != pdFAIL ) /*lint !e603 xMessage does not have to be initialised as it is passed out, not in, and it is not used unless xQueueReceive() returns pdTRUE. */
 	{
 		#if ( INCLUDE_xTimerPendFunctionCall == 1 )
@@ -839,7 +838,6 @@ int deleted_timer_count = 0;
 						listSET_LIST_ITEM_OWNER( xDeletedTimerListItem, pxTimer );
 						vListInsertEnd( xDeletedTimerList, xDeletedTimerListItem );
 					}
-					deleted_timer_count++;
 					/* The timer has already been removed from the active list,
 					just free up the memory if the memory was dynamically
 					allocated. */

--- a/components/freertos/timers.c
+++ b/components/freertos/timers.c
@@ -814,29 +814,30 @@ List_t* xDeletedTimerList = NULL;
 					/* Check if this timer pointer is already present in the list of
 					deleted timers */
 					bool found = pdFALSE;
-					if (xDeletedTimerList != NULL && !listLIST_IS_EMPTY( xDeletedTimerList )) {
-						ListItem_t* item = listGET_HEAD_ENTRY( xDeletedTimerList );
-						const ListItem_t* end = listGET_END_MARKER( xDeletedTimerList );
-						for( ; item != end; item = listGET_NEXT(item) ) {
-							/* If the list item owner pointer matches the current timer,
-							indicate the result has been found and stop checking */
-							if (listGET_LIST_ITEM_OWNER(item) == pxTimer) {
-								found = pdTRUE;
-								break;
+					if (xDeletedTimerList != NULL) {
+						if (!listLIST_IS_EMPTY( xDeletedTimerList )) {
+							ListItem_t* item = listGET_HEAD_ENTRY( xDeletedTimerList );
+							const ListItem_t* end = listGET_END_MARKER( xDeletedTimerList );
+							for( ; item != end; item = listGET_NEXT(item) ) {
+								/* If the list item owner pointer matches the current timer,
+								indicate the result has been found and stop checking */
+								if (listGET_LIST_ITEM_OWNER(item) == pxTimer) {
+									found = pdTRUE;
+									break;
+								}
 							}
 						}
-					}
-
-					if (found) {
-						break;
-					}
-					else {
-						/* Insert list item containing this timer, it will be deleted now */
-						ListItem_t* xDeletedTimerListItem = malloc(sizeof(ListItem_t));
-						vListInitialiseItem( xDeletedTimerListItem );
-						listSET_LIST_ITEM_VALUE( xDeletedTimerListItem, 0 );
-						listSET_LIST_ITEM_OWNER( xDeletedTimerListItem, pxTimer );
-						vListInsertEnd( xDeletedTimerList, xDeletedTimerListItem );
+						if (found) {
+							break;
+						}
+						else {
+							/* Insert list item containing this timer, it will be deleted now */
+							ListItem_t* xDeletedTimerListItem = malloc(sizeof(ListItem_t));
+							vListInitialiseItem( xDeletedTimerListItem );
+							listSET_LIST_ITEM_VALUE( xDeletedTimerListItem, 0 );
+							listSET_LIST_ITEM_OWNER( xDeletedTimerListItem, pxTimer );
+							vListInsertEnd( xDeletedTimerList, xDeletedTimerListItem );
+						}
 					}
 					/* The timer has already been removed from the active list,
 					just free up the memory if the memory was dynamically

--- a/components/freertos/timers.c
+++ b/components/freertos/timers.c
@@ -809,7 +809,9 @@ List_t* xDeletedTimerList = NULL;
 					more than once */
 					if (xDeletedTimerList == NULL) {
 						xDeletedTimerList = pvPortMalloc(sizeof(List_t));
-						vListInitialise( xDeletedTimerList );
+						if (xDeletedTimerList != NULL) {
+							vListInitialise( xDeletedTimerList );
+						}
 					}
 					/* Check if this timer pointer is already present in the list of
 					deleted timers */

--- a/components/freertos/timers.c
+++ b/components/freertos/timers.c
@@ -808,7 +808,7 @@ List_t* xDeletedTimerList = NULL;
 					/* Maintain a dynamic list of deleted timers, avoid deleting them
 					more than once */
 					if (xDeletedTimerList == NULL) {
-						xDeletedTimerList = malloc(sizeof(List_t));
+						xDeletedTimerList = pvPortMalloc(sizeof(List_t));
 						vListInitialise( xDeletedTimerList );
 					}
 					/* Check if this timer pointer is already present in the list of
@@ -876,9 +876,9 @@ List_t* xDeletedTimerList = NULL;
 		while (!listLIST_IS_EMPTY( xDeletedTimerList )) {
 			ListItem_t* item = listGET_HEAD_ENTRY( xDeletedTimerList );
 			uxListRemove( item );
-			free( item );
+			vPortFree( item );
 		}
-		free( xDeletedTimerList );
+		vPortFree( xDeletedTimerList );
 	}
 }
 /*-----------------------------------------------------------*/

--- a/components/freertos/timers.c
+++ b/components/freertos/timers.c
@@ -815,7 +815,7 @@ List_t* xDeletedTimerList = NULL;
 					}
 					/* Check if this timer pointer is already present in the list of
 					deleted timers */
-					bool found = pdFALSE;
+					BaseType_t xTimerAlreadyDeleted = pdFALSE;
 					if (xDeletedTimerList != NULL) {
 						if (!listLIST_IS_EMPTY( xDeletedTimerList )) {
 							ListItem_t* item = listGET_HEAD_ENTRY( xDeletedTimerList );
@@ -824,12 +824,12 @@ List_t* xDeletedTimerList = NULL;
 								/* If the list item owner pointer matches the current timer,
 								indicate the result has been found and stop checking */
 								if (listGET_LIST_ITEM_OWNER(item) == pxTimer) {
-									found = pdTRUE;
+									xTimerAlreadyDeleted = pdTRUE;
 									break;
 								}
 							}
 						}
-						if (found) {
+						if (xTimerAlreadyDeleted) {
 							break;
 						}
 						else {


### PR DESCRIPTION
To avoid double free on timers.

It resolves my issue here:
https://github.com/espressif/esp-idf/issues/2342

Perhaps seeing the solution (that worked for me) will illustrate the issue? I haven't been able to replicate it, only to verify that this PR fixes it for me (and perhaps protects against the double free issue if it did somehow happen anyway).