### PR TITLE
Use /usr/bin/env bash for portability (IDFGH-708)

### DIFF
--- a/components/esp32/ld/elf_to_ld.sh
+++ b/components/esp32/ld/elf_to_ld.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo '/*'
 echo 'ESP32 ROM address table'

--- a/components/espcoredump/test/test_espcoredump.sh
+++ b/components/espcoredump/test/test_espcoredump.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 if [ "$(xtensa-esp32-elf-gcc -dumpversion)" = "5.2.0" ]; then
     EXPECTED_OUTPUT="expected_output"

--- a/components/heap/test_multi_heap_host/test_all_configs.sh
+++ b/components/heap/test_multi_heap_host/test_all_configs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run the test suite with all configurations enabled
 #

--- a/docs/check_doc_warnings.sh
+++ b/docs/check_doc_warnings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Check for Documentation warnings:
 # doxygen-warning-log.txt should be an empty file

--- a/docs/check_lang_folder_sync.sh
+++ b/docs/check_lang_folder_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Check if folders with localized documentation are in sync
 #

--- a/examples/build_system/cmake/idf_as_lib/build.sh
+++ b/examples/build_system/cmake/idf_as_lib/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build this example, which does not use that standard IDF app template. See README.md for
 # more information about the build and how to run this example on the target once built.

--- a/tools/ci/build_examples.sh
+++ b/tools/ci/build_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build all examples from the examples directory, out of tree to
 # ensure they can run when copied to a new directory.

--- a/tools/ci/build_examples_cmake.sh
+++ b/tools/ci/build_examples_cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build all examples from the examples directory, out of tree to
 # ensure they can run when copied to a new directory.

--- a/tools/ci/check-executable.sh
+++ b/tools/ci/check-executable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script finds executable files in the repository, excluding some directories,
 # then prints the list of all files which are not in executable-list.txt.
 # Returns with error if this list is non-empty.

--- a/tools/ci/check_examples_cmake_make.sh
+++ b/tools/ci/check_examples_cmake_make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # While we support GNU Make & CMake together, check the same examples are present for both
 

--- a/tools/ci/check_ut_cmake_make.sh
+++ b/tools/ci/check_ut_cmake_make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # While we support GNU Make & CMake together, check that unit tests support both
 CMAKE_UT_PATHS=$( find ${IDF_PATH}/components/ -type f -name CMakeLists.txt | grep "/test/" | grep -v "mbedtls/programs")

--- a/tools/ci/get-full-sources.sh
+++ b/tools/ci/get-full-sources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Short script that is run as part of the CI environment
 # in .gitlab-ci.yml

--- a/tools/ci/mirror-submodule-update.sh
+++ b/tools/ci/mirror-submodule-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Redirects git submodules to the specified local mirrors and updates these recursively.
 #

--- a/tools/ci/mirror-synchronize.sh
+++ b/tools/ci/mirror-synchronize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script for automate mirroring
 # You can run this script manually

--- a/tools/ci/multirun_with_pyenv.sh
+++ b/tools/ci/multirun_with_pyenv.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # Tool for running scripts with several versions of Python by the use of pyenv (versions must be installed before in
 # the docker image)

--- a/tools/ci/push_to_github.sh
+++ b/tools/ci/push_to_github.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # gitlab-ci script to push current tested revision (tag or branch) to github
 

--- a/tools/ci/setup_python.sh
+++ b/tools/ci/setup_python.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # Regexp for matching job names which are incompatible with Python 3
 # - assign_test, nvs_compatible_test, IT - auto_test_script causes the incompatibility

--- a/tools/ci/test_build_system.sh
+++ b/tools/ci/test_build_system.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test the build system for basic consistency
 #

--- a/tools/ci/test_build_system_cmake.sh
+++ b/tools/ci/test_build_system_cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test the build system for basic consistency (Cmake/idf.py version)
 #

--- a/tools/ci/test_configure_ci_environment.sh
+++ b/tools/ci/test_configure_ci_environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Short script to verify behaviour of configure_ci_environment.sh
 #

--- a/tools/cmake/run_cmake_lint.sh
+++ b/tools/cmake/run_cmake_lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run cmakelint on all cmake files in IDF_PATH (except third party)
 #

--- a/tools/format-minimal.sh
+++ b/tools/format-minimal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Runs astyle with parameters which should be checked in a pre-commit hook
 astyle \
 	--style=otbs \

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Runs astyle with the full set of formatting options
 astyle \
 	--style=otbs \

--- a/tools/kconfig/lxdialog/check-lxdialog.sh
+++ b/tools/kconfig/lxdialog/check-lxdialog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check ncurses compatibility
 
 # What library to link

--- a/tools/test_idf_size/test.sh
+++ b/tools/test_idf_size/test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 { coverage debug sys \
     && coverage erase &> output \

--- a/tools/windows/eclipse_make.sh
+++ b/tools/windows/eclipse_make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "eclipse_make.sh has been replaced with eclipse_make.py. Check the Windows Eclipse docs for the new command."
 echo "This shell script will continue to work until the next major release."
 python ${IDF_PATH}/tools/windows/eclipse_make.py $@

--- a/tools/windows/tool_setup/build_installer.sh
+++ b/tools/windows/tool_setup/build_installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Setup script to build Windows tool installer with Inno Setup
 #

--- a/tools/windows/windows_install_prerequisites.sh
+++ b/tools/windows/windows_install_prerequisites.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Setup script to configure an MSYS2 environment for ESP-IDF.
 #


### PR DESCRIPTION
bash is not always installed in /bin/bash.  This could be related to
issue #2600 (or at least, manifests with similar symptoms).