### PR TITLE
Spiffsgen incorrect path delimiter (IDFGH-1100)

### DIFF
--- a/components/spiffs/spiffsgen.py
+++ b/components/spiffs/spiffsgen.py
@@ -516,7 +516,7 @@ def main():
         for root, dirs, files in os.walk(args.base_dir):
             for f in files:
                 full_path = os.path.join(root, f)
-                spiffs.create_file("/" + os.path.relpath(full_path, args.base_dir), full_path)
+                spiffs.create_file("/" + os.path.relpath(full_path, args.base_dir).replace("\\", "/"), full_path)
 
         image = spiffs.to_binary()
 

--- a/make/ldgen.mk
+++ b/make/ldgen.mk
@@ -14,7 +14,7 @@ endif
 # the components
 ifeq ($(ON_WINDOWS),y)
 define ldgen_process_template
-$(BUILD_DIR_BASE)/ldgen.section_infos: $(LDGEN_LIBRARIES) $(IDF_PATH)/make/ldgen.mk
+$(BUILD_DIR_BASE)/ldgen_libraries: $(LDGEN_LIBRARIES) $(IDF_PATH)/make/ldgen.mk
 	printf "$(foreach info,$(LDGEN_LIBRARIES),$(subst \,/,$(shell cygpath -w $(info)))\n)" > $(BUILD_DIR_BASE)/ldgen_libraries
 
 $(2): $(1) $(LDGEN_FRAGMENT_FILES) $(SDKCONFIG) $(BUILD_DIR_BASE)/ldgen_libraries


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-idf/issues/3416