### PR TITLE
Consistently enable gpio interrupts on the core, stored in gpio_isr_handle.

### DIFF
--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -114,14 +114,19 @@ static esp_err_t gpio_intr_enable_on_core (gpio_num_t gpio_num, uint32_t core_id
 
 esp_err_t gpio_intr_enable(gpio_num_t gpio_num)
 {
-    return gpio_intr_enable_on_core (gpio_num, xPortGetCoreID());
+    portENTER_CRITICAL(&gpio_spinlock);
+    const esp_err_t ret = gpio_intr_enable_on_core (gpio_num, xPortGetCoreID());
+    portEXIT_CRITICAL(&gpio_spinlock);
+    return ret;
 }
 
 esp_err_t gpio_intr_disable(gpio_num_t gpio_num)
 {
     GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+    portENTER_CRITICAL(&gpio_spinlock);
     GPIO.pin[gpio_num].int_ena = 0;                             //disable GPIO intr
     gpio_intr_status_clr(gpio_num);
+    portEXIT_CRITICAL(&gpio_spinlock);
     return ESP_OK;
 }
 

--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -88,6 +88,11 @@ esp_err_t gpio_set_intr_type(gpio_num_t gpio_num, gpio_int_type_t intr_type)
     GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
     GPIO_CHECK(intr_type < GPIO_INTR_MAX, "GPIO interrupt type error", ESP_ERR_INVALID_ARG);
     GPIO.pin[gpio_num].int_type = intr_type;
+    if (intr_type == GPIO_INTR_DISABLE) {
+        gpio_intr_disable(gpio_num);
+    } else {
+        gpio_intr_enable(gpio_num);
+    }
     return ESP_OK;
 }
 
@@ -300,11 +305,6 @@ esp_err_t gpio_config(const gpio_config_t *pGPIOConfig)
             }
             ESP_LOGI(GPIO_TAG, "GPIO[%d]| InputEn: %d| OutputEn: %d| OpenDrain: %d| Pullup: %d| Pulldown: %d| Intr:%d ", io_num, input_en, output_en, od_en, pu_en, pd_en, pGPIOConfig->intr_type);
             gpio_set_intr_type(io_num, pGPIOConfig->intr_type);
-            if (pGPIOConfig->intr_type) {
-                gpio_intr_enable(io_num);
-            } else {
-                gpio_intr_disable(io_num);
-            }
             PIN_FUNC_SELECT(io_reg, PIN_FUNC_GPIO); /*function number 2 is GPIO_FUNC for each pin */
         }
         io_num++;

--- a/components/driver/test/test_gpio.c
+++ b/components/driver/test/test_gpio.c
@@ -92,7 +92,7 @@ static void trigger_wake_up(void *arg)
     gpio_config(&io_config);
     gpio_set_level(GPIO_OUTPUT_IO, 0);
     gpio_install_isr_service(0);
-    gpio_isr_handler_add(GPIO_OUTPUT_IO, gpio_isr_level_handler, (void*) GPIO_INPUT_IO);
+    gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_level_handler, (void*) GPIO_INPUT_IO);
     gpio_set_level(GPIO_OUTPUT_IO, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
 }
@@ -400,6 +400,7 @@ TEST_CASE("GPIO get input level test", "[gpio][ignore]")
 
 TEST_CASE("GPIO io pull up/down function", "[gpio]")
 {
+    // Make sure GPIO_INPUT_IO is not connected to anything.
     gpio_config_t  io_conf = init_io(GPIO_INPUT_IO);
     gpio_config(&io_conf);
     gpio_set_direction(GPIO_INPUT_IO, GPIO_MODE_INPUT);
@@ -472,7 +473,7 @@ TEST_CASE("GPIO output and input mode test", "[gpio][test_env=UT_T1_GPIO]")
     TEST_ASSERT_EQUAL_INT_MESSAGE(gpio_get_level(GPIO_INPUT_IO), !level, "direction set error, it can't output");
 }
 
