### PR TITLE
docs: Improve Linux cmake getting started documentation (IDFGH-1020)

### DIFF
--- a/docs/en/get-started-cmake/index.rst
+++ b/docs/en/get-started-cmake/index.rst
@@ -283,7 +283,7 @@ Linux and MacOS
     cd ~/esp/hello_world
     idf.py menuconfig
 
-If your default version of Python is 3.x, you may need to run ``python2 idf.py`` instead.
+If your default version of Python is 3.x, you may need to run ``python2 $(which idf.py) menuconfig`` instead.
 
 Windows
 ~~~~~~~

--- a/docs/en/get-started-cmake/linux-setup.rst
+++ b/docs/en/get-started-cmake/linux-setup.rst
@@ -21,7 +21,7 @@ To compile with ESP-IDF you need to get the following packages:
 
 - Arch::
 
-    sudo pacman -S --needed gcc git make ncurses flex bison gperf python2-pyserial python2-cryptography python2-future python2-pyparsing python2-pyelftools cmake ninja ccache
+    sudo pacman -S --needed gcc git make ncurses flex bison gperf python2-pip python2-pyserial python2-cryptography python2-future python2-pyparsing python2-pyelftools cmake ninja ccache
 
 .. note::
     CMake version 3.5 or newer is required for use with ESP-IDF. Older Linux distributions may require updating, enabling of a "backports" repository, or installing of a "cmake3" package rather than "cmake".


### PR DESCRIPTION
Whilst I was going through the new cmake getting started guide, I think I encountered two minor imperfections in the documentation. 

#### Python2 usage
Firstly, if the default `python` command defaults to version 3 instead of 2, the guide recommends to run `idf.py` with the older `python2` interpreter. But the the way it was suggested will not work, since the `idf.py` script can not be passed as an argument to the `python2` interpreter but its path must then be used.
In this commit, I used a nested `which` command to find the path.

#### Discrepancy pip usage
In step 4 of the getting the started, `pip` is used to install the `requirements.txt` file. In the Ubuntu/Debian prerequisite package list `pip` is included, but in the Arch version it is not. It seems to make sense to add it to the Arch package list as well. (Even though imho it would make more sense to remove step 4 and do not use `pip` to install the packages again for a specific user)
