### PR TITLE
Synchronize the mDNS values with LWIP values for protocol type (IDFGH-1141)

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -34,8 +34,8 @@ extern "C" {
  * @brief   mDNS enum to specify the ip_protocol type
  */
 typedef enum {
-    MDNS_IP_PROTOCOL_V4,
-    MDNS_IP_PROTOCOL_V6,
+    MDNS_IP_PROTOCOL_V4 = IPADDR_TYPE_V4,
+    MDNS_IP_PROTOCOL_V6 = IPADDR_TYPE_V6,
     MDNS_IP_PROTOCOL_MAX
 } mdns_ip_protocol_t;
 


### PR DESCRIPTION
mDNS data contains an IP protocol type field, and these values are
sometimes assigned directly from the IP data.  Using the same
field values allows this to work with all combinations of data &
checks (if IPv4 else vs. if IPv6 else).   This prevents IPv6
addresses from sometimes being interpreted at IPv4 addresses.