### PR TITLE
console uart: Do not use REFTICK if the baud rate is above the reftick freq (IDFGH-1081)

### DIFF
--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -332,7 +332,7 @@ void start_cpu0_default(void)
     intr_matrix_clear();
 
 #ifndef CONFIG_CONSOLE_UART_NONE
-#ifdef CONFIG_PM_ENABLE
+#if defined(CONFIG_PM_ENABLE) && CONFIG_CONSOLE_UART_BAUDRATE <= REF_CLK_FREQ
     const int uart_clk_freq = REF_CLK_FREQ;
     /* When DFS is enabled, use REFTICK as UART clock source */
     CLEAR_PERI_REG_MASK(UART_CONF0_REG(CONFIG_CONSOLE_UART_NUM), UART_TICK_REF_ALWAYS_ON);


### PR DESCRIPTION
If the configured baud rate is higher than the reference tick rate, it's
impossible to meet that baud rate request.  Just default back to the APB
clock in this case.

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>