### PR TITLE
lwip: enable ipv6 dns server retrieval from ndp (IDFGH-1769)

### DIFF
--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -640,6 +640,13 @@
  */
 #define LWIP_IPV6                       1
 
+/**
+ * LWIP_ND6_RDNSS_MAX_DNS_SERVERS: Allow IPv6 DNS servers to be retrieved from
+ * NDP, up to the maximum number of allowed DNS servers (minus fallback slot)
+ */
+#define LWIP_ND6_RDNSS_MAX_DNS_SERVERS  (DNS_MAX_SERVERS - 1)
+
+
 /*
    ---------------------------------------
    ---------- Hook options ---------------


### PR DESCRIPTION
Combined with https://github.com/espressif/esp-lwip/pull/5, enables IPv6 DNS server address retrieval from Router Advertisements in NDP. Macro was missing from settings in port header file to enable this feature, so networks only supporting IPv6 (without DHCPv6 which doesnt seem supported yet in lwip used by ESP IDF) or only with IPv6 DNS servers can now be used as the DNS servers for lookups. Previously, IPv4 address was needed (and dhcp returns good DNS servers) to actually do a DNS lookup while all other network traffic was using IPv6.