### PR TITLE
esp_http_client: separate buffer_size config option for transmit (IDFGH-1226)

### DIFF
--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -116,7 +116,8 @@ typedef struct {
     int                         max_redirection_count;    /*!< Max redirection number, using default value if zero*/
     http_event_handle_cb        event_handler;             /*!< HTTP Event Handle */
     esp_http_client_transport_t transport_type;           /*!< HTTP transport type, see `esp_http_client_transport_t` */
-    int                         buffer_size;              /*!< HTTP buffer size (both send and receive) */
+    int                         buffer_size;              /*!< HTTP receive buffer size */
+    int                         buffer_size_tx;           /*!< HTTP transmit buffer size */
     void                        *user_data;               /*!< HTTP user_data context */
     bool                        is_async;                 /*!< Set asynchronous mode, only supported with HTTPS for now */
     bool                        use_global_ca_store;      /*!< Use a global ca_store for all the connections in which this bool is set. */
@@ -426,7 +427,7 @@ esp_http_client_transport_t esp_http_client_get_transport_type(esp_http_client_h
  *
  * @param[in]  client  The esp_http_client handle
  *
- * @return      
+ * @return
  *     - ESP_OK
  *     - ESP_FAIL
  */


### PR DESCRIPTION
This PR adds `buffer_size_tx` to `esp_http_client_config_t`.
It's important to have different buffer sizes when you need to download large files. To do so, you need RX buffer to be as big as you can afford. But you don't want to waste memory on TX buffer in this case. 

For example. I want 8K RX buffer (all I can afford). With single `buffer_size` this will allocate another 8K for TX buffer which I don't need. For TX buffer 2K is more than enough. 6K wasted. I'd rather allocate 14K for RX buffer in this case. 

Original issue https://github.com/espressif/esp-idf/issues/3285

Even if this PR will be rejected I really hope you'll implement this functionality b/c it's crucial for my project.

Thanks.