### PR TITLE
Add missing dependency

### DIFF
--- a/docs/en/api-guides/jtag-debugging/building-openocd-macos.rst
+++ b/docs/en/api-guides/jtag-debugging/building-openocd-macos.rst
@@ -22,7 +22,7 @@ Install Dependencies
 
 Install packages that are required to compile OpenOCD using Homebrew::
 
-	brew install automake libtool libusb wget gcc@4.9
+	brew install automake libtool libusb wget gcc@4.9 pkg-config
 
 Build OpenOCD
 =============


### PR DESCRIPTION
Without pkg-config the following error will result:

+ aclocal
+ glibtoolize --automake --copy
+ autoconf
configure.ac:12: error: possibly undefined macro: AC_MSG_WARN
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:240: error: possibly undefined macro: AC_MSG_NOTICE
configure.ac:342: error: possibly undefined macro: AC_DEFINE