### PR TITLE
Compilation error fix: invalid conversion

### DIFF
--- a/components/wpa_supplicant/src/wpa2/utils/base64.c
+++ b/components/wpa_supplicant/src/wpa2/utils/base64.c
@@ -39,7 +39,7 @@ unsigned char * base64_encode(const unsigned char *src, size_t len,
 	olen++; /* nul termination */
 	if (olen < len)
 		return NULL; /* integer overflow */
-	out = os_malloc(olen);
+	out = (unsigned char*)os_malloc(olen);
 	if (out == NULL)
 		return NULL;
 
@@ -116,7 +116,7 @@ unsigned char * base64_decode(const unsigned char *src, size_t len,
 		return NULL;
 
 	olen = count / 4 * 3;
-	pos = out = os_malloc(olen);
+	pos = out = (unsigned char*)os_malloc(olen);
 	if (out == NULL)
 		return NULL;
 


### PR DESCRIPTION
```
base64.cpp:42:6: error: invalid conversion from 'void*' to 'unsigned char*' [-fpermissive]
base64.cpp:119:12: error: invalid conversion from 'void*' to 'unsigned char*' [-fpermissive]
```