### PR TITLE
Easier use of -Wsign-conversion warnings needs changes in ESP-IDF (IDFGH-849)

### DIFF
--- a/components/driver/include/driver/gpio.h
+++ b/components/driver/include/driver/gpio.h
@@ -128,6 +128,7 @@ extern "C" {
 #define GPIO_IS_VALID_OUTPUT_GPIO(gpio_num)      ((GPIO_IS_VALID_GPIO(gpio_num)) && (gpio_num < 34))         /*!< Check whether it can be a valid GPIO number of output mode */
 
 typedef enum {
+    GPIO_NUM_NC = -1,    /*!< Use to signal not connected to S/W */
     GPIO_NUM_0 = 0,     /*!< GPIO0, input and output */
     GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
     GPIO_NUM_2 = 2,     /*!< GPIO2, input and output

--- a/components/freertos/include/freertos/portable.h
+++ b/components/freertos/include/freertos/portable.h
@@ -209,7 +209,7 @@ static inline uint32_t IRAM_ATTR xPortGetCoreID() {
         "rsr.prid %0\n"
         " extui %0,%0,13,1"
         :"=r"(id));
-    return id;
+    return (uint32_t)id;
 }
 
 /* Get tick rate per second */


### PR DESCRIPTION
I've enabled -Wsign-conversion and -Wconversion when compiling and stumbled upon these two required changes.

GPIO_NUM_NC is, as the comment indicates, to specify a not connected pin. I'm sure I've seen -1 used for this in other IDF-code too so lets give it a proper enum value, also removing the warning that -1 isn't a valid gpio_num_t value.

The cast in xPortGetCoreID() can perhaps be improved by defining `id` as uint32_t directly - I can't read the ASM so I can't tell if doing that would change anything.

I'm creating this as a PR-draft for now, might be more things that need changing too.