### PR TITLE
Fix "%d' directive output may be truncated writing between 1 and 10 b… (IDFGH-1282)

### DIFF
--- a/components/bt/common/osi/config.c
+++ b/components/bt/common/osi/config.c
@@ -386,7 +386,7 @@ bool config_save(const config_t *config, const char *filename)
     int err_code = 0;
     nvs_handle_t fp;
     char *line = osi_calloc(1024);
-    const size_t keyname_bufsz = sizeof(CONFIG_KEY) + 5 + 1; // including log10(sizeof(i))
+    const size_t keyname_bufsz = sizeof(CONFIG_KEY) + 10 + 1; // including log10(sizeof(i))
     char *keyname = osi_calloc(keyname_bufsz);
     int config_size = get_config_size(config);
     char *buf = osi_calloc(config_size + 100);

--- a/components/esp_gdbstub/src/gdbstub.c
+++ b/components/esp_gdbstub/src/gdbstub.c
@@ -205,7 +205,7 @@ static void handle_H_command(const unsigned char* cmd, int len)
         } else if (requested_task_index > s_scratch.task_count) {
             ret = "E00";
         } else {
-            TaskHandle_t handle;
+            TaskHandle_t handle = { 0 };
             get_task_handle(requested_task_index, &handle);
             /* FIXME: for the task currently running on the other CPU, extracting the registers from TCB
              * isn't valid. Need to use some IPC mechanism to obtain the registers of the other CPU


### PR DESCRIPTION
…ytes into a region of size 7" error in bluedroid

The 5 value implies a `uint16_t` was used at some point. I'd recommend either changing the appropriate values to `uint16_t`, or to simply increase the buffer size to handle a UINT32_MAX value to prevent compiler errors.