### PR TITLE
Handle esp_tls_conn_read return code 0 in ssl_read as an error.

### DIFF
--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -129,6 +129,7 @@ static int ssl_read(esp_transport_handle_t t, char *buffer, int len, int timeout
     ret = esp_tls_conn_read(ssl->tls, (unsigned char *)buffer, len);
     if (ret <= 0) {
         ESP_LOGE(TAG, "esp_tls_conn_read error, errno=%s", strerror(errno));
+        return -1;
     }
     return ret;
 }


### PR DESCRIPTION
Fixes #2805 TW#27831