### PR TITLE
Fix if condition in ESP Event Linker fragment (IDFGH-990)

### DIFF
--- a/components/esp_event/linker.lf
+++ b/components/esp_event/linker.lf
@@ -1,6 +1,8 @@
-if POST_EVENTS_FROM_IRAM_ISR = y:
-    [mapping:esp_event]
-    archive: libesp_event.a
-    entries:
+[mapping:esp_event]
+archive: libesp_event.a
+entries:
+    if POST_EVENTS_FROM_IRAM_ISR = y:
         esp_event:esp_event_isr_post_to (noflash)
         default_event_loop:esp_event_isr_post (noflash)
+    else:
+        * (default)


### PR DESCRIPTION
The if condition should not be part of the entries, but not
surrounding the fragment itself.
This got introduced in merge https://github.com/espressif/esp-idf/commit/0b59b6069e764b3c063047b5a18149b3ba3245bb - specifically https://github.com/espressif/esp-idf/commit/2b914f2d2222b507bed0db65e1cdced13ee02589

Previously this would result in:
`Scanning dependencies of target ldgen_esp32.project.ld_script
[ 98%] Generating esp32.project.ld
linker script generation failed for /Users/sieren/Documents/Development/esp-idf/components/esp32/ld/esp32.project.ld.in
ERROR: failed to parse /Users/sieren/Documents/Development/esp-idf/components/esp_event/linker.lf
fragment requires at least 1 values for key 'entries' (at char 44), (line:3, col:1)
make[3]: *** [esp-idf/esp32/esp32.project.ld] Error 1
make[2]: *** [esp-idf/esp32/CMakeFiles/ldgen_esp32.project.ld_script.dir/all] Error 2`