### PR TITLE
esp_efuse_fields.c: fix unused variable warning when NDEBUG (IDFGH-1108)

### DIFF
--- a/components/efuse/src/esp_efuse_fields.c
+++ b/components/efuse/src/esp_efuse_fields.c
@@ -104,6 +104,7 @@ void esp_efuse_write_random_key(uint32_t blk_wdata0_reg)
     } else { // 3/4 Coding Scheme
         bootloader_fill_random(raw, sizeof(raw));
         esp_err_t r = esp_efuse_apply_34_encoding(raw, buf, sizeof(raw));
+        (void) r;
         assert(r == ESP_OK);
     }
 


### PR DESCRIPTION
fixes https://github.com/espressif/esp-idf/issues/3432