### PR TITLE
Pr/strict prototypes (IDFGH-757)

### DIFF
--- a/components/app_trace/include/esp_app_trace.h
+++ b/components/app_trace/include/esp_app_trace.h
@@ -33,7 +33,7 @@ typedef enum {
  *
  * @return ESP_OK on success, otherwise see esp_err_t
  */
-esp_err_t esp_apptrace_init();
+esp_err_t esp_apptrace_init(void);
 
 /**
  * @brief Configures down buffer.

--- a/components/app_update/include/esp_ota_ops.h
+++ b/components/app_update/include/esp_ota_ops.h
@@ -202,7 +202,7 @@ esp_err_t esp_ota_get_partition_description(const esp_partition_t *partition, es
  * @return
  *  - ESP_OK: if successful.
  */
-esp_err_t esp_ota_mark_app_valid_cancel_rollback();
+esp_err_t esp_ota_mark_app_valid_cancel_rollback(void);
 
 /**
  * @brief This function is called to roll back to the previously workable app with reboot.
@@ -211,14 +211,14 @@ esp_err_t esp_ota_mark_app_valid_cancel_rollback();
  * @return
  *  - ESP_FAIL: if not successful.
  */
-esp_err_t esp_ota_mark_app_invalid_rollback_and_reboot();
+esp_err_t esp_ota_mark_app_invalid_rollback_and_reboot(void);
 
 /**
  * @brief Returns last partition with invalid state (ESP_OTA_IMG_INVALID or ESP_OTA_IMG_ABORTED).
  *
  * @return partition.
  */
-const esp_partition_t* esp_ota_get_last_invalid_partition();
+const esp_partition_t* esp_ota_get_last_invalid_partition(void);
 
 /**
  * @brief Returns state for given partition.

--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -34,7 +34,7 @@ static int selected_boot_partition(const bootloader_state_t *bs);
  * The hardware is mostly uninitialized, flash cache is down and the app CPU is in reset.
  * We do have a stack, so we can do the initialization in C.
  */
-void __attribute__((noreturn)) call_start_cpu0()
+void __attribute__((noreturn)) call_start_cpu0(void)
 {
     // 1. Hardware initialization
     if (bootloader_init() != ESP_OK) {

--- a/components/bootloader_support/include/esp_flash_encrypt.h
+++ b/components/bootloader_support/include/esp_flash_encrypt.h
@@ -112,6 +112,6 @@ esp_err_t esp_flash_encrypt_region(uint32_t src_addr, size_t data_length);
  *
  * @return 
  */
-void esp_flash_write_protect_crypt_cnt();
+void esp_flash_write_protect_crypt_cnt(void);
 
 #endif

--- a/components/bootloader_support/include_bootloader/bootloader_init.h
+++ b/components/bootloader_support/include_bootloader/bootloader_init.h
@@ -25,4 +25,4 @@
  *  @return ESP_OK   - If the setting is successful.
  *          ESP_FAIL - If the setting is not successful.
  */
-esp_err_t bootloader_init();
+esp_err_t bootloader_init(void);

--- a/components/bootloader_support/include_bootloader/bootloader_sha.h
+++ b/components/bootloader_support/include_bootloader/bootloader_sha.h
@@ -26,7 +26,7 @@
 
 typedef void *bootloader_sha256_handle_t;
 
-bootloader_sha256_handle_t bootloader_sha256_start();
+bootloader_sha256_handle_t bootloader_sha256_start(void);
 
 void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len);
 

--- a/components/bootloader_support/include_bootloader/flash_qio_mode.h
+++ b/components/bootloader_support/include_bootloader/flash_qio_mode.h
@@ -30,7 +30,7 @@ void bootloader_enable_qio_mode(void);
  *     mfg_id = (ID >> 16) & 0xFF;
        flash_id = ID & 0xffff;
  */
-uint32_t bootloader_read_flash_id();
+uint32_t bootloader_read_flash_id(void);
 
 #ifdef __cplusplus
 }

--- a/components/bootloader_support/src/bootloader_clock.c
+++ b/components/bootloader_support/src/bootloader_clock.c
@@ -19,7 +19,7 @@
 #include "soc/efuse_reg.h"
 #include "soc/rtc_cntl_reg.h"
 
-void bootloader_clock_configure()
+void bootloader_clock_configure(void)
 {
     // ROM bootloader may have put a lot of text into UART0 FIFO.
     // Wait for it to be printed.

--- a/components/bootloader_support/src/bootloader_init.c
+++ b/components/bootloader_support/src/bootloader_init.c
@@ -60,16 +60,16 @@ extern int _data_end;
 
 static const char* TAG = "boot";
 
-static esp_err_t bootloader_main();
+static esp_err_t bootloader_main(void);
 static void print_flash_info(const esp_image_header_t* pfhdr);
 static void update_flash_config(const esp_image_header_t* pfhdr);
-static void vddsdio_configure();
+static void vddsdio_configure(void);
 static void flash_gpio_configure(const esp_image_header_t* pfhdr);
 static void uart_console_configure(void);
 static void wdt_reset_check(void);
 
 
-esp_err_t bootloader_init()
+esp_err_t bootloader_init(void)
 {
     cpu_configure_region_protection();
     cpu_init_memctl();
@@ -117,7 +117,7 @@ esp_err_t bootloader_init()
     return ESP_OK;
 }
 
-static esp_err_t bootloader_main()
+static esp_err_t bootloader_main(void)
 {
     vddsdio_configure();
     /* Read and keep flash ID, for further use. */
@@ -287,7 +287,7 @@ static void print_flash_info(const esp_image_header_t* phdr)
 #endif
 }
 
-static void vddsdio_configure()
+static void vddsdio_configure(void)
 {
 #if CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V
     rtc_vddsdio_config_t cfg = rtc_vddsdio_get_config();
@@ -539,7 +539,7 @@ void __assert_func(const char *file, int line, const char *func, const char *exp
     while(1) {}
 }
 
-void abort()
+void abort(void)
 {
 #if !CONFIG_ESP32_PANIC_SILENT_REBOOT
     ets_printf("abort() was called at PC 0x%08x\r\n", (intptr_t)__builtin_return_address(0) - 3);

--- a/components/bootloader_support/src/flash_encrypt.c
+++ b/components/bootloader_support/src/flash_encrypt.c
@@ -33,7 +33,7 @@ static const char *TAG = "flash_encrypt";
 /* Static functions for stages of flash encryption */
 static esp_err_t initialise_flash_encryption(void);
 static esp_err_t encrypt_flash_contents(uint32_t flash_crypt_cnt, bool flash_crypt_wr_dis);
-static esp_err_t encrypt_bootloader();
+static esp_err_t encrypt_bootloader(void);
 static esp_err_t encrypt_and_load_partition_table(esp_partition_info_t *partition_table, int *num_partitions);
 static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partition);
 
@@ -212,7 +212,7 @@ static esp_err_t encrypt_flash_contents(uint32_t flash_crypt_cnt, bool flash_cry
     return ESP_OK;
 }
 
-static esp_err_t encrypt_bootloader()
+static esp_err_t encrypt_bootloader(void)
 {
     esp_err_t err;
     uint32_t image_length;

--- a/components/bootloader_support/src/flash_qio_mode.c
+++ b/components/bootloader_support/src/flash_qio_mode.c
@@ -39,7 +39,7 @@
 
 static const char *TAG = "qio_mode";
 
-typedef unsigned (*read_status_fn_t)();
+typedef unsigned (*read_status_fn_t)(void);
 typedef void (*write_status_fn_t)(unsigned);
 
 typedef struct __attribute__((packed)) {
@@ -53,11 +53,11 @@ typedef struct __attribute__((packed)) {
 } qio_info_t;
 
 /* Read 8 bit status using RDSR command */
-static unsigned read_status_8b_rdsr();
+static unsigned read_status_8b_rdsr(void);
 /* Read 8 bit status (second byte) using RDSR2 command */
-static unsigned read_status_8b_rdsr2();
+static unsigned read_status_8b_rdsr2(void);
 /* read 16 bit status using RDSR & RDSR2 (low and high bytes) */
-static unsigned read_status_16b_rdsr_rdsr2();
+static unsigned read_status_16b_rdsr_rdsr2(void);
 
 /* Write 8 bit status using WRSR */
 static void write_status_8b_wrsr(unsigned new_status);
@@ -67,7 +67,7 @@ static void write_status_8b_wrsr2(unsigned new_status);
 static void write_status_16b_wrsr(unsigned new_status);
 
 /* Read 8 bit status of XM25QU64A  */
-static unsigned read_status_8b_xmc25qu64a();
+static unsigned read_status_8b_xmc25qu64a(void);
 /* Write 8 bit status of XM25QU64A */
 static void write_status_8b_xmc25qu64a(unsigned new_status);
 
@@ -121,7 +121,7 @@ static uint32_t execute_flash_command(uint8_t command, uint32_t mosi_data, uint8
 
 /* dummy_len_plus values defined in ROM for SPI flash configuration */
 extern uint8_t g_rom_spiflash_dummy_len_plus[];
-uint32_t bootloader_read_flash_id()
+uint32_t bootloader_read_flash_id(void)
 {
     uint32_t id = execute_flash_command(CMD_RDID, 0, 0, 24);
     id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
@@ -223,17 +223,17 @@ static esp_err_t enable_qio_mode(read_status_fn_t read_status_fn,
     return ESP_OK;
 }
 
-static unsigned read_status_8b_rdsr()
+static unsigned read_status_8b_rdsr(void)
 {
     return execute_flash_command(CMD_RDSR, 0, 0, 8);
 }
 
-static unsigned read_status_8b_rdsr2()
+static unsigned read_status_8b_rdsr2(void)
 {
     return execute_flash_command(CMD_RDSR2, 0, 0, 8);
 }
 
-static unsigned read_status_16b_rdsr_rdsr2()
+static unsigned read_status_16b_rdsr_rdsr2(void)
 {
     return execute_flash_command(CMD_RDSR, 0, 0, 8) | (execute_flash_command(CMD_RDSR2, 0, 0, 8) << 8);
 }
@@ -253,7 +253,7 @@ static void write_status_16b_wrsr(unsigned new_status)
     execute_flash_command(CMD_WRSR, new_status, 16, 0);
 }
 
-static unsigned read_status_8b_xmc25qu64a()
+static unsigned read_status_8b_xmc25qu64a(void)
 {
     execute_flash_command(CMD_OTPEN, 0, 0, 0);  /* Enter OTP mode */
     esp_rom_spiflash_wait_idle(&g_rom_flashchip);

--- a/components/bootloader_support/src/secure_boot.c
+++ b/components/bootloader_support/src/secure_boot.c
@@ -93,7 +93,7 @@ static bool secure_boot_generate(uint32_t image_len){
 }
 
 /* Burn values written to the efuse write registers */
-static inline void burn_efuses()
+static inline void burn_efuses(void)
 {
 #ifdef CONFIG_SECURE_BOOT_TEST_MODE
     ESP_LOGE(TAG, "SECURE BOOT TEST MODE. Not really burning any efuses! NOT SECURE");

--- a/components/console/esp_console.h
+++ b/components/console/esp_console.h
@@ -52,7 +52,7 @@ esp_err_t esp_console_init(const esp_console_config_t* config);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if not initialized yet
  */
-esp_err_t esp_console_deinit();
+esp_err_t esp_console_deinit(void);
 
 
 /**
@@ -185,7 +185,7 @@ const char *esp_console_get_hint(const char *buf, int *color, int *bold);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE, if esp_console_init wasn't called
  */
-esp_err_t esp_console_register_help_command();
+esp_err_t esp_console_register_help_command(void);
 
 #ifdef __cplusplus
 }

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -204,7 +204,7 @@ void linenoiseSetDumbMode(int set) {
 /* Use the ESC [6n escape sequence to query the horizontal cursor position
  * and return it. On error -1 is returned, on success the position of the
  * cursor. */
-static int getCursorPosition() {
+static int getCursorPosition(void) {
     char buf[32];
     int cols, rows;
     unsigned int i = 0;
@@ -227,7 +227,7 @@ static int getCursorPosition() {
 
 /* Try to get the number of columns in the current terminal, or assume 80
  * if it fails. */
-static int getColumns() {
+static int getColumns(void) {
     int start, cols;
 
     /* Get the initial position so we can restore it later. */

--- a/components/console/linenoise/linenoise.h
+++ b/components/console/linenoise/linenoise.h
@@ -63,7 +63,7 @@ int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
-void linenoiseHistoryFree();
+void linenoiseHistoryFree(void);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoiseSetDumbMode(int set);

--- a/components/driver/adc1_i2s_private.h
+++ b/components/driver/adc1_i2s_private.h
@@ -29,7 +29,7 @@ extern "C" {
  * This is an internal API for I2S module to call to enable I2S-ADC function.
  * Note that adc_power_off() can still power down ADC.
  */
-void adc_power_always_on();
+void adc_power_always_on(void);
 
 /**
  * @brief For I2S dma to claim the usage of ADC1.
@@ -41,7 +41,7 @@ void adc_power_always_on();
  *      - ESP_OK success
  *      - ESP_ERR_TIMEOUT reserved for future use. Currently the function will wait until success.
  */
-esp_err_t adc1_i2s_mode_acquire();
+esp_err_t adc1_i2s_mode_acquire(void);
 
 /**
  * @brief For ADC1 to claim the usage of ADC1.
@@ -53,7 +53,7 @@ esp_err_t adc1_i2s_mode_acquire();
  *      - ESP_OK success
  *      - ESP_ERR_TIMEOUT reserved for future use. Currently the function will wait until success.
  */
-esp_err_t adc1_adc_mode_acquire();
+esp_err_t adc1_adc_mode_acquire(void);
 
 /**
  * @brief to let other tasks use the ADC1 when I2S is not work.
@@ -63,7 +63,7 @@ esp_err_t adc1_adc_mode_acquire();
  *
  * @return always return ESP_OK.
  */
-esp_err_t adc1_lock_release();
+esp_err_t adc1_lock_release(void);
 
 #ifdef __cplusplus
 }

--- a/components/driver/can.c
+++ b/components/driver/can.c
@@ -142,7 +142,7 @@ static portMUX_TYPE can_spinlock = portMUX_INITIALIZER_UNLOCKED;
 
 /* ------------------- Configuration Register Functions---------------------- */
 
-static inline esp_err_t can_enter_reset_mode()
+static inline esp_err_t can_enter_reset_mode(void)
 {
     /* Enter reset mode (required to write to configuration registers). Reset mode
        also prevents all CAN activity on the current module and is automatically
@@ -152,7 +152,7 @@ static inline esp_err_t can_enter_reset_mode()
     return ESP_OK;
 }
 
-static inline esp_err_t can_exit_reset_mode()
+static inline esp_err_t can_exit_reset_mode(void)
 {
     /* Exiting reset mode will return the CAN module to operating mode. Reset mode
        must also be exited in order to trigger BUS-OFF recovery sequence. */
@@ -161,7 +161,7 @@ static inline esp_err_t can_exit_reset_mode()
     return ESP_OK;
 }
 
-static inline void can_config_pelican()
+static inline void can_config_pelican(void)
 {
     //Use PeliCAN address layout. Exposes extra registers
     CAN.clock_divider_reg.can_mode = 1;
@@ -287,23 +287,23 @@ static void can_set_tx_buffer_and_transmit(can_frame_t *frame)
     can_set_command(command);
 }
 
-static inline uint32_t can_get_status()
+static inline uint32_t can_get_status(void)
 {
     return CAN.status_reg.val;
 }
 
-static inline uint32_t can_get_interrupt_reason()
+static inline uint32_t can_get_interrupt_reason(void)
 {
     return CAN.interrupt_reg.val;
 }
 
-static inline uint32_t can_get_arbitration_lost_capture()
+static inline uint32_t can_get_arbitration_lost_capture(void)
 {
     return CAN.arbitration_lost_captue_reg.val;
     //Todo: ALC read only to re-arm arb lost interrupt. Add function to decode ALC
 }
 
-static inline uint32_t can_get_error_code_capture()
+static inline uint32_t can_get_error_code_capture(void)
 {
     return CAN.error_code_capture_reg.val;
     //Todo: ECC read only to re-arm bus error interrupt. Add function to decode ECC
@@ -329,7 +329,7 @@ static inline void can_get_rx_buffer_and_clear(can_frame_t *frame)
     can_set_command(CMD_RELEASE_RX_BUFF);
 }
 
-static inline uint32_t can_get_rx_message_counter()
+static inline uint32_t can_get_rx_message_counter(void)
 {
     return CAN.rx_message_counter_reg.val;
 }
@@ -720,7 +720,7 @@ esp_err_t can_driver_install(const can_general_config_t *g_config, const can_tim
     return ret;
 }
 
-esp_err_t can_driver_uninstall()
+esp_err_t can_driver_uninstall(void)
 {
     can_obj_t *p_can_obj_dummy;
 
@@ -756,7 +756,7 @@ esp_err_t can_driver_uninstall()
     return ESP_OK;
 }
 
-esp_err_t can_start()
+esp_err_t can_start(void)
 {
     //Check state
     CAN_ENTER_CRITICAL();
@@ -786,7 +786,7 @@ esp_err_t can_start()
     return ESP_OK;
 }
 
-esp_err_t can_stop()
+esp_err_t can_stop(void)
 {
     //Check state
     CAN_ENTER_CRITICAL();
@@ -923,7 +923,7 @@ esp_err_t can_reconfigure_alerts(uint32_t alerts_enabled, uint32_t *current_aler
     return ESP_OK;
 }
 
-esp_err_t can_initiate_recovery()
+esp_err_t can_initiate_recovery(void)
 {
     CAN_ENTER_CRITICAL();
     //Check state

--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -918,7 +918,7 @@ esp_err_t i2c_set_pin(i2c_port_t i2c_num, int sda_io_num, int scl_io_num, gpio_p
     return ESP_OK;
 }
 
-i2c_cmd_handle_t i2c_cmd_link_create()
+i2c_cmd_handle_t i2c_cmd_link_create(void)
 {
 #if !CONFIG_SPIRAM_USE_MALLOC
     i2c_cmd_desc_t* cmd_desc = (i2c_cmd_desc_t*) calloc(1, sizeof(i2c_cmd_desc_t));

--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -714,7 +714,7 @@ esp_err_t i2s_set_dac_mode(i2s_dac_mode_t dac_mode)
     return ESP_OK;
 }
 
-static esp_err_t _i2s_adc_mode_recover()
+static esp_err_t _i2s_adc_mode_recover(void)
 {
     I2S_CHECK(((_i2s_adc_unit != -1) && (_i2s_adc_channel != -1)), "i2s ADC recover error, not initialized...", ESP_ERR_INVALID_ARG);
     return adc_i2s_mode_init(_i2s_adc_unit, _i2s_adc_channel);

--- a/components/driver/include/driver/adc.h
+++ b/components/driver/include/driver/adc.h
@@ -229,13 +229,13 @@ int adc1_get_voltage(adc1_channel_t channel) __attribute__((deprecated));
 /**
  * @brief Enable ADC power
  */
-void adc_power_on();
+void adc_power_on(void);
 
 /**
  * @brief Power off SAR ADC
  * This function will force power down for ADC
  */
-void adc_power_off();
+void adc_power_off(void);
 
 /**
  * @brief Initialize ADC pad
@@ -292,7 +292,7 @@ esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, adc_channel_t channel);
  * Note that adc1_config_channel_atten, adc1_config_width functions need
  * to be called to configure ADC1 channels, before ADC1 is used by the ULP.
  */
-void adc1_ulp_enable();
+void adc1_ulp_enable(void);
 
 /**
  * @brief Read Hall Sensor
@@ -313,7 +313,7 @@ void adc1_ulp_enable();
  *
  * @return The hall sensor reading.
  */
-int hall_sensor_read();
+int hall_sensor_read(void);
 
 /**
  * @brief Get the gpio number of a specific ADC2 channel.

--- a/components/driver/include/driver/can.h
+++ b/components/driver/include/driver/can.h
@@ -237,7 +237,7 @@ esp_err_t can_driver_install(const can_general_config_t *g_config, const can_tim
  *      - ESP_OK: Successfully uninstalled CAN driver
  *      - ESP_ERR_INVALID_STATE: Driver is not in stopped/bus-off state, or is not installed
  */
-esp_err_t can_driver_uninstall();
+esp_err_t can_driver_uninstall(void);
 
 /**
  * @brief   Start the CAN driver
@@ -252,7 +252,7 @@ esp_err_t can_driver_uninstall();
  *      - ESP_OK: CAN driver is now running
  *      - ESP_ERR_INVALID_STATE: Driver is not in stopped state, or is not installed
  */
-esp_err_t can_start();
+esp_err_t can_start(void);
 
 /**
  * @brief   Stop the CAN driver
@@ -271,7 +271,7 @@ esp_err_t can_start();
  *      - ESP_OK: CAN driver is now Stopped
  *      - ESP_ERR_INVALID_STATE: Driver is not in running state, or is not installed
  */
-esp_err_t can_stop();
+esp_err_t can_stop(void);
 
 /**
  * @brief   Transmit a CAN message
@@ -378,7 +378,7 @@ esp_err_t can_reconfigure_alerts(uint32_t alerts_enabled, uint32_t *current_aler
  *      - ESP_OK: Bus recovery started
  *      - ESP_ERR_INVALID_STATE: CAN driver is not in the bus-off state, or is not installed
  */
-esp_err_t can_initiate_recovery();
+esp_err_t can_initiate_recovery(void);
 
 /**
  * @brief   Get current status information of the CAN driver

--- a/components/driver/include/driver/dac.h
+++ b/components/driver/include/driver/dac.h
@@ -99,12 +99,12 @@ esp_err_t dac_output_disable(dac_channel_t channel);
 /**
  * @brief Enable DAC output data from I2S
  */
-esp_err_t dac_i2s_enable();
+esp_err_t dac_i2s_enable(void);
 
 /**
  * @brief Disable DAC output data from I2S
  */
-esp_err_t dac_i2s_disable();
+esp_err_t dac_i2s_disable(void);
 #ifdef __cplusplus
 }
 #endif

--- a/components/driver/include/driver/gpio.h
+++ b/components/driver/include/driver/gpio.h
@@ -472,7 +472,7 @@ esp_err_t gpio_install_isr_service(int intr_alloc_flags);
 /**
   * @brief Uninstall the driver's GPIO ISR service, freeing related resources.
   */
-void gpio_uninstall_isr_service();
+void gpio_uninstall_isr_service(void);
 
 /**
   * @brief Add ISR handler for the corresponding GPIO pin.

--- a/components/driver/include/driver/i2c.h
+++ b/components/driver/include/driver/i2c.h
@@ -224,7 +224,7 @@ esp_err_t i2c_set_pin(i2c_port_t i2c_num, int sda_io_num, int scl_io_num,
  *
  * @return i2c command link handler
  */
-i2c_cmd_handle_t i2c_cmd_link_create();
+i2c_cmd_handle_t i2c_cmd_link_create(void);
 
 /**
  * @brief Free I2C command link

--- a/components/driver/include/driver/ledc.h
+++ b/components/driver/include/driver/ledc.h
@@ -435,7 +435,7 @@ esp_err_t ledc_fade_func_install(int intr_alloc_flags);
  * @brief Uninstall LEDC fade function.
  *
  */
-void ledc_fade_func_uninstall();
+void ledc_fade_func_uninstall(void);
 
 /**
  * @brief Start LEDC fading.

--- a/components/driver/include/driver/rtc_io.h
+++ b/components/driver/include/driver/rtc_io.h
@@ -220,7 +220,7 @@ esp_err_t rtc_gpio_isolate(gpio_num_t gpio_num);
  * Force hold signal is enabled before going into deep sleep for pins which
  * are used for EXT1 wakeup.
  */
-void rtc_gpio_force_hold_dis_all();
+void rtc_gpio_force_hold_dis_all(void);
 
 /**
  * @brief Set RTC GPIO pad drive capability

--- a/components/driver/include/driver/sdio_slave.h
+++ b/components/driver/include/driver/sdio_slave.h
@@ -111,7 +111,7 @@ esp_err_t sdio_slave_initialize(sdio_slave_config_t *config);
 
 /** De-initialize the sdio slave driver to release the resources.
  */
-void sdio_slave_deinit();
+void sdio_slave_deinit(void);
 
 /** Start hardware for sending and receiving, as well as set the IOREADY1 to 1.
  *
@@ -122,19 +122,19 @@ void sdio_slave_deinit();
  *  - ESP_ERR_INVALID_STATE if already started.
  *  - ESP_OK otherwise.
  */
-esp_err_t sdio_slave_start();
+esp_err_t sdio_slave_start(void);
 
 /** Stop hardware from sending and receiving, also set IOREADY1 to 0.
  *
  * @note this will not clear the data already in the driver, and also not reset the PKT_LEN and TOKEN1 counting. Call ``sdio_slave_reset`` to do that.
  */
-void sdio_slave_stop();
+void sdio_slave_stop(void);
 
 /** Clear the data still in the driver, as well as reset the PKT_LEN and TOKEN1 counting.
  *
  * @return always return ESP_OK.
  */
-esp_err_t sdio_slave_reset();
+esp_err_t sdio_slave_reset(void);
 
 /*---------------------------------------------------------------------------
  *                  Receive
@@ -263,7 +263,7 @@ esp_err_t sdio_slave_write_reg(int pos, uint8_t reg);
  *
  * @return the interrupt mask.
  */
-sdio_slave_hostint_t sdio_slave_get_host_intena();
+sdio_slave_hostint_t sdio_slave_get_host_intena(void);
 
 /** Set the interrupt enable for host.
  *

--- a/components/driver/include/driver/sdmmc_host.h
+++ b/components/driver/include/driver/sdmmc_host.h
@@ -91,7 +91,7 @@ typedef struct {
  *      - ESP_ERR_INVALID_STATE if sdmmc_host_init was already called
  *      - ESP_ERR_NO_MEM if memory can not be allocated
  */
-esp_err_t sdmmc_host_init();
+esp_err_t sdmmc_host_init(void);
 
 /**
  * @brief Initialize given slot of SDMMC peripheral
@@ -218,7 +218,7 @@ esp_err_t sdmmc_host_io_int_wait(int slot, TickType_t timeout_ticks);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if sdmmc_host_init function has not been called
  */
-esp_err_t sdmmc_host_deinit();
+esp_err_t sdmmc_host_deinit(void);
 
 /**
  * @brief Enable the pull-ups of sd pins.

--- a/components/driver/include/driver/sdspi_host.h
+++ b/components/driver/include/driver/sdspi_host.h
@@ -88,7 +88,7 @@ typedef struct {
  *      - ESP_OK on success
  *      - other error codes may be returned in future versions
  */
-esp_err_t sdspi_host_init();
+esp_err_t sdspi_host_init(void);
 
 /**
 * @brief Initialize SD SPI driver for the specific SPI controller
@@ -154,7 +154,7 @@ esp_err_t sdspi_host_set_card_clk(int slot, uint32_t freq_khz);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if sdspi_host_init function has not been called
  */
-esp_err_t sdspi_host_deinit();
+esp_err_t sdspi_host_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/components/driver/include/driver/spi_common.h
+++ b/components/driver/include/driver/spi_common.h
@@ -328,7 +328,7 @@ bool spicommon_dmaworkaround_req_reset(int dmachan, dmaworkaround_cb_t cb, void 
  *
  * @return True when a DMA reset is requested but hasn't completed yet. False otherwise.
  */
-bool spicommon_dmaworkaround_reset_in_progress();
+bool spicommon_dmaworkaround_reset_in_progress(void);
 
 
 /**

--- a/components/driver/include/driver/touch_pad.h
+++ b/components/driver/include/driver/touch_pad.h
@@ -118,7 +118,7 @@ typedef intr_handle_t touch_isr_handle_t;
  *     - ESP_OK Success
  *     - ESP_FAIL Touch pad init error
  */
-esp_err_t touch_pad_init();
+esp_err_t touch_pad_init(void);
 
 /**
  * @brief Un-install touch pad driver.
@@ -127,7 +127,7 @@ esp_err_t touch_pad_init();
  *     - ESP_OK   Success
  *     - ESP_FAIL Touch pad driver not initialized
  */
-esp_err_t touch_pad_deinit();
+esp_err_t touch_pad_deinit(void);
 
 /**
  * @brief Configure touch pad interrupt threshold.
@@ -365,7 +365,7 @@ esp_err_t touch_pad_get_fsm_mode(touch_fsm_mode_t *mode);
  * @return
  *      - ESP_OK on success
  */
-esp_err_t touch_pad_sw_start();
+esp_err_t touch_pad_sw_start(void);
 
 /**
  * @brief Set touch sensor interrupt threshold
@@ -469,28 +469,28 @@ esp_err_t touch_pad_clear_group_mask(uint16_t set1_mask, uint16_t set2_mask, uin
  * @return
  *      - ESP_OK on success
  */
-esp_err_t touch_pad_clear_status();
+esp_err_t touch_pad_clear_status(void);
 
 /**
  * @brief Get the touch sensor status, usually used in ISR to decide which pads are 'touched'.
  * @return
  *      - touch status
  */
-uint32_t touch_pad_get_status();
+uint32_t touch_pad_get_status(void);
 
 /**
  * @brief To enable touch pad interrupt
  * @return
  *      - ESP_OK on success
  */
-esp_err_t touch_pad_intr_enable();
+esp_err_t touch_pad_intr_enable(void);
 
 /**
  * @brief To disable touch pad interrupt
  * @return
  *      - ESP_OK on success
  */
-esp_err_t touch_pad_intr_disable();
+esp_err_t touch_pad_intr_disable(void);
 
 /**
  * @brief set touch pad filter calibration period, in ms.
@@ -540,7 +540,7 @@ esp_err_t touch_pad_filter_start(uint32_t filter_period_ms);
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_STATE driver state error
  */
-esp_err_t touch_pad_filter_stop();
+esp_err_t touch_pad_filter_stop(void);
 
 /**
  * @brief delete touch pad filter driver and release the memory
@@ -549,7 +549,7 @@ esp_err_t touch_pad_filter_stop();
  *      - ESP_OK Success
  *      - ESP_ERR_INVALID_STATE driver state error
  */
-esp_err_t touch_pad_filter_delete();
+esp_err_t touch_pad_filter_delete(void);
 
 /**
  * @brief Get the touch pad which caused wakeup from sleep

--- a/components/driver/include/driver/uart_select.h
+++ b/components/driver/include/driver/uart_select.h
@@ -40,7 +40,7 @@ void uart_set_select_notif_callback(uart_port_t uart_num, uart_select_notif_call
 /**
  * @brief Get mutex guarding select() notifications
  */
-portMUX_TYPE *uart_get_selectlock();
+portMUX_TYPE *uart_get_selectlock(void);
 
 #ifdef __cplusplus
 }

--- a/components/driver/ledc.c
+++ b/components/driver/ledc.c
@@ -711,7 +711,7 @@ esp_err_t ledc_fade_func_install(int intr_alloc_flags)
     return ledc_isr_register(ledc_fade_isr, NULL, intr_alloc_flags | ESP_INTR_FLAG_IRAM, &s_ledc_fade_isr_handle);
 }
 
-void ledc_fade_func_uninstall()
+void ledc_fade_func_uninstall(void)
 {
     if (s_ledc_fade_rec == NULL) {
         return;

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -314,7 +314,7 @@ esp_err_t rmt_get_status(rmt_channel_t channel, uint32_t* status)
     return ESP_OK;
 }
 
-rmt_data_mode_t rmt_get_data_mode()
+rmt_data_mode_t rmt_get_data_mode(void)
 {
     return (rmt_data_mode_t) (RMT.apb_conf.fifo_mask);
 }

--- a/components/driver/rtc_module.c
+++ b/components/driver/rtc_module.c
@@ -1474,7 +1474,7 @@ esp_err_t adc1_config_width(adc_bits_width_t width_bit)
     return ESP_OK;
 }
 
-static inline void adc1_fsm_disable()
+static inline void adc1_fsm_disable(void)
 {
     //channel is set in the  convert function
     SENS.sar_meas_wait2.force_xpd_amp = SENS_FORCE_XPD_AMP_PD;
@@ -1487,7 +1487,7 @@ static inline void adc1_fsm_disable()
     SENS.sar_meas_wait2.sar_amp_wait3 = 1;    
 }
 
-esp_err_t adc1_i2s_mode_acquire()
+esp_err_t adc1_i2s_mode_acquire(void)
 {
     //lazy initialization
     //for i2s, block until acquire the lock
@@ -1501,7 +1501,7 @@ esp_err_t adc1_i2s_mode_acquire()
     return ESP_OK;
 }
 
-esp_err_t adc1_adc_mode_acquire()
+esp_err_t adc1_adc_mode_acquire(void)
 {
     //lazy initialization
     //for adc1, block until acquire the lock
@@ -1518,7 +1518,7 @@ esp_err_t adc1_adc_mode_acquire()
     return ESP_OK;
 }
 
-esp_err_t adc1_lock_release()
+esp_err_t adc1_lock_release(void)
 {
     RTC_MODULE_CHECK((uint32_t*)adc1_i2s_lock != NULL, "adc1 lock release called before acquire", ESP_ERR_INVALID_STATE );
     // for now the WiFi would use ADC2 and set xpd_sar force on.
@@ -1613,7 +1613,7 @@ esp_err_t adc2_pad_get_io_num(adc2_channel_t channel, gpio_num_t *gpio_num)
     return ESP_OK;
 }
 
-esp_err_t adc2_wifi_acquire()
+esp_err_t adc2_wifi_acquire(void)
 {
     //lazy initialization
     //for wifi, block until acquire the lock
@@ -1622,7 +1622,7 @@ esp_err_t adc2_wifi_acquire()
     return ESP_OK;
 }
 
-esp_err_t adc2_wifi_release()
+esp_err_t adc2_wifi_release(void)
 {
     RTC_MODULE_CHECK((uint32_t*)adc2_wifi_lock != NULL, "wifi release called before acquire", ESP_ERR_INVALID_STATE );
 
@@ -1905,7 +1905,7 @@ static inline void adc1_hall_enable(bool enable)
     RTCIO.hall_sens.xpd_hall = enable;        
 }
 
-static int hall_sensor_get_value()    //hall sensor without LNA
+static int hall_sensor_get_value(void)    //hall sensor without LNA
 {
     int Sens_Vp0;
     int Sens_Vn0;
@@ -1976,7 +1976,7 @@ static void rtc_isr(void* arg)
     REG_WRITE(RTC_CNTL_INT_CLR_REG, status);
 }
 
-static esp_err_t rtc_isr_ensure_installed()
+static esp_err_t rtc_isr_ensure_installed(void)
 {
     esp_err_t err = ESP_OK;
     portENTER_CRITICAL(&s_rtc_isr_handler_list_lock);

--- a/components/driver/sdio_slave.c
+++ b/components/driver/sdio_slave.c
@@ -215,17 +215,17 @@ static void sdio_intr_host(void*);
 static void sdio_intr_send(void*);
 static void sdio_intr_recv(void*);
 
-static esp_err_t send_flush_data();
-static esp_err_t send_reset_counter();
-static void recv_flush_data();
-static void recv_reset_counter();
+static esp_err_t send_flush_data(void);
+static esp_err_t send_reset_counter(void);
+static void recv_flush_data(void);
+static void recv_reset_counter(void);
 
-static esp_err_t send_start();
-static void send_stop();
-static esp_err_t recv_start();
-static void recv_stop();
+static esp_err_t send_start(void);
+static void send_stop(void);
+static esp_err_t recv_start(void);
+static void recv_stop(void);
 
-static void deinit_context();
+static void deinit_context(void);
 
 
 /**************** Ring buffer for SDIO use *****************/
@@ -375,7 +375,7 @@ static void __attribute((unused)) dump_ll(buf_stailq_t *queue)
     }
 }
 
-static inline void deinit_context()
+static inline void deinit_context(void)
 {
     context.config = (sdio_slave_config_t){};
     for(int i = 0; i < 9; i++) {
@@ -397,7 +397,7 @@ esp_err_t link_desc_to_last(uint8_t* desc, void* arg)
     return ESP_OK;
 }
 
-static esp_err_t init_ringbuf()
+static esp_err_t init_ringbuf(void)
 {
     esp_err_t ret = sdio_ringbuf_init(&context.sendbuf, sizeof(buf_desc_t), context.config.send_queue_size);
     if (ret != ESP_OK) return ret;
@@ -571,7 +571,7 @@ esp_err_t sdio_slave_initialize(sdio_slave_config_t *config)
     return ESP_OK;
 }
 
-void sdio_slave_deinit()
+void sdio_slave_deinit(void)
 {
     esp_err_t ret = esp_intr_free(context.intr_handle);
     assert(ret==ESP_OK);
@@ -579,7 +579,7 @@ void sdio_slave_deinit()
     deinit_context();
 }
 
-esp_err_t sdio_slave_start()
+esp_err_t sdio_slave_start(void)
 {
     esp_err_t ret;
     HOST.slc0_int_clr.val = UINT32_MAX;//clear all interrupts
@@ -591,7 +591,7 @@ esp_err_t sdio_slave_start()
     return ESP_OK;
 }
 
-esp_err_t sdio_slave_reset()
+esp_err_t sdio_slave_reset(void)
 {
     send_flush_data();
     send_reset_counter();
@@ -600,7 +600,7 @@ esp_err_t sdio_slave_reset()
     return ESP_OK;
 }
 
-void sdio_slave_stop()
+void sdio_slave_stop(void)
 {
     HINF.cfg_data1.sdio_ioready1 = 0;   //set IO ready to 1 to stop host from using
     send_stop();
@@ -676,7 +676,7 @@ esp_err_t sdio_slave_write_reg(int pos, uint8_t reg)
     return ESP_OK;
 }
 
-sdio_slave_hostint_t sdio_slave_get_host_intena()
+sdio_slave_hostint_t sdio_slave_get_host_intena(void)
 {
     return HOST.slc0_func1_int_ena.val;
 }
@@ -722,12 +722,12 @@ static inline void send_start_transmission(const void* desc)
     SLC.slc0_rx_link.start = 1;
 }
 
-static inline void send_stop_ll_operation()
+static inline void send_stop_ll_operation(void)
 {
     SLC.slc0_rx_link.stop = 1;
 }
 
-static inline uint32_t send_length_read()
+static inline uint32_t send_length_read(void)
 {
     return HOST.pkt_len.reg_slc0_len;
 }
@@ -740,7 +740,7 @@ DMA_ATTR static const buf_desc_t start_desc = {
     .eof = 1,
 };
 
-static inline void send_isr_invoker_enable()
+static inline void send_isr_invoker_enable(void)
 {
     //force trigger rx_done interrupt. the interrupt is abused to invoke ISR from the app by the enable bit and never cleared.
     send_start_transmission(&start_desc);
@@ -750,29 +750,29 @@ static inline void send_isr_invoker_enable()
     send_stop_ll_operation();
 }
 
-static inline void send_isr_invoker_disable()
+static inline void send_isr_invoker_disable(void)
 {
     SLC.slc0_int_clr.rx_done = 1;
 }
 
-static inline void send_intr_enable()
+static inline void send_intr_enable(void)
 {
     SLC.slc0_int_ena.rx_eof = 1;
     send_isr_invoker_enable();
 }
 
-static inline void send_intr_disable()
+static inline void send_intr_disable(void)
 {
     send_isr_invoker_disable();
     SLC.slc0_int_ena.rx_eof = 0;
 }
 
-static inline void send_isr_invoke()
+static inline void send_isr_invoke(void)
 {
     SLC.slc0_int_ena.rx_done = 1;
 }
 
-static inline send_state_t send_get_state()
+static inline send_state_t send_get_state(void)
 {
     return context.send_state;
 }
@@ -783,7 +783,7 @@ static inline void send_set_state(send_state_t state)
 }
 
 //start hw operation with existing data (if exist)
-static esp_err_t send_start()
+static esp_err_t send_start(void)
 {
     SDIO_SLAVE_CHECK(send_get_state() == STATE_IDLE,
         "already started", ESP_ERR_INVALID_STATE);
@@ -794,7 +794,7 @@ static esp_err_t send_start()
 }
 
 //only stop hw operations, no touch to data as well as counter
-static void send_stop()
+static void send_stop(void)
 {
     SLC.slc0_rx_link.stop = 1;
     send_intr_disable();
@@ -846,7 +846,7 @@ static inline esp_err_t send_isr_check_new_pkt(portBASE_TYPE *yield)
     return ESP_OK;
 }
 
-static inline esp_err_t send_isr_new_packet()
+static inline esp_err_t send_isr_new_packet(void)
 {
     // since eof is changed, we have to stop and reset the link list,
     // and restart new link list operation
@@ -953,7 +953,7 @@ esp_err_t sdio_slave_transmit(uint8_t* addr, size_t len)
 }
 
 //clear data but keep counter
-static esp_err_t send_flush_data()
+static esp_err_t send_flush_data(void)
 {
     //only works in idle state / wait to send state
     SDIO_SLAVE_CHECK(send_get_state() == STATE_IDLE,
@@ -998,7 +998,7 @@ static esp_err_t send_flush_data()
 }
 
 //clear counter but keep data
-static esp_err_t send_reset_counter()
+static esp_err_t send_reset_counter(void)
 {
     SDIO_SLAVE_CHECK(send_get_state() == STATE_IDLE,
         "reset counter when transmission started", ESP_ERR_INVALID_STATE);
@@ -1040,28 +1040,28 @@ static esp_err_t send_reset_counter()
 #define CHECK_HANDLE_IDLE(desc) do { if (desc == NULL || !desc->not_receiving) {\
     return ESP_ERR_INVALID_ARG; } } while(0)
 
-static inline void critical_enter_recv()
+static inline void critical_enter_recv(void)
 {
     portENTER_CRITICAL(&context.recv_spinlock);
 }
 
-static inline void critical_exit_recv()
+static inline void critical_exit_recv(void)
 {
     portEXIT_CRITICAL(&context.recv_spinlock);
 }
 
-static inline void recv_size_inc()
+static inline void recv_size_inc(void)
 {
     // fields wdata and inc_more should be written by the same instruction.
     SLC.slc0_token1.val = FIELD_TO_VALUE2(SLC_SLC0_TOKEN1_WDATA, 1) | FIELD_TO_VALUE2(SLC_SLC0_TOKEN1_INC_MORE, 1);
 }
 
-static inline void recv_size_reset()
+static inline void recv_size_reset(void)
 {
     SLC.slc0_token1.val = FIELD_TO_VALUE2(SLC_SLC0_TOKEN1_WDATA, 0) | FIELD_TO_VALUE2(SLC_SLC0_TOKEN1_WR, 1);
 }
 
-static inline buf_desc_t* recv_get_first_empty_buf()
+static inline buf_desc_t* recv_get_first_empty_buf(void)
 {
     buf_stailq_t *const queue = &context.recv_link_list;
     buf_desc_t *desc = STAILQ_FIRST(queue);
@@ -1071,7 +1071,7 @@ static inline buf_desc_t* recv_get_first_empty_buf()
     return desc;
 }
 
-static esp_err_t recv_start()
+static esp_err_t recv_start(void)
 {
     SLC.conf0.slc0_tx_rst = 1;
     SLC.conf0.slc0_tx_rst = 0;
@@ -1092,14 +1092,14 @@ static esp_err_t recv_start()
     return ESP_OK;
 }
 
-static void recv_stop()
+static void recv_stop(void)
 {
     SLC.slc0_tx_link.stop = 1;
     SLC.slc0_int_ena.tx_done = 0;
 }
 
 // reset the counter, but keep the data
-static void recv_reset_counter()
+static void recv_reset_counter(void)
 {
     recv_size_reset();
 
@@ -1114,7 +1114,7 @@ static void recv_reset_counter()
 }
 
 // remove data, still increase the counter
-static void recv_flush_data()
+static void recv_flush_data(void)
 {
     buf_stailq_t *const queue = &context.recv_link_list;
 

--- a/components/driver/sdmmc_host.c
+++ b/components/driver/sdmmc_host.c
@@ -30,7 +30,7 @@
 
 
 static void sdmmc_isr(void* arg);
-static void sdmmc_host_dma_init();
+static void sdmmc_host_dma_init(void);
 
 
 static const char* TAG = "sdmmc_periph";
@@ -40,7 +40,7 @@ static SemaphoreHandle_t s_io_intr_event;
 
 size_t s_slot_width[2] = {1,1};
 
-void sdmmc_host_reset()
+void sdmmc_host_reset(void)
 {
     // Set reset bits
     SDMMC.ctrl.controller_reset = 1;
@@ -97,7 +97,7 @@ static void sdmmc_host_set_clk_div(int div)
     ets_delay_us(10);
 }
 
-static void sdmmc_host_input_clk_disable()
+static void sdmmc_host_input_clk_disable(void)
 {
     SDMMC.clock.val = 0;
 }
@@ -216,7 +216,7 @@ esp_err_t sdmmc_host_start_command(int slot, sdmmc_hw_cmd_t cmd, uint32_t arg) {
     return ESP_OK;
 }
 
-esp_err_t sdmmc_host_init()
+esp_err_t sdmmc_host_init(void)
 {
     if (s_intr_handle) {
         return ESP_ERR_INVALID_STATE;
@@ -402,7 +402,7 @@ esp_err_t sdmmc_host_init_slot(int slot, const sdmmc_slot_config_t* slot_config)
     return ESP_OK;
 }
 
-esp_err_t sdmmc_host_deinit()
+esp_err_t sdmmc_host_deinit(void)
 {
     if (!s_intr_handle) {
         return ESP_ERR_INVALID_STATE;
@@ -490,7 +490,7 @@ esp_err_t sdmmc_host_set_bus_ddr_mode(int slot, bool ddr_enabled)
     return ESP_OK;
 }
 
-static void sdmmc_host_dma_init()
+static void sdmmc_host_dma_init(void)
 {
     SDMMC.ctrl.dma_enable = 1;
     SDMMC.bmod.val = 0;
@@ -501,7 +501,7 @@ static void sdmmc_host_dma_init()
 }
 
 
-void sdmmc_host_dma_stop()
+void sdmmc_host_dma_stop(void)
 {
     SDMMC.ctrl.use_internal_dma = 0;
     SDMMC.ctrl.dma_reset = 1;
@@ -524,12 +524,12 @@ void sdmmc_host_dma_prepare(sdmmc_desc_t* desc, size_t block_size, size_t data_s
     sdmmc_host_dma_resume();
 }
 
-void sdmmc_host_dma_resume()
+void sdmmc_host_dma_resume(void)
 {
     SDMMC.pldmnd = 1;
 }
 
-bool sdmmc_host_card_busy()
+bool sdmmc_host_card_busy(void)
 {
     return SDMMC.status.data_busy == 1;
 }

--- a/components/driver/sdmmc_private.h
+++ b/components/driver/sdmmc_private.h
@@ -26,7 +26,7 @@ typedef struct {
     uint32_t dma_status;        ///< masked DMA interrupt status
 } sdmmc_event_t;
 
-void sdmmc_host_reset();
+void sdmmc_host_reset(void);
 
 esp_err_t sdmmc_host_start_command(int slot, sdmmc_hw_cmd_t cmd, uint32_t arg);
 
@@ -34,13 +34,13 @@ esp_err_t sdmmc_host_wait_for_event(int tick_count, sdmmc_event_t* out_event);
 
 void sdmmc_host_dma_prepare(sdmmc_desc_t* desc, size_t block_size, size_t data_size);
 
-void sdmmc_host_dma_stop();
+void sdmmc_host_dma_stop(void);
 
-void sdmmc_host_dma_resume();
+void sdmmc_host_dma_resume(void);
 
-bool sdmmc_host_card_busy();
+bool sdmmc_host_card_busy(void);
 
-esp_err_t sdmmc_host_transaction_handler_init();
+esp_err_t sdmmc_host_transaction_handler_init(void);
 
-void sdmmc_host_transaction_handler_deinit();
+void sdmmc_host_transaction_handler_deinit(void);
 

--- a/components/driver/sdmmc_transaction.c
+++ b/components/driver/sdmmc_transaction.c
@@ -72,7 +72,7 @@ static bool s_is_app_cmd;   // This flag is set if the next command is an APP co
 static esp_pm_lock_handle_t s_pm_lock;
 #endif
 
-static esp_err_t handle_idle_state_events();
+static esp_err_t handle_idle_state_events(void);
 static sdmmc_hw_cmd_t make_hw_cmd(sdmmc_command_t* cmd);
 static esp_err_t handle_event(sdmmc_command_t* cmd, sdmmc_req_state_t* state,
         sdmmc_event_t* unhandled_events);
@@ -80,10 +80,10 @@ static esp_err_t process_events(sdmmc_event_t evt, sdmmc_command_t* cmd,
         sdmmc_req_state_t* pstate, sdmmc_event_t* unhandled_events);
 static void process_command_response(uint32_t status, sdmmc_command_t* cmd);
 static void fill_dma_descriptors(size_t num_desc);
-static size_t get_free_descriptors_count();
+static size_t get_free_descriptors_count(void);
 static bool wait_for_busy_cleared(int timeout_ms);
 
-esp_err_t sdmmc_host_transaction_handler_init()
+esp_err_t sdmmc_host_transaction_handler_init(void)
 {
     assert(s_request_mutex == NULL);
     s_request_mutex = xSemaphoreCreateMutex();
@@ -102,7 +102,7 @@ esp_err_t sdmmc_host_transaction_handler_init()
     return ESP_OK;
 }
 
-void sdmmc_host_transaction_handler_deinit()
+void sdmmc_host_transaction_handler_deinit(void)
 {
     assert(s_request_mutex);
 #ifdef CONFIG_PM_ENABLE
@@ -182,7 +182,7 @@ out:
     return ret;
 }
 
-static size_t get_free_descriptors_count()
+static size_t get_free_descriptors_count(void)
 {
     const size_t next = s_cur_transfer.next_desc;
     size_t count = 0;
@@ -234,7 +234,7 @@ static void fill_dma_descriptors(size_t num_desc)
     }
 }
 
-static esp_err_t handle_idle_state_events()
+static esp_err_t handle_idle_state_events(void)
 {
     /* Handle any events which have happened in between transfers.
      * Under current assumptions (no SDIO support) only card detect events

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1456,7 +1456,7 @@ void uart_set_select_notif_callback(uart_port_t uart_num, uart_select_notif_call
     }
 }
 
-portMUX_TYPE *uart_get_selectlock()
+portMUX_TYPE *uart_get_selectlock(void)
 {
     return &uart_selectlock;
 }

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -288,7 +288,7 @@ esp_err_t esp_tls_set_global_ca_store(const unsigned char *cacert_pem_buf, const
  *             - Pointer to the global CA store currently being used    if successful.
  *             - NULL                                                   if there is no global CA store set.
  */
-mbedtls_x509_crt *esp_tls_get_global_ca_store();
+mbedtls_x509_crt *esp_tls_get_global_ca_store(void);
 
 /**
  * @brief      Free the global CA store currently being used.
@@ -296,7 +296,7 @@ mbedtls_x509_crt *esp_tls_get_global_ca_store();
  * The memory being used by the global CA store to store all the parsed certificates is
  * freed up. The application can call this API if it no longer needs the global CA store.
  */
-void esp_tls_free_global_ca_store();
+void esp_tls_free_global_ca_store(void);
 
 
 #ifdef __cplusplus

--- a/components/esp32/brownout.c
+++ b/components/esp32/brownout.c
@@ -47,7 +47,7 @@ static void rtc_brownout_isr_handler(void *arg)
     esp_restart_noos();
 }
 
-void esp_brownout_init()
+void esp_brownout_init(void)
 {
     REG_WRITE(RTC_CNTL_BROWN_OUT_REG,
             RTC_CNTL_BROWN_OUT_ENA /* Enable BOD */

--- a/components/esp32/brownout.c
+++ b/components/esp32/brownout.c
@@ -31,7 +31,7 @@
 #define BROWNOUT_DET_LVL 0
 #endif //CONFIG_BROWNOUT_DET_LVL
 
-static void rtc_brownout_isr_handler()
+static void rtc_brownout_isr_handler(void *arg)
 {
     /* Normally RTC ISR clears the interrupt flag after the application-supplied
      * handler returns. Since restart is called here, the flag needs to be

--- a/components/esp32/cache_err_int.c
+++ b/components/esp32/cache_err_int.c
@@ -31,7 +31,7 @@
 #include "sdkconfig.h"
 #include "esp_dport_access.h"
 
-void esp_cache_err_int_init()
+void esp_cache_err_int_init(void)
 {
     uint32_t core_id = xPortGetCoreID();
     ESP_INTR_DISABLE(ETS_CACHEERR_INUM);
@@ -71,7 +71,7 @@ void esp_cache_err_int_init()
     ESP_INTR_ENABLE(ETS_CACHEERR_INUM);
 }
 
-int IRAM_ATTR esp_cache_err_get_cpuid()
+int IRAM_ATTR esp_cache_err_get_cpuid(void)
 {
     esp_dport_access_int_pause();
     const uint32_t pro_mask =

--- a/components/esp32/clk.c
+++ b/components/esp32/clk.c
@@ -209,7 +209,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk)
     esp_clk_slowclk_cal_set(cal_val);
 }
 
-void rtc_clk_select_rtc_slow_clk()
+void rtc_clk_select_rtc_slow_clk(void)
 {
     select_rtc_slow_clk(RTC_SLOW_FREQ_32K_XTAL);
 }

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -79,7 +79,7 @@
 void start_cpu0(void) __attribute__((weak, alias("start_cpu0_default"))) __attribute__((noreturn));
 void start_cpu0_default(void) IRAM_ATTR __attribute__((noreturn));
 #if !CONFIG_FREERTOS_UNICORE
-static void IRAM_ATTR call_start_cpu1() __attribute__((noreturn));
+static void IRAM_ATTR call_start_cpu1(void) __attribute__((noreturn));
 void start_cpu1(void) __attribute__((weak, alias("start_cpu1_default"))) __attribute__((noreturn));
 void start_cpu1_default(void) IRAM_ATTR __attribute__((noreturn));
 static bool app_cpu_started = false;
@@ -117,7 +117,7 @@ static bool s_spiram_okay=true;
  * and the app CPU is in reset. We do have a stack, so we can do the initialization in C.
  */
 
-void IRAM_ATTR call_start_cpu0()
+void IRAM_ATTR call_start_cpu0(void)
 {
 #if CONFIG_FREERTOS_UNICORE
     RESET_REASON rst_reas[1];
@@ -261,7 +261,7 @@ static void wdt_reset_cpu1_info_enable(void)
     DPORT_REG_CLR_BIT(DPORT_APP_CPU_RECORD_CTRL_REG, DPORT_APP_CPU_RECORD_ENABLE);
 }
 
-void IRAM_ATTR call_start_cpu1()
+void IRAM_ATTR call_start_cpu1(void)
 {
     asm volatile (\
                   "wsr    %0, vecbase\n" \
@@ -450,7 +450,7 @@ void start_cpu1_default(void)
 #endif //!CONFIG_FREERTOS_UNICORE
 
 #ifdef CONFIG_CXX_EXCEPTIONS
-size_t __cxx_eh_arena_size_get()
+size_t __cxx_eh_arena_size_get(void)
 {
     return CONFIG_CXX_EXCEPTIONS_EMG_POOL_SIZE;
 }

--- a/components/esp32/crosscore_int.c
+++ b/components/esp32/crosscore_int.c
@@ -44,7 +44,7 @@ static volatile uint32_t reason[ portNUM_PROCESSORS ];
 ToDo: There is a small chance the CPU already has yielded when this ISR is serviced. In that case, it's running the intended task but
 the ISR will cause it to switch _away_ from it. portYIELD_FROM_ISR will probably just schedule the task again, but have to check that.
 */
-static inline void IRAM_ATTR esp_crosscore_isr_handle_yield()
+static inline void IRAM_ATTR esp_crosscore_isr_handle_yield(void)
 {
     portYIELD_FROM_ISR();
 }

--- a/components/esp32/esp_clk_internal.h
+++ b/components/esp32/esp_clk_internal.h
@@ -41,4 +41,4 @@ void esp_perip_clk_init(void);
 /* Selects an external clock source (32 kHz) for RTC.
  * Only internal use in unit test.
  */
-void rtc_clk_select_rtc_slow_clk();
+void rtc_clk_select_rtc_slow_clk(void);

--- a/components/esp32/esp_himem.c
+++ b/components/esp32/esp_himem.c
@@ -137,7 +137,7 @@ size_t esp_himem_reserved_area_size() {
 }
 
 
-void __attribute__((constructor)) esp_himem_init()
+void __attribute__((constructor)) esp_himem_init(void)
 {
     if (SPIRAM_BANKSWITCH_RESERVE == 0) return;
     int maxram=esp_spiram_get_size();

--- a/components/esp32/esp_system_internal.h
+++ b/components/esp32/esp_system_internal.h
@@ -29,7 +29,7 @@ extern "C" {
  * This is an internal function called by esp_restart. It is called directly
  * by the panic handler and brownout detector interrupt.
  */
-void esp_restart_noos() __attribute__ ((noreturn));
+void esp_restart_noos(void) __attribute__ ((noreturn));
 
 /**
  * @brief  Internal function to set reset reason hint

--- a/components/esp32/esp_timer.c
+++ b/components/esp32/esp_timer.c
@@ -54,12 +54,12 @@ struct esp_timer {
     LIST_ENTRY(esp_timer) list_entry;
 };
 
-static bool is_initialized();
+static bool is_initialized(void);
 static esp_err_t timer_insert(esp_timer_handle_t timer);
 static esp_err_t timer_remove(esp_timer_handle_t timer);
 static bool timer_armed(esp_timer_handle_t timer);
-static void timer_list_lock();
-static void timer_list_unlock();
+static void timer_list_lock(void);
+static void timer_list_unlock(void);
 
 #if WITH_PROFILING
 static void timer_insert_inactive(esp_timer_handle_t timer);
@@ -251,12 +251,12 @@ static IRAM_ATTR bool timer_armed(esp_timer_handle_t timer)
     return timer->alarm > 0;
 }
 
-static IRAM_ATTR void timer_list_lock()
+static IRAM_ATTR void timer_list_lock(void)
 {
     portENTER_CRITICAL(&s_timer_lock);
 }
 
-static IRAM_ATTR void timer_list_unlock()
+static IRAM_ATTR void timer_list_unlock(void)
 {
     portEXIT_CRITICAL(&s_timer_lock);
 }
@@ -331,7 +331,7 @@ static void IRAM_ATTR timer_alarm_handler(void* arg)
     }
 }
 
-static IRAM_ATTR bool is_initialized()
+static IRAM_ATTR bool is_initialized(void)
 {
     return s_timer_task != NULL;
 }
@@ -498,7 +498,7 @@ esp_err_t esp_timer_dump(FILE* stream)
     return ESP_OK;
 }
 
-int64_t IRAM_ATTR esp_timer_get_next_alarm()
+int64_t IRAM_ATTR esp_timer_get_next_alarm(void)
 {
     int64_t next_alarm = INT64_MAX;
     timer_list_lock();
@@ -510,7 +510,7 @@ int64_t IRAM_ATTR esp_timer_get_next_alarm()
     return next_alarm;
 }
 
-int64_t IRAM_ATTR esp_timer_get_time()
+int64_t IRAM_ATTR esp_timer_get_time(void)
 {
     return (int64_t) esp_timer_impl_get_time();
 }

--- a/components/esp32/esp_timer_esp32.c
+++ b/components/esp32/esp_timer_esp32.c
@@ -150,7 +150,7 @@ portMUX_TYPE s_time_update_lock = portMUX_INITIALIZER_UNLOCKED;
 #define TIMER_IS_AFTER_OVERFLOW(a) (ALARM_OVERFLOW_VAL < (a) && (a) <= FRC_TIMER_LOAD_VALUE(1))
 
 // Check if timer overflow has happened (but was not handled by ISR yet)
-static inline bool IRAM_ATTR timer_overflow_happened()
+static inline bool IRAM_ATTR timer_overflow_happened(void)
 {
     if (s_overflow_happened) {
         return true;

--- a/components/esp32/esp_timer_impl.h
+++ b/components/esp32/esp_timer_impl.h
@@ -38,7 +38,7 @@ esp_err_t esp_timer_impl_init(intr_handler_t alarm_handler);
 /**
  * @brief Deinitialize platform specific layer of esp_timer
  */
-void esp_timer_impl_deinit();
+void esp_timer_impl_deinit(void);
 
 /**
  * @brief Set up the timer interrupt to fire at a particular time
@@ -73,7 +73,7 @@ void esp_timer_impl_advance(int64_t time_us);
  * @brief Get time, in microseconds, since esp_timer_impl_init was called
  * @return timestamp in microseconds
  */
-uint64_t esp_timer_impl_get_time();
+uint64_t esp_timer_impl_get_time(void);
 
 /**
  * @brief Get minimal timer period, in microseconds
@@ -83,7 +83,7 @@ uint64_t esp_timer_impl_get_time();
  * callback, preventing other tasks from running.
  * @return minimal period of periodic timer, in microseconds
  */
-uint64_t esp_timer_impl_get_min_period_us();
+uint64_t esp_timer_impl_get_min_period_us(void);
 
 /**
  * @brief obtain internal critical section used esp_timer implementation
@@ -92,10 +92,10 @@ uint64_t esp_timer_impl_get_min_period_us();
  * the calls. Should be treated in the same way as a spinlock.
  * Call esp_timer_impl_unlock to release the lock
  */
-void esp_timer_impl_lock();
+void esp_timer_impl_lock(void);
 
 
 /**
  * @brief counterpart of esp_timer_impl_lock
  */
-void esp_timer_impl_unlock();
+void esp_timer_impl_unlock(void);

--- a/components/esp32/gdbstub.c
+++ b/components/esp32/gdbstub.c
@@ -34,7 +34,7 @@ static char chsum;						//Running checksum of the output packet
 #define ATTR_GDBFN
 
 //Receive a char from the uart. Uses polling and feeds the watchdog.
-static int ATTR_GDBFN gdbRecvChar() {
+static int ATTR_GDBFN gdbRecvChar(void) {
 	int i;
 	while (((READ_PERI_REG(UART_STATUS_REG(0))>>UART_RXFIFO_CNT_S)&UART_RXFIFO_CNT)==0) ;
 	i=READ_PERI_REG(UART_FIFO_REG(0));
@@ -48,7 +48,7 @@ static void ATTR_GDBFN gdbSendChar(char c) {
 }
 
 //Send the start of a packet; reset checksum calculation.
-static void ATTR_GDBFN gdbPacketStart() {
+static void ATTR_GDBFN gdbPacketStart(void) {
 	chsum=0;
 	gdbSendChar('$');
 }
@@ -83,7 +83,7 @@ static void ATTR_GDBFN gdbPacketHex(int val, int bits) {
 }
 
 //Finish sending a packet.
-static void ATTR_GDBFN gdbPacketEnd() {
+static void ATTR_GDBFN gdbPacketEnd(void) {
 	gdbSendChar('#');
 	gdbPacketHex(chsum, 8);
 }
@@ -243,7 +243,7 @@ static void dumpHwToRegfile(XtExcFrame *frame) {
 
 
 //Send the reason execution is stopped to GDB.
-static void sendReason() {
+static void sendReason(void) {
 	//exception-to-signal mapping
 	char exceptionSignal[]={4,31,11,11,2,6,8,0,6,7,0,0,7,7,7,7};
 	int i=0;
@@ -300,7 +300,7 @@ static int gdbHandleCommand(unsigned char *cmd, int len) {
 //Returns ST_OK on success, ST_ERR when checksum fails, a 
 //character if it is received instead of the GDB packet
 //start char.
-static int gdbReadCommand() {
+static int gdbReadCommand(void) {
 	unsigned char c;
 	unsigned char chsum=0, rchsum;
 	unsigned char sentchs[2];

--- a/components/esp32/hwcrypto/sha.c
+++ b/components/esp32/hwcrypto/sha.c
@@ -128,7 +128,7 @@ void esp_sha_unlock_memory_block(void)
 */
 static _lock_t state_change_lock;
 
-inline static bool sha_engines_all_idle() {
+inline static bool sha_engines_all_idle(void) {
     return !engine_states[0].in_use
         && !engine_states[1].in_use
         && !engine_states[2].in_use;

--- a/components/esp32/include/esp_brownout.h
+++ b/components/esp32/include/esp_brownout.h
@@ -16,6 +16,6 @@
 #ifndef __ESP_BROWNOUT_H
 #define __ESP_BROWNOUT_H
 
-void esp_brownout_init();
+void esp_brownout_init(void);
 
 #endif

--- a/components/esp32/include/esp_cache_err_int.h
+++ b/components/esp32/include/esp_cache_err_int.h
@@ -20,7 +20,7 @@
  * to interrupt input number ETS_CACHEERR_INUM (see soc/soc.h). It is called
  * from the startup code.
  */
-void esp_cache_err_int_init();
+void esp_cache_err_int_init(void);
 
 
 /**
@@ -30,4 +30,4 @@ void esp_cache_err_int_init();
  *  - APP_CPU_NUM, if APP_CPU has caused cache IA interrupt
  *  - (-1) otherwise
  */
-int esp_cache_err_get_cpuid();
+int esp_cache_err_get_cpuid(void);

--- a/components/esp32/include/esp_clk.h
+++ b/components/esp32/include/esp_clk.h
@@ -29,7 +29,7 @@
  *
  * @return the calibration value obtained using rtc_clk_cal, at startup time
  */
-uint32_t esp_clk_slowclk_cal_get();
+uint32_t esp_clk_slowclk_cal_get(void);
 
 /**
  * @brief Update the calibration value of RTC slow clock
@@ -84,4 +84,4 @@ int esp_clk_xtal_freq(void);
  *
  * @return Value or RTC counter, expressed in microseconds
  */
-uint64_t esp_clk_rtc_time();
+uint64_t esp_clk_rtc_time(void);

--- a/components/esp32/include/esp_core_dump.h
+++ b/components/esp32/include/esp_core_dump.h
@@ -24,7 +24,7 @@
  *
  * @note  Should be called at system startup.
  */
-void esp_core_dump_init();
+void esp_core_dump_init(void);
 
 /**
  * @brief  Saves core dump to flash.
@@ -54,7 +54,7 @@ void esp_core_dump_init();
  * 4) Task's stack is placed after TCB data. Size is (STACK_END - STACK_TOP) bytes.
  * 5) CRC is placed at the end of the data.
  */
-void esp_core_dump_to_flash();
+void esp_core_dump_to_flash(void);
 
 /**
  * @brief  Print base64-encoded core dump to UART.
@@ -64,7 +64,7 @@ void esp_core_dump_to_flash();
  * 2) Since CRC is omitted TOTAL_LEN does not include its size.
  * 3) Printed base64 data are surrounded with special messages to help user recognize the start and end of actual data.
  */
-void esp_core_dump_to_uart();
+void esp_core_dump_to_uart(void);
 
 
 /**************************************************************************************/

--- a/components/esp32/include/esp_crosscore_int.h
+++ b/components/esp32/include/esp_crosscore_int.h
@@ -24,7 +24,7 @@
  * called automatically by the startup code and should not
  * be called manually.
  */
-void esp_crosscore_int_init();
+void esp_crosscore_int_init(void);
 
 
 /**

--- a/components/esp32/include/esp_event_legacy.h
+++ b/components/esp32/include/esp_event_legacy.h
@@ -172,13 +172,13 @@ esp_err_t esp_event_process_default(system_event_t *event);
   * @brief  Install default event handlers for Ethernet interface
   *
   */
-void esp_event_set_default_eth_handlers();
+void esp_event_set_default_eth_handlers(void);
 
 /**
   * @brief  Install default event handlers for Wi-Fi interfaces (station and AP)
   *
   */
-void esp_event_set_default_wifi_handlers();
+void esp_event_set_default_wifi_handlers(void);
 
 #ifdef __cplusplus
 }

--- a/components/esp32/include/esp_freertos_hooks.h
+++ b/components/esp32/include/esp_freertos_hooks.h
@@ -26,8 +26,8 @@ extern "C"
 /*
  Definitions for the tickhook and idlehook callbacks
 */
-typedef bool (*esp_freertos_idle_cb_t)();
-typedef void (*esp_freertos_tick_cb_t)();
+typedef bool (*esp_freertos_idle_cb_t)(void);
+typedef void (*esp_freertos_tick_cb_t)(void);
 
 /**
   * @brief  Register a callback to be called from the specified core's idle hook.

--- a/components/esp32/include/esp_himem.h
+++ b/components/esp32/include/esp_himem.h
@@ -125,14 +125,14 @@ esp_err_t esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr, size_t len);
  *
  * @returns Amount of memory, in bytes
  */
-size_t esp_himem_get_phys_size();
+size_t esp_himem_get_phys_size(void);
 
 /**
  * @brief Get free amount of memory under control of himem API
  *
  * @returns Amount of free memory, in bytes
  */
-size_t esp_himem_get_free_size();
+size_t esp_himem_get_free_size(void);
 
 
 /**
@@ -143,7 +143,7 @@ size_t esp_himem_get_free_size();
  *
  * @returns Amount of reserved area, in bytes
  */
-size_t esp_himem_reserved_area_size();
+size_t esp_himem_reserved_area_size(void);
 
 
 #ifdef __cplusplus

--- a/components/esp32/include/esp_int_wdt.h
+++ b/components/esp32/include/esp_int_wdt.h
@@ -43,7 +43,7 @@ This uses the TIMERG1 WDT.
   *         is enabled in menuconfig.
   *
   */
-void esp_int_wdt_init();
+void esp_int_wdt_init(void);
 
 /**
   * @brief  Enable the interrupt watchdog on the current CPU. This is called
@@ -51,7 +51,7 @@ void esp_int_wdt_init();
   *         in menuconfig.
   *
   */
-void esp_int_wdt_cpu_init();
+void esp_int_wdt_cpu_init(void);
 
 
 

--- a/components/esp32/include/esp_intr_alloc.h
+++ b/components/esp32/include/esp_intr_alloc.h
@@ -278,13 +278,13 @@ esp_err_t esp_intr_set_in_iram(intr_handle_t handle, bool is_in_iram);
 /**
  * @brief Disable interrupts that aren't specifically marked as running from IRAM
  */
-void esp_intr_noniram_disable();
+void esp_intr_noniram_disable(void);
 
 
 /**
  * @brief Re-enable interrupts disabled by esp_intr_noniram_disable
  */
-void esp_intr_noniram_enable();
+void esp_intr_noniram_enable(void);
 
 /**@}*/
 

--- a/components/esp32/include/esp_phy_init.h
+++ b/components/esp32/include/esp_phy_init.h
@@ -103,7 +103,7 @@ typedef enum{
  *
  * @return pointer to PHY init data structure
  */
-const esp_phy_init_data_t* esp_phy_get_init_data();
+const esp_phy_init_data_t* esp_phy_get_init_data(void);
 
 /**
  * @brief Release PHY init data

--- a/components/esp32/include/esp_sleep.h
+++ b/components/esp32/include/esp_sleep.h
@@ -97,7 +97,7 @@ esp_err_t esp_sleep_disable_wakeup_source(esp_sleep_source_t source);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if ULP co-processor is not enabled or if wakeup triggers conflict
  */
-esp_err_t esp_sleep_enable_ulp_wakeup();
+esp_err_t esp_sleep_enable_ulp_wakeup(void);
 
 /**
  * @brief Enable wakeup by timer
@@ -123,7 +123,7 @@ esp_err_t esp_sleep_enable_timer_wakeup(uint64_t time_in_us);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if wakeup triggers conflict
  */
-esp_err_t esp_sleep_enable_touchpad_wakeup();
+esp_err_t esp_sleep_enable_touchpad_wakeup(void);
 
 /**
  * @brief Get the touch pad which caused wakeup
@@ -132,7 +132,7 @@ esp_err_t esp_sleep_enable_touchpad_wakeup();
  *
  * @return touch pad which caused wakeup
  */
-touch_pad_t esp_sleep_get_touchpad_wakeup_status();
+touch_pad_t esp_sleep_get_touchpad_wakeup_status(void);
 
 /**
  * @brief Enable wakeup using a pin
@@ -211,7 +211,7 @@ esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_sleep_ext1_wakeup_mode
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if wakeup triggers conflict
  */
-esp_err_t esp_sleep_enable_gpio_wakeup();
+esp_err_t esp_sleep_enable_gpio_wakeup(void);
 
 /**
  * @brief Enable wakeup from light sleep using UART
@@ -237,7 +237,7 @@ esp_err_t esp_sleep_enable_uart_wakeup(int uart_num);
  *
  * @return bit mask, if GPIOn caused wakeup, BIT(n) will be set
  */
-uint64_t esp_sleep_get_ext1_wakeup_status();
+uint64_t esp_sleep_get_ext1_wakeup_status(void);
 
 /**
  * @brief Set power down mode for an RTC power domain in sleep mode
@@ -258,7 +258,7 @@ esp_err_t esp_sleep_pd_config(esp_sleep_pd_domain_t domain,
  *
  * This function does not return.
  */
-void esp_deep_sleep_start() __attribute__((noreturn));
+void esp_deep_sleep_start(void) __attribute__((noreturn));
 
 /**
  * @brief Enter light sleep with the configured wakeup options
@@ -267,7 +267,7 @@ void esp_deep_sleep_start() __attribute__((noreturn));
  *  - ESP_OK on success (returned after wakeup)
  *  - ESP_ERR_INVALID_STATE if WiFi or BT is not stopped
  */
-esp_err_t esp_light_sleep_start();
+esp_err_t esp_light_sleep_start(void);
 
 /**
  * @brief Enter deep-sleep mode
@@ -309,7 +309,7 @@ void system_deep_sleep(uint64_t time_in_us) __attribute__((noreturn, deprecated)
  *
  * @return cause of wake up from last sleep (deep sleep or light sleep)
  */
-esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause();
+esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause(void);
 
 
 /**

--- a/components/esp32/include/esp_spiram.h
+++ b/components/esp32/include/esp_spiram.h
@@ -33,14 +33,14 @@ typedef enum {
  *     - ESP_SPIRAM_SIZE_INVALID if SPI RAM not enabled or not valid
  *     - SPI RAM size
  */
-esp_spiram_size_t esp_spiram_get_chip_size();
+esp_spiram_size_t esp_spiram_get_chip_size(void);
 
 /**
  * @brief Initialize spiram interface/hardware. Normally called from cpu_start.c.
  *
  * @return ESP_OK on success
  */
-esp_err_t esp_spiram_init();
+esp_err_t esp_spiram_init(void);
 
 /**
  * @brief Configure Cache/MMU for access to external SPI RAM.
@@ -51,7 +51,7 @@ esp_err_t esp_spiram_init();
  *
  * @attention this function must be called with flash cache disabled.
  */
-void esp_spiram_init_cache();
+void esp_spiram_init_cache(void);
 
 
 /**
@@ -62,13 +62,13 @@ void esp_spiram_init_cache();
  *
  * @return true on success, false on failed memory test
  */
-bool esp_spiram_test();
+bool esp_spiram_test(void);
 
 
 /**
  * @brief Add the initialized SPI RAM to the heap allocator.
  */
-esp_err_t esp_spiram_add_to_heapalloc();
+esp_err_t esp_spiram_add_to_heapalloc(void);
 
 
 /**
@@ -76,7 +76,7 @@ esp_err_t esp_spiram_add_to_heapalloc();
  *
  * @return Size in bytes, or 0 if no external RAM chip support compiled in.
  */
-size_t esp_spiram_get_size();
+size_t esp_spiram_get_size(void);
 
 
 /**
@@ -86,7 +86,7 @@ size_t esp_spiram_get_size();
  *
  * This is meant for use from within the SPI flash code.
  */
-void esp_spiram_writeback_cache();
+void esp_spiram_writeback_cache(void);
 
 
 

--- a/components/esp32/include/esp_task_wdt.h
+++ b/components/esp32/include/esp_task_wdt.h
@@ -56,7 +56,7 @@ esp_err_t esp_task_wdt_init(uint32_t timeout, bool panic);
  *      - ESP_ERR_INVALID_STATE: Error, tasks are still subscribed to the TWDT
  *      - ESP_ERR_NOT_FOUND: Error, TWDT has already been deinitialized
  */
-esp_err_t esp_task_wdt_deinit();
+esp_err_t esp_task_wdt_deinit(void);
 
 /**
   * @brief  Subscribe a task to the Task Watchdog Timer (TWDT)
@@ -102,7 +102,7 @@ esp_err_t esp_task_wdt_add(TaskHandle_t handle);
   *                          to the TWDT
   *     - ESP_ERR_INVALID_STATE: Error, the TWDT has not been initialized yet
   */
-esp_err_t esp_task_wdt_reset();
+esp_err_t esp_task_wdt_reset(void);
 
 /**
   * @brief  Unsubscribes a task from the Task Watchdog Timer (TWDT)
@@ -155,7 +155,7 @@ esp_err_t esp_task_wdt_status(TaskHandle_t handle);
   * function, then proceed to reset the TWDT on subsequent calls of this
   * function.
   */
-void esp_task_wdt_feed() __attribute__ ((deprecated));
+void esp_task_wdt_feed(void) __attribute__ ((deprecated));
 
 
 #ifdef __cplusplus

--- a/components/esp32/include/esp_timer.h
+++ b/components/esp32/include/esp_timer.h
@@ -95,7 +95,7 @@ typedef struct {
  *      - ESP_ERR_INVALID_STATE if already initialized
  *      - other errors from interrupt allocator
  */
-esp_err_t esp_timer_init();
+esp_err_t esp_timer_init(void);
 
 /**
  * @brief De-initialize esp_timer library
@@ -106,7 +106,7 @@ esp_err_t esp_timer_init();
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if not yet initialized
  */
-esp_err_t esp_timer_deinit();
+esp_err_t esp_timer_deinit(void);
 
 /**
  * @brief Create an esp_timer instance
@@ -187,14 +187,14 @@ esp_err_t esp_timer_delete(esp_timer_handle_t timer);
  * @return number of microseconds since esp_timer_init was called (this normally
  *          happens early during application startup).
  */
-int64_t esp_timer_get_time();
+int64_t esp_timer_get_time(void);
 
 /**
  * @brief Get the timestamp when the next timeout is expected to occur
  * @return Timestamp of the nearest timer event, in microseconds.
  *         The timebase is the same as for the values returned by esp_timer_get_time.
  */
-int64_t esp_timer_get_next_alarm();
+int64_t esp_timer_get_next_alarm(void);
 
 /**
  * @brief Dump the list of timers to a stream

--- a/components/esp32/include/xtensa/xtruntime.h
+++ b/components/esp32/include/xtensa/xtruntime.h
@@ -58,7 +58,7 @@ extern "C" {
 #ifdef __cplusplus
 typedef void (_xtos_handler_func)(...);
 #else
-typedef void (_xtos_handler_func)();
+typedef void (_xtos_handler_func)(void);
 #endif
 typedef _xtos_handler_func *_xtos_handler;
 

--- a/components/esp32/ipc.c
+++ b/components/esp32/ipc.c
@@ -82,9 +82,9 @@ static void IRAM_ATTR ipc_task(void* arg)
  * woken up to execute the callback provided to esp_ipc_call_nonblocking or
  * esp_ipc_call_blocking.
  */
-static void esp_ipc_init() __attribute__((constructor));
+static void esp_ipc_init(void) __attribute__((constructor));
 
-static void esp_ipc_init()
+static void esp_ipc_init(void)
 {
     s_ipc_mutex = xSemaphoreCreateMutex();
     s_ipc_ack = xSemaphoreCreateBinary();

--- a/components/esp32/panic.c
+++ b/components/esp32/panic.c
@@ -137,7 +137,7 @@ esp_reset_reason_t __attribute__((weak)) esp_reset_reason_get_hint(void)
 
 static bool abort_called;
 
-static __attribute__((noreturn)) inline void invoke_abort()
+static __attribute__((noreturn)) inline void invoke_abort(void)
 {
     abort_called = true;
 #if CONFIG_ESP32_APPTRACE_ENABLE
@@ -156,7 +156,7 @@ static __attribute__((noreturn)) inline void invoke_abort()
     }
 }
 
-void abort()
+void abort(void)
 {
 #if !CONFIG_ESP32_PANIC_SILENT_REBOOT
     ets_printf("abort() was called at PC 0x%08x on core %d\r\n", (intptr_t)__builtin_return_address(0) - 3, xPortGetCoreID());
@@ -187,12 +187,12 @@ static const char *edesc[] = {
 #define NUM_EDESCS (sizeof(edesc) / sizeof(char *))
 
 static void commonErrorHandler(XtExcFrame *frame);
-static inline void disableAllWdts();
+static inline void disableAllWdts(void);
 static void illegal_instruction_helper(XtExcFrame *frame);
 
 //The fact that we've panic'ed probably means the other CPU is now running wild, possibly
 //messing up the serial output, so we stall it here.
-static void haltOtherCore()
+static void haltOtherCore(void)
 {
     esp_cpu_stall( xPortGetCoreID() == 0 ? 1 : 0 );
 }
@@ -397,7 +397,7 @@ static void illegal_instruction_helper(XtExcFrame *frame)
   all watchdogs except the timer group 0 watchdog, and it reconfigures that to reset the chip after
   one second.
 */
-static void reconfigureAllWdts()
+static void reconfigureAllWdts(void)
 {
     TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
     TIMERG0.wdt_feed = 1;
@@ -417,7 +417,7 @@ static void reconfigureAllWdts()
 /*
   This disables all the watchdogs for when we call the gdbstub.
 */
-static inline void disableAllWdts()
+static inline void disableAllWdts(void)
 {
     TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
     TIMERG0.wdt_config0.en = 0;
@@ -427,9 +427,9 @@ static inline void disableAllWdts()
     TIMERG1.wdt_wprotect = 0;
 }
 
-static void esp_panic_dig_reset() __attribute__((noreturn));
+static void esp_panic_dig_reset(void) __attribute__((noreturn));
 
-static void esp_panic_dig_reset()
+static void esp_panic_dig_reset(void)
 {
     // make sure all the panic handler output is sent from UART FIFO
     uart_tx_wait_idle(CONFIG_CONSOLE_UART_NUM);

--- a/components/esp32/phy.h
+++ b/components/esp32/phy.h
@@ -44,7 +44,7 @@ int register_chipv7_phy(const esp_phy_init_data_t* init_data, esp_phy_calibratio
  * @brief Get the format version of calibration data used by PHY library.
  * @return Format version number, OR'ed with BIT(16) if PHY is in WIFI only mode.
  */
-uint32_t phy_get_rf_cal_version();
+uint32_t phy_get_rf_cal_version(void);
 
 /**
  * @brief Set RF/BB for only WIFI mode or coexist(WIFI & BT) mode

--- a/components/esp32/pm_esp32.c
+++ b/components/esp32/pm_esp32.c
@@ -144,9 +144,9 @@ static const char* s_mode_names[] = {
 
 static const char* TAG = "pm_esp32";
 
-static void update_ccompare();
+static void update_ccompare(void);
 static void do_switch(pm_mode_t new_mode);
-static void leave_idle();
+static void leave_idle(void);
 static void on_freq_update(uint32_t old_ticks_per_us, uint32_t ticks_per_us);
 
 
@@ -245,7 +245,7 @@ esp_err_t esp_pm_configure(const void* vconfig)
     return ESP_OK;
 }
 
-static pm_mode_t IRAM_ATTR get_lowest_allowed_mode()
+static pm_mode_t IRAM_ATTR get_lowest_allowed_mode(void)
 {
     /* TODO: optimize using ffs/clz */
     if (s_mode_mask >= BIT(PM_MODE_CPU_MAX)) {
@@ -417,7 +417,7 @@ static void IRAM_ATTR do_switch(pm_mode_t new_mode)
  * would happen without the frequency change.
  * Assumes that the new_frequency = old_frequency * s_ccount_mul / s_ccount_div.
  */
-static void IRAM_ATTR update_ccompare()
+static void IRAM_ATTR update_ccompare(void)
 {
     uint32_t ccount = XTHAL_GET_CCOUNT();
     uint32_t ccompare = XTHAL_GET_CCOMPARE(XT_TIMER_INDEX);
@@ -431,7 +431,7 @@ static void IRAM_ATTR update_ccompare()
     }
 }
 
-static void IRAM_ATTR leave_idle()
+static void IRAM_ATTR leave_idle(void)
 {
     int core_id = xPortGetCoreID();
     if (s_core_idle[core_id]) {
@@ -441,7 +441,7 @@ static void IRAM_ATTR leave_idle()
     }
 }
 
-void esp_pm_impl_idle_hook()
+void esp_pm_impl_idle_hook(void)
 {
     int core_id = xPortGetCoreID();
     uint32_t state = portENTER_CRITICAL_NESTED();
@@ -453,7 +453,7 @@ void esp_pm_impl_idle_hook()
     ESP_PM_TRACE_ENTER(IDLE, core_id);
 }
 
-void IRAM_ATTR esp_pm_impl_isr_hook()
+void IRAM_ATTR esp_pm_impl_isr_hook(void)
 {
     int core_id = xPortGetCoreID();
     ESP_PM_TRACE_ENTER(ISR_HOOK, core_id);
@@ -470,7 +470,7 @@ void IRAM_ATTR esp_pm_impl_isr_hook()
     ESP_PM_TRACE_EXIT(ISR_HOOK, core_id);
 }
 
-void esp_pm_impl_waiti()
+void esp_pm_impl_waiti(void)
 {
 #if CONFIG_FREERTOS_USE_TICKLESS_IDLE
     int core_id = xPortGetCoreID();
@@ -589,7 +589,7 @@ void esp_pm_impl_dump_stats(FILE* out)
 }
 #endif // WITH_PROFILING
 
-void esp_pm_impl_init()
+void esp_pm_impl_init(void)
 {
 #ifdef CONFIG_PM_TRACE
     esp_pm_trace_init();

--- a/components/esp32/pm_impl.h
+++ b/components/esp32/pm_impl.h
@@ -80,19 +80,19 @@ void esp_pm_impl_switch_mode(pm_mode_t mode, pm_mode_switch_t lock_or_unlock, pm
 /**
  * @brief Call once at startup to initialize pm implementation
  */
-void esp_pm_impl_init();
+void esp_pm_impl_init(void);
 
 /**
  * @brief Hook function for the idle task
  * Must be called from the IDLE task on each CPU before entering waiti state.
  */
-void esp_pm_impl_idle_hook();
+void esp_pm_impl_idle_hook(void);
 
 /**
  * @brief Hook function for the interrupt dispatcher
  * Must be called soon after entering the ISR
  */
-void esp_pm_impl_isr_hook();
+void esp_pm_impl_isr_hook(void);
 
 /**
  * @brief Dump the information about time spent in each of the pm modes.
@@ -107,7 +107,7 @@ void esp_pm_impl_dump_stats(FILE* out);
 /**
  * @brief Hook function implementing `waiti` instruction, should be invoked from idle task context
  */
-void esp_pm_impl_waiti();
+void esp_pm_impl_waiti(void);
 
 #ifdef CONFIG_PM_PROFILING
 #define WITH_PROFILING

--- a/components/esp32/pm_trace.c
+++ b/components/esp32/pm_trace.c
@@ -30,7 +30,7 @@ static const int DRAM_ATTR s_trace_io[] = {
         BIT(27), BIT(27), // ESP_PM_TRACE_SLEEP
 };
 
-void esp_pm_trace_init()
+void esp_pm_trace_init(void)
 {
     for (size_t i = 0; i < sizeof(s_trace_io)/sizeof(s_trace_io[0]); ++i) {
         int io = __builtin_ffs(s_trace_io[i]);

--- a/components/esp32/pm_trace.h
+++ b/components/esp32/pm_trace.h
@@ -26,7 +26,7 @@ typedef enum {
     ESP_PM_TRACE_TYPE_MAX
 } esp_pm_trace_event_t;
 
-void esp_pm_trace_init();
+void esp_pm_trace_init(void);
 void esp_pm_trace_enter(esp_pm_trace_event_t event, int core_id);
 void esp_pm_trace_exit(esp_pm_trace_event_t event, int core_id);
 

--- a/components/esp32/reset_reason.c
+++ b/components/esp32/reset_reason.c
@@ -17,7 +17,7 @@
 #include "rom/rtc.h"
 #include "soc/rtc_cntl_reg.h"
 
-static void esp_reset_reason_clear_hint();
+static void esp_reset_reason_clear_hint(void);
 
 static esp_reset_reason_t s_reset_reason;
 
@@ -119,7 +119,7 @@ esp_reset_reason_t IRAM_ATTR esp_reset_reason_get_hint(void)
     }
     return (esp_reset_reason_t) low;
 }
-static void esp_reset_reason_clear_hint()
+static void esp_reset_reason_clear_hint(void)
 {
     REG_WRITE(RTC_RESET_CAUSE_REG, 0);
 }

--- a/components/esp32/sleep_modes.c
+++ b/components/esp32/sleep_modes.c
@@ -89,10 +89,10 @@ static _lock_t lock_rtc_memory_crc;
 
 static const char* TAG = "sleep";
 
-static uint32_t get_power_down_flags();
-static void ext0_wakeup_prepare();
-static void ext1_wakeup_prepare();
-static void timer_wakeup_prepare();
+static uint32_t get_power_down_flags(void);
+static void ext0_wakeup_prepare(void);
+static void ext1_wakeup_prepare(void);
+static void timer_wakeup_prepare(void);
 
 /* Wake from deep sleep stub
    See esp_deepsleep.h esp_wake_deep_sleep() comments for details.
@@ -148,14 +148,14 @@ void esp_deep_sleep(uint64_t time_in_us)
     esp_deep_sleep_start();
 }
 
-static void IRAM_ATTR flush_uarts()
+static void IRAM_ATTR flush_uarts(void)
 {
     for (int i = 0; i < 3; ++i) {
         uart_tx_wait_idle(i);
     }
 }
 
-static void IRAM_ATTR suspend_uarts()
+static void IRAM_ATTR suspend_uarts(void)
 {
     for (int i = 0; i < 3; ++i) {
         REG_SET_BIT(UART_FLOW_CONF_REG(i), UART_FORCE_XOFF);
@@ -165,7 +165,7 @@ static void IRAM_ATTR suspend_uarts()
     }
 }
 
-static void IRAM_ATTR resume_uarts()
+static void IRAM_ATTR resume_uarts(void)
 {
     for (int i = 0; i < 3; ++i) {
         REG_CLR_BIT(UART_FLOW_CONF_REG(i), UART_FORCE_XOFF);
@@ -222,7 +222,7 @@ static uint32_t IRAM_ATTR esp_sleep_start(uint32_t pd_flags)
     return result;
 }
 
-void IRAM_ATTR esp_deep_sleep_start()
+void IRAM_ATTR esp_deep_sleep_start(void)
 {
     // record current RTC time
     s_config.rtc_ticks_at_sleep_start = rtc_time_get();
@@ -277,7 +277,7 @@ static esp_err_t esp_light_sleep_inner(uint32_t pd_flags,
     return err;
 }
 
-esp_err_t esp_light_sleep_start()
+esp_err_t esp_light_sleep_start(void)
 {
     static portMUX_TYPE light_sleep_lock = portMUX_INITIALIZER_UNLOCKED;
     portENTER_CRITICAL(&light_sleep_lock);
@@ -399,7 +399,7 @@ esp_err_t esp_sleep_disable_wakeup_source(esp_sleep_source_t source)
     return ESP_OK;
 }
 
-esp_err_t esp_sleep_enable_ulp_wakeup()
+esp_err_t esp_sleep_enable_ulp_wakeup(void)
 {
 #ifdef CONFIG_ULP_COPROC_ENABLED
     if(s_config.wakeup_triggers & RTC_EXT0_TRIG_EN) {
@@ -420,7 +420,7 @@ esp_err_t esp_sleep_enable_timer_wakeup(uint64_t time_in_us)
     return ESP_OK;
 }
 
-static void timer_wakeup_prepare()
+static void timer_wakeup_prepare(void)
 {
     uint32_t period = esp_clk_slowclk_cal_get();
     int64_t sleep_duration = (int64_t) s_config.sleep_duration - (int64_t) s_config.sleep_time_adjustment;
@@ -432,7 +432,7 @@ static void timer_wakeup_prepare()
     rtc_sleep_set_wakeup_time(s_config.rtc_ticks_at_sleep_start + rtc_count_delta);
 }
 
-esp_err_t esp_sleep_enable_touchpad_wakeup()
+esp_err_t esp_sleep_enable_touchpad_wakeup(void)
 {
     if (s_config.wakeup_triggers & (RTC_EXT0_TRIG_EN)) {
         ESP_LOGE(TAG, "Conflicting wake-up trigger: ext0");
@@ -442,7 +442,7 @@ esp_err_t esp_sleep_enable_touchpad_wakeup()
     return ESP_OK;
 }
 
-touch_pad_t esp_sleep_get_touchpad_wakeup_status()
+touch_pad_t esp_sleep_get_touchpad_wakeup_status(void)
 {
     if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_TOUCHPAD) {
         return TOUCH_PAD_MAX;
@@ -471,7 +471,7 @@ esp_err_t esp_sleep_enable_ext0_wakeup(gpio_num_t gpio_num, int level)
     return ESP_OK;
 }
 
-static void ext0_wakeup_prepare()
+static void ext0_wakeup_prepare(void)
 {
     int rtc_gpio_num = s_config.ext0_rtc_gpio_num;
     // Set GPIO to be used for wakeup
@@ -514,7 +514,7 @@ esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_sleep_ext1_wakeup_mode
     return ESP_OK;
 }
 
-static void ext1_wakeup_prepare()
+static void ext1_wakeup_prepare(void)
 {
     // Configure all RTC IOs selected as ext1 wakeup inputs
     uint32_t rtc_gpio_mask = s_config.ext1_rtc_gpio_mask;
@@ -550,7 +550,7 @@ static void ext1_wakeup_prepare()
             s_config.ext1_trigger_mode, RTC_CNTL_EXT_WAKEUP1_LV_S);
 }
 
-uint64_t esp_sleep_get_ext1_wakeup_status()
+uint64_t esp_sleep_get_ext1_wakeup_status(void)
 {
     if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_EXT1) {
         return 0;
@@ -571,7 +571,7 @@ uint64_t esp_sleep_get_ext1_wakeup_status()
     return gpio_mask;
 }
 
-esp_err_t esp_sleep_enable_gpio_wakeup()
+esp_err_t esp_sleep_enable_gpio_wakeup(void)
 {
     if (s_config.wakeup_triggers & (RTC_TOUCH_TRIG_EN | RTC_ULP_TRIG_EN)) {
         ESP_LOGE(TAG, "Conflicting wake-up triggers: touch / ULP");
@@ -594,7 +594,7 @@ esp_err_t esp_sleep_enable_uart_wakeup(int uart_num)
     return ESP_OK;
 }
 
-esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause()
+esp_sleep_wakeup_cause_t esp_sleep_get_wakeup_cause(void)
 {
     if (rtc_get_reset_reason(0) != DEEPSLEEP_RESET && !s_light_sleep_wakeup) {
         return ESP_SLEEP_WAKEUP_UNDEFINED;
@@ -630,7 +630,7 @@ esp_err_t esp_sleep_pd_config(esp_sleep_pd_domain_t domain,
     return ESP_OK;
 }
 
-static uint32_t get_power_down_flags()
+static uint32_t get_power_down_flags(void)
 {
     // Where needed, convert AUTO options to ON. Later interpret AUTO as OFF.
 

--- a/components/esp32/spiram_psram.h
+++ b/components/esp32/spiram_psram.h
@@ -52,7 +52,7 @@ typedef enum {
  *     - PSRAM_SIZE_MAX if psram not enabled or not valid
  *     - PSRAM size
  */
-psram_size_t psram_get_size();
+psram_size_t psram_get_size(void);
 
 /**
  * @brief psram cache enable function

--- a/components/esp32/system_api.c
+++ b/components/esp32/system_api.c
@@ -245,7 +245,7 @@ esp_err_t esp_register_shutdown_handler(shutdown_handler_t handler)
      return ESP_FAIL;
 }
 
-void esp_restart_noos() __attribute__ ((noreturn));
+void esp_restart_noos(void) __attribute__ ((noreturn));
 
 void IRAM_ATTR esp_restart(void)
 {
@@ -266,7 +266,7 @@ void IRAM_ATTR esp_restart(void)
  * core are already stopped. Stalls other core, resets hardware,
  * triggers restart.
 */
-void IRAM_ATTR esp_restart_noos()
+void IRAM_ATTR esp_restart_noos(void)
 {
     // Disable interrupts
     xt_ints_off(0xFFFFFFFF);

--- a/components/esp32/task_wdt.c
+++ b/components/esp32/task_wdt.c
@@ -106,7 +106,7 @@ static twdt_task_t *find_task_in_twdt_list(TaskHandle_t handle, bool *all_reset)
  * Resets the hardware timer and has_reset flags of each task on the list.
  * Called within critical
  */
-static void reset_hw_timer()
+static void reset_hw_timer(void)
 {
     //All tasks have reset; time to reset the hardware timer.
     TIMERG0.wdt_wprotect=TIMG_WDT_WKEY_VALUE;

--- a/components/esp32/wifi_init.c
+++ b/components/esp32/wifi_init.c
@@ -27,7 +27,7 @@ mesh_event_cb_t g_mesh_event_cb = NULL;
 static esp_pm_lock_handle_t s_wifi_modem_sleep_lock;
 #endif
 
-static void __attribute__((constructor)) s_set_default_wifi_log_level()
+static void __attribute__((constructor)) s_set_default_wifi_log_level(void)
 {
     /* WiFi libraries aren't compiled to know CONFIG_LOG_DEFAULT_LEVEL,
        so set it at runtime startup. Done here not in esp_wifi_init() to allow
@@ -36,7 +36,7 @@ static void __attribute__((constructor)) s_set_default_wifi_log_level()
     esp_log_level_set("wifi", CONFIG_LOG_DEFAULT_LEVEL);
 }
 
-static void esp_wifi_set_debug_log()
+static void esp_wifi_set_debug_log(void)
 {
     /* set WiFi log level and module */
 #if CONFIG_ESP32_WIFI_DEBUG_LOG_ENABLE

--- a/components/esp_adc_cal/esp_adc_cal.c
+++ b/components/esp_adc_cal/esp_adc_cal.c
@@ -110,13 +110,13 @@ static const uint32_t lut_adc2_high[LUT_POINTS] = {2657, 2698, 2738, 2774, 2807,
                                                    2971, 2996, 3020, 3043, 3067, 3092, 3116, 3139, 3162, 3185};
 
 /* ----------------------- EFuse Access Functions --------------------------- */
-static bool check_efuse_vref()
+static bool check_efuse_vref(void)
 {
     //Check if Vref is burned in eFuse
     return (REG_GET_FIELD(VREF_REG, EFUSE_RD_ADC_VREF) != 0) ? true : false;
 }
 
-static bool check_efuse_tp()
+static bool check_efuse_tp(void)
 {
     //Check if Two Point values are burned in eFuse
     if (CHECK_BLK3_FLAG && (REG_GET_FIELD(BLK3_RESERVED_REG, EFUSE_RD_BLK3_PART_RESERVE) == 0)) {
@@ -150,7 +150,7 @@ static inline int decode_bits(uint32_t bits, uint32_t mask, bool is_twos_compl)
     return ret;
 }
 
-static uint32_t read_efuse_vref()
+static uint32_t read_efuse_vref(void)
 {
     //eFuse stores deviation from ideal reference voltage
     uint32_t ret = VREF_OFFSET;       //Ideal vref

--- a/components/esp_event/include/esp_event.h
+++ b/components/esp_event/include/esp_event.h
@@ -75,7 +75,7 @@ esp_err_t esp_event_loop_delete(esp_event_loop_handle_t event_loop);
  *  - ESP_FAIL: Failed to create task loop
  *  - Others: Fail
  */
-esp_err_t esp_event_loop_create_default();
+esp_err_t esp_event_loop_create_default(void);
 
 /**
  * @brief Delete the default event loop
@@ -84,7 +84,7 @@ esp_err_t esp_event_loop_create_default();
  *  - ESP_OK: Success
  *  - Others: Fail
  */
-esp_err_t esp_event_loop_delete_default();
+esp_err_t esp_event_loop_delete_default(void);
 
 /**
  * @brief Dispatch events posted to an event loop.

--- a/components/esp_event/private_include/esp_event_private.h
+++ b/components/esp_event/private_include/esp_event_private.h
@@ -45,7 +45,7 @@ bool esp_event_is_handler_registered(esp_event_loop_handle_t event_loop, esp_eve
  *  - ESP_OK: Success
  *  - Others: Fail
  */
-esp_err_t esp_event_loop_deinit();
+esp_err_t esp_event_loop_deinit(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/components/esp_http_client/lib/include/http_header.h
+++ b/components/esp_http_client/lib/include/http_header.h
@@ -32,7 +32,7 @@ typedef struct http_header_item *http_header_item_handle_t;
  *     - http_header_handle_t
  *     - NULL if any errors
  */
-http_header_handle_t http_header_init();
+http_header_handle_t http_header_init(void);
 
 /**
  * @brief      Cleanup and free all http header pairs

--- a/components/esp_http_server/src/port/esp32/osal.h
+++ b/components/esp_http_server/src/port/esp32/osal.h
@@ -42,7 +42,7 @@ static inline int httpd_os_thread_create(othread_t *thread,
 }
 
 /* Only self delete is supported */
-static inline void httpd_os_thread_delete()
+static inline void httpd_os_thread_delete(void)
 {
     vTaskDelete(xTaskGetCurrentTaskHandle());
 }
@@ -52,12 +52,12 @@ static inline void httpd_os_thread_sleep(int msecs)
     vTaskDelay(msecs / portTICK_RATE_MS);
 }
 
-static inline int64_t httpd_os_get_timestamp()
+static inline int64_t httpd_os_get_timestamp(void)
 {
     return esp_timer_get_time();
 }
 
-static inline othread_t httpd_os_thread_handle()
+static inline othread_t httpd_os_thread_handle(void)
 {
     return xTaskGetCurrentTaskHandle();
 }

--- a/components/ethernet/emac_main.c
+++ b/components/ethernet/emac_main.c
@@ -327,12 +327,12 @@ static void emac_set_user_config_data(eth_config_t *config)
     emac_config.emac_phy_power_enable = config->phy_power_enable;
 }
 
-static void emac_enable_intr()
+static void emac_enable_intr(void)
 {
     REG_WRITE(EMAC_DMAIN_EN_REG, EMAC_INTR_ENABLE_BIT);
 }
 
-static void emac_disable_intr()
+static void emac_disable_intr(void)
 {
     REG_WRITE(EMAC_DMAIN_EN_REG, 0);
 }

--- a/components/ethernet/include/eth_phy/phy_lan8720.h
+++ b/components/ethernet/include/eth_phy/phy_lan8720.h
@@ -26,7 +26,7 @@ extern "C" {
  * @note These registers are dumped at 'debug' level, so output
  * may not be visible depending on default log levels.
  */
-void phy_lan8720_dump_registers();
+void phy_lan8720_dump_registers(void);
 
 /** @brief Default LAN8720 phy_check_init function.
  */

--- a/components/ethernet/include/eth_phy/phy_tlk110.h
+++ b/components/ethernet/include/eth_phy/phy_tlk110.h
@@ -25,7 +25,7 @@ extern "C" {
  * @note These registers are dumped at 'debug' level, so output
  * may not be visible depending on default log levels.
  */
-void phy_tlk110_dump_registers();
+void phy_tlk110_dump_registers(void);
 
 /** @brief Default TLK110 phy_check_init function.
  */

--- a/components/fatfs/src/esp_vfs_fat.h
+++ b/components/fatfs/src/esp_vfs_fat.h
@@ -63,7 +63,7 @@ esp_err_t esp_vfs_fat_register(const char* base_path, const char* fat_drive,
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if FATFS is not registered in VFS
  */
-esp_err_t esp_vfs_fat_unregister() __attribute__((deprecated));
+esp_err_t esp_vfs_fat_unregister(void) __attribute__((deprecated));
 
 /**
  * @brief Un-register FATFS from VFS
@@ -160,7 +160,7 @@ esp_err_t esp_vfs_fat_sdmmc_mount(const char* base_path,
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_sdmmc_mount hasn't been called
  */
-esp_err_t esp_vfs_fat_sdmmc_unmount();
+esp_err_t esp_vfs_fat_sdmmc_unmount(void);
 
 /**
  * @brief Convenience function to initialize FAT filesystem in SPI flash and register it in VFS

--- a/components/fatfs/src/vfs_fat.c
+++ b/components/fatfs/src/vfs_fat.c
@@ -102,7 +102,7 @@ static size_t find_context_index_by_path(const char* base_path)
     return FF_VOLUMES;
 }
 
-static size_t find_unused_context_index()
+static size_t find_unused_context_index(void)
 {
     for(size_t i=0; i<FF_VOLUMES; i++) {
         if (!s_fat_ctxs[i]) {
@@ -199,7 +199,7 @@ esp_err_t esp_vfs_fat_unregister_path(const char* base_path)
     return ESP_OK;
 }
 
-esp_err_t esp_vfs_fat_unregister()
+esp_err_t esp_vfs_fat_unregister(void)
 {
     if (s_fat_ctx == NULL) {
         return ESP_ERR_INVALID_STATE;

--- a/components/fatfs/src/vfs_fat_sdmmc.c
+++ b/components/fatfs/src/vfs_fat_sdmmc.c
@@ -170,7 +170,7 @@ esp_err_t esp_vfs_fat_sdmmc_unmount()
     char drv[3] = {(char)('0' + s_pdrv), ':', 0};
     f_mount(0, drv, 0);
     // release SD driver
-    esp_err_t (*host_deinit)() = s_card->host.deinit;
+    esp_err_t (*host_deinit)(void) = s_card->host.deinit;
     ff_diskio_unregister(s_pdrv);
     free(s_card);
     s_card = NULL;

--- a/components/freemodbus/modbus_controller/mbcontroller.c
+++ b/components/freemodbus/modbus_controller/mbcontroller.c
@@ -95,7 +95,7 @@ static uint16_t mb_parity = 0;
 static mb_register_area_descriptor_t mb_area_descriptors[MB_PARAM_COUNT] = { 0 };
 
 // The helper function to get time stamp in microseconds
-static uint64_t get_time_stamp()
+static uint64_t get_time_stamp(void)
 {
     uint64_t time_stamp = esp_timer_get_time();
     return time_stamp;

--- a/components/freemodbus/port/port.h
+++ b/components/freemodbus/port/port.h
@@ -88,7 +88,7 @@ void vMBPortEnterCritical(void);
 
 void vMBPortExitCritical(void);
 
-BOOL xMBPortSerialTxPoll();
+BOOL xMBPortSerialTxPoll(void);
 
 
 #ifdef __cplusplus

--- a/components/freemodbus/port/portserial.c
+++ b/components/freemodbus/port/portserial.c
@@ -258,7 +258,7 @@ BOOL xMBPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate,
     return TRUE;
 }
 
-void vMBPortSerialClose()
+void vMBPortSerialClose(void)
 {
     (void)vTaskSuspend(xMbTaskHandle);
     (void)vTaskDelete(xMbTaskHandle);

--- a/components/freemodbus/port/porttimer.c
+++ b/components/freemodbus/port/porttimer.c
@@ -106,7 +106,7 @@ BOOL xMBPortTimersInit(USHORT usTim1Timerout50us)
     return TRUE;
 }
 
-void vMBPortTimersEnable()
+void vMBPortTimersEnable(void)
 {
 #ifdef CONFIG_MB_TIMER_PORT_ENABLED
     ESP_ERROR_CHECK(timer_pause(usTimerGroupIndex, usTimerIndex));
@@ -116,7 +116,7 @@ void vMBPortTimersEnable()
 #endif
 }
 
-void vMBPortTimersDisable()
+void vMBPortTimersDisable(void)
 {
 #ifdef CONFIG_MB_TIMER_PORT_ENABLED
     ESP_ERROR_CHECK(timer_pause(usTimerGroupIndex, usTimerIndex));
@@ -126,7 +126,7 @@ void vMBPortTimersDisable()
 #endif
 }
 
-void vMBPortTimerClose()
+void vMBPortTimerClose(void)
 {
 #ifdef CONFIG_MB_TIMER_PORT_ENABLED
     ESP_ERROR_CHECK(timer_pause(usTimerGroupIndex, usTimerIndex));

--- a/components/freertos/include/freertos/portable.h
+++ b/components/freertos/include/freertos/portable.h
@@ -181,13 +181,13 @@ void vPortSetStackWatchpoint( void* pxStackStart );
  * Returns true if the current core is in ISR context; low prio ISR, med prio ISR or timer tick ISR. High prio ISRs
  * aren't detected here, but they normally cannot call C code, so that should not be an issue anyway.
  */
-BaseType_t xPortInIsrContext();
+BaseType_t xPortInIsrContext(void);
 
 /*
  * This function will be called in High prio ISRs. Returns true if the current core was in ISR context
  * before calling into high prio ISR context.
  */
-BaseType_t xPortInterruptedFromISRContext();
+BaseType_t xPortInterruptedFromISRContext(void);
 
 /*
  * The structures and methods of manipulating the MPU are contained within the
@@ -203,7 +203,7 @@ BaseType_t xPortInterruptedFromISRContext();
 #endif
 
 /* Multi-core: get current core ID */
-static inline uint32_t IRAM_ATTR xPortGetCoreID() {
+static inline uint32_t IRAM_ATTR xPortGetCoreID(void) {
     int id;
     __asm__ (
         "rsr.prid %0\n"

--- a/components/freertos/include/freertos/portmacro.h
+++ b/components/freertos/include/freertos/portmacro.h
@@ -170,7 +170,7 @@ typedef struct {
 
 
 #define portASSERT_IF_IN_ISR()        vPortAssertIfInISR()
-void vPortAssertIfInISR();
+void vPortAssertIfInISR(void);
 
 #define portCRITICAL_NESTING_IN_TCB 1
 
@@ -245,7 +245,7 @@ void vPortCPUReleaseMutex(portMUX_TYPE *mux);
 // Cleaner solution allows nested interrupts disabling and restoring via local registers or stack.
 // They can be called from interrupts too.
 // WARNING: Only applies to current CPU. See notes above.
-static inline unsigned portENTER_CRITICAL_NESTED() {
+static inline unsigned portENTER_CRITICAL_NESTED(void) {
 	unsigned state = XTOS_SET_INTLEVEL(XCHAL_EXCM_LEVEL);
 	portbenchmarkINTERRUPT_DISABLE();
 	return state;
@@ -318,7 +318,7 @@ void _frxt_setup_switch( void );
 #define portYIELD()					vPortYield()
 #define portYIELD_FROM_ISR()        {traceISR_EXIT_TO_SCHEDULER(); _frxt_setup_switch();}
 
-static inline uint32_t xPortGetCoreID();
+static inline uint32_t xPortGetCoreID(void);
 
 /* Yielding within an API call (when interrupts are off), means the yield should be delayed
    until interrupts are re-enabled.

--- a/components/heap/include/esp_heap_caps.h
+++ b/components/heap/include/esp_heap_caps.h
@@ -308,7 +308,7 @@ void heap_caps_dump(uint32_t caps);
  * Output is the same as for heap_caps_dump.
  *
  */
-void heap_caps_dump_all();
+void heap_caps_dump_all(void);
 
 #ifdef __cplusplus
 }

--- a/components/heap/include/esp_heap_caps_init.h
+++ b/components/heap/include/esp_heap_caps_init.h
@@ -27,7 +27,7 @@ extern "C" {
  * This is called once in the IDF startup code. Do not call it
  * at other times.
  */
-void heap_caps_init();
+void heap_caps_init(void);
 
 /**
  * @brief Enable heap(s) in memory regions where the startup stacks are located.
@@ -37,7 +37,7 @@ void heap_caps_init();
  * completely started, they do not use that memory anymore and heap(s) there can
  * be enabled.
  */
-void heap_caps_enable_nonos_stack_heaps();
+void heap_caps_enable_nonos_stack_heaps(void);
 
 /**
  * @brief Add a region of memory to the collection of heaps at runtime.

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -104,7 +104,7 @@ static inline void add_to_cache(const char* tag, esp_log_level_t level);
 static void heap_bubble_down(int index);
 static inline void heap_swap(int i, int j);
 static inline bool should_output(esp_log_level_t level_for_message, esp_log_level_t level_for_tag);
-static inline void clear_log_level_list();
+static inline void clear_log_level_list(void);
 
 vprintf_like_t esp_log_set_vprintf(vprintf_like_t func)
 {
@@ -172,7 +172,7 @@ void esp_log_level_set(const char* tag, esp_log_level_t level)
     xSemaphoreGive(s_log_mutex);
 }
 
-void clear_log_level_list()
+void clear_log_level_list(void)
 {
     while( !SLIST_EMPTY(&s_log_tags)) {
         SLIST_REMOVE_HEAD(&s_log_tags, entries );
@@ -323,14 +323,14 @@ static inline void heap_swap(int i, int j)
 //as a workaround before the interface for this variable
 extern uint32_t g_ticks_per_us_pro;
 
-uint32_t ATTR esp_log_early_timestamp()
+uint32_t ATTR esp_log_early_timestamp(void)
 {
     return xthal_get_ccount() / (g_ticks_per_us_pro * 1000);
 }
 
 #ifndef BOOTLOADER_BUILD
 
-uint32_t IRAM_ATTR esp_log_timestamp()
+uint32_t IRAM_ATTR esp_log_timestamp(void)
 {
     if (xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED) {
         return esp_log_early_timestamp();
@@ -344,7 +344,7 @@ uint32_t IRAM_ATTR esp_log_timestamp()
 
 #else
 
-uint32_t esp_log_timestamp() __attribute__((alias("esp_log_early_timestamp")));
+uint32_t esp_log_timestamp(void) __attribute__((alias("esp_log_early_timestamp")));
 
 #endif //BOOTLOADER_BUILD
 

--- a/components/lwip/include/apps/dhcpserver/dhcpserver.h
+++ b/components/lwip/include/apps/dhcpserver/dhcpserver.h
@@ -88,7 +88,7 @@ void *dhcps_option_info(u8_t op_id, u32_t opt_len);
 void dhcps_set_option_info(u8_t op_id, void *opt_info, u32_t opt_len);
 bool dhcp_search_ip_on_mac(u8_t *mac, ip4_addr_t *ip);
 void dhcps_dns_setserver(const ip_addr_t *dnsserver);
-ip4_addr_t dhcps_dns_getserver();
+ip4_addr_t dhcps_dns_getserver(void);
 void dhcps_set_new_lease_cb(dhcps_cb_t cb);
 
 #endif

--- a/components/lwip/port/esp32/include/arch/vfs_lwip.h
+++ b/components/lwip/port/esp32/include/arch/vfs_lwip.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-void esp_vfs_lwip_sockets_register();
+void esp_vfs_lwip_sockets_register(void);
 
 #ifdef __cplusplus
 }

--- a/components/lwip/port/esp32/vfs_lwip.c
+++ b/components/lwip/port/esp32/vfs_lwip.c
@@ -28,7 +28,7 @@
 
 _Static_assert(MAX_FDS >= CONFIG_LWIP_MAX_SOCKETS, "MAX_FDS < CONFIG_LWIP_MAX_SOCKETS");
 
-static void lwip_stop_socket_select()
+static void lwip_stop_socket_select(void)
 {
     sys_sem_signal(sys_thread_sem_get()); //socket_select will return
 }
@@ -50,7 +50,7 @@ static int lwip_ioctl_r_wrapper(int fd, int cmd, va_list args)
     return lwip_ioctl_r(fd, cmd, va_arg(args, void *));
 }
 
-void esp_vfs_lwip_sockets_register()
+void esp_vfs_lwip_sockets_register(void)
 {
     esp_vfs_t vfs = {
         .flags = ESP_VFS_FLAG_DEFAULT,

--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -86,13 +86,13 @@ typedef struct mdns_result_s {
  *     - ESP_ERR_NO_MEM on memory error
  *     - ESP_ERR_WIFI_NOT_INIT when WiFi is not initialized by eps_wifi_init
  */
-esp_err_t mdns_init();
+esp_err_t mdns_init(void);
 
 /**
  * @brief  Stop and free mDNS server
  *
  */
-void mdns_free();
+void mdns_free(void);
 
 /**
  * @brief  Set the hostname for mDNS server
@@ -234,7 +234,7 @@ esp_err_t mdns_service_txt_item_remove(const char * service_type, const char * p
  *     - ESP_OK success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t mdns_service_remove_all();
+esp_err_t mdns_service_remove_all(void);
 
 /**
  * @brief  Query mDNS for host or service

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -32,7 +32,7 @@ static const char *TAG = "MDNS";
 static volatile TaskHandle_t _mdns_service_task_handle = NULL;
 static SemaphoreHandle_t _mdns_service_semaphore = NULL;
 
-static void _mdns_search_finish_done();
+static void _mdns_search_finish_done(void);
 static mdns_search_once_t * _mdns_search_find_from(mdns_search_once_t * search, mdns_name_t * name, uint16_t type, tcpip_adapter_if_t tcpip_if, mdns_ip_protocol_t ip_protocol);
 static void _mdns_search_result_add_ip(mdns_search_once_t * search, const char * hostname, ip_addr_t * ip, tcpip_adapter_if_t tcpip_if, mdns_ip_protocol_t ip_protocol);
 static void _mdns_search_result_add_srv(mdns_search_once_t * search, const char * hostname, uint16_t port, tcpip_adapter_if_t tcpip_if, mdns_ip_protocol_t ip_protocol);
@@ -1010,7 +1010,7 @@ static void _mdns_schedule_tx_packet(mdns_tx_packet_t * packet, uint32_t ms_afte
 /**
  * @brief  free all packets scheduled for sending
  */
-static void _mdns_clear_tx_queue_head()
+static void _mdns_clear_tx_queue_head(void)
 {
     mdns_tx_packet_t * q;
     while (_mdns_server->tx_queue_head) {
@@ -1661,7 +1661,7 @@ static void _mdns_send_final_bye(bool include_ip)
 /**
  * @brief  Stop the responder on all services without instance
  */
-static void _mdns_send_bye_all_pcbs_no_instance()
+static void _mdns_send_bye_all_pcbs_no_instance(void)
 {
     size_t srv_count = 0;
     mdns_srv_item_t * a = _mdns_server->services;
@@ -1689,7 +1689,7 @@ static void _mdns_send_bye_all_pcbs_no_instance()
 /**
  * @brief  Restart the responder on all services without instance
  */
-static void _mdns_restart_all_pcbs_no_instance()
+static void _mdns_restart_all_pcbs_no_instance(void)
 {
     size_t srv_count = 0;
     mdns_srv_item_t * a = _mdns_server->services;
@@ -1717,7 +1717,7 @@ static void _mdns_restart_all_pcbs_no_instance()
 /**
  * @brief  Restart the responder on all active PCBs
  */
-static void _mdns_restart_all_pcbs()
+static void _mdns_restart_all_pcbs(void)
 {
     _mdns_clear_tx_queue_head();
     size_t srv_count = 0;
@@ -3854,7 +3854,7 @@ static esp_err_t _mdns_send_search_action(mdns_action_type_t type, mdns_search_o
 /**
  * @brief  Called from timer task to run mDNS responder
  */
-static void _mdns_scheduler_run()
+static void _mdns_scheduler_run(void)
 {
     MDNS_SERVICE_LOCK();
     mdns_tx_packet_t * p = _mdns_server->tx_queue_head;
@@ -3885,7 +3885,7 @@ static void _mdns_scheduler_run()
 /**
  * @brief  Called from timer task to run active searches
  */
-static void _mdns_search_run()
+static void _mdns_search_run(void)
 {
     MDNS_SERVICE_LOCK();
     mdns_search_once_t * s = _mdns_server->search_once;
@@ -3944,7 +3944,7 @@ static void _mdns_timer_cb(void * arg)
     _mdns_search_run();
 }
 
-static esp_err_t _mdns_start_timer(){
+static esp_err_t _mdns_start_timer(void){
     esp_timer_create_args_t timer_conf = {
         .callback = _mdns_timer_cb,
         .arg = NULL,
@@ -3958,7 +3958,7 @@ static esp_err_t _mdns_start_timer(){
     return esp_timer_start_periodic(_mdns_server->timer_handle, MDNS_TIMER_PERIOD_US);
 }
 
-static esp_err_t _mdns_stop_timer(){
+static esp_err_t _mdns_stop_timer(void){
     esp_err_t err = ESP_OK;
     if (_mdns_server->timer_handle) {
         err = esp_timer_stop(_mdns_server->timer_handle);
@@ -3977,7 +3977,7 @@ static esp_err_t _mdns_stop_timer(){
  *      - ESP_OK on success
  *      - ESP_FAIL on error
  */
-static esp_err_t _mdns_service_task_start()
+static esp_err_t _mdns_service_task_start(void)
 {
     if (!_mdns_service_semaphore) {
         _mdns_service_semaphore = xSemaphoreCreateMutex();
@@ -4007,7 +4007,7 @@ static esp_err_t _mdns_service_task_start()
  * @return
  *      - ESP_OK
  */
-static esp_err_t _mdns_service_task_stop()
+static esp_err_t _mdns_service_task_stop(void)
 {
     MDNS_SERVICE_LOCK();
     _mdns_stop_timer();
@@ -4051,7 +4051,7 @@ esp_err_t mdns_handle_system_event(void *ctx, system_event_t *event)
     return ESP_OK;
 }
 
-esp_err_t mdns_init()
+esp_err_t mdns_init(void)
 {
     esp_err_t err = ESP_OK;
 
@@ -4109,7 +4109,7 @@ free_server:
     return err;
 }
 
-void mdns_free()
+void mdns_free(void)
 {
     uint8_t i, j;
     if (!_mdns_server) {
@@ -4455,7 +4455,7 @@ esp_err_t mdns_service_remove(const char * service, const char * proto)
     return ESP_OK;
 }
 
-esp_err_t mdns_service_remove_all()
+esp_err_t mdns_service_remove_all(void)
 {
     if (!_mdns_server) {
         return ESP_ERR_INVALID_ARG;

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -4115,7 +4115,7 @@ void mdns_free()
     if (!_mdns_server) {
         return;
     }
-    mdns_service_remove_all(_mdns_server);
+    mdns_service_remove_all();
     _mdns_service_task_stop();
     for (i=0; i<TCPIP_ADAPTER_IF_MAX; i++) {
         for (j=0; j<MDNS_IP_PROTOCOL_MAX; j++) {

--- a/components/mdns/mdns_console.c
+++ b/components/mdns/mdns_console.c
@@ -99,7 +99,7 @@ static int cmd_mdns_query_a(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_a()
+static void register_mdns_query_a(void)
 {
     mdns_query_a_args.hostname = arg_str1(NULL, NULL, "<hostname>", "Hostname that is searched for");
     mdns_query_a_args.timeout = arg_int0("t", "timeout", "<timeout>", "Timeout for this query");
@@ -156,7 +156,7 @@ static int cmd_mdns_query_aaaa(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_aaaa()
+static void register_mdns_query_aaaa(void)
 {
     mdns_query_a_args.hostname = arg_str1(NULL, NULL, "<hostname>", "Hostname that is searched for");
     mdns_query_a_args.timeout = arg_int0("t", "timeout", "<timeout>", "Timeout for this query");
@@ -215,7 +215,7 @@ static int cmd_mdns_query_srv(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_srv()
+static void register_mdns_query_srv(void)
 {
     mdns_query_srv_args.instance = arg_str1(NULL, NULL, "<instance>", "Instance to search for");
     mdns_query_srv_args.service = arg_str1(NULL, NULL, "<service>", "Service to search for (ex. _http, _smb, etc.)");
@@ -277,7 +277,7 @@ static int cmd_mdns_query_txt(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_txt()
+static void register_mdns_query_txt(void)
 {
     mdns_query_txt_args.instance = arg_str1(NULL, NULL, "<instance>", "Instance to search for");
     mdns_query_txt_args.service = arg_str1(NULL, NULL, "<service>", "Service to search for (ex. _http, _smb, etc.)");
@@ -343,7 +343,7 @@ static int cmd_mdns_query_ptr(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_ptr()
+static void register_mdns_query_ptr(void)
 {
     mdns_query_ptr_args.service = arg_str1(NULL, NULL, "<service>", "Service to search for (ex. _http, _smb, etc.)");
     mdns_query_ptr_args.proto = arg_str1(NULL, NULL, "<proto>", "Protocol to search for (_tcp, _udp, etc.)");
@@ -412,7 +412,7 @@ static int cmd_mdns_query_ip(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_ip()
+static void register_mdns_query_ip(void)
 {
     mdns_query_ip_args.hostname = arg_str1(NULL, NULL, "<hostname>", "Hostname that is searched for");
     mdns_query_ip_args.timeout = arg_int0("t", "timeout", "<timeout>", "Timeout for this query");
@@ -479,7 +479,7 @@ static int cmd_mdns_query_svc(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_query_svc()
+static void register_mdns_query_svc(void)
 {
     mdns_query_svc_args.instance = arg_str1(NULL, NULL, "<instance>", "Instance to search for");
     mdns_query_svc_args.service = arg_str1(NULL, NULL, "<service>", "Service to search for (ex. _http, _smb, etc.)");
@@ -528,7 +528,7 @@ static int cmd_mdns_init(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_init()
+static void register_mdns_init(void)
 {
     mdns_init_args.hostname = arg_str0("h", "hostname", "<hostname>", "Hostname that the server will advertise");
     mdns_init_args.instance = arg_str0("i", "instance", "<instance>", "Default instance name for services");
@@ -551,7 +551,7 @@ static int cmd_mdns_free(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_free()
+static void register_mdns_free(void)
 {
     const esp_console_cmd_t cmd_free = {
         .command = "mdns_free",
@@ -586,7 +586,7 @@ static int cmd_mdns_set_hostname(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_set_hostname()
+static void register_mdns_set_hostname(void)
 {
     mdns_set_hostname_args.hostname = arg_str1(NULL, NULL, "<hostname>", "Hostname that the server will advertise");
     mdns_set_hostname_args.end = arg_end(2);
@@ -624,7 +624,7 @@ static int cmd_mdns_set_instance(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_set_instance()
+static void register_mdns_set_instance(void)
 {
     mdns_set_instance_args.instance = arg_str1(NULL, NULL, "<instance>", "Default instance name for services");
     mdns_set_instance_args.end = arg_end(2);
@@ -733,7 +733,7 @@ static int cmd_mdns_service_add(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_add()
+static void register_mdns_service_add(void)
 {
     mdns_add_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_add_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -776,7 +776,7 @@ static int cmd_mdns_service_remove(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_remove()
+static void register_mdns_service_remove(void)
 {
     mdns_remove_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_remove_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -817,7 +817,7 @@ static int cmd_mdns_service_instance_set(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_instance_set()
+static void register_mdns_service_instance_set(void)
 {
     mdns_service_instance_set_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_service_instance_set_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -858,7 +858,7 @@ static int cmd_mdns_service_port_set(int argc, char** argv) {
     return 0;
 }
 
-static void register_mdns_service_port_set()
+static void register_mdns_service_port_set(void)
 {
     mdns_service_port_set_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_service_port_set_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -910,7 +910,7 @@ static int cmd_mdns_service_txt_replace(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_txt_replace()
+static void register_mdns_service_txt_replace(void)
 {
     mdns_txt_replace_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_txt_replace_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -953,7 +953,7 @@ static int cmd_mdns_service_txt_set(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_txt_set()
+static void register_mdns_service_txt_set(void)
 {
     mdns_txt_set_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_txt_set_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -996,7 +996,7 @@ static int cmd_mdns_service_txt_remove(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_txt_remove()
+static void register_mdns_service_txt_remove(void)
 {
     mdns_txt_remove_args.service = arg_str1(NULL, NULL, "<service>", "MDNS Service");
     mdns_txt_remove_args.proto = arg_str1(NULL, NULL, "<proto>", "IP Protocol");
@@ -1020,7 +1020,7 @@ static int cmd_mdns_service_remove_all(int argc, char** argv)
     return 0;
 }
 
-static void register_mdns_service_remove_all()
+static void register_mdns_service_remove_all(void)
 {
     const esp_console_cmd_t cmd_free = {
         .command = "mdns_service_remove_all",
@@ -1033,7 +1033,7 @@ static void register_mdns_service_remove_all()
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_free) );
 }
 
-void mdns_console_register()
+void mdns_console_register(void)
 {
     register_mdns_init();
     register_mdns_free();

--- a/components/mdns/mdns_networking.c
+++ b/components/mdns/mdns_networking.c
@@ -23,7 +23,7 @@ static void _udp_recv(void *arg, struct udp_pcb *upcb, struct pbuf *pb, const ip
 /**
  * @brief  Low level UDP PCB Initialize
  */
-static esp_err_t _udp_pcb_main_init()
+static esp_err_t _udp_pcb_main_init(void)
 {
     if(_pcb_main) {
         return ESP_OK;
@@ -47,7 +47,7 @@ static esp_err_t _udp_pcb_main_init()
 /**
  * @brief  Low level UDP PCB Free
  */
-static void _udp_pcb_main_deinit()
+static void _udp_pcb_main_deinit(void)
 {
     if(_pcb_main){
         udp_recv(_pcb_main, NULL, NULL);
@@ -177,7 +177,7 @@ static void _udp_recv(void *arg, struct udp_pcb *upcb, struct pbuf *pb, const ip
 /**
  * @brief  Check if any of the interfaces is up
  */
-static bool _udp_pcb_is_in_use(){
+static bool _udp_pcb_is_in_use(void){
     int i, p;
     for (i=0; i<TCPIP_ADAPTER_IF_MAX; i++) {
         for (p=0; p<MDNS_IP_PROTOCOL_MAX; p++) {

--- a/components/newlib/platform_include/esp_newlib.h
+++ b/components/newlib/platform_include/esp_newlib.h
@@ -31,16 +31,16 @@ void esp_reent_init(struct _reent* r);
  * Called from the startup code, not intended to be called from application
  * code.
  */
-void esp_setup_syscall_table();
+void esp_setup_syscall_table(void);
 
 /**
  * Update current microsecond time from RTC
  */
-void esp_set_time_from_rtc();
+void esp_set_time_from_rtc(void);
 
 /*
  * Sync counters RTC and FRC. Update boot_time.
  */
-void esp_sync_counters_rtc_and_frc();
+void esp_sync_counters_rtc_and_frc(void);
 
 #endif //__ESP_NEWLIB_H__

--- a/components/newlib/time.c
+++ b/components/newlib/time.c
@@ -47,7 +47,7 @@
 #endif
 
 #ifdef WITH_RTC
-static uint64_t get_rtc_time_us()
+static uint64_t get_rtc_time_us(void)
 {
     const uint64_t ticks = rtc_time_get();
     const uint32_t cal = esp_clk_slowclk_cal_get();
@@ -85,7 +85,7 @@ static uint64_t adjtime_start = 0;
 // is how many microseconds total to slew
 static int64_t adjtime_total_correction = 0;
 #define ADJTIME_CORRECTION_FACTOR 6
-static uint64_t get_time_since_boot();
+static uint64_t get_time_since_boot(void);
 #endif
 // Offset between FRC timer and the RTC.
 // Initialized after reset or light sleep.
@@ -106,7 +106,7 @@ static void set_boot_time(uint64_t time_us)
     _lock_release(&s_boot_time_lock);
 }
 
-static uint64_t get_boot_time()
+static uint64_t get_boot_time(void)
 {
     uint64_t result;
     _lock_acquire(&s_boot_time_lock);
@@ -120,7 +120,7 @@ static uint64_t get_boot_time()
 }
 
 // This function gradually changes boot_time to the correction value and immediately updates it.
-static uint64_t adjust_boot_time()
+static uint64_t adjust_boot_time(void)
 {
     uint64_t boot_time = get_boot_time();
     if ((boot_time == 0) || (get_time_since_boot() < adjtime_start)) {
@@ -239,12 +239,12 @@ void esp_clk_slowclk_cal_set(uint32_t new_cal)
     REG_WRITE(RTC_SLOW_CLK_CAL_REG, new_cal);
 }
 
-uint32_t esp_clk_slowclk_cal_get()
+uint32_t esp_clk_slowclk_cal_get(void)
 {
     return REG_READ(RTC_SLOW_CLK_CAL_REG);
 }
 
-void esp_set_time_from_rtc()
+void esp_set_time_from_rtc(void)
 {
 #if defined( WITH_FRC ) && defined( WITH_RTC )
     // initialize time from RTC clock
@@ -274,7 +274,7 @@ clock_t IRAM_ATTR _times_r(struct _reent *r, struct tms *ptms)
 }
 
 #if defined( WITH_FRC ) || defined( WITH_RTC )
-static uint64_t get_time_since_boot()
+static uint64_t get_time_since_boot(void)
 {
     uint64_t microseconds = 0;
 #ifdef WITH_FRC
@@ -372,7 +372,7 @@ uint64_t system_get_rtc_time(void)
 #endif
 }
 
-void esp_sync_counters_rtc_and_frc()
+void esp_sync_counters_rtc_and_frc(void)
 {
 #if defined( WITH_FRC ) && defined( WITH_RTC )
     adjtime_corr_stop();

--- a/components/openssl/include/internal/ssl_x509.h
+++ b/components/openssl/include/internal/ssl_x509.h
@@ -159,7 +159,7 @@ BIO *BIO_new(void * method);
 /**
  * @brief get the memory BIO method function
  */
-void *BIO_s_mem();
+void *BIO_s_mem(void);
 
 /**
  * @brief free a BIO  object

--- a/components/protocomm/include/common/protocomm.h
+++ b/components/protocomm/include/common/protocomm.h
@@ -48,7 +48,7 @@ typedef struct protocomm protocomm_t;
  *  - protocomm_t* : On success
  *  - NULL : No memory for allocating new instance
  */
-protocomm_t *protocomm_new();
+protocomm_t *protocomm_new(void);
 
 /**
  * @brief   Delete a protocomm instance

--- a/components/protocomm/include/security/protocomm_security.h
+++ b/components/protocomm/include/security/protocomm_security.h
@@ -50,12 +50,12 @@ typedef struct protocomm_security {
      * Function for initialising/allocating security
      * infrastructure
      */
-    esp_err_t (*init)();
+    esp_err_t (*init)(void);
 
     /**
      * Function for deallocating security infrastructure
      */
-    esp_err_t (*cleanup)();
+    esp_err_t (*cleanup)(void);
 
     /**
      * Starts new secure transport session with specified ID

--- a/components/protocomm/src/common/protocomm.c
+++ b/components/protocomm/src/common/protocomm.c
@@ -26,7 +26,7 @@
 
 static const char *TAG = "protocomm";
 
-protocomm_t *protocomm_new()
+protocomm_t *protocomm_new(void)
 {
     protocomm_t *pc;
 

--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -411,12 +411,12 @@ static void sec1_session_setup_cleanup(uint32_t session_id, SessionData *resp)
     return;
 }
 
-static esp_err_t sec1_init()
+static esp_err_t sec1_init(void)
 {
     return ESP_OK;
 }
 
-static esp_err_t sec1_cleanup()
+static esp_err_t sec1_cleanup(void)
 {
     if (cur_session) {
         ESP_LOGD(TAG, "Closing current session with id %u", cur_session->id);

--- a/components/pthread/include/esp_pthread.h
+++ b/components/pthread/include/esp_pthread.h
@@ -41,7 +41,7 @@ typedef struct {
  * @return
  *      A default configuration structure.
  */
-esp_pthread_cfg_t esp_pthread_get_default_config();
+esp_pthread_cfg_t esp_pthread_get_default_config(void);
 
 /**
  * @brief Configure parameters for creating pthread

--- a/components/pthread/pthread.c
+++ b/components/pthread/pthread.c
@@ -167,12 +167,12 @@ esp_err_t esp_pthread_get_cfg(esp_pthread_cfg_t *p)
     return ESP_ERR_NOT_FOUND;
 }
 
-static int get_default_pthread_core()
+static int get_default_pthread_core(void)
 {
     return CONFIG_ESP32_PTHREAD_TASK_CORE_DEFAULT == -1 ? tskNO_AFFINITY : CONFIG_ESP32_PTHREAD_TASK_CORE_DEFAULT;
 }
 
-esp_pthread_cfg_t esp_pthread_get_default_config()
+esp_pthread_cfg_t esp_pthread_get_default_config(void)
 {
     esp_pthread_cfg_t cfg = {
         .stack_size = CONFIG_ESP32_PTHREAD_TASK_STACK_SIZE_DEFAULT,

--- a/components/pthread/pthread_internal.h
+++ b/components/pthread/pthread_internal.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 #pragma once
 
-void pthread_internal_local_storage_destructor_callback();
+void pthread_internal_local_storage_destructor_callback(void);

--- a/components/pthread/pthread_local_storage.c
+++ b/components/pthread/pthread_local_storage.c
@@ -166,7 +166,7 @@ void __wrap_vPortCleanUpTCB(void *tcb)
 #endif
 
 /* this function called from pthread_task_func for "early" cleanup of TLS in a pthread */
-void pthread_internal_local_storage_destructor_callback()
+void pthread_internal_local_storage_destructor_callback(void)
 {
     void *tls = pvTaskGetThreadLocalStoragePointer(NULL, PTHREAD_TLS_INDEX);
     if (tls != NULL) {

--- a/components/soc/esp32/cpu_util.c
+++ b/components/soc/esp32/cpu_util.c
@@ -50,7 +50,7 @@ void IRAM_ATTR esp_cpu_reset(int cpu_id)
             cpu_id == 0 ? RTC_CNTL_SW_PROCPU_RST_M : RTC_CNTL_SW_APPCPU_RST_M);
 }
 
-bool IRAM_ATTR esp_cpu_in_ocd_debug_mode()
+bool IRAM_ATTR esp_cpu_in_ocd_debug_mode(void)
 {
 #if CONFIG_ESP32_DEBUG_OCDAWARE
     int dcr;

--- a/components/soc/esp32/include/soc/cpu.h
+++ b/components/soc/esp32/include/soc/cpu.h
@@ -30,7 +30,7 @@
 /** @brief Read current stack pointer address
  *
  */
-static inline void *get_sp()
+static inline void *get_sp(void)
 {
     void *sp;
     asm volatile ("mov %0, sp;" : "=r" (sp));
@@ -52,7 +52,7 @@ static inline void cpu_write_itlb(unsigned vpn, unsigned attr)
     asm volatile ("witlb  %1, %0; isync\n" :: "r" (vpn), "r" (attr));
 }
 
-static inline void cpu_init_memctl()
+static inline void cpu_init_memctl(void)
 {
 #if XCHAL_ERRATUM_572
     uint32_t memctl = XCHAL_CACHE_MEMCTL_DEFAULT;
@@ -71,7 +71,7 @@ static inline void cpu_init_memctl()
  * 15 — no access, raise exception
  */
 
-static inline void cpu_configure_region_protection()
+static inline void cpu_configure_region_protection(void)
 {
     const uint32_t pages_to_protect[] = {0x00000000, 0x80000000, 0xa0000000, 0xc0000000, 0xe0000000};
     for (int i = 0; i < sizeof(pages_to_protect)/sizeof(pages_to_protect[0]); ++i) {
@@ -108,6 +108,6 @@ void esp_cpu_reset(int cpu_id);
  * @note If "Make exception and panic handlers JTAG/OCD aware"
  * is disabled, this function always returns false.
  */
-bool esp_cpu_in_ocd_debug_mode();
+bool esp_cpu_in_ocd_debug_mode(void);
 
 #endif

--- a/components/soc/esp32/include/soc/rtc.h
+++ b/components/soc/esp32/include/soc/rtc.h
@@ -175,7 +175,7 @@ void rtc_clk_init(rtc_clk_config_t cfg);
  *
  * @return XTAL frequency, one of rtc_xtal_freq_t
  */
-rtc_xtal_freq_t rtc_clk_xtal_freq_get();
+rtc_xtal_freq_t rtc_clk_xtal_freq_get(void);
 
 /**
  * @brief Update XTAL frequency
@@ -196,13 +196,13 @@ void rtc_clk_32k_enable(bool en);
 /**
  * @brief Configure 32 kHz XTAL oscillator to accept external clock signal
  */
-void rtc_clk_32k_enable_external();
+void rtc_clk_32k_enable_external(void);
 
 /**
  * @brief Get the state of 32k XTAL oscillator
  * @return true if 32k XTAL oscillator has been enabled
  */
-bool rtc_clk_32k_enabled();
+bool rtc_clk_32k_enabled(void);
 
 /**
  * @brief Enable 32k oscillator, configuring it for fast startup time.
@@ -238,13 +238,13 @@ void rtc_clk_8m_enable(bool clk_8m_en, bool d256_en);
  * @brief Get the state of 8 MHz internal oscillator
  * @return true if the oscillator is enabled
  */
-bool rtc_clk_8m_enabled();
+bool rtc_clk_8m_enabled(void);
 
 /**
  * @brief Get the state of /256 divider which is applied to 8MHz clock
  * @return true if the divided output is enabled
  */
-bool rtc_clk_8md256_enabled();
+bool rtc_clk_8md256_enabled(void);
 
 /**
  * @brief Enable or disable APLL
@@ -275,7 +275,7 @@ void rtc_clk_slow_freq_set(rtc_slow_freq_t slow_freq);
  * @brief Get the RTC_SLOW_CLK source
  * @return currently selected clock source (one of rtc_slow_freq_t values)
  */
-rtc_slow_freq_t rtc_clk_slow_freq_get();
+rtc_slow_freq_t rtc_clk_slow_freq_get(void);
 
 /**
  * @brief Get the approximate frequency of RTC_SLOW_CLK, in Hz
@@ -289,7 +289,7 @@ rtc_slow_freq_t rtc_clk_slow_freq_get();
  *
  * @return RTC_SLOW_CLK frequency, in Hz
  */
-uint32_t rtc_clk_slow_freq_get_hz();
+uint32_t rtc_clk_slow_freq_get_hz(void);
 
 /**
  * @brief Select source for RTC_FAST_CLK
@@ -301,7 +301,7 @@ void rtc_clk_fast_freq_set(rtc_fast_freq_t fast_freq);
  * @brief Get the RTC_FAST_CLK source
  * @return currently selected clock source (one of rtc_fast_freq_t values)
  */
-rtc_fast_freq_t rtc_clk_fast_freq_get();
+rtc_fast_freq_t rtc_clk_fast_freq_get(void);
 
 /**
  * @brief Switch CPU frequency
@@ -354,7 +354,7 @@ void rtc_clk_cpu_freq_set_fast(rtc_cpu_freq_t cpu_freq) __attribute__((deprecate
  *
  * @return CPU frequency (one of rtc_cpu_freq_t values)
  */
-rtc_cpu_freq_t rtc_clk_cpu_freq_get()  __attribute__((deprecated));
+rtc_cpu_freq_t rtc_clk_cpu_freq_get(void)  __attribute__((deprecated));
 
 /**
  * @brief Get corresponding frequency value for rtc_cpu_freq_t enum value
@@ -443,7 +443,7 @@ uint32_t rtc_clk_cpu_freq_value(rtc_cpu_freq_t cpu_freq)  __attribute__((depreca
   * rtc_clk_cpu_freq_set_config when a switch to XTAL is needed.
   * Assumes that XTAL frequency has been determined — don't call in startup code.
   */
- void rtc_clk_cpu_freq_set_xtal();
+ void rtc_clk_cpu_freq_set_xtal(void);
 
 
 /**
@@ -464,7 +464,7 @@ void rtc_clk_apb_freq_update(uint32_t apb_freq);
  * @brief Get the current stored APB frequency.
  * @return The APB frequency value as last set via rtc_clk_apb_freq_update(), in Hz.
  */
-uint32_t rtc_clk_apb_freq_get();
+uint32_t rtc_clk_apb_freq_get(void);
 
 #define RTC_CLK_CAL_FRACT  19  //!< Number of fractional bits in values returned by rtc_clk_cal
 
@@ -521,7 +521,7 @@ uint64_t rtc_time_slowclk_to_us(uint64_t rtc_cycles, uint32_t period);
  *
  * @return current value of RTC counter
  */
-uint64_t rtc_time_get();
+uint64_t rtc_time_get(void);
 
 /**
  * @brief Busy loop until next RTC_SLOW_CLK cycle
@@ -530,7 +530,7 @@ uint64_t rtc_time_get();
  * In some cases (e.g. when RTC_SLOW_CLK cycle is very close), it may return
  * one RTC_SLOW_CLK cycle later.
  */
-void rtc_clk_wait_for_slow_cycle();
+void rtc_clk_wait_for_slow_cycle(void);
 
 /**
  * @brief sleep configuration for rtc_sleep_init function
@@ -709,7 +709,7 @@ typedef struct {
  * Otherwise, use default values and the level of MTDI bootstrapping pin.
  * @return currently used VDDSDIO configuration
  */
-rtc_vddsdio_config_t rtc_vddsdio_get_config();
+rtc_vddsdio_config_t rtc_vddsdio_get_config(void);
 
 /**
  * Set new VDDSDIO configuration using RTC registers.

--- a/components/soc/esp32/rtc_clk.c
+++ b/components/soc/esp32/rtc_clk.c
@@ -98,9 +98,9 @@
 #define RTC_PLL_FREQ_320M   320
 #define RTC_PLL_FREQ_480M   480
 
-static void rtc_clk_cpu_freq_to_8m();
-static void rtc_clk_bbpll_disable();
-static void rtc_clk_bbpll_enable();
+static void rtc_clk_cpu_freq_to_8m(void);
+static void rtc_clk_bbpll_disable(void);
+static void rtc_clk_bbpll_enable(void);
 static void rtc_clk_cpu_freq_to_pll_mhz(int cpu_freq_mhz);
 static bool rtc_clk_cpu_freq_from_mhz_internal(int mhz, rtc_cpu_freq_t* out_val);
 
@@ -130,7 +130,7 @@ void rtc_clk_32k_enable(bool enable)
     }
 }
 
-void rtc_clk_32k_enable_external()
+void rtc_clk_32k_enable_external(void)
 {
     rtc_clk_32k_enable_common(XTAL_32K_EXT_DAC_VAL, XTAL_32K_EXT_DRES_VAL, XTAL_32K_EXT_DBIAS_VAL);
 }
@@ -170,7 +170,7 @@ void rtc_clk_32k_bootstrap(uint32_t cycle)
             XTAL_32K_BOOTSTRAP_DRES_VAL, XTAL_32K_BOOTSTRAP_DBIAS_VAL);
 }
 
-bool rtc_clk_32k_enabled()
+bool rtc_clk_32k_enabled(void)
 {
     return GET_PERI_REG_MASK(RTC_IO_XTAL_32K_PAD_REG, RTC_IO_XPD_XTAL_32K) != 0;
 }
@@ -193,12 +193,12 @@ void rtc_clk_8m_enable(bool clk_8m_en, bool d256_en)
     }
 }
 
-bool rtc_clk_8m_enabled()
+bool rtc_clk_8m_enabled(void)
 {
     return GET_PERI_REG_MASK(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_ENB_CK8M) == 0;
 }
 
-bool rtc_clk_8md256_enabled()
+bool rtc_clk_8md256_enabled(void)
 {
     return GET_PERI_REG_MASK(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_ENB_CK8M_DIV) == 0;
 }
@@ -253,12 +253,12 @@ void rtc_clk_slow_freq_set(rtc_slow_freq_t slow_freq)
     ets_delay_us(DELAY_SLOW_CLK_SWITCH);
 }
 
-rtc_slow_freq_t rtc_clk_slow_freq_get()
+rtc_slow_freq_t rtc_clk_slow_freq_get(void)
 {
     return REG_GET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_ANA_CLK_RTC_SEL);
 }
 
-uint32_t rtc_clk_slow_freq_get_hz()
+uint32_t rtc_clk_slow_freq_get_hz(void)
 {
     switch(rtc_clk_slow_freq_get()) {
         case RTC_SLOW_FREQ_RTC: return RTC_SLOW_CLK_FREQ_150K;
@@ -274,7 +274,7 @@ void rtc_clk_fast_freq_set(rtc_fast_freq_t fast_freq)
     ets_delay_us(DELAY_FAST_CLK_SWITCH);
 }
 
-rtc_fast_freq_t rtc_clk_fast_freq_get()
+rtc_fast_freq_t rtc_clk_fast_freq_get(void)
 {
     return REG_GET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_FAST_CLK_RTC_SEL);
 }
@@ -405,7 +405,7 @@ void rtc_clk_cpu_freq_to_xtal(int freq, int div)
     }
 }
 
-static void rtc_clk_cpu_freq_to_8m()
+static void rtc_clk_cpu_freq_to_8m(void)
 {
     ets_update_cpu_frequency(8);
     REG_SET_FIELD(RTC_CNTL_REG, RTC_CNTL_DIG_DBIAS_WAK, DIG_DBIAS_XTAL);
@@ -415,7 +415,7 @@ static void rtc_clk_cpu_freq_to_8m()
     rtc_clk_apb_freq_update(RTC_FAST_CLK_FREQ_8M);
 }
 
-static void rtc_clk_bbpll_disable()
+static void rtc_clk_bbpll_disable(void)
 {
     SET_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG,
             RTC_CNTL_BB_I2C_FORCE_PD | RTC_CNTL_BBPLL_FORCE_PD |
@@ -430,7 +430,7 @@ static void rtc_clk_bbpll_disable()
     }
 }
 
-static void rtc_clk_bbpll_enable()
+static void rtc_clk_bbpll_enable(void)
 {
     CLEAR_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG,
              RTC_CNTL_BIAS_I2C_FORCE_PD | RTC_CNTL_BB_I2C_FORCE_PD |
@@ -487,7 +487,7 @@ void rtc_clk_cpu_freq_set_fast(rtc_cpu_freq_t cpu_freq)
     rtc_clk_cpu_freq_set_config_fast(&config);
 }
 
-void rtc_clk_cpu_freq_set_xtal()
+void rtc_clk_cpu_freq_set_xtal(void)
 {
     int freq_mhz = (int) rtc_clk_xtal_freq_get();
 
@@ -496,7 +496,7 @@ void rtc_clk_cpu_freq_set_xtal()
     rtc_clk_bbpll_disable();
 }
 
-rtc_cpu_freq_t rtc_clk_cpu_freq_get()
+rtc_cpu_freq_t rtc_clk_cpu_freq_get(void)
 {
     rtc_cpu_freq_config_t config;
     rtc_clk_cpu_freq_get_config(&config);
@@ -737,7 +737,7 @@ void rtc_clk_cpu_freq_set_config_fast(const rtc_cpu_freq_config_t* config)
     }
 }
 
-rtc_xtal_freq_t rtc_clk_xtal_freq_get()
+rtc_xtal_freq_t rtc_clk_xtal_freq_get(void)
 {
     /* We may have already written XTAL value into RTC_XTAL_FREQ_REG */
     uint32_t xtal_freq_reg = READ_PERI_REG(RTC_XTAL_FREQ_REG);
@@ -761,7 +761,7 @@ void rtc_clk_apb_freq_update(uint32_t apb_freq)
     WRITE_PERI_REG(RTC_APB_FREQ_REG, clk_val_to_reg_val(apb_freq >> 12));
 }
 
-uint32_t rtc_clk_apb_freq_get()
+uint32_t rtc_clk_apb_freq_get(void)
 {
     uint32_t freq_hz = reg_val_to_clk_val(READ_PERI_REG(RTC_APB_FREQ_REG)) << 12;
     // round to the nearest MHz
@@ -773,4 +773,4 @@ uint32_t rtc_clk_apb_freq_get()
 /* Name used in libphy.a:phy_chip_v7.o
  * TODO: update the library to use rtc_clk_xtal_freq_get
  */
-rtc_xtal_freq_t rtc_get_xtal() __attribute__((alias("rtc_clk_xtal_freq_get")));
+rtc_xtal_freq_t rtc_get_xtal(void) __attribute__((alias("rtc_clk_xtal_freq_get")));

--- a/components/soc/esp32/rtc_clk_init.c
+++ b/components/soc/esp32/rtc_clk_init.c
@@ -38,7 +38,7 @@
  */
 #define XTAL_FREQ_EST_CYCLES            10
 
-static rtc_xtal_freq_t rtc_clk_xtal_freq_estimate();
+static rtc_xtal_freq_t rtc_clk_xtal_freq_estimate(void);
 
 static const char* TAG = "rtc_clk_init";
 
@@ -142,7 +142,7 @@ void rtc_clk_init(rtc_clk_config_t cfg)
     rtc_clk_slow_freq_set(cfg.slow_freq);
 }
 
-static rtc_xtal_freq_t rtc_clk_xtal_freq_estimate()
+static rtc_xtal_freq_t rtc_clk_xtal_freq_estimate(void)
 {
     /* Enable 8M/256 clock if needed */
     const bool clk_8m_enabled = rtc_clk_8m_enabled();

--- a/components/soc/esp32/rtc_pm.c
+++ b/components/soc/esp32/rtc_pm.c
@@ -30,14 +30,14 @@ typedef enum{
 /* These MAC-related functions are defined in the closed source part of
  * RTC library
  */
-extern void pm_mac_init();
-extern int pm_check_mac_idle();
-extern void pm_mac_deinit();
+extern void pm_mac_init(void);
+extern int pm_check_mac_idle(void);
+extern void pm_mac_deinit(void);
 
 /* This sleep-related function is called from the closed source part of RTC
  * library.
  */
-pm_sw_reject_t pm_set_sleep_mode(pm_sleep_mode_t sleep_mode, void(*pmac_save_params)())
+pm_sw_reject_t pm_set_sleep_mode(pm_sleep_mode_t sleep_mode, void(*pmac_save_params)(void))
 {
     (void) pmac_save_params; /* unused */
 

--- a/components/soc/include/soc/rtc_wdt.h
+++ b/components/soc/include/soc/rtc_wdt.h
@@ -101,34 +101,34 @@ typedef enum {
  * @return
  *         - True if the protect of RTC_WDT is set
  */
-bool rtc_wdt_get_protect_status();
+bool rtc_wdt_get_protect_status(void);
 
 /**
  * @brief Set protect of rtc_wdt.
  */
-void rtc_wdt_protect_on();
+void rtc_wdt_protect_on(void);
 
 /**
  * @brief Reset protect of rtc_wdt.
  */
-void rtc_wdt_protect_off();
+void rtc_wdt_protect_off(void);
 
 /**
  * @brief Enable rtc_wdt.
  */
-void rtc_wdt_enable();
+void rtc_wdt_enable(void);
 
 /**
  * @brief Disable rtc_wdt.
  */
-void rtc_wdt_disable();
+void rtc_wdt_disable(void);
 
 /**
  * @brief Reset counter rtc_wdt.
  *
  * It returns to stage 0 and its expiry counter restarts from 0.
  */
-void rtc_wdt_feed();
+void rtc_wdt_feed(void);
 
 /**
  * @brief Set time for required stage.
@@ -184,7 +184,7 @@ esp_err_t rtc_wdt_set_length_of_reset_signal(rtc_wdt_reset_sig_t reset_src, rtc_
  * @return
  *         - True rtc_wdt is enabled
  */
-bool rtc_wdt_is_on();
+bool rtc_wdt_is_on(void);
 
 #ifdef __cplusplus
 }

--- a/components/soc/include/soc/soc_memory_layout.h
+++ b/components/soc/include/soc/soc_memory_layout.h
@@ -137,7 +137,7 @@ size_t soc_get_available_memory_regions(soc_memory_region_t *regions);
  * returned by soc_get_available_memory_regions(). Used to size the
  * array passed to that function.
  */
-size_t soc_get_available_memory_region_max_count();
+size_t soc_get_available_memory_region_max_count(void);
 
 inline static bool IRAM_ATTR esp_ptr_dma_capable(const void *p)
 {

--- a/components/soc/src/memory_layout_utils.c
+++ b/components/soc/src/memory_layout_utils.c
@@ -34,14 +34,14 @@ extern int _data_start, _bss_end, _iram_start, _iram_end;
 /* static DRAM & IRAM chunks */
 static const size_t EXTRA_RESERVED_REGIONS = 2;
 
-static size_t s_get_num_reserved_regions()
+static size_t s_get_num_reserved_regions(void)
 {
     return ( ( &soc_reserved_memory_region_end
                - &soc_reserved_memory_region_start ) +
              EXTRA_RESERVED_REGIONS );
 }
 
-size_t soc_get_available_memory_region_max_count()
+size_t soc_get_available_memory_region_max_count(void)
 {
     /* Worst-case: each reserved memory region splits an available
        region in two, so the maximum possible number of regions

--- a/components/spi_flash/cache_utils.c
+++ b/components/spi_flash/cache_utils.c
@@ -45,18 +45,18 @@ static volatile bool s_flash_op_complete = false;
 static volatile int s_flash_op_cpu = -1;
 #endif
 
-void spi_flash_init_lock()
+void spi_flash_init_lock(void)
 {
     s_flash_op_mutex = xSemaphoreCreateRecursiveMutex();
     assert(s_flash_op_mutex != NULL);
 }
 
-void spi_flash_op_lock()
+void spi_flash_op_lock(void)
 {
     xSemaphoreTakeRecursive(s_flash_op_mutex, portMAX_DELAY);
 }
 
-void spi_flash_op_unlock()
+void spi_flash_op_unlock(void)
 {
     xSemaphoreGiveRecursive(s_flash_op_mutex);
 }
@@ -90,7 +90,7 @@ void IRAM_ATTR spi_flash_op_block_func(void* arg)
     xTaskResumeAll();
 }
 
-void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu()
+void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu(void)
 {
     spi_flash_op_lock();
 
@@ -141,7 +141,7 @@ void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu()
     spi_flash_disable_cache(other_cpuid, &s_flash_op_cache_state[other_cpuid]);
 }
 
-void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu()
+void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu(void)
 {
     const uint32_t cpuid = xPortGetCoreID();
     const uint32_t other_cpuid = (cpuid == 0) ? 1 : 0;
@@ -178,7 +178,7 @@ void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu()
     spi_flash_op_unlock();
 }
 
-void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os()
+void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os(void)
 {
     const uint32_t cpuid = xPortGetCoreID();
     const uint32_t other_cpuid = (cpuid == 0) ? 1 : 0;
@@ -191,7 +191,7 @@ void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os()
     spi_flash_disable_cache(cpuid, &s_flash_op_cache_state[cpuid]);
 }
 
-void IRAM_ATTR spi_flash_enable_interrupts_caches_no_os()
+void IRAM_ATTR spi_flash_enable_interrupts_caches_no_os(void)
 {
     const uint32_t cpuid = xPortGetCoreID();
 
@@ -203,36 +203,36 @@ void IRAM_ATTR spi_flash_enable_interrupts_caches_no_os()
 
 #else // CONFIG_FREERTOS_UNICORE
 
-void spi_flash_init_lock()
+void spi_flash_init_lock(void)
 {
 }
 
-void spi_flash_op_lock()
+void spi_flash_op_lock(void)
 {
     vTaskSuspendAll();
 }
 
-void spi_flash_op_unlock()
+void spi_flash_op_unlock(void)
 {
     xTaskResumeAll();
 }
 
 
-void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu()
+void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu(void)
 {
     spi_flash_op_lock();
     esp_intr_noniram_disable();
     spi_flash_disable_cache(0, &s_flash_op_cache_state[0]);
 }
 
-void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu()
+void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu(void)
 {
     spi_flash_restore_cache(0, s_flash_op_cache_state[0]);
     esp_intr_noniram_enable();
     spi_flash_op_unlock();
 }
 
-void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os()
+void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os(void)
 {
     // Kill interrupts that aren't located in IRAM
     esp_intr_noniram_disable();
@@ -240,7 +240,7 @@ void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os()
     spi_flash_disable_cache(0, &s_flash_op_cache_state[0]);
 }
 
-void IRAM_ATTR spi_flash_enable_interrupts_caches_no_os()
+void IRAM_ATTR spi_flash_enable_interrupts_caches_no_os(void)
 {
     // Re-enable cache on this CPU
     spi_flash_restore_cache(0, s_flash_op_cache_state[0]);
@@ -291,7 +291,7 @@ static void IRAM_ATTR spi_flash_restore_cache(uint32_t cpuid, uint32_t saved_sta
 }
 
 
-IRAM_ATTR bool spi_flash_cache_enabled()
+IRAM_ATTR bool spi_flash_cache_enabled(void)
 {
     bool result = (DPORT_REG_GET_BIT(DPORT_PRO_CACHE_CTRL_REG, DPORT_PRO_CACHE_ENABLE) != 0);
 #if portNUM_PROCESSORS == 2

--- a/components/spi_flash/cache_utils.h
+++ b/components/spi_flash/cache_utils.h
@@ -23,30 +23,30 @@
  */
 
 // Init mutex protecting access to spi_flash_* APIs
-void spi_flash_init_lock();
+void spi_flash_init_lock(void);
 
 // Take mutex protecting access to spi_flash_* APIs
-void spi_flash_op_lock();
+void spi_flash_op_lock(void);
 
 // Release said mutex
-void spi_flash_op_unlock();
+void spi_flash_op_unlock(void);
 
 // Suspend the scheduler on both CPUs, disable cache.
 // Contrary to its name this doesn't do anything with interrupts, yet.
 // Interrupt disabling capability will be added once we implement
 // interrupt allocation API.
-void spi_flash_disable_interrupts_caches_and_other_cpu();
+void spi_flash_disable_interrupts_caches_and_other_cpu(void);
 
 // Enable cache, enable interrupts (to be added in future), resume scheduler
-void spi_flash_enable_interrupts_caches_and_other_cpu();
+void spi_flash_enable_interrupts_caches_and_other_cpu(void);
 
 // Disables non-IRAM interrupt handlers on current CPU and caches on both CPUs.
 // This function is implied to be called when other CPU is not running or running code from IRAM.
-void spi_flash_disable_interrupts_caches_and_other_cpu_no_os();
+void spi_flash_disable_interrupts_caches_and_other_cpu_no_os(void);
 
 // Enable cache, enable interrupts on current CPU.
 // This function is implied to be called when other CPU is not running or running code from IRAM.
-void spi_flash_enable_interrupts_caches_no_os();
+void spi_flash_enable_interrupts_caches_no_os(void);
 
 // Mark the pages containing a flash region as having been
 // erased or written to. This means the flash cache needs

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -74,7 +74,7 @@ static uint8_t s_mmap_page_refcnt[REGIONS_COUNT * PAGES_PER_REGION] = {0};
 static uint32_t s_mmap_last_handle = 0;
 
 
-static void IRAM_ATTR spi_flash_mmap_init()
+static void IRAM_ATTR spi_flash_mmap_init(void)
 {
     if (s_mmap_page_refcnt[0] != 0) {
         return; /* mmap data already initialised */
@@ -286,7 +286,7 @@ void IRAM_ATTR spi_flash_munmap(spi_flash_mmap_handle_t handle)
     free(it);
 }
 
-static void IRAM_ATTR NOINLINE_ATTR spi_flash_protected_mmap_init()
+static void IRAM_ATTR NOINLINE_ATTR spi_flash_protected_mmap_init(void)
 {
     spi_flash_disable_interrupts_caches_and_other_cpu();
     spi_flash_mmap_init();
@@ -302,7 +302,7 @@ static uint32_t IRAM_ATTR NOINLINE_ATTR spi_flash_protected_read_mmu_entry(int i
     return value;
 }
 
-void spi_flash_mmap_dump()
+void spi_flash_mmap_dump(void)
 {
     spi_flash_protected_mmap_init();
 

--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -145,45 +145,45 @@ void IRAM_ATTR spi_flash_guard_set(const spi_flash_guard_funcs_t *funcs)
     s_flash_guard_ops = funcs;
 }
 
-const spi_flash_guard_funcs_t *IRAM_ATTR spi_flash_guard_get()
+const spi_flash_guard_funcs_t *IRAM_ATTR spi_flash_guard_get(void)
 {
     return s_flash_guard_ops;
 }
 
-size_t IRAM_ATTR spi_flash_get_chip_size()
+size_t IRAM_ATTR spi_flash_get_chip_size(void)
 {
     return g_rom_flashchip.chip_size;
 }
 
-static inline void IRAM_ATTR spi_flash_guard_start()
+static inline void IRAM_ATTR spi_flash_guard_start(void)
 {
     if (s_flash_guard_ops && s_flash_guard_ops->start) {
         s_flash_guard_ops->start();
     }
 }
 
-static inline void IRAM_ATTR spi_flash_guard_end()
+static inline void IRAM_ATTR spi_flash_guard_end(void)
 {
     if (s_flash_guard_ops && s_flash_guard_ops->end) {
         s_flash_guard_ops->end();
     }
 }
 
-static inline void IRAM_ATTR spi_flash_guard_op_lock()
+static inline void IRAM_ATTR spi_flash_guard_op_lock(void)
 {
     if (s_flash_guard_ops && s_flash_guard_ops->op_lock) {
         s_flash_guard_ops->op_lock();
     }
 }
 
-static inline void IRAM_ATTR spi_flash_guard_op_unlock()
+static inline void IRAM_ATTR spi_flash_guard_op_unlock(void)
 {
     if (s_flash_guard_ops && s_flash_guard_ops->op_unlock) {
         s_flash_guard_ops->op_unlock();
     }
 }
 
-static esp_rom_spiflash_result_t IRAM_ATTR spi_flash_unlock()
+static esp_rom_spiflash_result_t IRAM_ATTR spi_flash_unlock(void)
 {
     static bool unlocked = false;
     if (!unlocked) {
@@ -665,17 +665,17 @@ static inline void dump_counter(spi_flash_counter_t *counter, const char *name)
              counter->count, counter->time, counter->bytes);
 }
 
-const spi_flash_counters_t *spi_flash_get_counters()
+const spi_flash_counters_t *spi_flash_get_counters(void)
 {
     return &s_flash_stats;
 }
 
-void spi_flash_reset_counters()
+void spi_flash_reset_counters(void)
 {
     memset(&s_flash_stats, 0, sizeof(s_flash_stats));
 }
 
-void spi_flash_dump_counters()
+void spi_flash_dump_counters(void)
 {
     dump_counter(&s_flash_stats.read,  "read ");
     dump_counter(&s_flash_stats.write, "write");

--- a/components/spi_flash/include/esp_spi_flash.h
+++ b/components/spi_flash/include/esp_spi_flash.h
@@ -42,7 +42,7 @@ extern "C" {
  *  no need to call it from application code.
  *
  */
-void spi_flash_init();
+void spi_flash_init(void);
 
 /**
  * @brief  Get flash chip size, as set in binary image header
@@ -51,7 +51,7 @@ void spi_flash_init();
  *
  * @return size of flash chip, in bytes
  */
-size_t spi_flash_get_chip_size();
+size_t spi_flash_get_chip_size(void);
 
 /**
  * @brief  Erase the Flash sector.
@@ -239,7 +239,7 @@ void spi_flash_munmap(spi_flash_mmap_handle_t handle);
  * of pages allocated to each handle. It also lists all non-zero entries of
  * MMU table and corresponding reference counts.
  */
-void spi_flash_mmap_dump();
+void spi_flash_mmap_dump(void);
 
 /**
  * @brief get free pages number which can be mmap
@@ -294,7 +294,7 @@ const void *spi_flash_phys2cache(size_t phys_offs, spi_flash_mmap_memory_t memor
  *
  * @return true if both CPUs have flash cache enabled, false otherwise.
  */
-bool spi_flash_cache_enabled();
+bool spi_flash_cache_enabled(void);
 
 /**
  * @brief SPI flash critical section enter function.
@@ -375,7 +375,7 @@ void spi_flash_guard_set(const spi_flash_guard_funcs_t* funcs);
  * @return The guard functions that were set via spi_flash_guard_set(). These functions
  * can be called if implementing custom low-level SPI flash operations.
  */
-const spi_flash_guard_funcs_t *spi_flash_guard_get();
+const spi_flash_guard_funcs_t *spi_flash_guard_get(void);
 
 /**
  * @brief Default OS-aware flash access guard functions
@@ -410,12 +410,12 @@ typedef struct {
 /**
  * @brief  Reset SPI flash operation counters
  */
-void spi_flash_reset_counters();
+void spi_flash_reset_counters(void);
 
 /**
  * @brief  Print SPI flash operation counters
  */
-void spi_flash_dump_counters();
+void spi_flash_dump_counters(void);
 
 /**
  * @brief  Return current SPI flash operation counters
@@ -423,7 +423,7 @@ void spi_flash_dump_counters();
  * @return  pointer to the spi_flash_counters_t structure holding values
  *          of the operation counters
  */
-const spi_flash_counters_t* spi_flash_get_counters();
+const spi_flash_counters_t* spi_flash_get_counters(void);
 
 #endif //CONFIG_SPI_FLASH_ENABLE_COUNTERS
 

--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -50,7 +50,7 @@ typedef struct esp_partition_iterator_opaque_ {
 
 
 static esp_partition_iterator_opaque_t* iterator_create(esp_partition_type_t type, esp_partition_subtype_t subtype, const char* label);
-static esp_err_t load_partitions();
+static esp_err_t load_partitions(void);
 
 
 static SLIST_HEAD(partition_list_head_, partition_list_item_) s_partition_list =
@@ -142,7 +142,7 @@ static esp_partition_iterator_opaque_t* iterator_create(esp_partition_type_t typ
 
 // Create linked list of partition_list_item_t structures.
 // This function is called only once, with s_partition_list_lock taken.
-static esp_err_t load_partitions()
+static esp_err_t load_partitions(void)
 {
     const uint32_t* ptr;
     spi_flash_mmap_handle_t handle;

--- a/components/tcp_transport/include/esp_transport.h
+++ b/components/tcp_transport/include/esp_transport.h
@@ -38,7 +38,7 @@ typedef esp_transport_handle_t (*payload_transfer_func)(esp_transport_handle_t);
  *
  * @return     A handle can hold all transports
  */
-esp_transport_list_handle_t esp_transport_list_init();
+esp_transport_list_handle_t esp_transport_list_init(void);
 
 /**
  * @brief      Cleanup and free all transports, include itself,
@@ -91,7 +91,7 @@ esp_transport_handle_t esp_transport_list_get_transport(esp_transport_list_handl
  *
  * @return     The transport handle
  */
-esp_transport_handle_t esp_transport_init();
+esp_transport_handle_t esp_transport_init(void);
 
 /**
  * @brief      Cleanup and free memory the transport

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -27,7 +27,7 @@ extern "C" {
  *
  * @return      the allocated esp_transport_handle_t, or NULL if the handle can not be allocated
  */
-esp_transport_handle_t esp_transport_ssl_init();
+esp_transport_handle_t esp_transport_ssl_init(void);
 
 /**
  * @brief      Set SSL certificate data (as PEM format).

--- a/components/tcp_transport/include/esp_transport_tcp.h
+++ b/components/tcp_transport/include/esp_transport_tcp.h
@@ -26,7 +26,7 @@ extern "C" {
  *
  * @return  the allocated esp_transport_handle_t, or NULL if the handle can not be allocated
  */
-esp_transport_handle_t esp_transport_tcp_init();
+esp_transport_handle_t esp_transport_tcp_init(void);
 
 
 #ifdef __cplusplus

--- a/components/tcp_transport/transport_tcp.c
+++ b/components/tcp_transport/transport_tcp.c
@@ -153,7 +153,7 @@ static esp_err_t tcp_destroy(esp_transport_handle_t t)
     return 0;
 }
 
-esp_transport_handle_t esp_transport_tcp_init()
+esp_transport_handle_t esp_transport_tcp_init(void)
 {
     esp_transport_handle_t t = esp_transport_init();
     transport_tcp_t *tcp = calloc(1, sizeof(transport_tcp_t));

--- a/components/unity/include/unity_test_runner.h
+++ b/components/unity/include/unity_test_runner.h
@@ -168,7 +168,7 @@ void unity_run_test_by_name(const char *name);
 
 void unity_run_tests_by_tag(const char *tag, bool invert);
 
-void unity_run_all_tests();
+void unity_run_all_tests(void);
 
-void unity_run_menu();
+void unity_run_menu(void);
 

--- a/components/vfs/include/esp_vfs.h
+++ b/components/vfs/include/esp_vfs.h
@@ -221,11 +221,11 @@ typedef struct
     /** socket select function for socket FDs with the functionality of POSIX select(); this should be set only for the socket VFS */
     int (*socket_select)(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds, struct timeval *timeout);
     /** called by VFS to interrupt the socket_select call when select is activated from a non-socket VFS driver; set only for the socket driver */
-    void (*stop_socket_select)();
+    void (*stop_socket_select)(void);
     /** stop_socket_select which can be called from ISR; set only for the socket driver */
     void (*stop_socket_select_isr)(BaseType_t *woken);
     /** end_select is called to stop the I/O multiplexing and deinitialize the environment created by start_select for the given VFS */
-    void (*end_select)();
+    void (*end_select)(void);
 } esp_vfs_t;
 
 

--- a/components/vfs/include/esp_vfs_dev.h
+++ b/components/vfs/include/esp_vfs_dev.h
@@ -34,7 +34,7 @@ typedef enum {
  *
  * This function is called from startup code to enable serial output
  */
-void esp_vfs_dev_uart_register();
+void esp_vfs_dev_uart_register(void);
 
 /**
  * @brief Set the line endings expected to be received on UART

--- a/components/vfs/vfs_uart.c
+++ b/components/vfs/vfs_uart.c
@@ -91,7 +91,7 @@ static esp_line_endings_t s_rx_mode[UART_NUM] = { [0 ... UART_NUM-1] =
 #endif
 };
 
-static void uart_end_select();
+static void uart_end_select(void);
 
 // Functions used to write bytes to UART. Default to "basic" functions.
 static tx_func_t s_uart_tx_func[UART_NUM] = {
@@ -411,7 +411,7 @@ static esp_err_t uart_start_select(int nfds, fd_set *readfds, fd_set *writefds, 
     return ESP_OK;
 }
 
-static void uart_end_select()
+static void uart_end_select(void)
 {
     portENTER_CRITICAL(uart_get_selectlock());
     for (int i = 0; i < UART_NUM; ++i) {

--- a/components/wpa_supplicant/include/wpa/wpa.h
+++ b/components/wpa_supplicant/include/wpa/wpa.h
@@ -93,7 +93,7 @@ struct wpa_sm {
     void (*install_ppkey) (enum wpa_alg alg, u8 *addr, int key_idx, int set_tx,
                u8 *seq, unsigned int seq_len, u8 *key, unsigned int key_len, int key_entry_valid);
     void (*wpa_deauthenticate)(u8 reason_code);
-    void (*wpa_neg_complete)();
+    void (*wpa_neg_complete)(void);
     struct wpa_gtk_data gd; //used for calllback save param
     u16 key_info; 	//used for txcallback param    
 };

--- a/examples/bluetooth/a2dp_gatts_coex/main/main.c
+++ b/examples/bluetooth/a2dp_gatts_coex/main/main.c
@@ -627,7 +627,7 @@ static void bt_av_hdl_stack_evt(uint16_t event, void *p_param)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/a2dp_sink/main/main.c
+++ b/examples/bluetooth/a2dp_sink/main/main.c
@@ -42,7 +42,7 @@ enum {
 static void bt_av_hdl_stack_evt(uint16_t event, void *p_param);
 
 
-void app_main()
+void app_main(void)
 {
     /* Initialize NVS — it is used to store PHY calibration data */
     esp_err_t err = nvs_flash_init();

--- a/examples/bluetooth/a2dp_source/main/main.c
+++ b/examples/bluetooth/a2dp_source/main/main.c
@@ -96,7 +96,7 @@ static char *bda2str(esp_bd_addr_t bda, char *str, size_t size)
     return str;
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/ble_adv/main/app_bt.c
+++ b/examples/bluetooth/ble_adv/main/app_bt.c
@@ -210,7 +210,7 @@ void bleAdvtTask(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     /* Initialize NVS — it is used to store PHY calibration data */
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/ble_compatibility_test/main/ble_compatibility_test.c
+++ b/examples/bluetooth/ble_compatibility_test/main/ble_compatibility_test.c
@@ -615,7 +615,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/ble_eddystone/main/esp_eddystone_demo.c
+++ b/examples/bluetooth/ble_eddystone/main/esp_eddystone_demo.c
@@ -160,7 +160,7 @@ void esp_eddystone_init(void)
     esp_eddystone_appRegister();
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));

--- a/examples/bluetooth/ble_hid_device_demo/main/ble_hidd_demo_main.c
+++ b/examples/bluetooth/ble_hid_device_demo/main/ble_hidd_demo_main.c
@@ -259,7 +259,7 @@ void hid_demo_task(void *pvParameters)
 }
 
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/ble_ibeacon/main/ibeacon_demo.c
+++ b/examples/bluetooth/ble_ibeacon/main/ibeacon_demo.c
@@ -163,7 +163,7 @@ void ble_ibeacon_init(void)
     ble_ibeacon_appRegister();
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));

--- a/examples/bluetooth/ble_spp_client/main/spp_client_demo.c
+++ b/examples/bluetooth/ble_spp_client/main/spp_client_demo.c
@@ -598,7 +598,7 @@ static void spp_uart_init(void)
     xTaskCreate(uart_task, "uTask", 2048, (void*)UART_NUM_0, 8, NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/ble_spp_server/main/ble_spp_server_demo.c
+++ b/examples/bluetooth/ble_spp_server/main/ble_spp_server_demo.c
@@ -648,7 +648,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();

--- a/examples/bluetooth/ble_throughput/throughput_client/main/example_ble_client_throughput.c
+++ b/examples/bluetooth/ble_throughput/throughput_client/main/example_ble_client_throughput.c
@@ -510,7 +510,7 @@ static void throughput_client_task(void *param)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/ble_throughput/throughput_server/main/example_ble_server_throughput.c
+++ b/examples/bluetooth/ble_throughput/throughput_server/main/example_ble_server_throughput.c
@@ -640,7 +640,7 @@ void throughput_server_task(void *param)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/blufi/main/blufi_example_main.c
+++ b/examples/bluetooth/blufi/main/blufi_example_main.c
@@ -375,7 +375,7 @@ static void example_gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_
     }
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/bt_discovery/main/bt_discovery.c
+++ b/examples/bluetooth/bt_discovery/main/bt_discovery.c
@@ -269,7 +269,7 @@ void bt_app_gap_start_up(void)
     esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
 }
 
-void app_main()
+void app_main(void)
 {
     /* Initialize NVS — it is used to store PHY calibration data */
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/bt_spp_acceptor/main/example_spp_acceptor_demo.c
+++ b/examples/bluetooth/bt_spp_acceptor/main/example_spp_acceptor_demo.c
@@ -154,7 +154,7 @@ void esp_bt_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
     return;
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/bluetooth/bt_spp_initiator/main/example_spp_initiator_demo.c
+++ b/examples/bluetooth/bt_spp_initiator/main/example_spp_initiator_demo.c
@@ -235,7 +235,7 @@ static void esp_bt_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *pa
     }
 }
 
-void app_main()
+void app_main(void)
 {
     for (int i = 0; i < SPP_DATA_LEN; ++i) {
         spp_data[i] = i;

--- a/examples/bluetooth/bt_spp_vfs_acceptor/main/example_spp_vfs_acceptor_demo.c
+++ b/examples/bluetooth/bt_spp_vfs_acceptor/main/example_spp_vfs_acceptor_demo.c
@@ -159,7 +159,7 @@ void esp_bt_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
     return;
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/bluetooth/bt_spp_vfs_initiator/main/example_spp_vfs_initiator_demo.c
+++ b/examples/bluetooth/bt_spp_vfs_initiator/main/example_spp_vfs_initiator_demo.c
@@ -223,7 +223,7 @@ static void esp_spp_stack_cb(esp_spp_cb_event_t event, esp_spp_cb_param_t *param
     spp_task_work_dispatch(esp_spp_cb, event, param, sizeof(esp_spp_cb_param_t), NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     for (int i = 0; i < SPP_DATA_LEN; ++i) {
         spp_data[i] = i;

--- a/examples/bluetooth/controller_hci_uart/main/controller_hci_uart_demo.c
+++ b/examples/bluetooth/controller_hci_uart/main/controller_hci_uart_demo.c
@@ -31,7 +31,7 @@ static void uart_gpio_reset(void)
 #endif
 }
 
-void app_main()
+void app_main(void)
 { 
     esp_err_t ret;
 

--- a/examples/bluetooth/gatt_client/main/gattc_demo.c
+++ b/examples/bluetooth/gatt_client/main/gattc_demo.c
@@ -417,7 +417,7 @@ static void esp_gattc_cb(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/gatt_client/tutorial/Gatt_Client_Example_Walkthrough.md
+++ b/examples/bluetooth/gatt_client/tutorial/Gatt_Client_Example_Walkthrough.md
@@ -37,7 +37,7 @@ These `includes` are required for the FreeRTOS and underlaying system components
 The program’s entry point is the app_main() function:
 
 ```c
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/gatt_security_client/main/example_ble_sec_gattc_demo.c
+++ b/examples/bluetooth/gatt_security_client/main/example_ble_sec_gattc_demo.c
@@ -509,7 +509,7 @@ static void esp_gattc_cb(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t ret = nvs_flash_init();

--- a/examples/bluetooth/gatt_security_server/main/example_ble_sec_gatts_demo.c
+++ b/examples/bluetooth/gatt_security_server/main/example_ble_sec_gatts_demo.c
@@ -497,7 +497,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/gatt_server/main/gatts_demo.c
+++ b/examples/bluetooth/gatt_server/main/gatts_demo.c
@@ -671,7 +671,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/gatt_server_service_table/main/gatts_table_creat_demo.c
+++ b/examples/bluetooth/gatt_server_service_table/main/gatts_table_creat_demo.c
@@ -512,7 +512,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/gatt_server_service_table/tutorial/Gatt_Server_Service_Table_Example_Walkthrough.md
+++ b/examples/bluetooth/gatt_server_service_table/tutorial/Gatt_Server_Service_Table_Example_Walkthrough.md
@@ -75,7 +75,7 @@ The enumeration elements are set up in the same order as the Heart Rate Profile 
 The entry point to this example is the ``app_main()`` function:
 
 ```c
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/bluetooth/gattc_multi_connect/main/gattc_multi_connect.c
+++ b/examples/bluetooth/gattc_multi_connect/main/gattc_multi_connect.c
@@ -883,7 +883,7 @@ static void esp_gattc_cb(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp
     } while (0);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/build_system/cmake/idf_as_lib/main.c
+++ b/examples/build_system/cmake/idf_as_lib/main.c
@@ -12,7 +12,7 @@
 #include "esp_system.h"
 #include "esp_spi_flash.h"
 
-void app_main()
+void app_main(void)
 {
     printf("Hello world!\n");
 

--- a/examples/ethernet/ethernet/main/ethernet_example_main.c
+++ b/examples/ethernet/ethernet/main/ethernet_example_main.c
@@ -135,7 +135,7 @@ static esp_err_t eth_event_handler(void *ctx, system_event_t *event)
     return ESP_OK;
 }
 
-void app_main()
+void app_main(void)
 {
     tcpip_adapter_init();
 

--- a/examples/ethernet/iperf/main/iperf_example_main.c
+++ b/examples/ethernet/iperf/main/iperf_example_main.c
@@ -110,7 +110,7 @@ static void initialize_console()
 #endif
 }
 
-void app_main()
+void app_main(void)
 {
     initialize_nvs();
 

--- a/examples/get-started/blink/main/blink.c
+++ b/examples/get-started/blink/main/blink.c
@@ -38,7 +38,7 @@ void blink_task(void *pvParameter)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(&blink_task, "blink_task", configMINIMAL_STACK_SIZE, NULL, 5, NULL);
 }

--- a/examples/get-started/hello_world/Makefile
+++ b/examples/get-started/hello_world/Makefile
@@ -5,5 +5,10 @@
 
 PROJECT_NAME := hello-world
 
+EXTRA_CPPFLAGS := \
+	-Wall \
+	-Wextra \
+	-Werror
+
 include $(IDF_PATH)/make/project.mk
 

--- a/examples/get-started/hello_world/main/hello_world_main.c
+++ b/examples/get-started/hello_world/main/hello_world_main.c
@@ -13,7 +13,7 @@
 #include "esp_spi_flash.h"
 
 
-void app_main()
+void app_main(void)
 {
     printf("Hello world!\n");
 

--- a/examples/peripherals/adc/main/adc1_example_main.c
+++ b/examples/peripherals/adc/main/adc1_example_main.c
@@ -50,7 +50,7 @@ static void print_char_val_type(esp_adc_cal_value_t val_type)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     //Check if Two Point or Vref are burned into eFuse
     check_efuse();

--- a/examples/peripherals/can/can_alert_and_recovery/main/can_alert_and_recovery_example_main.c
+++ b/examples/peripherals/can/can_alert_and_recovery/main/can_alert_and_recovery_example_main.c
@@ -127,7 +127,7 @@ static void ctrl_task(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     tx_task_sem = xSemaphoreCreateBinary();
     ctrl_task_sem = xSemaphoreCreateBinary();

--- a/examples/peripherals/can/can_network/can_network_listen_only/main/can_network_example_listen_only_main.c
+++ b/examples/peripherals/can/can_network/can_network_listen_only/main/can_network_example_listen_only_main.c
@@ -97,7 +97,7 @@ static void can_receive_task(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     rx_sem = xSemaphoreCreateBinary();
     xTaskCreatePinnedToCore(can_receive_task, "CAN_rx", 4096, NULL, RX_TASK_PRIO, NULL, tskNO_AFFINITY);

--- a/examples/peripherals/can/can_network/can_network_master/main/can_network_example_master_main.c
+++ b/examples/peripherals/can/can_network/can_network_master/main/can_network_example_master_main.c
@@ -203,7 +203,7 @@ void can_control_task(void *arg) {
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     //Create tasks, queues, and semaphores
     rx_task_queue = xQueueCreate(1, sizeof(rx_task_action_t));

--- a/examples/peripherals/can/can_network/can_network_slave/main/can_network_example_slave_main.c
+++ b/examples/peripherals/can/can_network/can_network_slave/main/can_network_example_slave_main.c
@@ -225,7 +225,7 @@ static void can_control_task(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     //Add short delay to allow master it to initialize first
     for (int i = 3; i > 0; i--) {

--- a/examples/peripherals/can/can_self_test/main/can_self_test_example_main.c
+++ b/examples/peripherals/can/can_self_test/main/can_self_test_example_main.c
@@ -107,7 +107,7 @@ static void can_control_task(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     //Create tasks and synchronization primitives
     tx_sem = xSemaphoreCreateBinary();

--- a/examples/peripherals/gpio/main/gpio_example_main.c
+++ b/examples/peripherals/gpio/main/gpio_example_main.c
@@ -57,7 +57,7 @@ static void gpio_task_example(void* arg)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     gpio_config_t io_conf;
     //disable interrupt

--- a/examples/peripherals/i2c/i2c_self_test/main/i2c_example_main.c
+++ b/examples/peripherals/i2c/i2c_self_test/main/i2c_example_main.c
@@ -281,7 +281,7 @@ static void i2c_test_task(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     print_mux = xSemaphoreCreateMutex();
     ESP_ERROR_CHECK(i2c_slave_init());

--- a/examples/peripherals/i2c/i2c_tools/main/i2ctools_example_main.c
+++ b/examples/peripherals/i2c/i2c_tools/main/i2ctools_example_main.c
@@ -110,7 +110,7 @@ static void initialize_console()
 #endif
 }
 
-void app_main()
+void app_main(void)
 {
     initialize_nvs();
 

--- a/examples/peripherals/i2s/main/i2s_example_main.c
+++ b/examples/peripherals/i2s/main/i2s_example_main.c
@@ -77,7 +77,7 @@ static void setup_triangle_sine_waves(int bits)
 
     free(samples_data);
 }
-void app_main()
+void app_main(void)
 {
     //for 36Khz sample rates, we create 100Hz sine wave, every cycle need 36000/100 = 360 samples (4-bytes or 8-bytes each sample)
     //depend on bits_per_sample

--- a/examples/peripherals/ledc/main/ledc_example_main.c
+++ b/examples/peripherals/ledc/main/ledc_example_main.c
@@ -51,7 +51,7 @@
 #define LEDC_TEST_DUTY         (4000)
 #define LEDC_TEST_FADE_TIME    (3000)
 
-void app_main()
+void app_main(void)
 {
     int ch;
 

--- a/examples/peripherals/mcpwm/mcpwm_basic_config/main/mcpwm_basic_config_example.c
+++ b/examples/peripherals/mcpwm/mcpwm_basic_config/main/mcpwm_basic_config_example.c
@@ -283,7 +283,7 @@ static void mcpwm_example_config(void *arg)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     printf("Testing MCPWM...\n");
     cap_queue = xQueueCreate(1, sizeof(capture)); //comment if you don't want to use capture module

--- a/examples/peripherals/mcpwm/mcpwm_bldc_control/main/mcpwm_bldc_control_hall_sensor_example.c
+++ b/examples/peripherals/mcpwm/mcpwm_bldc_control/main/mcpwm_bldc_control_hall_sensor_example.c
@@ -308,7 +308,7 @@ static void mcpwm_example_bldc_control(void *arg)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     printf("Testing MCPWM BLDC Control...\n");
 #if CHANGE_DUTY_CONTINUOUSLY

--- a/examples/peripherals/mcpwm/mcpwm_brushed_dc_control/main/mcpwm_brushed_dc_control_example.c
+++ b/examples/peripherals/mcpwm/mcpwm_brushed_dc_control/main/mcpwm_brushed_dc_control_example.c
@@ -89,7 +89,7 @@ static void mcpwm_example_brushed_motor_control(void *arg)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     printf("Testing brushed motor...\n");
     xTaskCreate(mcpwm_example_brushed_motor_control, "mcpwm_examlpe_brushed_motor_control", 4096, NULL, 5, NULL);

--- a/examples/peripherals/mcpwm/mcpwm_servo_control/main/mcpwm_servo_control_example.c
+++ b/examples/peripherals/mcpwm/mcpwm_servo_control/main/mcpwm_servo_control_example.c
@@ -71,7 +71,7 @@ void mcpwm_example_servo_control(void *arg)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     printf("Testing servo motor.......\n");
     xTaskCreate(mcpwm_example_servo_control, "mcpwm_example_servo_control", 4096, NULL, 5, NULL);

--- a/examples/peripherals/pcnt/main/pcnt_example_main.c
+++ b/examples/peripherals/pcnt/main/pcnt_example_main.c
@@ -168,7 +168,7 @@ static void pcnt_example_init(void)
     pcnt_counter_resume(PCNT_TEST_UNIT);
 }
 
-void app_main()
+void app_main(void)
 {
     /* Initialize LEDC to generate sample pulse signal */
     ledc_init();

--- a/examples/peripherals/rmt_nec_tx_rx/main/infrared_nec_main.c
+++ b/examples/peripherals/rmt_nec_tx_rx/main/infrared_nec_main.c
@@ -357,7 +357,7 @@ static void rmt_example_nec_tx_task()
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(rmt_example_nec_rx_task, "rmt_nec_rx_task", 2048, NULL, 10, NULL);
     xTaskCreate(rmt_example_nec_tx_task, "rmt_nec_tx_task", 2048, NULL, 10, NULL);

--- a/examples/peripherals/sdio/host/main/app_main.c
+++ b/examples/peripherals/sdio/host/main/app_main.c
@@ -316,7 +316,7 @@ void job_getint(esp_slave_context_t *context)
     slave_inform_job(context, JOB_SEND_INT);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_slave_context_t context;
     esp_err_t err;

--- a/examples/peripherals/sdio/slave/main/app_main.c
+++ b/examples/peripherals/sdio/slave/main/app_main.c
@@ -158,7 +158,7 @@ static void event_cb(uint8_t pos)
 DMA_ATTR uint8_t buffer[BUFFER_NUM][BUFFER_SIZE] = {};
 
 //Main application
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
 

--- a/examples/peripherals/sigmadelta/main/sigmadelta_example_main.c
+++ b/examples/peripherals/sigmadelta/main/sigmadelta_example_main.c
@@ -35,7 +35,7 @@ static void sigmadelta_example_init(void)
  *  Perform the sigma-delta modulation test
  *  by changing the duty of the output signal.
  */
-void app_main()
+void app_main(void)
 {
     sigmadelta_example_init();
 

--- a/examples/peripherals/spi_master/main/spi_master_example_main.c
+++ b/examples/peripherals/spi_master/main/spi_master_example_main.c
@@ -387,7 +387,7 @@ static void display_pretty_colors(spi_device_handle_t spi)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
     spi_device_handle_t spi;

--- a/examples/peripherals/spi_slave/receiver/main/app_main.c
+++ b/examples/peripherals/spi_slave/receiver/main/app_main.c
@@ -68,7 +68,7 @@ void my_post_trans_cb(spi_slave_transaction_t *trans) {
 }
 
 //Main application
-void app_main()
+void app_main(void)
 {
     int n=0;
     esp_err_t ret;

--- a/examples/peripherals/spi_slave/sender/main/app_main.c
+++ b/examples/peripherals/spi_slave/sender/main/app_main.c
@@ -82,7 +82,7 @@ static void IRAM_ATTR gpio_handshake_isr_handler(void* arg)
 }
 
 //Main application
-void app_main()
+void app_main(void)
 {
     esp_err_t ret;
     spi_device_handle_t handle;

--- a/examples/peripherals/timer_group/main/timer_group_example_main.c
+++ b/examples/peripherals/timer_group/main/timer_group_example_main.c
@@ -164,7 +164,7 @@ static void timer_example_evt_task(void *arg)
 /*
  * In this example, we will test hardware timer0 and timer1 of timer group0.
  */
-void app_main()
+void app_main(void)
 {
     timer_queue = xQueueCreate(10, sizeof(timer_event_t));
     example_tg0_timer_init(TIMER_0, TEST_WITHOUT_RELOAD, TIMER_INTERVAL0_SEC);

--- a/examples/peripherals/touch_pad_interrupt/main/tp_interrupt_main.c
+++ b/examples/peripherals/touch_pad_interrupt/main/tp_interrupt_main.c
@@ -145,7 +145,7 @@ static void tp_example_touch_pad_init()
     }
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize touch pad peripheral, it will start a timer to run a filter
     ESP_LOGI(TAG, "Initializing touch pad");

--- a/examples/peripherals/touch_pad_read/main/tp_read_main.c
+++ b/examples/peripherals/touch_pad_read/main/tp_read_main.c
@@ -52,7 +52,7 @@ static void tp_example_touch_pad_init()
     }
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize touch pad peripheral.
     // The default fsm mode is software trigger mode.

--- a/examples/peripherals/uart/nmea0183_parser/main/nmea_parser_example_main.c
+++ b/examples/peripherals/uart/nmea0183_parser/main/nmea_parser_example_main.c
@@ -52,7 +52,7 @@ static void gps_event_handler(void *event_handler_arg, esp_event_base_t event_ba
     }
 }
 
-void app_main()
+void app_main(void)
 {
     /* NMEA parser configuration */
     nmea_parser_config_t config = NMEA_PARSER_CONFIG_DEFAULT();

--- a/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
+++ b/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
@@ -67,7 +67,7 @@ static void rx_task()
     free(data);
 }
 
-void app_main()
+void app_main(void)
 {
     init();
     xTaskCreate(rx_task, "uart_rx_task", 1024*2, NULL, configMAX_PRIORITIES, NULL);

--- a/examples/peripherals/uart/uart_echo/main/uart_echo_example_main.c
+++ b/examples/peripherals/uart/uart_echo/main/uart_echo_example_main.c
@@ -56,7 +56,7 @@ static void echo_task()
     }
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(echo_task, "uart_echo_task", 1024, NULL, 10, NULL);
 }

--- a/examples/peripherals/uart/uart_echo_rs485/main/rs485_example.c
+++ b/examples/peripherals/uart/uart_echo_rs485/main/rs485_example.c
@@ -119,7 +119,7 @@ static void echo_task()
     }
 }
 
-void app_main()
+void app_main(void)
 {
     //A uart read/write example without event queue;
     xTaskCreate(echo_task, "uart_echo_task", ECHO_TASK_STACK_SIZE, NULL, ECHO_TASK_PRIO, NULL);

--- a/examples/peripherals/uart/uart_events/main/uart_events_example_main.c
+++ b/examples/peripherals/uart/uart_events/main/uart_events_example_main.c
@@ -117,7 +117,7 @@ static void uart_event_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_log_level_set(TAG, ESP_LOG_INFO);
 

--- a/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
+++ b/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
@@ -87,7 +87,7 @@ static void uart_select_task()
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(uart_select_task, "uart_select_task", 4*1024, NULL, 5, NULL);
 }

--- a/examples/protocols/aws_iot/subscribe_publish/main/subscribe_publish_sample.c
+++ b/examples/protocols/aws_iot/subscribe_publish/main/subscribe_publish_sample.c
@@ -317,7 +317,7 @@ static void initialise_wifi(void)
 }
 
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t err = nvs_flash_init();

--- a/examples/protocols/aws_iot/thing_shadow/main/thing_shadow_sample.c
+++ b/examples/protocols/aws_iot/thing_shadow/main/thing_shadow_sample.c
@@ -355,7 +355,7 @@ static void initialise_wifi(void)
 }
 
 
-void app_main()
+void app_main(void)
 {
     esp_err_t err = nvs_flash_init();
     if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/protocols/esp_http_client/main/esp_http_client_example.c
+++ b/examples/protocols/esp_http_client/main/esp_http_client_example.c
@@ -393,7 +393,7 @@ static void http_test_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/protocols/http2_request/main/http2_request_example_main.c
+++ b/examples/protocols/http2_request/main/http2_request_example_main.c
@@ -191,7 +191,7 @@ static void initialise_wifi(void)
     ESP_ERROR_CHECK( esp_wifi_start() );
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/http_request/main/http_request_example_main.c
+++ b/examples/protocols/http_request/main/http_request_example_main.c
@@ -184,7 +184,7 @@ static void http_get_task(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/http_server/advanced_tests/main/main.c
+++ b/examples/protocols/http_server/advanced_tests/main/main.c
@@ -74,7 +74,7 @@ static void initialise_wifi(void)
     ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
     initialise_wifi();

--- a/examples/protocols/http_server/persistent_sockets/main/main.c
+++ b/examples/protocols/http_server/persistent_sockets/main/main.c
@@ -244,7 +244,7 @@ static void initialise_wifi(void *arg)
     ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-void app_main()
+void app_main(void)
 {
     static httpd_handle_t server = NULL;
     ESP_ERROR_CHECK(nvs_flash_init());

--- a/examples/protocols/http_server/simple/main/main.c
+++ b/examples/protocols/http_server/simple/main/main.c
@@ -271,7 +271,7 @@ static void initialise_wifi(void *arg)
     ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-void app_main()
+void app_main(void)
 {
     static httpd_handle_t server = NULL;
     ESP_ERROR_CHECK(nvs_flash_init());

--- a/examples/protocols/https_mbedtls/main/https_mbedtls_example_main.c
+++ b/examples/protocols/https_mbedtls/main/https_mbedtls_example_main.c
@@ -333,7 +333,7 @@ static void https_get_task(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/https_request/main/https_request_example_main.c
+++ b/examples/protocols/https_request/main/https_request_example_main.c
@@ -209,7 +209,7 @@ static void https_get_task(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/https_server/main/main.c
+++ b/examples/protocols/https_server/main/main.c
@@ -142,7 +142,7 @@ static void initialise_wifi(void *arg)
     ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-void app_main()
+void app_main(void)
 {
     static httpd_handle_t server = NULL;
     ESP_ERROR_CHECK(nvs_flash_init());

--- a/examples/protocols/mdns/main/mdns_example_main.c
+++ b/examples/protocols/mdns/main/mdns_example_main.c
@@ -251,7 +251,7 @@ static void mdns_example_task(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_mdns();

--- a/examples/protocols/modbus_slave/main/freemodbus.c
+++ b/examples/protocols/modbus_slave/main/freemodbus.c
@@ -57,7 +57,7 @@ static void setup_reg_data()
 // See deviceparams.h file for more information about assigned Modbus parameters.
 // These parameters can be accessed from main application and also can be changed
 // by external Modbus master host.
-void app_main()
+void app_main(void)
 {
     mb_param_info_t reg_info; // keeps the Modbus registers access information
     mb_communication_info_t comm_info; // Modbus communication parameters

--- a/examples/protocols/mqtt/ssl/main/app_main.c
+++ b/examples/protocols/mqtt/ssl/main/app_main.c
@@ -129,7 +129,7 @@ static void mqtt_app_start(void)
     esp_mqtt_client_start(client);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "[APP] Startup..");
     ESP_LOGI(TAG, "[APP] Free memory: %d bytes", esp_get_free_heap_size());

--- a/examples/protocols/mqtt/ssl_mutual_auth/main/app_main.c
+++ b/examples/protocols/mqtt/ssl_mutual_auth/main/app_main.c
@@ -132,7 +132,7 @@ static void mqtt_app_start(void)
     esp_mqtt_client_start(client);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "[APP] Startup..");
     ESP_LOGI(TAG, "[APP] Free memory: %d bytes", esp_get_free_heap_size());

--- a/examples/protocols/mqtt/tcp/main/app_main.c
+++ b/examples/protocols/mqtt/tcp/main/app_main.c
@@ -152,7 +152,7 @@ static void mqtt_app_start(void)
     esp_mqtt_client_start(client);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "[APP] Startup..");
     ESP_LOGI(TAG, "[APP] Free memory: %d bytes", esp_get_free_heap_size());

--- a/examples/protocols/mqtt/ws/main/app_main.c
+++ b/examples/protocols/mqtt/ws/main/app_main.c
@@ -124,7 +124,7 @@ static void mqtt_app_start(void)
     esp_mqtt_client_start(client);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "[APP] Startup..");
     ESP_LOGI(TAG, "[APP] Free memory: %d bytes", esp_get_free_heap_size());

--- a/examples/protocols/mqtt/wss/main/app_main.c
+++ b/examples/protocols/mqtt/wss/main/app_main.c
@@ -129,7 +129,7 @@ static void mqtt_app_start(void)
     esp_mqtt_client_start(client);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "[APP] Startup..");
     ESP_LOGI(TAG, "[APP] Free memory: %d bytes", esp_get_free_heap_size());

--- a/examples/protocols/pppos_client/main/pppos_client_main.c
+++ b/examples/protocols/pppos_client/main/pppos_client_main.c
@@ -289,7 +289,7 @@ static void pppos_client_task()
     }
 }
 
-void app_main()
+void app_main(void)
 {
     tcpip_adapter_init();
     xTaskCreate(&pppos_client_task, "pppos_client_task", 2048, NULL, 5, NULL);

--- a/examples/protocols/sntp/main/sntp_example_main.c
+++ b/examples/protocols/sntp/main/sntp_example_main.c
@@ -54,7 +54,7 @@ static void initialise_wifi(void);
 static esp_err_t event_handler(void *ctx, system_event_t *event);
 
 
-void app_main()
+void app_main(void)
 {
     ++boot_count;
     ESP_LOGI(TAG, "Boot count: %d", boot_count);

--- a/examples/protocols/sockets/tcp_client/main/tcp_client.c
+++ b/examples/protocols/sockets/tcp_client/main/tcp_client.c
@@ -182,7 +182,7 @@ static void tcp_client_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/sockets/tcp_server/main/tcp_server.c
+++ b/examples/protocols/sockets/tcp_server/main/tcp_server.c
@@ -202,7 +202,7 @@ static void tcp_server_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/sockets/udp_client/main/udp_client.c
+++ b/examples/protocols/sockets/udp_client/main/udp_client.c
@@ -181,7 +181,7 @@ static void udp_client_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/sockets/udp_multicast/main/udp_multicast_example_main.c
+++ b/examples/protocols/sockets/udp_multicast/main/udp_multicast_example_main.c
@@ -545,7 +545,7 @@ static void mcast_example_task(void *pvParameters)
 
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/protocols/sockets/udp_server/main/udp_server.c
+++ b/examples/protocols/sockets/udp_server/main/udp_server.c
@@ -185,7 +185,7 @@ static void udp_server_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/provisioning/ble_prov/main/app_main.c
+++ b/examples/provisioning/ble_prov/main/app_main.c
@@ -69,7 +69,7 @@ static void wifi_init_sta()
     ESP_ERROR_CHECK(esp_wifi_start() );
 }
 
-void app_main()
+void app_main(void)
 {
     /* Security version */
     int security = 0;

--- a/examples/provisioning/console_prov/main/app_main.c
+++ b/examples/provisioning/console_prov/main/app_main.c
@@ -69,7 +69,7 @@ static void wifi_init_sta()
     ESP_ERROR_CHECK(esp_wifi_start() );
 }
 
-void app_main()
+void app_main(void)
 {
     /* Security version */
     int security = 0;

--- a/examples/provisioning/custom_config/main/app_main.c
+++ b/examples/provisioning/custom_config/main/app_main.c
@@ -69,7 +69,7 @@ static void wifi_init_sta()
     ESP_ERROR_CHECK(esp_wifi_start() );
 }
 
-void app_main()
+void app_main(void)
 {
     /* Security version */
     int security = 0;

--- a/examples/provisioning/softap_prov/main/app_main.c
+++ b/examples/provisioning/softap_prov/main/app_main.c
@@ -69,7 +69,7 @@ static void wifi_init_sta()
     ESP_ERROR_CHECK(esp_wifi_start() );
 }
 
-void app_main()
+void app_main(void)
 {
     /* Security version */
     int security = 0;

--- a/examples/storage/nvs_rw_blob/main/nvs_blob_example_main.c
+++ b/examples/storage/nvs_rw_blob/main/nvs_blob_example_main.c
@@ -150,7 +150,7 @@ esp_err_t print_what_saved(void)
 }
 
 
-void app_main()
+void app_main(void)
 {
     esp_err_t err = nvs_flash_init();
     if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/examples/storage/nvs_rw_value/main/nvs_value_example_main.c
+++ b/examples/storage/nvs_rw_value/main/nvs_value_example_main.c
@@ -16,7 +16,7 @@
 #include "nvs_flash.h"
 #include "nvs.h"
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS
     esp_err_t err = nvs_flash_init();

--- a/examples/system/app_trace_to_host/main/app_trace_to_host_test.c
+++ b/examples/system/app_trace_to_host/main/app_trace_to_host_test.c
@@ -134,7 +134,7 @@ void test_task(void *arg)
 }
 
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(test_task, "test_task", 1024 * 3, NULL, 10, NULL);
 }

--- a/examples/system/base_mac_address/main/base_mac_address_example_main.c
+++ b/examples/system/base_mac_address/main/base_mac_address_example_main.c
@@ -30,7 +30,7 @@ static esp_err_t external_storage_mac_get(uint8_t *mac)
 }
 #endif//CONFIG_BASE_MAC_STORED_OTHER_EXTERNAL_STORAGE
 
-void app_main()
+void app_main(void)
 {
 #if defined(CONFIG_BASE_MAC_STORED_EFUSE_BLK3) || defined(CONFIG_BASE_MAC_STORED_OTHER_EXTERNAL_STORAGE)
     uint8_t mac_addr[8] = {0};

--- a/examples/system/console/main/console_example_main.c
+++ b/examples/system/console/main/console_example_main.c
@@ -116,7 +116,7 @@ static void initialize_console()
 #endif
 }
 
-void app_main()
+void app_main(void)
 {
     initialize_nvs();
 

--- a/examples/system/deep_sleep/main/deep_sleep_example_main.c
+++ b/examples/system/deep_sleep/main/deep_sleep_example_main.c
@@ -77,7 +77,7 @@ static inline void ulp_data_write(size_t offset, uint16_t value)
 static void calibrate_touch_pad(touch_pad_t pad);
 #endif
 
-void app_main()
+void app_main(void)
 {
     struct timeval now;
     gettimeofday(&now, NULL);

--- a/examples/system/esp_timer/main/esp_timer_example_main.c
+++ b/examples/system/esp_timer/main/esp_timer_example_main.c
@@ -20,7 +20,7 @@ static void oneshot_timer_callback(void* arg);
 
 static const char* TAG = "example";
 
-void app_main()
+void app_main(void)
 {
     /* Create two timers:
      * 1. a periodic timer which will run every 0.5s, and print a message

--- a/examples/system/gcov/main/gcov_example.c
+++ b/examples/system/gcov/main/gcov_example.c
@@ -52,7 +52,7 @@ static void blink_task(void *pvParameter)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(&blink_task, "blink_task", configMINIMAL_STACK_SIZE, NULL, 5, NULL);
 }

--- a/examples/system/himem/main/himem_test_main.c
+++ b/examples/system/himem/main/himem_test_main.c
@@ -87,7 +87,7 @@ static bool test_region(int check_size, int seed)
 }
 
 
-void app_main()
+void app_main(void)
 {
     size_t memcnt=esp_himem_get_phys_size();
     size_t memfree=esp_himem_get_free_size();

--- a/examples/system/light_sleep/main/light_sleep_example_main.c
+++ b/examples/system/light_sleep/main/light_sleep_example_main.c
@@ -27,7 +27,7 @@
 /* "Boot" button on GPIO0 is active low */
 #define BUTTON_WAKEUP_LEVEL_DEFAULT     0
 
-void app_main()
+void app_main(void)
 {
     /* Configure the button GPIO as input, enable wakeup */
     const int button_gpio_num = BUTTON_GPIO_NUM_DEFAULT;

--- a/examples/system/ota/native_ota_example/main/native_ota_example.c
+++ b/examples/system/ota/native_ota_example/main/native_ota_example.c
@@ -260,7 +260,7 @@ static void ota_example_task(void *pvParameter)
     return ;
 }
 
-void app_main()
+void app_main(void)
 {
     uint8_t sha_256[HASH_LEN] = { 0 };
     esp_partition_t partition;

--- a/examples/system/ota/otatool/main/otatool_main.c
+++ b/examples/system/ota/otatool/main/otatool_main.c
@@ -13,7 +13,7 @@
 
 static const char *TAG = "example";
 
-void app_main()
+void app_main(void)
 {
     ESP_LOGI(TAG, "OTA Tool Example");
 

--- a/examples/system/ota/simple_ota_example/main/simple_ota_example.c
+++ b/examples/system/ota/simple_ota_example/main/simple_ota_example.c
@@ -129,7 +129,7 @@ void simple_ota_example_task(void * pvParameter)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS.
     esp_err_t err = nvs_flash_init();

--- a/examples/system/select/main/select_example.c
+++ b/examples/system/select/main/select_example.c
@@ -198,7 +198,7 @@ static void select_task(void *param)
     vTaskDelete(NULL);
 }
 
-void app_main()
+void app_main(void)
 {
     xTaskCreate(uart1_write_task, "uart1_write_task", 4*1024, NULL, 5, NULL);
     xTaskCreate(socket_write_task, "socket_write_task", 4*1024, NULL, 5, NULL);

--- a/examples/system/sysview_tracing/main/sysview_tracing.c
+++ b/examples/system/sysview_tracing/main/sysview_tracing.c
@@ -181,7 +181,7 @@ static void example_task(void *p)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     static example_event_data_t event_data[portNUM_PROCESSORS] = {
         {

--- a/examples/system/task_watchdog/main/task_watchdog_example_main.c
+++ b/examples/system/task_watchdog/main/task_watchdog_example_main.c
@@ -42,7 +42,7 @@ void reset_task(void *arg)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     printf("Initialize TWDT\n");
     //Initialize or reinitialize TWDT

--- a/examples/system/ulp/main/ulp_example_main.c
+++ b/examples/system/ulp/main/ulp_example_main.c
@@ -25,7 +25,7 @@ extern const uint8_t ulp_main_bin_end[]   asm("_binary_ulp_main_bin_end");
 static void init_ulp_program();
 static void update_pulse_count();
 
-void app_main()
+void app_main(void)
 {
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
     if (cause != ESP_SLEEP_WAKEUP_ULP) {

--- a/examples/system/ulp_adc/main/ulp_adc_example_main.c
+++ b/examples/system/ulp_adc/main/ulp_adc_example_main.c
@@ -34,7 +34,7 @@ static void init_ulp_program();
  */
 static void start_ulp_program();
 
-void app_main()
+void app_main(void)
 {
     esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
     if (cause != ESP_SLEEP_WAKEUP_ULP) {

--- a/examples/system/unit_test/test/main/example_unit_test_test.c
+++ b/examples/system/unit_test/test/main/example_unit_test_test.c
@@ -13,7 +13,7 @@
 
 static void print_banner(const char* text);
 
-void app_main()
+void app_main(void)
 {
     /* These are the different ways of running registered tests.
      * In practice, only one of them is usually needed.

--- a/examples/wifi/espnow/main/espnow_example_main.c
+++ b/examples/wifi/espnow/main/espnow_example_main.c
@@ -373,7 +373,7 @@ static void example_espnow_deinit(example_espnow_send_param_t *send_param)
     esp_now_deinit();
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS
     esp_err_t ret = nvs_flash_init();

--- a/examples/wifi/getting_started/softAP/main/softap_example_main.c
+++ b/examples/wifi/getting_started/softAP/main/softap_example_main.c
@@ -82,7 +82,7 @@ void wifi_init_softap()
              EXAMPLE_ESP_WIFI_SSID, EXAMPLE_ESP_WIFI_PASS);
 }
 
-void app_main()
+void app_main(void)
 {
     //Initialize NVS
     esp_err_t ret = nvs_flash_init();

--- a/examples/wifi/getting_started/station/main/station_example_main.c
+++ b/examples/wifi/getting_started/station/main/station_example_main.c
@@ -93,7 +93,7 @@ void wifi_init_sta()
              EXAMPLE_ESP_WIFI_SSID, EXAMPLE_ESP_WIFI_PASS);
 }
 
-void app_main()
+void app_main(void)
 {
     //Initialize NVS
     esp_err_t ret = nvs_flash_init();

--- a/examples/wifi/power_save/main/power_save.c
+++ b/examples/wifi/power_save/main/power_save.c
@@ -85,7 +85,7 @@ static void wifi_power_save(void)
     esp_wifi_set_ps(DEFAULT_PS_MODE);
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS
     esp_err_t ret = nvs_flash_init();

--- a/examples/wifi/scan/main/scan.c
+++ b/examples/wifi/scan/main/scan.c
@@ -113,7 +113,7 @@ static void wifi_scan(void)
     ESP_ERROR_CHECK(esp_wifi_start());
 }
 
-void app_main()
+void app_main(void)
 {
     // Initialize NVS
     esp_err_t ret = nvs_flash_init();

--- a/examples/wifi/smart_config/main/smartconfig_main.c
+++ b/examples/wifi/smart_config/main/smartconfig_main.c
@@ -118,7 +118,7 @@ void smartconfig_example_task(void * parm)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/wifi/wpa2_enterprise/main/wpa2_enterprise_main.c
+++ b/examples/wifi/wpa2_enterprise/main/wpa2_enterprise_main.c
@@ -148,7 +148,7 @@ static void wpa2_enterprise_example_task(void *pvParameters)
     }
 }
 
-void app_main()
+void app_main(void)
 {
     ESP_ERROR_CHECK( nvs_flash_init() );
     initialise_wifi();

--- a/examples/wifi/wps/main/wps.c
+++ b/examples/wifi/wps/main/wps.c
@@ -108,7 +108,7 @@ static void start_wps(void)
     ESP_ERROR_CHECK(esp_wifi_wps_start(0));
 }
 
-void app_main()
+void app_main(void)
 {
     /* Initialize NVS — it is used to store PHY calibration data */
     esp_err_t ret = nvs_flash_init();

--- a/make/project.mk
+++ b/make/project.mk
@@ -355,7 +355,7 @@ CFLAGS := $(strip \
 	-std=gnu99 \
 	$(OPTIMIZATION_FLAGS) $(DEBUG_FLAGS) \
 	$(COMMON_FLAGS) \
-	$(COMMON_WARNING_FLAGS) -Wno-old-style-declaration \
+	$(COMMON_WARNING_FLAGS) -Wno-old-style-declaration -Wstrict-prototypes \
 	$(CFLAGS) \
 	$(EXTRA_CFLAGS))
 


### PR DESCRIPTION
While in C++ `()` is the same as `(void)`, in C it's not and can be quite dangerous.