### PR TITLE
Sped the gpio_intr_service ISR up by 1.5 uSeconds (+-50% faster).

### DIFF
--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -366,13 +366,17 @@ void IRAM_ATTR gpio_intr_service(void* arg)
 
     //read status to get interrupt status for GPIO0-31
     const uint32_t gpio_intr_status = GPIO.status;
-    gpio_isr_loop(gpio_intr_status, 0);
-    GPIO.status_w1tc = gpio_intr_status;
+    if (gpio_intr_status) {
+        gpio_isr_loop(gpio_intr_status, 0);
+        GPIO.status_w1tc = gpio_intr_status;
+    }
 
     //read status1 to get interrupt status for GPIO32-39
-    uint32_t gpio_intr_status_h = GPIO.status1.intr_st;
-    gpio_isr_loop(gpio_intr_status_h, 32);
-    GPIO.status1_w1tc.intr_st = gpio_intr_status_h;
+    const uint32_t gpio_intr_status_h = GPIO.status1.intr_st;
+    if (gpio_intr_status_h & ((1<<(GPIO_NUM_MAX-32))-1)) {
+        gpio_isr_loop(gpio_intr_status_h, 32);
+        GPIO.status1_w1tc.intr_st = gpio_intr_status_h;
+    }
 }
 
 esp_err_t gpio_isr_handler_add(gpio_num_t gpio_num, gpio_isr_t isr_handler, void* args)

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -330,19 +330,19 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
 static inline int IRAM_ATTR num_lsb_zero_bits(const uint32_t v) {
     // From: https://en.wikipedia.org/wiki/De_Bruijn_sequence
     // This function returns the amount of unset (zero) bits starting from the LSB.
+    // Note: A value of 0 is returned when v == 0.
     static const int MultiplyDeBruijnBitPosition[32] = {
         0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
         31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
     };
-    const int r = MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
-    return v ? r : 32;
+    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
 }
 
 static inline void IRAM_ATTR gpio_isr_loop(const uint32_t s, const uint32_t gpio_num_start) {
     uint32_t status = s;
     uint32_t gpio_num = gpio_num_start;
     while (status) {
-        const int n = num_lsb_zero_bits(s);
+        const int n = num_lsb_zero_bits(status);
         gpio_num += n; // Offset the gpio_num by the amount of unset (zero) bits found, starting from the LSB.
         if (gpio_isr_func[gpio_num].fn != NULL) {
             gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -330,34 +330,29 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
 void IRAM_ATTR gpio_intr_service(void* arg)
 {
     //GPIO intr process
-    uint32_t gpio_num = 0;
-    //read status to get interrupt status for GPIO0-31
-    uint32_t gpio_intr_status;
-    gpio_intr_status = GPIO.status;
-    //read status1 to get interrupt status for GPIO32-39
-    uint32_t gpio_intr_status_h;
-    gpio_intr_status_h = GPIO.status1.intr_st;
-
     if (gpio_isr_func == NULL) {
         return;
     }
+
+    //read status to get interrupt status for GPIO0-31
+    uint32_t gpio_num = 0;
+    uint32_t gpio_intr_status = GPIO.status;
     do {
-        if (gpio_num < 32) {
-            if (gpio_intr_status & BIT(gpio_num)) { //gpio0-gpio31
-                if (gpio_isr_func[gpio_num].fn != NULL) {
-                    gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);
-                }
-                GPIO.status_w1tc = BIT(gpio_num);
-            }
-        } else {
-            if (gpio_intr_status_h & BIT(gpio_num - 32)) {
-                if (gpio_isr_func[gpio_num].fn != NULL) {
-                    gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);
-                }
-                GPIO.status1_w1tc.intr_st = BIT(gpio_num - 32);
-            }
+        if ((gpio_intr_status & BIT(gpio_num)) && (gpio_isr_func[gpio_num].fn != NULL)) {
+            gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);
         }
+    } while (++gpio_num < 32);
+    GPIO.status_w1tc = gpio_intr_status;
+
+    //read status1 to get interrupt status for GPIO32-39
+    uint32_t gpio_intr_status_h = GPIO.status1.intr_st;
+    do {
+        if ((gpio_intr_status_h & BIT(gpio_num - 32)) && (gpio_isr_func[gpio_num].fn != NULL)) {
+            gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);
+        }
+        gpio_num++;
     } while (++gpio_num < GPIO_PIN_COUNT);
+    GPIO.status1_w1tc.intr_st = gpio_intr_status_h;
 }
 
 esp_err_t gpio_isr_handler_add(gpio_num_t gpio_num, gpio_isr_t isr_handler, void* args)

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -327,22 +327,11 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
     return ESP_OK;
 }
 
