### PR TITLE
Add support for listing tasks to gdb in gdbstub  (IDFGH-729)

### DIFF
--- a/components/esp32/gdbstub.c
+++ b/components/esp32/gdbstub.c
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 /******************************************************************************
- * Description: A stub to make the ESP32 debuggable by GDB over the serial 
+ * Description: A stub to make the ESP32 debuggable by GDB over the serial
  * port, at least enough to do a backtrace on panic. This gdbstub is read-only:
- * it allows inspecting the ESP32 state 
+ * it allows inspecting the ESP32 state
  *******************************************************************************/
 
 #include "rom/ets_sys.h"
 #include "soc/uart_reg.h"
 #include "soc/io_mux_reg.h"
 #include "esp_gdbstub.h"
+#include "esp_panic.h"
 #include "driver/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -34,6 +35,15 @@ static unsigned char cmd[PBUFLEN];		//GDB command input buffer
 static char chsum;						//Running checksum of the output packet
 
 #define ATTR_GDBFN
+
+//If you want more than (default) 32 tasks to be dumped, you'll need to enable the coredump feature and specify
+//here your amount.
+#ifdef CONFIG_ESP32_CORE_DUMP_MAX_TASKS_NUM
+	#define STUB_TASKS_NUM CONFIG_ESP32_CORE_DUMP_MAX_TASKS_NUM
+#else
+	#define STUB_TASKS_NUM 32
+#endif
+
 
 //Receive a char from the uart. Uses polling and feeds the watchdog.
 static int ATTR_GDBFN gdbRecvChar() {
@@ -189,7 +199,7 @@ typedef struct {
 
 GdbRegFile gdbRegFile;
 
-/* 
+/*
 //Register format as the Xtensa HAL has it:
 STRUCT_FIELD (long, 4, XT_STK_EXIT,     exit)
 STRUCT_FIELD (long, 4, XT_STK_PC,       pc)
@@ -203,7 +213,7 @@ STRUCT_FIELD (long, 4, XT_STK_EXCVADDR, excvaddr)
 STRUCT_FIELD (long, 4, XT_STK_LBEG,   lbeg)
 STRUCT_FIELD (long, 4, XT_STK_LEND,   lend)
 STRUCT_FIELD (long, 4, XT_STK_LCOUNT, lcount)
-// Temporary space for saving stuff during window spill 
+// Temporary space for saving stuff during window spill
 STRUCT_FIELD (long, 4, XT_STK_TMP0,   tmp0)
 STRUCT_FIELD (long, 4, XT_STK_TMP1,   tmp1)
 STRUCT_FIELD (long, 4, XT_STK_TMP2,   tmp2)
@@ -213,33 +223,17 @@ STRUCT_FIELD (long, 4, XT_STK_OVLY,   ovly)
 STRUCT_END(XtExcFrame)
 */
 
-static inline bool isValidStack(long sp)
-{
-    return !(sp < 0x3ffae010UL || sp > 0x3fffffffUL);
-}
 
 //Remember the exception frame that caused panic since it's not saved in TCB
 static XtExcFrame paniced_frame;
- 
-static void dumpHwToRegfile(XtExcFrame *frame) {
-	int i;
-	long *frameAregs=&frame->a0;
-	gdbRegFile.pc=(frame->pc & 0x3fffffffU)|0x40000000U;
-	for (i=0; i<16; i++) gdbRegFile.a[i]=frameAregs[i];
-	for (i=16; i<64; i++) gdbRegFile.a[i]=0xDEADBEEF;
-	if (gdbRegFile.a[0] & 0x8000000U) gdbRegFile.a[0] = (gdbRegFile.a[0] & 0x3fffffffU) | 0x40000000U; //Replicate correction from espcoredump.py:560 
-	if (!isValidStack(gdbRegFile.a[1])) gdbRegFile.a[1] = 0xDEADBEEF;
-	gdbRegFile.lbeg=frame->lbeg;
-	gdbRegFile.lend=frame->lend;
-	gdbRegFile.lcount=frame->lcount;
-	gdbRegFile.sar=frame->sar;
-	//All windows have been spilled to the stack by the ISR routines. The following values should indicate that.
-	gdbRegFile.sar=frame->sar;
+
+static void commonRegfile() {
+	if (gdbRegFile.a[0] & 0x8000000U) gdbRegFile.a[0] = (gdbRegFile.a[0] & 0x3fffffffU) | 0x40000000U;
+	if (!esp_stack_ptr_is_sane(gdbRegFile.a[1])) gdbRegFile.a[1] = 0xDEADBEEF;
 	gdbRegFile.windowbase=0; //0
 	gdbRegFile.windowstart=0x1; //1
 	gdbRegFile.configid0=0xdeadbeef; //ToDo
 	gdbRegFile.configid1=0xdeadbeef; //ToDo
-	gdbRegFile.ps=(frame->ps & (1U<<5)) ? (frame->ps & ~(1U<<4)) : frame->ps; //Replicate correction from espcoredump.py:546
 	gdbRegFile.threadptr=0xdeadbeef; //ToDo
 	gdbRegFile.br=0xdeadbeef; //ToDo
 	gdbRegFile.scompare1=0xdeadbeef; //ToDo
@@ -249,6 +243,21 @@ static void dumpHwToRegfile(XtExcFrame *frame) {
 	gdbRegFile.m1=0xdeadbeef; //ToDo
 	gdbRegFile.m2=0xdeadbeef; //ToDo
 	gdbRegFile.m3=0xdeadbeef; //ToDo
+}
+
+static void dumpHwToRegfile(XtExcFrame *frame) {
+	int i;
+	long *frameAregs=&frame->a0;
+	gdbRegFile.pc=(frame->pc & 0x3fffffffU)|0x40000000U;
+	for (i=0; i<16; i++) gdbRegFile.a[i]=frameAregs[i];
+	for (i=16; i<64; i++) gdbRegFile.a[i]=0xDEADBEEF;
+	gdbRegFile.lbeg=frame->lbeg;
+	gdbRegFile.lend=frame->lend;
+	gdbRegFile.lcount=frame->lcount;
+	gdbRegFile.ps=(frame->ps & PS_UM) ? (frame->ps & ~PS_EXCM) : frame->ps;
+	//All windows have been spilled to the stack by the ISR routines. The following values should indicate that.
+	gdbRegFile.sar=frame->sar;
+	commonRegfile();
 	gdbRegFile.expstate=frame->exccause; //ToDo
 }
 
@@ -261,7 +270,7 @@ static void sendReason() {
 	gdbPacketChar('T');
 	i=gdbRegFile.expstate&0x7f;
 	if (i<sizeof(exceptionSignal)) {
-		gdbPacketHex(exceptionSignal[i], 8); 
+		gdbPacketHex(exceptionSignal[i], 8);
 	} else {
 		gdbPacketHex(11, 8);
 	}
@@ -276,58 +285,41 @@ static int sendPacket(const char * text) {
 	return ST_OK;
 }
 
-#if configUSE_TRACE_FACILITY == 1
 static void dumpTaskToRegfile(XtSolFrame *frame) {
 	int i;
 	long *frameAregs=&frame->a0;
 	gdbRegFile.pc=(frame->pc & 0x3fffffffU)|0x40000000U;
 	for (i=0; i<4; i++) gdbRegFile.a[i]=frameAregs[i];
 	for (i=4; i<64; i++) gdbRegFile.a[i]=0xDEADBEEF;
-	if (gdbRegFile.a[0] & 0x8000000U) gdbRegFile.a[0] = (gdbRegFile.a[0] & 0x3fffffffU) | 0x40000000U; //Replicate correction from espcoredump.py:560 
-	if (!isValidStack(gdbRegFile.a[1])) gdbRegFile.a[1] = 0xDEADBEEF;
 	gdbRegFile.lbeg=0;
 	gdbRegFile.lend=0;
 	gdbRegFile.lcount=0;
+	gdbRegFile.ps=(frame->ps & PS_UM) ? (frame->ps & ~PS_EXCM) : frame->ps;
 	//All windows have been spilled to the stack by the ISR routines. The following values should indicate that.
 	gdbRegFile.sar=0;
-	gdbRegFile.windowbase=0; //0
-	gdbRegFile.windowstart=0x1; //1
-	gdbRegFile.configid0=0xdeadbeef; //ToDo
-	gdbRegFile.configid1=0xdeadbeef; //ToDo
-	gdbRegFile.ps=(frame->ps & (1U<<5)) ? (frame->ps & ~(1U<<4)) : frame->ps; //Replicate correction from espcoredump.py:546
-	gdbRegFile.threadptr=0xdeadbeef; //ToDo
-	gdbRegFile.br=0xdeadbeef; //ToDo
-	gdbRegFile.scompare1=0xdeadbeef; //ToDo
-	gdbRegFile.acclo=0xdeadbeef; //ToDo
-	gdbRegFile.acchi=0xdeadbeef; //ToDo
-	gdbRegFile.m0=0xdeadbeef; //ToDo
-	gdbRegFile.m1=0xdeadbeef; //ToDo
-	gdbRegFile.m2=0xdeadbeef; //ToDo
-	gdbRegFile.m3=0xdeadbeef; //ToDo
+	commonRegfile();
 	gdbRegFile.expstate=0; //ToDo
 }
 
 //Fetch the task status
 static unsigned getAllTasksHandle(unsigned index, unsigned * handle, const char ** name, unsigned * coreId) {
 	static unsigned taskCount = 0;
-    static TaskStatus_t tasks[32];
+	static TaskSnapshot_t tasks[STUB_TASKS_NUM];
 
     if (!taskCount) {
-		unsigned runTime = 0;
-		taskCount = uxTaskGetNumberOfTasks();
-		taskCount = uxTaskGetSystemState(tasks, 32, &runTime);
+		unsigned tcbSize = 0;
+		taskCount = uxTaskGetSnapshotAll(tasks, STUB_TASKS_NUM, &tcbSize);
     }
 	if (index < taskCount) {
-		if (handle) *handle = (unsigned)tasks[index].xHandle;
-		if (name) *name = tasks[index].pcTaskName;
-#if configTASKLIST_INCLUDE_COREID
-		if (coreId) *coreId = tasks[index].xCoreID;
-#endif
-    }	
+		TaskHandle_t h = (TaskHandle_t)tasks[index].pxTCB;
+		if (handle) *handle = (unsigned)h;
+		if (name) *name = pcTaskGetTaskName(h);
+		if (coreId) *coreId = xTaskGetAffinity(h);
+    }
 	return taskCount;
 }
 
-typedef struct 
+typedef struct
 {
 	uint8_t * topOfStack;
 } DumpTCB;
@@ -335,7 +327,7 @@ typedef struct
 
 static void dumpTCBToRegFile(unsigned handle) {
 	// A task handle is a pointer to a TCB in FreeRTOS
-	DumpTCB * tcb = (DumpTCB*)handle;	
+	DumpTCB * tcb = (DumpTCB*)handle;
 	uint8_t * pxTopOfStack = tcb->topOfStack;
 
 	//Deduced from coredump code
@@ -361,7 +353,6 @@ static int findCurrentTaskIndex() {
 	}
 	return curTaskIndex;
 }
-#endif
 
 //Handle a command as received from GDB.
 static int gdbHandleCommand(unsigned char *cmd, int len) {
@@ -388,82 +379,82 @@ static int gdbHandleCommand(unsigned char *cmd, int len) {
 		gdbPacketEnd();
 	} else if (cmd[0]=='?') {	//Reply with stop reason
 		sendReason();
-#if configUSE_TRACE_FACILITY == 1
-	} else if (cmd[0]=='H' && reenteredHandler != -1) { //Continue with task
-		if (cmd[1]=='g' || cmd[1]=='c') {
-			const char * ret = "OK";
+	} else if (reenteredHandler != -1) {
+		if (cmd[0]=='H') { //Continue with task
+			if (cmd[1]=='g' || cmd[1]=='c') {
+				const char * ret = "OK";
+				data++;
+				i=gdbGetHexVal(&data, -1);
+				reenteredHandler = 1; //Hg0 is the first packet received after connect
+				j = findCurrentTaskIndex();
+				if (i == j || (j == -1 && !i)) { //The first task requested must be the one that crashed and it does not have a valid TCB anyway since it's not saved yet
+					dumpHwToRegfile(&paniced_frame);
+				} else {
+					unsigned handle, count;
+					//Get the handle for that task
+					count = getAllTasksHandle(i, &handle, 0, 0);
+					//Then extract TCB and gdbRegFile from it
+					if (i < count) dumpTCBToRegFile(handle);
+					else ret = "E00";
+				}
+				return sendPacket(ret);
+			}
+			return sendPacket(NULL);
+		} else if (cmd[0]=='T') {	//Task alive check
+			unsigned count;
 			data++;
 			i=gdbGetHexVal(&data, -1);
-			reenteredHandler = 1; //Hg0 is the first packet received after connect
-			j = findCurrentTaskIndex();
-			if (i == j || (j == -1 && !i)) { //The first task requested must be the one that crashed and it does not have a valid TCB anyway since it's not saved yet
-				dumpHwToRegfile(&paniced_frame);
-			} else {
-				unsigned handle, count;
-				//Get the handle for that task
-				count = getAllTasksHandle(i, &handle, 0, 0);
-				//Then extract TCB and gdbRegFile from it
-				if (i < count) dumpTCBToRegFile(handle);
-				else ret = "E00";
-			}
-			return sendPacket(ret);
-		}
-		return sendPacket(NULL);
-	} else if (cmd[0]=='T' && reenteredHandler != -1) {	//Task alive check
-		unsigned count;
-		data++;
-		i=gdbGetHexVal(&data, -1);
-		count = getAllTasksHandle(i, 0, 0, 0);
-		return sendPacket(i < count ? "OK": "E00");
-	} else if (cmd[0]=='q' && reenteredHandler != -1) {	//Extended query
-		// React to qThreadExtraInfo or qfThreadInfo or qsThreadInfo or qC, without using strcmp
-		if (len > 16 && cmd[1] == 'T' && cmd[2] == 'h' && cmd[3] == 'r' && cmd[7] == 'E' && cmd[12] == 'I' && cmd[16] == ',') {
-			data=&cmd[17];
-			i=gdbGetHexVal(&data, -1);
+			count = getAllTasksHandle(i, 0, 0, 0);
+			return sendPacket(i < count ? "OK": "E00");
+		} else if (cmd[0]=='q') {	//Extended query
+			// React to qThreadExtraInfo or qfThreadInfo or qsThreadInfo or qC, without using strcmp
+			if (len > 16 && cmd[1] == 'T' && cmd[2] == 'h' && cmd[3] == 'r' && cmd[7] == 'E' && cmd[12] == 'I' && cmd[16] == ',') {
+				data=&cmd[17];
+				i=gdbGetHexVal(&data, -1);
 
-			unsigned handle = 0, coreId = 3;
-			const char * name = 0;
-			// Extract the task name and CPU from freeRTOS
-			unsigned tCount = getAllTasksHandle(i, &handle, &name, &coreId);			
-			if (i < tCount)	{
+				unsigned handle = 0, coreId = 3;
+				const char * name = 0;
+				// Extract the task name and CPU from freeRTOS
+				unsigned tCount = getAllTasksHandle(i, &handle, &name, &coreId);
+				if (i < tCount)	{
+					gdbPacketStart();
+					for(k=0; name[k]; k++)	gdbPacketHex(name[k], 8);
+					gdbPacketStr("20435055"); // CPU
+					gdbPacketStr(coreId == 0 ? "30": coreId == 1 ? "31" : "78"); // 0 or 1 or x
+					gdbPacketEnd();
+					return ST_OK;
+				}
+			} else if (len >= 12 && (cmd[1] == 'f' || cmd[1] == 's') && (cmd[2] == 'T' && cmd[3] == 'h' && cmd[4] == 'r' && cmd[5] == 'e' && cmd[6] == 'a' && cmd[7] == 'd' && cmd[8] == 'I')) {
+				// Only react to qfThreadInfo and qsThreadInfo, not using strcmp here since it can be in ROM
+				// Extract the number of task from freeRTOS
+				static int taskIndex = 0;
+				unsigned tCount = 0;
+	 		    if (cmd[1] == 'f') {
+					taskIndex = 0;
+					reenteredHandler = 1;	//It seems it's the first request GDB is sending
+				}
+				tCount = getAllTasksHandle(0, 0, 0, 0);
+				if (taskIndex < tCount)	{
+					gdbPacketStart();
+					gdbPacketStr("m");
+					gdbPacketHex(taskIndex, 32);
+					gdbPacketEnd();
+	                taskIndex++;
+				} else return sendPacket("l");
+			} else if (len >= 2 && cmd[1] == 'C') {
+				// Get current task id
 				gdbPacketStart();
-				for(k=0; name[k]; k++)	gdbPacketHex(name[k], 8);
-				gdbPacketStr("20435055"); // CPU
-				gdbPacketStr(coreId == 0 ? "30": coreId == 1 ? "31" : "78"); // 0 or 1 or x 
+				k = findCurrentTaskIndex();
+				if (k != -1) {
+					gdbPacketStr("QC");
+					gdbPacketHex(k, 32);
+				} else gdbPacketStr("bad");
 				gdbPacketEnd();
 				return ST_OK;
-			} 
-		} else if (len >= 12 && (cmd[1] == 'f' || cmd[1] == 's') && (cmd[2] == 'T' && cmd[3] == 'h' && cmd[4] == 'r' && cmd[5] == 'e' && cmd[6] == 'a' && cmd[7] == 'd' && cmd[8] == 'I')) {
-			// Only react to qfThreadInfo and qsThreadInfo, not using strcmp here since it can be in ROM
-			// Extract the number of task from freeRTOS
-			static int taskIndex = 0;
-			unsigned tCount = 0;
- 		    if (cmd[1] == 'f') { 
-				taskIndex = 0;
-				reenteredHandler = 1;	//It seems it's the first request GDB is sending
 			}
-			tCount = getAllTasksHandle(0, 0, 0, 0);
-			if (taskIndex < tCount)	{
-				gdbPacketStart();
-				gdbPacketStr("m");
-				gdbPacketHex(taskIndex, 32);
-				gdbPacketEnd();
-                taskIndex++;
-			} else return sendPacket("l");
-		} else if (len >= 2 && cmd[1] == 'C') {
-			// Get current task id
-			gdbPacketStart();
-			k = findCurrentTaskIndex();
-			if (k != -1) {
-				gdbPacketStr("QC");
-				gdbPacketHex(k, 32);
-			} else gdbPacketStr("bad");
-			gdbPacketEnd();
-			return ST_OK;
+			return sendPacket(0);
 		}
-		return sendPacket(0);			
-#endif
-	} else 
+	} else
 		//We don't recognize or support whatever GDB just sent us.
 		return sendPacket(0);
 	return ST_OK;
@@ -472,7 +463,7 @@ static int gdbHandleCommand(unsigned char *cmd, int len) {
 
 //Lower layer: grab a command packet and check the checksum
 //Calls gdbHandleCommand on the packet if the checksum is OK
-//Returns ST_OK on success, ST_ERR when checksum fails, a 
+//Returns ST_OK on success, ST_ERR when checksum fails, a
 //character if it is received instead of the GDB packet
 //start char.
 static int gdbReadCommand() {
@@ -523,6 +514,7 @@ static int gdbReadCommand() {
 void esp_gdbstub_panic_handler(XtExcFrame *frame) {
 	if (reenteredHandler == 1) {
 		//Prevent using advanced FreeRTOS features since they seems to crash
+		gdbPacketEnd(); // Ends up any pending GDB packet (this creates a garbage value)
 		reenteredHandler = -1;
 	} else {
 		//Need to remember the frame that panic'd since gdb will ask for all thread before ours
@@ -542,4 +534,3 @@ void esp_gdbstub_panic_handler(XtExcFrame *frame) {
 	while(gdbReadCommand()!=ST_CONT);
 	while(1);
 }
-

--- a/components/esp32/gdbstub.c
+++ b/components/esp32/gdbstub.c
@@ -517,16 +517,17 @@ static int gdbReadCommand() {
 
 
 void esp_gdbstub_panic_handler(XtExcFrame *frame) {
-	//Need to remember the frame that panic'd since gdb will ask for all thread before ours
-    uint8_t * pf = (uint8_t*)&paniced_frame, *f = (uint8_t*)frame;
-	//Could not use memcpy here
-    for(int i = 0; i < sizeof(*frame); i++) pf[i] = f[i];
 	if (reenteredHandler == 1) {
 		//Prevent using advanced FreeRTOS features since they seems to crash
 		reenteredHandler = -1;
+	} else {
+		//Need to remember the frame that panic'd since gdb will ask for all thread before ours
+	    uint8_t * pf = (uint8_t*)&paniced_frame, *f = (uint8_t*)frame;
+		//Could not use memcpy here
+	    for(int i = 0; i < sizeof(*frame); i++) pf[i] = f[i];
 	}
 	//Let's start from something
-	dumpHwToRegfile(frame);
+	dumpHwToRegfile(&paniced_frame);
 
 	//Make sure txd/rxd are enabled
 	gpio_pullup_dis(1);

--- a/components/esp32/gdbstub.c
+++ b/components/esp32/gdbstub.c
@@ -409,14 +409,9 @@ static int gdbHandleCommand(unsigned char *cmd, int len) {
 		unsigned count;
 		data++;
 		i=gdbGetHexVal(&data, -1);
-		const char * ret = "OK";
-		if (i == findCurrentTaskIndex()) ret = "E00";
-		else {			
-			count = getAllTasksHandle(i, 0, 0, 0);
-			if (i >= count) ret = "E00";
-		}
+		count = getAllTasksHandle(i, 0, 0, 0);
 		gdbPacketStart();
-		gdbPacketStr(ret);
+		gdbPacketStr(i < count ? "OK" : "E00");
 		gdbPacketEnd();
 		return ST_OK;
 	} else if (cmd[0]=='q') {	//Extended query


### PR DESCRIPTION
This is supposed to fix #2818 

This adds all the required commands in the gdbstub (via UART) to:

1. List all tasks/threads (including their name and CPU)
2. Get a backtrace for them
3. Switch to them to analyze them more carefully

To tease the current support, you can now do this:
```
Guru Meditation Error: Core  0 panic'ed (StoreProhibited). Exception was unhandled.
Core 0 register dump:
PC      : 0x400d8281  PS      : 0x00060030  A0      : 0x800e1a6a  A1      : 0x3ffda250
0x400d8281: devXXX(HttpdConnData*) at /esp/app/main/HTTPServer.cpp:712

A2      : 0x00000000  A3      : 0x3ffe43b3  A4      : 0x00000007  A5      : 0x0000ff00
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x00000038  A9      : 0x00000038
A10     : 0x00000001  A11     : 0x00000001  A12     : 0x3ffc2618  A13     : 0x3ffc2610
A14     : 0x3ffe43a9  A15     : 0x000000c0  SAR     : 0x00000019  EXCCAUSE: 0x0000001d
EXCVADDR: 0x00000000  LBEG    : 0x400012c5  LEND    : 0x400012d5  LCOUNT  : 0xfffffff5

Backtrace: 0x400d8281:0x3ffda250 0x400e1a67:0x3ffda270 0x400e1e67:0x3ffda2a0 0x400e1205:0x3ffda2e0
0x400d8281: devXXX(HttpdConnData*) at /esp/app/main/HTTPServer.cpp:712

0x400e1a67: httpdProcessRequest at /esp/app/components/libesphttpd/core/httpd.c:833

0x400e1e67: httpdRecvCb at /esp/app/components/libesphttpd/core/httpd.c:920

0x400e1205: platHttpServerTask at /esp/app/components/libesphttpd/core/httpd-freertos.c:772


Entering gdb stub now.
$T04#b8GNU gdb (crosstool-NG crosstool-ng-1.22.0-80-g6c4433a) 7.10
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "--host=x86_64-build_apple-darwin16.3.0 --target=xtensa-esp32-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /esp/app/build/nvse.elf...done.
Remote debugging using /dev/cu.SLAB_USBtoUART
0x400d8281 in devXXX (connData=<optimized out>) at /esp/app/main/HTTPServer.cpp:712
712	    *(int*)0 = 0; // Crash here
(gdb) bt
#0  0x400d8281 in devXXX (connData=<optimized out>) at /esp/app/main/HTTPServer.cpp:712
#1  0x400e1a6a in httpdProcessRequest (pInstance=0x3ffd93f8, conn=0x3ffe4388) at /esp/app/components/libesphttpd/core/httpd.c:649
#2  0x400e1e6a in httpdRecvCb (pInstance=0x3ffd93f8, conn=0x3ffe4388,
    data=0x3ffd8bf1 "POST /devXXX HTTP/1.1\r\nHost: 192.168.0.97\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:63.0) Gecko/20100101 Firefox/63.0\r\nAccept: */*\r\nAccept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en"...,
    len=452) at /esp/app/components/libesphttpd/core/httpd.c:920
#3  0x400e1208 in platHttpServerTask (pvParameters=0x3ffd8bd4) at /esp/app/components/libesphttpd/core/httpd-freertos.c:505
(gdb) i th 1
  Id   Target Id         Frame
* 1    Remote target     0x400d8281 in devXXX (connData=<optimized out>) at /esp/app/main/HTTPServer.cpp:712
(gdb) i th 2
  Id   Target Id         Frame
  2    Thread 1 (IDLE1 CPUx) 0x40144846 in esp_pm_impl_waiti () at /esp/esp-idf/components/esp32/pm_esp32.c:487
(gdb) i th 3
  Id   Target Id         Frame
  3    Thread 2 (IDLE0 CPUx) 0x40144846 in esp_pm_impl_waiti () at /esp/esp-idf/components/esp32/pm_esp32.c:487
(gdb) i th 4
  Id   Target Id         Frame
  4    Thread 3 (uart CPUx) xEventGroupWaitBits (xEventGroup=0x3ffb6e88, uxBitsToWaitFor=1, xClearOnExit=1, xWaitForAllBits=1, xTicksToWait=<optimized out>) at /esp/esp-idf/components/freertos/event_groups.c:445
(gdb) thr apply 3 bt

Thread 3 (Thread 2):
#0  0x401447da in esp_pm_impl_waiti () at /esp/esp-idf/components/esp32/pm_esp32.c:487
#1  0x400d2c76 in esp_vApplicationIdleHook () at /esp/esp-idf/components/esp32/freertos_hooks.c:63
#2  0x4008f13c in prvIdleTask (pvParameters=<optimized out>) at /esp/esp-idf/components/freertos/tasks.c:3412


```

This is a large change with many redundant code since I could not access the other components static's / internal stuff.
Mainly, I've duplicated the `dumpHwRegfile` function to support Xtensa's `XtSolFrame`, made a backup of the current panic handler (since as soon as gdb detects there are threads, it switches them, so the `gdbregfile` is lost), and dealt with FreeRTOS's TCB structure.

I didn't want to copy all the TCB structure declaration (I only needed a the top of the stack which is guaranteed to be the first element in the structure). So I declared a dummy structure with just a single element, and I'm using this. I'm not using `uxTaskSnapshotAll` here since this does not give the task name and CPU id. Instead, I'm using `uxTaskGetSystemState` that gives everything (name, TCB/handle, cpu id).

I've added all protections for address validity checking (copied from espcoredump.py and coredump.c)

There is still a bug within gdb when it's receiving a dump with a code that's built with -Os (with inlining) but it has already been reported in your forum, and it's unrelated to this work (it also happens when doing coredump).

Please let me know if you need more changes.