### PR TITLE
WPS_CONFIG_INIT_DEFAULT(type) error (IDFGH-1191)

### DIFF
--- a/components/esp32/include/esp_wps.h
+++ b/components/esp32/include/esp_wps.h
@@ -78,10 +78,10 @@ typedef struct {
     .wps_type = type, \
     .crypto_funcs = &g_wifi_default_wps_crypto_funcs, \
     .factory_info = {   \
-        .manufacturer = "ESPRESSIF",  \
-        .model_number = "ESP32",  \
-        .model_name = "ESPRESSIF IOT",  \
-        .device_name = "ESP STATION",  \
+        {.manufacturer = "ESPRESSIF"},  \
+        {.model_number = "ESP32"},  \
+        {.model_name = "ESPRESSIF IOT"},  \
+        {.device_name = "ESP STATION"},  \
     }  \
 }
 


### PR DESCRIPTION
Add brackets to be compatible with C99 (error: C99 designator '.manufacturer' outside aggregate initializer)