### PR TITLE
pm: Fix atomicity of rtos idle lock acquiring (IDFGH-876)

### DIFF
--- a/components/esp32/pm_esp32.c
+++ b/components/esp32/pm_esp32.c
@@ -434,11 +434,13 @@ static void IRAM_ATTR update_ccompare()
 static void IRAM_ATTR leave_idle()
 {
     int core_id = xPortGetCoreID();
+    uint32_t state = portENTER_CRITICAL_NESTED();
     if (s_core_idle[core_id]) {
         // TODO: possible optimization: raise frequency here first
         esp_pm_lock_acquire(s_rtos_lock_handle[core_id]);
         s_core_idle[core_id] = false;
     }
+    portEXIT_CRITICAL_NESTED(state);
 }
 
 void esp_pm_impl_idle_hook()


### PR DESCRIPTION
It's possible for esp_pm_impl_isr_hook(...) to be nested due to the fact
that interrupts are nested on the ESP32.  To fix this we need to place the
acquiring of the lock into a critical section to ensure it does not get
nested on the system, otherwise the system will never release the idle
lock when this occurs and will not go into lower power states.

A sample backtrace encountering this (the code was instrumented to go into
a while(1) loop when the condition was hit to get this backtrace) from
commit d7a7a683:

    #0  leave_idle () at esp-idf/components/esp32/pm_esp32.c:444
    #1  0x4008143a in esp_pm_impl_isr_hook () at esp-idf/components/esp32/pm_esp32.c:473
    #2  0x40082750 in _xt_medint2 () at esp-idf/components/freertos/xtensa_vectors.S:1243
    #3  0x4000bff0 in ?? ()
    #4  0x40090bb0 in vTaskExitCritical (mux=0x3ffbd230) at esp-idf/components/freertos/tasks.c:4304
    #5  0x40081758 in esp_pm_lock_acquire (handle=0x3ffbd218) at esp-idf/components/esp32/pm_locks.c:126
    #6  0x40081399 in leave_idle () at esp-idf/components/esp32/pm_esp32.c:440
    #7  0x4008143a in esp_pm_impl_isr_hook () at esp-idf/components/esp32/pm_esp32.c:473
    #8  0x400826b8 in _xt_lowint1 () at esp-idf/components/freertos/xtensa_vectors.S:1154
    #9  0x400d14b0 in esp_pm_impl_waiti () at esp-idf/components/esp32/pm_esp32.c:483
    #10 0x400d2c77 in esp_vApplicationIdleHook () at esp-idf/components/esp32/freertos_hooks.c:63
    #11 0x40091008 in prvIdleTask (pvParameters=0x0) at esp-idf/components/freertos/tasks.c:3412
    #12 0x40090344 in vPortTaskWrapper (pxCode=0x40090ffc <prvIdleTask>, pvParameters=0x0) at esp-idf/components/freertos/port.c:143

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>