### PR TITLE
Initialized some uninitialized variables in rtc_clk.c and ringbuf.c.

### DIFF
--- a/components/esp_ringbuf/ringbuf.c
+++ b/components/esp_ringbuf/ringbuf.c
@@ -920,7 +920,7 @@ BaseType_t xRingbufferReceiveSplitFromISR(RingbufHandle_t xRingbuffer, void **pp
     configASSERT(ppvHeadItem != NULL && ppvTailItem != NULL);
 
     //Attempt to retrieve multiple items
-    void *pvTempHeadItem, *pvTempTailItem;
+    void *pvTempHeadItem = NULL, *pvTempTailItem = NULL;
     size_t xTempHeadSize, xTempTailSize;
     if (prvReceiveGenericFromISR(pxRingbuffer, &pvTempHeadItem, &pvTempTailItem, &xTempHeadSize, &xTempTailSize, 0) == pdTRUE) {
         //At least one item was received

--- a/components/soc/esp32/rtc_clk.c
+++ b/components/soc/esp32/rtc_clk.c
@@ -500,7 +500,7 @@ rtc_cpu_freq_t rtc_clk_cpu_freq_get()
 {
     rtc_cpu_freq_config_t config;
     rtc_clk_cpu_freq_get_config(&config);
-    rtc_cpu_freq_t freq;
+    rtc_cpu_freq_t freq = RTC_CPU_FREQ_XTAL;
     rtc_clk_cpu_freq_from_mhz_internal(config.freq_mhz, &freq);
     return freq;
 }


### PR DESCRIPTION
The following 2 compiler warnings are only reproducible when setting:
   OPTIMIZATION_FLAGS = -Ofast

esp-idf/components/soc/esp32/rtc_clk.c:
In function 'rtc_clk_cpu_freq_get':
esp-idf/components/soc/esp32/rtc_clk.c:506:12:
error: 'freq' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
	return freq;

esp-idf/components/esp_ringbuf/ringbuf.c:
In function 'xRingbufferReceiveSplitFromISR':
esp-idf/components/esp_ringbuf/ringbuf.c:934:26:
error: 'pvTempTailItem' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
	*ppvTailItem = pvTempTailItem;