### PR TITLE
Add static qualifier to s_light_sleep_wakeup variable to prevent it from being global.

### DIFF
--- a/components/esp32/sleep_modes.c
+++ b/components/esp32/sleep_modes.c
@@ -81,7 +81,9 @@ static sleep_config_t s_config = {
     .wakeup_triggers = 0
 };
 
-bool s_light_sleep_wakeup = false;
+/* Internal variable used to track if light sleep wakeup sources are to be
+   expected when determining wakeup cause. */
+static bool s_light_sleep_wakeup = false;
 
 /* Updating RTC_MEMORY_CRC_REG register via set_rtc_memory_crc()
    is not thread-safe. */


### PR DESCRIPTION
Just poking around and noticed this variable was missing the static keyword, making it accessible to other code that it probably shouldn't be. Couldn't find any references to it outside of this file, so it seems like a safe choice to make it `static`.