### PR TITLE
examples/bluetooth: Fix output to internal DAC and add optional dithering (IDFGH-1245)

### DIFF
--- a/examples/bluetooth/a2dp_sink/main/Kconfig.projbuild
+++ b/examples/bluetooth/a2dp_sink/main/Kconfig.projbuild
@@ -18,6 +18,13 @@ menu "A2DP Example Configuration"
 
     endchoice
 
+    config EXAMPLE_A2DP_SINK_OUTPUT_INTERNAL_DAC_DITHER
+        bool "Use Dithering for 16->8 bit reduction"
+        depends on EXAMPLE_A2DP_SINK_OUTPUT_INTERNAL_DAC
+        help
+            Select this to perform dithering during 16->8
+            bit sample reduction.
+
     config EXAMPLE_I2S_LRCK_PIN
         int "I2S LRCK (WS) GPIO"
         default 22

--- a/examples/bluetooth/a2dp_sink/main/bt_app_av.c
+++ b/examples/bluetooth/a2dp_sink/main/bt_app_av.c
@@ -75,7 +75,15 @@ void bt_app_a2d_data_cb(const uint8_t *data, uint32_t len)
     uint16_t *dt = (uint16_t*)data;
     uint32_t count = len / 2;
     while (count-- > 0) {
+#ifdef CONFIG_EXAMPLE_A2DP_SINK_OUTPUT_INTERNAL_DAC_DITHER
+        static int16_t old_rnd = 0;
+        const int16_t rnd = (esp_random() & 0x00ff) - 0x80;
+        const int16_t dither = rnd - old_rnd;
+        old_rnd = rnd;
+        *dt += 0x8000U + dither;
+#else
         *dt += 0x8000U;
+#endif
         dt++;
     }
 #endif

--- a/examples/bluetooth/a2dp_sink/main/bt_app_av.c
+++ b/examples/bluetooth/a2dp_sink/main/bt_app_av.c
@@ -70,6 +70,16 @@ void bt_app_a2d_cb(esp_a2d_cb_event_t event, esp_a2d_cb_param_t *param)
 void bt_app_a2d_data_cb(const uint8_t *data, uint32_t len)
 {
     size_t bytes_written;
+
+#ifdef CONFIG_EXAMPLE_A2DP_SINK_OUTPUT_INTERNAL_DAC
+    uint16_t *dt = (uint16_t*)data;
+    uint32_t count = len / 2;
+    while (count-- > 0) {
+        *dt += 0x8000U;
+        dt++;
+    }
+#endif
+
     i2s_write(0, data, len, &bytes_written, portMAX_DELAY);
     if (++s_pkt_cnt % 100 == 0) {
         ESP_LOGI(BT_AV_TAG, "Audio packet count %u", s_pkt_cnt);


### PR DESCRIPTION
This first commit fixes the output to the ESP32's internal DAC in the a2dp_sink example, which repeatedly created bugs (#1614, #1819, #3260). It implements the suggested solution of changing signed samples to unsigned samples before submitting them to the I2S controller.

The second commit adds optional support for dithering when using the internal DAC by adding some (triangular density) noise from the ESP32's hardware random number generator during the 16->8 bit conversion.

The changes were done and tested against the current master branch.