### PR TITLE
corrected '$PATH' export order in docs (en)

### DIFF
--- a/docs/en/get-started-cmake/add-idf_path-to-profile.rst
+++ b/docs/en/get-started-cmake/add-idf_path-to-profile.rst
@@ -43,7 +43,7 @@ Linux and MacOS
 Set up ``IDF_PATH`` and add ``idf.py`` to the PATH by adding the following two lines to your ``~/.profile`` file::
 
     export IDF_PATH=~/esp/esp-idf
-    export PATH="$IDF_PATH/tools:$PATH"
+    export PATH="$PATH:$IDF_PATH/tools"
 
 .. note::
 
@@ -70,6 +70,6 @@ A path like ``${IDF_PATH}/tools/idf.py`` should be printed.
 If you do not like to have ``IDF_PATH`` or ``PATH`` modifications set, you can enter it manually in terminal window on each restart or logout::
 
     export IDF_PATH=~/esp/esp-idf
-    export PATH="$IDF_PATH/tools:$PATH"
+    export PATH="$PATH:$IDF_PATH/tools"
 
 If you got here from section :ref:`get-started-setup-path-cmake`, while installing s/w for ESP32 development, then go back to section :ref:`get-started-start-project-cmake`.

--- a/docs/en/get-started-cmake/macos-setup.rst
+++ b/docs/en/get-started-cmake/macos-setup.rst
@@ -59,11 +59,11 @@ The toolchain will be extracted into ``~/esp/xtensa-esp32-elf/`` directory.
 
 To use it, you will need to update your ``PATH`` environment variable in ``~/.profile`` file. To make ``xtensa-esp32-elf`` available for all terminal sessions, add the following line to your ``~/.profile`` file::
 
-    export PATH=$HOME/esp/xtensa-esp32-elf/bin:$PATH
+    export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin
 
 Alternatively, you may create an alias for the above command. This way you can get the toolchain only when you need it. To do this, add different line to your ``~/.profile`` file::
 
-    alias get_esp32="export PATH=$HOME/esp/xtensa-esp32-elf/bin:$PATH"
+    alias get_esp32="export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin"
 
 Then when you need the toolchain you can type ``get_esp32`` on the command line and the toolchain will be added to your ``PATH``.
 

--- a/docs/en/get-started/linux-setup.rst
+++ b/docs/en/get-started/linux-setup.rst
@@ -55,11 +55,11 @@ ESP32 toolchain for Linux is available for download from Espressif website:
 
     To use it, you will need to update your ``PATH`` environment variable in ``~/.profile`` file. To make ``xtensa-esp32-elf`` available for all terminal sessions, add the following line to your ``~/.profile`` file::
 
-        export PATH="$HOME/esp/xtensa-esp32-elf/bin:$PATH"
+        export PATH="$PATH:$HOME/esp/xtensa-esp32-elf/bin"
 
     Alternatively, you may create an alias for the above command. This way you can get the toolchain only when you need it. To do this, add different line to your ``~/.profile`` file::
 
-        alias get_esp32='export PATH="$HOME/esp/xtensa-esp32-elf/bin:$PATH"'
+        alias get_esp32='export PATH="$PATH:$HOME/esp/xtensa-esp32-elf/bin"'
 
     Then when you need the toolchain you can type ``get_esp32`` on the command line and the toolchain will be added to your ``PATH``.
 

--- a/docs/en/get-started/macos-setup.rst
+++ b/docs/en/get-started/macos-setup.rst
@@ -33,11 +33,11 @@ The toolchain will be extracted into ``~/esp/xtensa-esp32-elf/`` directory.
 
 To use it, you will need to update your ``PATH`` environment variable in ``~/.profile`` file. To make ``xtensa-esp32-elf`` available for all terminal sessions, add the following line to your ``~/.profile`` file::
 
-    export PATH=$HOME/esp/xtensa-esp32-elf/bin:$PATH
+    export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin
 
 Alternatively, you may create an alias for the above command. This way you can get the toolchain only when you need it. To do this, add different line to your ``~/.profile`` file::
 
-    alias get_esp32="export PATH=$HOME/esp/xtensa-esp32-elf/bin:$PATH"
+    alias get_esp32="export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin"
 
 Then when you need the toolchain you can type ``get_esp32`` on the command line and the toolchain will be added to your ``PATH``.
 


### PR DESCRIPTION
fixed order of '$PATH' export. xtensa-esp32-elf/bin was added at beginning of '$PATH' instead of end (which the docs later suggested to check w/ printenv