### PR TITLE
Fix deps check on Arch Linux and msys2 (IDFGH-1173)

### DIFF
--- a/tools/check_python_dependencies.py
+++ b/tools/check_python_dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 # Copyright 2018 Espressif Systems (Shanghai) PTE LTD
 #


### PR DESCRIPTION
This still needs testing on macOS: I think they have a python2.7 symlink. If they don't, this situation needs to be completely reconsidered so the python2 from the kconfig is used rather than whatever python is in the system path. Additionally, `menuconfig` needs to be allowed to run if the user doesn't have the right dependencies on their system `python` executable.

Anyway, this fixes menuconfig and probably other stuff on Arch Linux and any other system which has a `python2.7` symlink to a python 2.7.