### PR TITLE
Feature/deep sleep fast wake (IDFGH-967)

### DIFF
--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -400,6 +400,26 @@ menu "Security features"
 
             Refer to https://docs.espressif.com/projects/esp-idf/en/latest/security/secure-boot.html before enabling.
 
+    config BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+        bool "Skip image validation when exiting deep sleep"
+        depends on (SECURE_BOOT_ENABLED && SECURE_BOOT_INSECURE) || !SECURE_BOOT_ENABLED
+        select BOOTLOADER_RESERVE_RTC
+        default N
+        help
+            This option disables the normal validation of an image coming out of
+            deep sleep (checksums, SHA256, and signature).  This is a trade-off
+            between wakeup performance from deep sleep, and image integrity checks.
+
+            Only enable this if you know what you are doing.  It should not be used
+            in conjunction with using deep_sleep() entry and changing the active OTA
+            partition as this would skip the validation upon first load of the new
+            OTA partition.
+
+    config BOOTLOADER_RESERVE_RTC
+        hex
+        default 0x10 if BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+        default 0
+
     config FLASH_ENCRYPTION_ENABLED
         bool "Enable flash encryption on boot (READ DOCS FIRST)"
         default N

--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -125,7 +125,8 @@ typedef enum {
     ESP_IMAGE_VERIFY,        /* Verify image contents, load metadata. Print errors. */
     ESP_IMAGE_VERIFY_SILENT, /* Verify image contents, load metadata. Don't print errors. */
 #ifdef BOOTLOADER_BUILD
-    ESP_IMAGE_LOAD,          /* Verify image contents, load to memory. Print errors. */
+    ESP_IMAGE_LOAD,             /* Verify image contents, load to memory. Print errors. */
+    ESP_IMAGE_LOAD_NO_VALIDATE, /* Load to memory. Print errors. */
 #endif
 } esp_image_load_mode_t;
 
@@ -211,6 +212,29 @@ esp_err_t esp_image_verify(esp_image_load_mode_t mode, const esp_partition_pos_t
  * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
  */
 esp_err_t bootloader_load_image(const esp_partition_pos_t *part, esp_image_metadata_t *data);
+
+/**
+ * @brief Load an app image without verification (available only in space of bootloader).
+ *
+ * If encryption is enabled, data will be transparently decrypted.
+ *
+ * @param part Partition to load the app from.
+ * @param[inout] data Pointer to the image metadata structure which is be filled in by this function.
+ *                    'start_addr' member should be set (to the start address of the image.)
+ *                    Other fields will all be initialised by this function.
+ *
+ * Image validation checks:
+ * - Magic byte.
+ * - Partition smaller than 16MB.
+ * - All segments & image fit in partition.
+ *
+ * @return
+ * - ESP_OK if verify or load was successful
+ * - ESP_ERR_IMAGE_FLASH_FAIL if a SPI flash error occurs
+ * - ESP_ERR_IMAGE_INVALID if the image appears invalid.
+ * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
+ */
+esp_err_t bootloader_load_image_no_verify(const esp_partition_pos_t *part, esp_image_metadata_t *data);
 
 /**
  * @brief Verify the bootloader image.

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -186,9 +186,9 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
 
     data->image_len = end_addr - data->start_addr;
     ESP_LOGV(TAG, "image start 0x%08x end of last section 0x%08x", data->start_addr, end_addr);
-    if (NULL != checksum && !esp_cpu_in_ocd_debug_mode()) {
+    if (NULL != checksum) {
         err = verify_checksum(sha_handle, checksum_word, data);
-        if (err != ESP_OK) {
+        if (err != ESP_OK && !esp_cpu_in_ocd_debug_mode()) {
             goto err;
         }
     }

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -496,15 +496,15 @@ static bool should_load(uint32_t load_addr)
 
     if (!load_rtc_memory) {
         if (load_addr >= SOC_RTC_IRAM_LOW && load_addr < SOC_RTC_IRAM_HIGH) {
-            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x\n", load_addr);
+            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x", load_addr);
             return false;
         }
         if (load_addr >= SOC_RTC_DRAM_LOW && load_addr < SOC_RTC_DRAM_HIGH) {
-            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x\n", load_addr);
+            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x", load_addr);
             return false;
         }
         if (load_addr >= SOC_RTC_DATA_LOW && load_addr < SOC_RTC_DATA_HIGH) {
-            ESP_LOGD(TAG, "Skipping RTC slow memory segment at 0x%08x\n", load_addr);
+            ESP_LOGD(TAG, "Skipping RTC slow memory segment at 0x%08x", load_addr);
             return false;
         }
     }

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -243,7 +243,7 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
     }
 
 #ifdef BOOTLOADER_BUILD
-    if (do_load) { // Need to deobfuscate RAM
+    if (ram_obfs_value[0] != 0 && ram_obfs_value[1] != 0 && do_load) { // Need to deobfuscate RAM
         for (int i = 0; i < data->image.segment_count; i++) {
             uint32_t load_addr = data->segments[i].load_addr;
             if (should_load(load_addr)) {
@@ -438,6 +438,13 @@ static esp_err_t process_segment_data(intptr_t load_addr, uint32_t data_addr, ui
         ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed",
                  data_addr, data_len);
         return ESP_FAIL;
+    }
+
+    if (NULL == checksum && NULL == sha_handle)
+    {
+        memcpy((void *)load_addr, data, data_len);
+        bootloader_munmap(data);
+        return ESP_OK;
     }
 
 #ifdef BOOTLOADER_BUILD

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -21,6 +21,10 @@
 #define CONFIG_BT_RESERVE_DRAM 0
 #endif
 
+#ifndef CONFIG_BOOTLOADER_RESERVE_RTC
+#define CONFIG_BOOTLOADER_RESERVE_RTC 0
+#endif
+
 MEMORY
 {
   /* All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
@@ -60,10 +64,10 @@ MEMORY
 
   /* RTC fast memory (executable). Persists over deep sleep.
    */
-  rtc_iram_seg(RWX) :                org = 0x400C0000, len = 0x2000
+  rtc_iram_seg(RWX) :                org = 0x400C0000, len = 0x2000 - CONFIG_BOOTLOADER_RESERVE_RTC
   
   /* RTC fast memory (same block as above), viewed from data bus */
-  rtc_data_seg(RW) :                 org = 0x3ff80000, len = 0x2000
+  rtc_data_seg(RW) :                 org = 0x3ff80000, len = 0x2000 - CONFIG_BOOTLOADER_RESERVE_RTC
 
   /* RTC slow memory (data accessible). Persists over deep sleep.
 


### PR DESCRIPTION
This patchset adds an optional compile-time flag to the bootloader to reduce the time spent in image validation when waking from deep sleep.  This changeset assumes that the image hasn't changed
since the last time the bootloader ran which may not always be a valid assumption to take depending on board design.  This can reduce the boot time to 10% of normal when an otherwise normal boot would be doing full image validation (including validating the secure boot signature).

There are a couple of potential corner cases that this would be bad for secure boot in which are documented inside of the Kconfig menu option, and it can only be enabled if insecure options are enabled in the bootloader.