### PR TITLE
esp32: Fix rtos pm locks to use a no_light_sleep lock

### DIFF
--- a/components/esp32/pm_esp32.c
+++ b/components/esp32/pm_esp32.c
@@ -600,11 +600,11 @@ void esp_pm_impl_init()
 #ifdef CONFIG_PM_TRACE
     esp_pm_trace_init();
 #endif
-    ESP_ERROR_CHECK(esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX, 0, "rtos0",
+    ESP_ERROR_CHECK(esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "rtos0",
             &s_rtos_lock_handle[0]));
     ESP_ERROR_CHECK(esp_pm_lock_acquire(s_rtos_lock_handle[0]));
 #if portNUM_PROCESSORS == 2
-    ESP_ERROR_CHECK(esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX, 0, "rtos1",
+    ESP_ERROR_CHECK(esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "rtos1",
             &s_rtos_lock_handle[1]));
     ESP_ERROR_CHECK(esp_pm_lock_acquire(s_rtos_lock_handle[1]));
 #endif // portNUM_PROCESSORS == 2


### PR DESCRIPTION
Commit message:

The documentation[1] for the pm configuration states that when no locks
are taken, the minimum CPU frequency is in use.  However, since the
idle code takes a CPU_FREQ_MAX lock whenever an task is running, this
does not actually hold true.  If we shift the default lock to a no light
sleep lock, then unless the user is holding another power management lock,
the CPU will be at the minimum CPU frequency specified.

[1] https://github.com/espressif/esp-idf/blob/bec70ce2986b79a28ed1269760fa79da9603c90b/components/esp32/include/esp32/pm.h#L37

Additional notes:

I'm not sure what the intent of this lock was - I'm assuming it was to prevent the system from entering light sleep, so I think it makes sense to leave it as a light sleep lock.  If I have a task that simply spins (or just wakes up for a little bit), without acquiring the maximum CPU frequency lock, the system always enters the maximum CPU frequency while this task is doing something.  This is contrary to what one would expect due to the availability of a maximum CPU frequency lock.
