### PR TITLE
feat(memory-map) allow fixed static ram and heap size boundaries (IDFGH-858)

### DIFF
--- a/components/bootloader/subproject/main/esp32.bootloader.ld
+++ b/components/bootloader/subproject/main/esp32.bootloader.ld
@@ -149,7 +149,6 @@ SECTIONS
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
     . = ALIGN(4);
-    _heap_start = ABSOLUTE(.);
   } >dram_seg
 
   .iram.text :

--- a/components/esp32/Kconfig
+++ b/components/esp32/Kconfig
@@ -929,24 +929,24 @@ menu "ESP32-specific"
             This option depends on the CONFIG_FREERTOS_UNICORE option because RTC fast memory
             can be accessed only by PRO_CPU core.
 
-config USE_FIXED_STATIC_RAM_SIZE
-	bool "Use fixed static RAM size"
-	default n
-    help
-	    Without this option, the Dram part of the heap starts right after the .bss sections,
-		within the dram0_0 region. As a result, adding or removing some static variables,
-		indirectly decreases or reduces the heap size.
-		With this option, the Dram part of the heap starts right after the dram0_0 region,
-		where its length is set with FIXED_STATIC_RAM_SIZE
+    config ESP32_USE_FIXED_STATIC_RAM_SIZE
+        bool "Use fixed static RAM size"
+        default n
+        help
+            Without this option, the Dram part of the heap starts right after the .bss sections,
+            within the dram0_0 region. As a result, adding or removing some static variables,
+            indirectly decreases or reduces the heap size.
+            With this option, the Dram part of the heap starts right after the dram0_0 region,
+            where its length is set with ESP32_FIXED_STATIC_RAM_SIZE
 
-config FIXED_STATIC_RAM_SIZE
-	hex "Fixed Static RAM size"
-	default 0x1E000
-	range 0 0x2c200
-    depends on USE_FIXED_STATIC_RAM_SIZE
-	help
-	    Ram size dedicated for static variables.
-		Please note that the actual length will be reduced by BT_RESERVE_DRAM if configured.
+    config ESP32_FIXED_STATIC_RAM_SIZE
+        hex "Fixed Static RAM size"
+        default 0x1E000
+        range 0 0x2c200
+        depends on ESP32_USE_FIXED_STATIC_RAM_SIZE
+        help
+            Ram size dedicated for static variables.
+            Please note that the actual length will be reduced by BT_RESERVE_DRAM if configured.
 
 endmenu  # ESP32-Specific
 

--- a/components/esp32/Kconfig
+++ b/components/esp32/Kconfig
@@ -931,7 +931,7 @@ menu "ESP32-specific"
 
 config USE_FIXED_STATIC_RAM_SIZE
 	bool "Use fixed static RAM size"
-	default false
+	default n
     help
 	    Without this option, the Dram part of the heap starts right after the .bss sections,
 		within the dram0_0 region. As a result, adding or removing some static variables,
@@ -942,9 +942,10 @@ config USE_FIXED_STATIC_RAM_SIZE
 config FIXED_STATIC_RAM_SIZE
 	hex "Fixed Static RAM size"
 	default 0x1E000
+	range 0 0x2c200
     depends on USE_FIXED_STATIC_RAM_SIZE
 	help
-	    Ram size dedicated for static variables. Should be smaller than 0x2c200.
+	    Ram size dedicated for static variables.
 		Please note that the actual length will be reduced by BT_RESERVE_DRAM if configured.
 
 endmenu  # ESP32-Specific

--- a/components/esp32/Kconfig
+++ b/components/esp32/Kconfig
@@ -929,6 +929,24 @@ menu "ESP32-specific"
             This option depends on the CONFIG_FREERTOS_UNICORE option because RTC fast memory
             can be accessed only by PRO_CPU core.
 
