### PR TITLE
feat(heap) make heap size fixed and configurable (IDFGH-780)

### DIFF
--- a/components/esp32/ld/esp32.common.ld
+++ b/components/esp32/ld/esp32.common.ld
@@ -175,8 +175,6 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-    /* The heap starts right after end of this section */
-    _heap_start = ABSOLUTE(.);
   } > dram0_0_seg
 
   .flash.rodata :

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -21,6 +21,12 @@
 #define CONFIG_BT_RESERVE_DRAM 0
 #endif
 
+#if CONFIG_HEAP_SIZE > (0x50000 - (0x2c200 - CONFIG_BT_RESERVE_DRAM))
+#define DRAM0_0_SEG_LEN (0x50000 - CONFIG_HEAP_SIZE - CONFIG_BT_RESERVE_DRAM)
+#else
+#define DRAM0_0_SEG_LEN  (0x2c200 - CONFIG_BT_RESERVE_DRAM)
+#endif
+
 MEMORY
 {
   /* All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
@@ -51,7 +57,7 @@ MEMORY
      additional static memory temporarily cannot be used.
   */
   dram0_0_seg (RW) :                 org = 0x3FFB0000 + CONFIG_BT_RESERVE_DRAM,
-                                     len = 0x2c200 - CONFIG_BT_RESERVE_DRAM
+                                     len = DRAM0_0_SEG_LEN,
 
   /* Flash mapped constant data */
   drom0_0_seg (R) :                  org = 0x3F400018, len = 0x400000-0x18
@@ -71,4 +77,5 @@ MEMORY
 }
 
 /* Heap ends at top of dram0_0_seg */
+_heap_start = 0x40000000 - CONFIG_TRACEMEM_RESERVE_DRAM - CONFIG_HEAP_SIZE;
 _heap_end = 0x40000000 - CONFIG_TRACEMEM_RESERVE_DRAM;

--- a/components/heap/Kconfig
+++ b/components/heap/Kconfig
@@ -47,3 +47,12 @@ config HEAP_TASK_TRACKING
         allocated.
 
 endmenu
+
+menu "Heap size"
+config HEAP_SIZE
+   hex "Heap size in bytes"
+   default 0x32000
+   help
+       Number of bytes reserved for the heap.
+
+endmenu


### PR DESCRIPTION
Currently the heap size is defined at link time as "the remaining ram", what is not deterministic.

Once the product is released, and a minor revision is created, it should be ensured that critical parameters of the system are not impacted.
With a non deterministic heap size, no one can guarantee that connectivity is not impacted by any code change, even a minimal innocent one.

This patch makes the heap size configurable from Kconfig. Any change of the heap size is fully under control.
