### PR TITLE
better handling wrong addresses (IDFGH-979)

### DIFF
--- a/examples/protocols/sockets/udp_multicast/main/udp_multicast_example_main.c
+++ b/examples/protocols/sockets/udp_multicast/main/udp_multicast_example_main.c
@@ -131,6 +131,8 @@ static int socket_add_ipv4_multicast_group(int sock, bool assign_source_if)
     err = inet_aton(MULTICAST_IPV4_ADDR, &imreq.imr_multiaddr.s_addr);
     if (err != 1) {
         ESP_LOGE(V4TAG, "Configured IPV4 multicast address '%s' is invalid.", MULTICAST_IPV4_ADDR);
+        // Errors in the return value have to be negative
+        err = -1:
         goto err;
     }
     ESP_LOGI(TAG, "Configured IPV4 Multicast address %s", inet_ntoa(imreq.imr_multiaddr.s_addr));
@@ -494,6 +496,10 @@ static void mcast_example_task(void *pvParameters)
                                       &res);
                 if (err < 0) {
                     ESP_LOGE(TAG, "getaddrinfo() failed for IPV4 destination address. error: %d", err);
+                    break;
+                }
+                if (res == 0) {
+                    ESP_LOGE(TAG, "getaddrinfo() did not return any addresses");
                     break;
                 }
 #ifdef CONFIG_EXAMPLE_IPV4_ONLY


### PR DESCRIPTION
a bad address gave a warning in line 133, but didn't abort socket creation via error code. This resulted in a zero pointer returned from getaddrinfo, which wasn't handled and resulted in a "Guru Meditation Error: Core  1 panic'ed (LoadProhibited)" and reboot after dereferencing the zero pointer.