+config USE_FIXED_STATIC_RAM_SIZE
+	bool "Use fixed static RAM size"
+	default false
+    help
+	    Without this option, the Dram part of the heap starts right after the .bss sections,
+		within the dram0_0 region. As a result, adding or removing some static variables,
+		indirectly decreases or reduces the heap size.
+		With this option, the Dram part of the heap starts right after the dram0_0 region,
+		where its length is set with FIXED_STATIC_RAM_SIZE
+
+config FIXED_STATIC_RAM_SIZE
+	hex "Fixed Static RAM size"
+	default 0x1E000
+    depends on USE_FIXED_STATIC_RAM_SIZE
+	help
+	    Ram size dedicated for static variables. Should be smaller than 0x2c200.
+		Please note that the actual length will be reduced by BT_RESERVE_DRAM if configured.
+
 endmenu  # ESP32-Specific
 
 menu Wi-Fi

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -21,12 +21,12 @@
 #define CONFIG_BT_RESERVE_DRAM 0
 #endif
 
-#if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
+#if defined(CONFIG_ESP32_USE_FIXED_STATIC_RAM_SIZE)
 
-ASSERT((CONFIG_FIXED_STATIC_RAM_SIZE <= 0x2c200),
+ASSERT((CONFIG_ESP32_FIXED_STATIC_RAM_SIZE <= 0x2c200),
           "Fixed static ram data does not fit.")
 
-#define DRAM0_0_SEG_LEN CONFIG_FIXED_STATIC_RAM_SIZE
+#define DRAM0_0_SEG_LEN CONFIG_ESP32_FIXED_STATIC_RAM_SIZE
 
 #else
 #define DRAM0_0_SEG_LEN 0x2c200
@@ -72,7 +72,7 @@ MEMORY
   /* RTC fast memory (executable). Persists over deep sleep.
    */
   rtc_iram_seg(RWX) :                org = 0x400C0000, len = 0x2000
-  
+
   /* RTC fast memory (same block as above), viewed from data bus */
   rtc_data_seg(RW) :                 org = 0x3ff80000, len = 0x2000
 
@@ -88,7 +88,7 @@ MEMORY
                                      len = 0x400000
 }
 
-#if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
+#if defined(CONFIG_ESP32_USE_FIXED_STATIC_RAM_SIZE)
 /* static data ends at defined address */
 _static_data_end = 0x3FFB0000 + DRAM0_0_SEG_LEN;
 #else
@@ -100,9 +100,9 @@ _heap_end = 0x40000000 - CONFIG_TRACEMEM_RESERVE_DRAM;
 
 _data_seg_org = ORIGIN(rtc_data_seg);
 
-/* The lines below define location alias for .rtc.data section based on Kconfig option. 
-   When the option is not defined then use slow memory segment 
-   else the data will be placed in fast memory segment */ 
+/* The lines below define location alias for .rtc.data section based on Kconfig option.
+   When the option is not defined then use slow memory segment
+   else the data will be placed in fast memory segment */
 #ifndef CONFIG_ESP32_RTCDATA_IN_FAST_MEM
 REGION_ALIAS("rtc_data_location", rtc_slow_seg );
 #else

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -21,6 +21,18 @@
 #define CONFIG_BT_RESERVE_DRAM 0
 #endif
 
+#if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
+
+#if (CONFIG_FIXED_STATIC_RAM_SIZE > 0x2c200)
+#error "Fixed static ram out of boundary."
+#else
+#define DRAM0_0_SEG_LEN CONFIG_FIXED_STATIC_RAM_SIZE
+#endif
+
+#else
+#define DRAM0_0_SEG_LEN 0x2c200
+#endif
+
 MEMORY
 {
   /* All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
@@ -51,7 +63,7 @@ MEMORY
      additional static memory temporarily cannot be used.
   */
   dram0_0_seg (RW) :                 org = 0x3FFB0000 + CONFIG_BT_RESERVE_DRAM,
-                                     len = 0x2c200 - CONFIG_BT_RESERVE_DRAM
+                                     len = DRAM0_0_SEG_LEN - CONFIG_BT_RESERVE_DRAM
 
   /* Flash mapped constant data */
   drom0_0_seg (R) :                  org = 0x3F400018, len = 0x400000-0x18
@@ -76,6 +88,13 @@ MEMORY
   extern_ram_seg(RWX)  :             org = 0x3F800000,
                                      len = 0x400000
 }
+
+#if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
+/* heap start at defined address */
+_heap_start = 0x3FFB0000 + DRAM0_0_SEG_LEN;
+#else
+_heap_start = _bss_end;
+#endif
 
 /* Heap ends at top of dram0_0_seg */
 _heap_end = 0x40000000 - CONFIG_TRACEMEM_RESERVE_DRAM;

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -23,11 +23,10 @@
 
 #if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
 