-TEST_CASE("GPIO repeate call service and isr has no memory leak test","[gpio][test_env=UT_T1_GPIO][timeout=90]")
+TEST_CASE("GPIO repeated calling of service and isr has no memory leak test","[gpio][test_env=UT_T1_GPIO][timeout=90]")
 {
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
@@ -498,7 +499,7 @@ TEST_CASE("GPIO repeate call service and isr has no memory leak test","[gpio][te
 
 #if !WAKE_UP_IGNORE
 //this function development is not completed yet, set it ignored
-TEST_CASE("GPIO wake up enable and disenable test", "[gpio][ignore]")
+TEST_CASE("GPIO wake up enable and disable test", "[gpio][ignore]")
 {
     xTaskCreate(sleep_wake_up, "sleep_wake_up", 4096, NULL, 5, NULL);
     xTaskCreate(trigger_wake_up, "trigger_wake_up", 4096, NULL, 5, NULL);

--- a/components/driver/test/test_gpio.c
+++ b/components/driver/test/test_gpio.c
@@ -158,20 +158,20 @@ TEST_CASE("GPIO rising edge interrupt test", "[gpio][test_env=UT_T1_GPIO]")
     //init input and output gpio
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 0));
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     //rising edge intr
     TEST_ESP_OK(gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_POSEDGE));
-    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_edge_handler, (void*)GPIO_INPUT_IO);
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 1));
-    TEST_ASSERT_EQUAL_INT(edge_intr_times, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
+    TEST_ASSERT_EQUAL_INT(edge_intr_times, 1);
     gpio_isr_handler_remove(GPIO_INPUT_IO);
     gpio_uninstall_isr_service();
 }
@@ -181,15 +181,15 @@ TEST_CASE("GPIO falling edge interrupt test", "[gpio][test_env=UT_T1_GPIO]")
     edge_intr_times = 0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 1));
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_NEGEDGE);
-    gpio_install_isr_service(0);
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_edge_handler, (void*) GPIO_INPUT_IO);
     gpio_set_level(GPIO_OUTPUT_IO, 0);
     vTaskDelay(100 / portTICK_RATE_MS);
@@ -204,7 +204,7 @@ TEST_CASE("GPIO both rising and falling edge interrupt test", "[gpio][test_env=U
     edge_intr_times = 0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
@@ -212,8 +212,8 @@ TEST_CASE("GPIO both rising and falling edge interrupt test", "[gpio][test_env=U
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 0));
     int level = 0;
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_ANYEDGE);
-    gpio_install_isr_service(0);
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_edge_handler, (void*) GPIO_INPUT_IO);
     // for rising edge in GPIO_INTR_ANYEDGE
     while(1) {
@@ -246,15 +246,15 @@ TEST_CASE("GPIO input high level trigger, cut the interrupt source exit interrup
     level_intr_times=0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 0));
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_HIGH_LEVEL);
-    gpio_install_isr_service(0);
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_level_handler2, (void*) GPIO_INPUT_IO);
     gpio_set_level(GPIO_OUTPUT_IO, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
@@ -269,15 +269,15 @@ TEST_CASE("GPIO low level interrupt test", "[gpio][test_env=UT_T1_GPIO]")
     disable_intr_times=0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 1));
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_LOW_LEVEL);
-    gpio_install_isr_service(0);
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_level_handler, (void*) GPIO_INPUT_IO);
     gpio_set_level(GPIO_OUTPUT_IO, 0);
     printf("get level:%d\n",gpio_get_level(GPIO_INPUT_IO));
@@ -292,15 +292,15 @@ TEST_CASE("GPIO multi-level interrupt test, to cut the interrupt source exit int
     level_intr_times=0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 0));
 
+    TEST_ESP_OK(gpio_install_isr_service(0));
     gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_HIGH_LEVEL);
-    gpio_install_isr_service(0);
     gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_level_handler2, (void*) GPIO_INPUT_IO);
     gpio_set_level(GPIO_OUTPUT_IO, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
@@ -314,16 +314,18 @@ TEST_CASE("GPIO multi-level interrupt test, to cut the interrupt source exit int
 
 TEST_CASE("GPIO enable and disable interrupt test", "[gpio][test_env=UT_T1_GPIO]")
 {
+    disable_intr_times=0;
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
     TEST_ESP_OK(gpio_config(&input_io));
+    TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 0));
 
-    TEST_ESP_OK(gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_HIGH_LEVEL));
     TEST_ESP_OK(gpio_install_isr_service(0));
