### PR TITLE
project_config_mk: fix if condition (IDFGH-1105)

### DIFF
--- a/make/project_config.mk
+++ b/make/project_config.mk
@@ -4,7 +4,7 @@
 COMPONENT_KCONFIGS := $(foreach component,$(COMPONENT_PATHS),$(wildcard $(component)/Kconfig))
 COMPONENT_KCONFIGS_PROJBUILD := $(foreach component,$(COMPONENT_PATHS),$(wildcard $(component)/Kconfig.projbuild))
 
-ifdef MSYSTEM
+ifeq ($(OS),Windows_NT)
 # kconfiglib requires Windows-style paths for kconfig files
 COMPONENT_KCONFIGS := $(shell cygpath -w $(COMPONENT_KCONFIGS))
 COMPONENT_KCONFIGS_PROJBUILD := $(shell cygpath -w $(COMPONENT_KCONFIGS_PROJBUILD))


### PR DESCRIPTION
Fixes failed build on Windows (Eclipse). Condition **ifdef MSYSTEM** not performs.
"make" uses /bin/sh as default shell interpreter where variable **MSYSTEM** is not defined. I suggest to use **OS** variable instead