### PR TITLE
Fix typo in error message in esp_bluedroid_init.

### DIFF
--- a/components/bt/bluedroid/api/esp_bt_main.c
+++ b/components/bt/bluedroid/api/esp_bt_main.c
@@ -119,7 +119,7 @@ esp_err_t esp_bluedroid_init(void)
     future_t **future_p;
 
     if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED) {
-        LOG_ERROR("Conroller not initialised\n");
+        LOG_ERROR("Controller not initialised\n");
         return ESP_ERR_INVALID_STATE;
     }
 


### PR DESCRIPTION
Just a quick fix for a typo in an error message within `esp_bluedroid_init` that gets displayed when the controller is not enabled.