### PR TITLE
Bugfix eddystone example (IDFGH-963)

### DIFF
--- a/examples/bluetooth/ble_eddystone/main/esp_eddystone_api.h
+++ b/examples/bluetooth/ble_eddystone/main/esp_eddystone_api.h
@@ -53,7 +53,7 @@ static inline uint16_t big_endian_read_16(const uint8_t *buffer, uint8_t pos)
 
 static inline uint32_t big_endian_read_32(const uint8_t *buffer, uint8_t pos)
 {
-    return (((uint32_t)buffer[pos]) << 24) | (((uint32_t)buffer[(pos)+1]) >> 16) | (((uint32_t)buffer[(pos)+2]) >> 8) | ((uint32_t)buffer[(pos)+3]);
+    return (((uint32_t)buffer[pos]) << 24) | (((uint32_t)buffer[(pos)+1]) << 16) | (((uint32_t)buffer[(pos)+2]) << 8) | ((uint32_t)buffer[(pos)+3]);
 }
 
 /*

--- a/examples/bluetooth/ble_eddystone/main/esp_eddystone_demo.c
+++ b/examples/bluetooth/ble_eddystone/main/esp_eddystone_demo.c
@@ -70,7 +70,7 @@ static void esp_eddystone_show_inform(const esp_eddystone_result_t* res)
             ESP_LOGI(DEMO_TAG, "battery voltage: %d mV", res->inform.tlm.battery_voltage);
             ESP_LOGI(DEMO_TAG, "beacon temperature in degrees Celsius: %6.1f", res->inform.tlm.temperature);
             ESP_LOGI(DEMO_TAG, "adv pdu count since power-up: %d", res->inform.tlm.adv_count);
-            ESP_LOGI(DEMO_TAG, "time since power-up: %d s", res->inform.tlm.time);
+            ESP_LOGI(DEMO_TAG, "time since power-up: %d s", (res->inform.tlm.time)/10);
             break;
         }
         default:


### PR DESCRIPTION
Fixed incorrect bitshifts in esp_eddystone_api.h within big_endian_read_32 function that converts from big endian to little endian.
```
static inline uint32_t big_endian_read_32(const uint8_t *buffer, uint8_t pos)
{
    return (((uint32_t)buffer[pos]) << 24) | (((uint32_t)buffer[(pos)+1]) >> 16) | (((uint32_t)buffer[(pos)+2]) >> 8) | ((uint32_t)buffer[(pos)+3]);
}
```
to
```
static inline uint32_t big_endian_read_32(const uint8_t *buffer, uint8_t pos)
{
    return (((uint32_t)buffer[pos]) << 24) | (((uint32_t)buffer[(pos)+1]) << 16) | (((uint32_t)buffer[(pos)+2]) << 8) | ((uint32_t)buffer[(pos)+3]);
}
```
In addition, fixed the derivation of seconds elapsed within esp_eddystone_demo.c as the value within the Eddystone TLM frame represents centiseconds. This is noted here: https://github.com/google/eddystone/blob/master/eddystone-tlm/tlm-plain.md . SEC_CNT is a 0.1 second resolution counter that represents time since beacon power-up or reboot.