+    TEST_ESP_OK(gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_HIGH_LEVEL));
     TEST_ESP_OK(gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_level_handler, (void*) GPIO_INPUT_IO));
     TEST_ESP_OK(gpio_set_level(GPIO_OUTPUT_IO, 1));
     TEST_ESP_OK(gpio_isr_handler_remove(GPIO_INPUT_IO));
@@ -474,7 +476,7 @@ TEST_CASE("GPIO repeate call service and isr has no memory leak test","[gpio][te
 {
     gpio_config_t output_io = init_io(GPIO_OUTPUT_IO);
     gpio_config_t input_io = init_io(GPIO_INPUT_IO);
-    input_io.intr_type = GPIO_INTR_POSEDGE;
+    input_io.intr_type = GPIO_INTR_DISABLE;
     input_io.mode = GPIO_MODE_INPUT;
     input_io.pull_up_en = 1;
     TEST_ESP_OK(gpio_config(&output_io));
@@ -483,8 +485,8 @@ TEST_CASE("GPIO repeate call service and isr has no memory leak test","[gpio][te
     //rising edge
     uint32_t size = esp_get_free_heap_size();
     for(int i=0;i<1000;i++) {
-        TEST_ESP_OK(gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_POSEDGE));
         TEST_ESP_OK(gpio_install_isr_service(0));
+        TEST_ESP_OK(gpio_set_intr_type(GPIO_INPUT_IO, GPIO_INTR_POSEDGE));
         TEST_ESP_OK(gpio_isr_handler_add(GPIO_INPUT_IO, gpio_isr_edge_handler, (void*)GPIO_INPUT_IO));
         gpio_set_level(GPIO_OUTPUT_IO, 1);
         TEST_ESP_OK(gpio_isr_handler_remove(GPIO_INPUT_IO));
@@ -508,6 +510,8 @@ TEST_CASE("GPIO wake up enable and disenable test", "[gpio][ignore]")
     gpio_set_level(GPIO_OUTPUT_IO, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
     TEST_ASSERT_FALSE(wake_up_result);
+    TEST_ESP_OK(gpio_isr_handler_remove(GPIO_INPUT_IO));
+    gpio_uninstall_isr_service();
 }
 #endif
 


### PR DESCRIPTION
This PR aims to do the following:                                                                                                                                                              
                                                                                                                                                                                               
- consistently enable gpio interrupts on the correct core.                                                                                                                                     
- enable and disable interrupts according to the value of the intr_type.                                                                                                                       
- fix all gpio tests, touched by the above changes.                                                                                                                                            
- added a gpio test for enabling interrupts on a core other than the one on                                                                                                                          
  which the isr_sevice was started.

It is now possible to:
   - call  gpio_intr_disable from anywhere and expect the interrupt _not_ to occur again.
   - rely on gpio_intr_disable to disable an interrupt consistently.
   - call gpio_intr_enable from any task, regardless on which core it runs.

For more information, please read the elaborate commit messages below.

Here follows the original text, with which this PR was started:

> At the moment (commit db8bc3ee), gpio_intr_enable and
gpio_intr_disable do not have critical sections for guarding status,
enable and disable flags, which are also manipulated in the ISR,
gpio_intr_service. It was probably OK up to now, as these functions
were only called from critical sections within the gpio.c code. One
exception is of course the call from the gpio_config function, but the
chances that this would have caused a problem, would have been
minimal, as no-one would probably have thought of calling gpio_config
more than once, for a given port.

> A major problem is however, that both gpio_intr_enable and
gpio_intr_disable are published in the gpio.h file, opening the door
to anyone to call these, at any time. This could certainly cause
havoc, as both these functions manipulate the interrupt status
flags. The ISR, gpio_intr_service, relies on the status flags to stay
constant during the interrupt, so these _must_ be protected.

> This patch protects gpio_intr_enable and gpio_intr_disable with a
critical section. Note that FreeRTOS allows and supports nested
critical sections, so no fancy checking is done inside the functions,
in order to see if we're already inside a critical section or
not, as it doesn't matter. This patch makes it safe to call
gpio_intr_enable and gpio_intr_disable from anywhere, except from
within an ISR.