### PR TITLE
BT: Check if CCB's fixed channel info is NULL (IDFGH-2874)

### DIFF
--- a/components/bt/bluedroid/stack/l2cap/l2c_api.c
+++ b/components/bt/bluedroid/stack/l2cap/l2c_api.c
@@ -1842,10 +1842,10 @@ UINT16 L2CA_SendFixedChnlData (UINT16 fixed_cid, BD_ADDR rem_bda, BT_HDR *p_buf)
 
 BOOLEAN L2CA_CheckIsCongest(UINT16 fixed_cid, UINT16 handle)
 {
-    tL2C_LCB *p_lcb;
-    p_lcb = l2cu_find_lcb_by_handle(handle);
+    tL2C_LCB *p_lcb = l2cu_find_lcb_by_handle(handle);
+    size_t chnl = fixed_cid - L2CAP_FIRST_FIXED_CHNL;
 
-    if (p_lcb != NULL) {
+    if (p_lcb != NULL && p_lcb->p_fixed_ccbs[chnl] != NULL) {
         return p_lcb->p_fixed_ccbs[fixed_cid - L2CAP_FIRST_FIXED_CHNL]->cong_sent;
     }
 


### PR DESCRIPTION
A BT device can disconnect while other actions (such as requesting BLE GATT attributes) can be underway. This sets various bits of state to NULL under our feet. When these two states raced, it was possible an ESP32 would crash with a load exception.

When checking for congestion, return TRUE, indicating the channel is congested, so that the caller's error paths can take over.