-static inline int IRAM_ATTR num_lsb_zero_bits(const uint32_t v) {
-    // From: https://en.wikipedia.org/wiki/De_Bruijn_sequence
-    // This function returns the amount of unset (zero) bits starting from the LSB.
-    // Note: A value of 0 is returned when v == 0.
-    static const int MultiplyDeBruijnBitPosition[32] = {
-        0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
-        31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
-    };
-    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
-}
-
 static inline void IRAM_ATTR gpio_isr_loop(const uint32_t s, const uint32_t gpio_num_start) {
     uint32_t status = s;
     uint32_t gpio_num = gpio_num_start;
     while (status) {
-        const int n = num_lsb_zero_bits(status);
+        const int n = __builtin_ctz(status);
         status >>= n + 1; // Advance to the next status bit, skipping all unset (zero) bits.
         gpio_num += n; // Offset the gpio_num by the amount of unset (zero) bits found, starting from the LSB.
         if (gpio_isr_func[gpio_num].fn != NULL) {

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -368,8 +368,9 @@ void IRAM_ATTR gpio_intr_service(void* arg)
 
     //read status1 to get interrupt status for GPIO32-39
     const uint32_t gpio_intr_status_h = GPIO.status1.intr_st;
-    if (gpio_intr_status_h & ((1<<(GPIO_NUM_MAX-32))-1)) {
-        gpio_isr_loop(gpio_intr_status_h, 32);
+    const uint32_t masked_status = gpio_intr_status_h & ((1<<(GPIO_NUM_MAX-32))-1);
+    if (masked_status) {
+        gpio_isr_loop(masked_status, 32);
         GPIO.status1_w1tc.intr_st = gpio_intr_status_h;
     }
 }

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -343,17 +343,12 @@ static inline void IRAM_ATTR gpio_isr_loop(const uint32_t s, const uint32_t gpio
     uint32_t gpio_num = gpio_num_start;
     while (status) {
         const int n = num_lsb_zero_bits(status);
+        status >>= n + 1; // Advance to the next status bit, skipping all unset (zero) bits.
         gpio_num += n; // Offset the gpio_num by the amount of unset (zero) bits found, starting from the LSB.
         if (gpio_isr_func[gpio_num].fn != NULL) {
             gpio_isr_func[gpio_num].fn(gpio_isr_func[gpio_num].args);
         }
-        if (n) {
-            status >>= n; // Advance to the next status bit, skipping all unset (zero) bits.
-        }
-        else { // LSB is not zero.
-            status >>= 1; // Advance to the next status bit.
-            gpio_num++; // Advance to the next gpio_num.
-        }
+        gpio_num++; // Advance to the next gpio_num.
     }
 }
 


### PR DESCRIPTION
Removed as much branching (if statements) from the
gpio_intr_service ISR, as possible and split the while loop into
two. Also forced writing the two status*_w1tc variables only once,
instead of every time after calling the external function hooks.

The measurements below, was done using the following tools:

Toolchain version: crosstool-ng-1.22.0-80-g6c4433a
Compiler version: 5.2.0

Here follows a comparison of the gpio_intr_service ISR's
execution time, using a DS1054 oscilloscope. All the time spent
calling external functions, via the function pointers
gpio_isr_func[gpio_num].fn, were disregarded.

With OPTIMIZATION_FLAGS = -Og, 1.34 uSeconds faster:

3.22 uSec (with this patch)
4.56 uSec (with commit 71c90ac4)

100 - (100 * 4.56 / 3.22) = 42% faster

With OPTIMIZATION_FLAGS = -Os, 1.65 uSeconds faster:

2.89 uSec (with this patch)
4.54 uSec (with commit 71c90ac4)

100 - (100 * 4.54 / 2.89) = 57% faster