### PR TITLE
Fix log tag comparison when using variable tags (such as non-literals). (IDFGH-897)

### DIFF
--- a/components/log/log.c
+++ b/components/log/log.c
@@ -164,7 +164,7 @@ void esp_log_level_set(const char* tag, esp_log_level_t level)
 #ifdef LOG_BUILTIN_CHECKS
         assert(i == 0 || s_log_cache[(i - 1) / 2].generation < s_log_cache[i].generation);
 #endif
-        if (s_log_cache[i].tag == tag) {
+        if (strcmp(s_log_cache[i].tag, tag) == 0) {
             s_log_cache[i].level = level;
             break;
         }


### PR DESCRIPTION
Setting a log level by tag does not work when the tag is provided as a variable (rather than a literal string). This is because there is an incorrect equality performed in `esp_log_level_set()`. A copy of the tag is made but the contents of this copy is not compared - instead the tag _pointers_ are compared, which does not work for non-literal tags.

Refer to this forum post: https://www.esp32.com/viewtopic.php?f=13&t=9004