### PR TITLE
Fixed excess data coming from uninitialized variable in esp_efuse_get_pkg_ver (IDFGH-976)

### DIFF
--- a/components/efuse/src/esp_efuse_fields.c
+++ b/components/efuse/src/esp_efuse_fields.c
@@ -39,7 +39,7 @@ uint8_t esp_efuse_get_chip_ver(void)
 // Returns chip package from efuse
 uint32_t esp_efuse_get_pkg_ver(void)
 {
-    uint32_t pkg_ver;
+    uint32_t pkg_ver = 0;
     esp_efuse_read_field_blob(ESP_EFUSE_CHIP_VER_PKG, &pkg_ver, 3);
     return pkg_ver;
 }


### PR DESCRIPTION
The call to `esp_efuse_read_field_blob` only seems to set the 3 last bits of `pkg_ver`. So the other uninitialised 29 bits in `pkg_ver` gets returned.

Before: 1073677826 (in binary) `111111111111110000011000000010`, note the last 3 bits are correct
After: 2