### PR TITLE
added IDF_CXX_STD cmake var and removed default -std=gnu++11 (IDFGH-1788)

### DIFF
--- a/tools/cmake/idf_functions.cmake
+++ b/tools/cmake/idf_functions.cmake
@@ -67,7 +67,7 @@ function(idf_set_global_compiler_options)
 
     add_c_compile_options(-std=gnu99)
 
-    add_cxx_compile_options(-std=gnu++11 -fno-rtti)
+    add_cxx_compile_options(${IDF_CXX_STD} -fno-rtti)
 
     if(CONFIG_CXX_EXCEPTIONS)
         add_cxx_compile_options(-fexceptions)


### PR DESCRIPTION
This allows using c++14 . As well as c++17 when using the 8.2.0 toolchain