### PR TITLE
Fixed rare crash of DHCP Server during WIFI AP network reconfiguratio… (IDFGH-1151)

### DIFF
--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -808,6 +808,7 @@ esp_err_t tcpip_adapter_dhcps_start(tcpip_adapter_if_t tcpip_if)
         if (p_netif != NULL && netif_is_up(p_netif)) {
             tcpip_adapter_ip_info_t default_ip;
             tcpip_adapter_get_ip_info(ESP_IF_WIFI_AP, &default_ip);
+            dhcps_set_new_lease_cb(tcpip_adapter_dhcps_cb);
             dhcps_start(p_netif, default_ip.ip);
             dhcps_status = TCPIP_ADAPTER_DHCP_STARTED;
             ESP_LOGD(TAG, "dhcp server start successfully");


### PR DESCRIPTION
…n and DHCP restart due to missed callback

There are few places of dhcps_start(), but at one of them doesn't have initialization of dhcps_cb by dhcps_set_new_lease_cb(). 

Unexpected condition while network reconfiguration with calling of dhcps_start() from another place happened a few times and caused to system crash by reading NULL ptr.