### PR TITLE
ldgen.mk: fix wrong target name (IDFGH-1101)

### DIFF
--- a/make/ldgen.mk
+++ b/make/ldgen.mk
@@ -14,7 +14,7 @@ endif
 # the components
 ifeq ($(ON_WINDOWS),y)
 define ldgen_process_template
-$(BUILD_DIR_BASE)/ldgen.section_infos: $(LDGEN_LIBRARIES) $(IDF_PATH)/make/ldgen.mk
+$(BUILD_DIR_BASE)/ldgen_libraries: $(LDGEN_LIBRARIES) $(IDF_PATH)/make/ldgen.mk
 	printf "$(foreach info,$(LDGEN_LIBRARIES),$(subst \,/,$(shell cygpath -w $(info)))\n)" > $(BUILD_DIR_BASE)/ldgen_libraries
 
 $(2): $(1) $(LDGEN_FRAGMENT_FILES) $(SDKCONFIG) $(BUILD_DIR_BASE)/ldgen_libraries


### PR DESCRIPTION
fixes
`make: *** No rule to make target '/d/workspaces/esp32_workspace/smartbar_ctrl/build/ldgen_libraries', needed by '/d/workspaces/esp32_workspace/smartbar_ctrl/build/esp32/esp32.project.ld'.  Stop.`
described in https://github.com/espressif/esp-idf/issues/3419