### PR TITLE
Moving flag into section for esp_event linker file (IDFGH-1007)

### DIFF
--- a/components/esp_event/linker.lf
+++ b/components/esp_event/linker.lf
@@ -1,6 +1,6 @@
-if POST_EVENTS_FROM_IRAM_ISR = y:
-    [mapping:esp_event]
-    archive: libesp_event.a
-    entries:
+[mapping:esp_event]
+archive: libesp_event.a
+entries:
+    if POST_EVENTS_FROM_IRAM_ISR = y:
         esp_event:esp_event_isr_post_to (noflash)
         default_event_loop:esp_event_isr_post (noflash)


### PR DESCRIPTION
If this flag is at the top level the linker generation script throws an error.

It appears that when this file was added an incorrect syntax was used. This pull request follows the syntax found for other components and allows the build of hello world to succeed. This fixes https://github.com/espressif/esp-idf/issues/3295

