### PR TITLE
fixed bug where esp_vfs_unregister would unregister root file system (IDFGH-17810)

### DIFF
--- a/components/vfs/vfs.c
+++ b/components/vfs/vfs.c
@@ -171,12 +171,14 @@ esp_err_t esp_vfs_register_with_id(const esp_vfs_t *vfs, void *ctx, esp_vfs_id_t
 
 esp_err_t esp_vfs_unregister(const char* base_path)
 {
+    size_t base_path_len = strlen(base_path);
     for (size_t i = 0; i < s_vfs_count; ++i) {
         vfs_entry_t* vfs = s_vfs[i];
         if (vfs == NULL) {
             continue;
         }
-        if (memcmp(base_path, vfs->path_prefix, vfs->path_prefix_len) == 0) {
+        if (base_path_len == vfs->path_prefix_len
+        && memcmp(base_path, vfs->path_prefix, vfs->path_prefix_len) == 0) {
             free(vfs);
             s_vfs[i] = NULL;
 


### PR DESCRIPTION
when it should unregister sub-filesystem (such as /sdcard)
path comparison must be exact here