### PR TITLE
Fixed newline escaping

### DIFF
--- a/tools/ldgen/ldgen.py
+++ b/tools/ldgen/ldgen.py
@@ -79,7 +79,7 @@ def main():
     try:
         sections_infos = SectionsInfo()
 
-        section_info_contents = [s.strip() for s in sections_info_files.read().split("\n")]
+        section_info_contents = [s.strip() for s in sections_info_files.read().split("\\n")]
         section_info_contents = [s for s in section_info_contents if s]
 
         for sections_info_file in section_info_contents:


### PR DESCRIPTION
Backslash needs to be escaped to properly split filenames. Fixes #2796 