### PR TITLE
docs(en): "Adding user to dialout on Linux" added specific command for Arch linux

### DIFF
--- a/docs/en/get-started-cmake/establish-serial-connection.rst
+++ b/docs/en/get-started-cmake/establish-serial-connection.rst
@@ -67,6 +67,10 @@ The currently logged user should have read and write access the serial port over
 
     sudo usermod -a -G dialout $USER
 
+on Arch linux instead this is done by adding the user to ``uucp`` group with the following command::
+
+    sudo usermod -a -G uucp $USER
+
 Make sure you re-login to enable read and write permissions for the serial port. 
 
 

--- a/docs/en/get-started/establish-serial-connection.rst
+++ b/docs/en/get-started/establish-serial-connection.rst
@@ -82,6 +82,10 @@ The currently logged user should have read and write access the serial port over
 
     sudo usermod -a -G dialout $USER
 
+on Arch linux instead this is done by adding the user to ``uucp`` group with the following command::
+
+    sudo usermod -a -G uucp $USER
+
 Make sure you re-login to enable read and write permissions for the serial port. 
 
 


### PR DESCRIPTION
Improvement of English docs, added specific command for arch linux where `dialout` group doesn't exist (by default) and `/dev/ttyUSB0` is managed by `uucp` group.