-#if (CONFIG_FIXED_STATIC_RAM_SIZE > 0x2c200)
-#error "Fixed static ram out of boundary."
-#else
+ASSERT((CONFIG_FIXED_STATIC_RAM_SIZE <= 0x2c200),
+          "Fixed static ram data does not fit.")
+
 #define DRAM0_0_SEG_LEN CONFIG_FIXED_STATIC_RAM_SIZE
-#endif
 
 #else
 #define DRAM0_0_SEG_LEN 0x2c200
@@ -90,10 +89,10 @@ MEMORY
 }
 
 #if defined(CONFIG_USE_FIXED_STATIC_RAM_SIZE)
-/* heap start at defined address */
-_heap_start = 0x3FFB0000 + DRAM0_0_SEG_LEN;
+/* static data ends at defined address */
+_static_data_end = 0x3FFB0000 + DRAM0_0_SEG_LEN;
 #else
-_heap_start = _bss_end;
+_static_data_end = _bss_end;
 #endif
 
 /* Heap ends at top of dram0_0_seg */

--- a/components/esp32/ld/esp32.project.ld.in
+++ b/components/esp32/ld/esp32.project.ld.in
@@ -239,8 +239,6 @@ SECTIONS
 
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-    /* The heap starts right after end of this section */
-    _heap_start = ABSOLUTE(.);
   } > dram0_0_seg
 
   ASSERT(((_bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),

--- a/components/soc/src/memory_layout_utils.c
+++ b/components/soc/src/memory_layout_utils.c
@@ -29,7 +29,7 @@ extern soc_reserved_region_t soc_reserved_memory_region_end;
 These variables have the start and end of the data and static IRAM
 area used by the program. Defined in the linker script.
 */
-extern int _data_start, _bss_end, _iram_start, _iram_end;
+extern int _data_start, _static_data_end, _iram_start, _iram_end;
 
 /* static DRAM & IRAM chunks */
 static const size_t EXTRA_RESERVED_REGIONS = 2;
@@ -68,7 +68,7 @@ static void s_prepare_reserved_regions(soc_reserved_region_t *reserved, size_t c
 
     /* Add the EXTRA_RESERVED_REGIONS at the beginning */
     reserved[0].start = (intptr_t)&_data_start; /* DRAM used by data+bss */
-    reserved[0].end = (intptr_t)&_bss_end;
+    reserved[0].end = (intptr_t)&_static_data_end;
     reserved[1].start = (intptr_t)&_iram_start; /* IRAM used by code */
     reserved[1].end = (intptr_t)&_iram_end;
 

--- a/tools/ldgen/samples/template.ld
+++ b/tools/ldgen/samples/template.ld
@@ -110,7 +110,7 @@ SECTIONS
     *(.jcr)
     _data_end = ABSOLUTE(.);
     . = ALIGN(4);
-  } >dram0_0_seg
+  } > dram0_0_seg
 
   /* Shared RAM */
   .dram0.bss (NOLOAD) :
@@ -134,8 +134,7 @@ SECTIONS
 
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-    _heap_start = ABSOLUTE(.);
-  } >dram0_0_seg
+  } > dram0_0_seg
 
   .flash.rodata :
   {

--- a/tools/ldgen/samples/template.ld
+++ b/tools/ldgen/samples/template.ld
@@ -110,7 +110,7 @@ SECTIONS
     *(.jcr)
     _data_end = ABSOLUTE(.);
     . = ALIGN(4);
-  } > dram0_0_seg
+  } >dram0_0_seg
 
   /* Shared RAM */
   .dram0.bss (NOLOAD) :
@@ -134,7 +134,7 @@ SECTIONS
 
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-  } > dram0_0_seg
+  } >dram0_0_seg
 
   .flash.rodata :
   {


### PR DESCRIPTION
Currently the heap size is defined at link time as "the remaining ram", what is not deterministic.

Once the product is released, and a minor revision is created, it should be ensured that critical parameters of the system are not impacted.
With a non deterministic heap size, no one can guarantee that connectivity is not impacted by any code change, even a minimal innocent one.

This patch makes the static ram size configurable from Kconfig, and indirectly fixed the heap size. Any change of the heap size is fully under control.