### PR TITLE
nvs_flash: Fix typo in README.rst (IDFGH-836)

### DIFF
--- a/components/nvs_flash/README.rst
+++ b/components/nvs_flash/README.rst
@@ -51,7 +51,7 @@ NVS is not directly compatible with the ESP32 flash encryption system. However, 
 
 If NVS encryption is not used, it is possible for anyone with physical access to the flash chip to alter, erase, or add key-value pairs. With NVS encryption enabled, it is not possible to alter or add a key-value pair and get recognized as a valid pair without knowing corresponding NVS encryption keys. However, there is no tamper-resistance against erase operation.
 
-The library does try to recover from conditions when flash memory is in an inconsistent state. In particular, one should be able to power off the device at any point and time and then power it back on. This should not result in loss of data, expect for the new key-value pair if it was being written at the moment of power off. The library should also be able to initialize properly with any random data present in flash memory.
+The library does try to recover from conditions when flash memory is in an inconsistent state. In particular, one should be able to power off the device at any point and time and then power it back on. This should not result in loss of data, except for the new key-value pair if it was being written at the moment of power off. The library should also be able to initialize properly with any random data present in flash memory.
 
 Internals
 ---------


### PR DESCRIPTION
This should read "except for the new key-value pair" instead of
"expect for the new key-value pair".

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>