### PR TITLE
MCPWM pulse duration measurement (IDFGH-1079)

### DIFF
--- a/components/driver/include/driver/mcpwm.h
+++ b/components/driver/include/driver/mcpwm.h
@@ -196,8 +196,9 @@ typedef enum {
  * @brief MCPWM select capture starts from which edge
  */
 typedef enum {
-    MCPWM_NEG_EDGE = 0,  /*!<Capture starts from negative edge*/
-    MCPWM_POS_EDGE,      /*!<Capture starts from positive edge*/
+    MCPWM_NEG_EDGE = 0x1,   /*!<Capture starts from negative edge*/
+    MCPWM_POS_EDGE = 0x2,   /*!<Capture starts from positive edge*/
+    MCPWM_BOTH_EDGE = 0x3,  /*!<Capture starts from both edge*/
 } mcpwm_capture_on_edge_t;
 
 /**

--- a/components/driver/mcpwm.c
+++ b/components/driver/mcpwm.c
@@ -658,7 +658,7 @@ esp_err_t mcpwm_capture_enable(mcpwm_unit_t mcpwm_num, mcpwm_capture_signal_t ca
     portENTER_CRITICAL(&mcpwm_spinlock);
     MCPWM[mcpwm_num]->cap_timer_cfg.timer_en = 1;
     MCPWM[mcpwm_num]->cap_cfg_ch[cap_sig].en = 1;
-    MCPWM[mcpwm_num]->cap_cfg_ch[cap_sig].mode = (1 << cap_edge);
+    MCPWM[mcpwm_num]->cap_cfg_ch[cap_sig].mode = cap_edge;
     MCPWM[mcpwm_num]->cap_cfg_ch[cap_sig].prescale = num_of_pulse;
     portEXIT_CRITICAL(&mcpwm_spinlock);
     return ESP_OK;


### PR DESCRIPTION
These modifications allow to measure the duration of a pulse
(duration between a rising edge and a falling edge)

Original fix by @vgonet 