### PR TITLE
partition: Fix "encrypted" read/write when encryption is disabled (IDFGH-1000)

### DIFF
--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -168,10 +168,13 @@ static esp_err_t load_partitions()
         item->info.type = it->type;
         item->info.subtype = it->subtype;
         item->info.encrypted = it->flags & PART_FLAG_ENCRYPTED;
-        if (esp_flash_encryption_enabled() && (
-                it->type == PART_TYPE_APP
+
+        if (!esp_flash_encryption_enabled()) {
+            /* If flash encryption is not turned on, no partitions should be encrypted */
+            item->info.encrypted = false;
+        } else if (it->type == PART_TYPE_APP
                 || (it->type == PART_TYPE_DATA && it->subtype == PART_SUBTYPE_DATA_OTA)
-                || (it->type == PART_TYPE_DATA && it->subtype == PART_SUBTYPE_DATA_NVS_KEYS))) {
+                || (it->type == PART_TYPE_DATA && it->subtype == PART_SUBTYPE_DATA_NVS_KEYS)) {
             /* If encryption is turned on, all app partitions and OTA data
                are always encrypted */
             item->info.encrypted = true;


### PR DESCRIPTION
According to the documentation[1][2] for partitions, setting the encrypted
flag for partitions should be a no-op when system level encryption isn't
enabled.  The current implementation, however, does not actually match
the documentation and it ends up with an unreadable partition via the
partition API if a partition flag is marked as encrypted without
system-level encryption enabled.  (This is because the writes go through
the encryption block, and reads do not go through the encryption block
when this situation occurs causing unreadable data to the application
running.) This fixes up the read-back of the partition table to match
whether or not the partition is currently encrypted under the hood.

This should not affect the bootloader's code for reading/writing encrypted
partitions as the bootloader directly invokes the spi_flash_write*(...)
APIs.

[1] https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/partition-tables.html#flags
[2] https://docs.espressif.com/projects/esp-idf/en/latest/security/flash-encryption.html#encrypted-partition-flag

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>