### PR TITLE
transport_ws: Stop connecting when the parent's connect call has failed (IDFGH-896)

### DIFF
--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -81,6 +81,7 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
     transport_ws_t *ws = esp_transport_get_context_data(t);
     if (esp_transport_connect(ws->parent, host, port, timeout_ms) < 0) {
         ESP_LOGE(TAG, "Error connect to ther server");
+        return -1;
     }
 
     unsigned char random_key[16];


### PR DESCRIPTION
Fixes the issue where the websocket protocol tries to send data over a closed connection, resulting in crashes like the one below:

```
E (2806) esp-tls: Failed to connnect to host (errno 104)
E (2816) esp-tls: Failed to open new connection
E (2816) TRANS_SSL: Failed to open a new connection
E (2816) TRANSPORT_WS: Error connect to ther server

Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.
Core 0 register dump:
PC      : 0x400fa6ac  PS      : 0x00060930  A0      : 0x8015b314  A1      : 0x3ffd0700
0x400fa6ac: ssl_poll_write at /mnt/c/Projects/esp-idf/components/tcp_transport/transport_ssl.c:97

A2      : 0x3ffccfcc  A3      : 0x00002710  A4      : 0x3ffcd161  A5      : 0x00000000
A6      : 0x0000000c  A7      : 0xff000000  A8      : 0x00000600  A9      : 0x3ffd0708
A10     : 0x00000000  A11     : 0x00000004  A12     : 0x3ffd0644  A13     : 0x3ffae914
A14     : 0x00000000  A15     : 0x00000000  SAR     : 0x00000004  EXCCAUSE: 0x0000001c
EXCVADDR: 0x000006cc  LBEG    : 0x400014fd  LEND    : 0x4000150d  LCOUNT  : 0xfffffff9

Backtrace: 0x400fa6ac:0x3ffd0700 0x4015b311:0x3ffd0730 0x400fa770:0x3ffd0750 0x4015b2d9:0x3ffd0780 0x400fa3bd:0x3ffd07a0 0x4015b299:0x3ffd08a0 0x400e6edb:0x3ffd08c0 0x4008e3fd:0x3ffd08e0
0x400fa6ac: ssl_poll_write at /mnt/c/Projects/esp-idf/components/tcp_transport/transport_ssl.c:97
0x4015b311: esp_transport_poll_write at /mnt/c/Projects/esp-idf/components/tcp_transport/transport.c:192
0x400fa770: ssl_write at /mnt/c/Projects/esp-idf/components/tcp_transport/transport_ssl.c:108
0x4015b2d9: esp_transport_write at /mnt/c/Projects/esp-idf/components/tcp_transport/transport.c:176
0x400fa3bd: ws_connect at /mnt/c/Projects/esp-idf/components/tcp_transport/transport_ws.c:112
0x4015b299: esp_transport_connect at /mnt/c/Projects/esp-idf/components/tcp_transport/transport.c:163
0x400e6edb: esp_mqtt_task at /mnt/c/Projects/esp-idf/components/mqtt/esp-mqtt/mqtt_client.c:951
0x4008e3fd: vPortTaskWrapper at /mnt/c/Projects/esp-idf/components/freertos/port.c:403
```