### PR TITLE
To avoid error 112 (Address already in use), set socket to Reuse Addr… (IDFGH-1306)

### DIFF
--- a/examples/protocols/sockets/tcp_server/main/tcp_server.c
+++ b/examples/protocols/sockets/tcp_server/main/tcp_server.c
@@ -64,7 +64,10 @@ static void tcp_server_task(void *pvParameters)
         ESP_LOGI(TAG, "Socket created");
 
         int flag = 1;
-        setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+        if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) < 0) {
+            ESP_LOGE(TAG, "Unable to set socket option: errno %d", errno);
+            break;
+        }
 
         int err = bind(listen_sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
         if (err != 0) {

--- a/examples/protocols/sockets/tcp_server/main/tcp_server.c
+++ b/examples/protocols/sockets/tcp_server/main/tcp_server.c
@@ -63,6 +63,9 @@ static void tcp_server_task(void *pvParameters)
         }
         ESP_LOGI(TAG, "Socket created");
 
+        int flag = 1;
+        setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+
         int err = bind(listen_sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
         if (err != 0) {
             ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
@@ -123,6 +126,7 @@ static void tcp_server_task(void *pvParameters)
             ESP_LOGE(TAG, "Shutting down socket and restarting...");
             shutdown(sock, 0);
             close(sock);
+            close(listen_sock);
         }
     }
     vTaskDelete(NULL);


### PR DESCRIPTION
…ess. Ensure listening socket is closed when client disconnects.

This is a quick fix to the example as it is written. However a better example would probably not close and reopen the listening socket each iteration. There is no need to continually close and rebind this socket when clients disconnect.

Therefore I suggest that this PR be considered for the time being, but that this example be revisited to behave in a more standard manner.