### PR TITLE
Documentation: fix SPI_USE_RXDATA, SPI_USE_TXDATA  (IDFGH-1243)

### DIFF
--- a/components/driver/include/driver/spi_master.h
+++ b/components/driver/include/driver/spi_master.h
@@ -132,11 +132,11 @@ struct spi_transaction_t {
     void *user;                     ///< User-defined variable. Can be used to store eg transaction ID.
     union {
         const void *tx_buffer;      ///< Pointer to transmit buffer, or NULL for no MOSI phase
-        uint8_t tx_data[4];         ///< If SPI_USE_TXDATA is set, data set here is sent directly from this variable.
+        uint8_t tx_data[4];         ///< If SPI_TRANS_USE_TXDATA is set, data set here is sent directly from this variable.
     };
     union {
         void *rx_buffer;            ///< Pointer to receive buffer, or NULL for no MISO phase. Written by 4 bytes-unit if DMA is used.
-        uint8_t rx_data[4];         ///< If SPI_USE_RXDATA is set, data is received directly to this variable
+        uint8_t rx_data[4];         ///< If SPI_TRANS_USE_RXDATA is set, data is received directly to this variable
     };
 } ;        //the rx data should start from a 32-bit aligned address to get around dma issue.
 

--- a/docs/en/api-reference/peripherals/spi_master.rst
+++ b/docs/en/api-reference/peripherals/spi_master.rst
@@ -78,8 +78,8 @@ and/or address. This is reflected in the device configuration: when the ``comman
 fields are set to zero, no command or address phase is done.
 
 Something similar is true for the read and write phase: not every transaction needs both data to be written
-as well as data to be read. When ``rx_buffer`` is NULL (and SPI_USE_RXDATA) is not set) the read phase
-is skipped. When ``tx_buffer`` is NULL (and SPI_USE_TXDATA) is not set) the write phase is skipped.
+as well as data to be read. When ``rx_buffer`` is NULL (and SPI_TRANS_USE_RXDATA) is not set) the read phase
+is skipped. When ``tx_buffer`` is NULL (and SPI_TRANS_USE_TXDATA) is not set) the write phase is skipped.
 
 The driver offers two different kinds of transactions: the interrupt
 transactions and the polling transactions. Each device can choose one kind of
@@ -205,8 +205,8 @@ Tips
 1. Transactions with small amount of data:
     Sometimes, the amount of data is very small making it less than optimal allocating a separate buffer
     for it. If the data to be transferred is 32 bits or less, it can be stored in the transaction struct
-    itself. For transmitted data, use the ``tx_data`` member for this and set the ``SPI_USE_TXDATA`` flag
-    on the transmission. For received data, use ``rx_data`` and set ``SPI_USE_RXDATA``. In both cases, do
+    itself. For transmitted data, use the ``tx_data`` member for this and set the ``SPI_TRANS_USE_TXDATA`` flag
+    on the transmission. For received data, use ``rx_data`` and set ``SPI_TRANS_USE_RXDATA``. In both cases, do
     not touch the ``tx_buffer`` or ``rx_buffer`` members, because they use the same memory locations
     as ``tx_data`` and ``rx_data``.
 


### PR DESCRIPTION
To avoid a confusion, change `SPI_USE_RXDATA` and `SPI_USE_TXDATA` to `SPI_TRANS_USE_RXDATA` and `SPI_TRANS_USE_TXDATA` in documentation to make it consistent with the code.