### PR TITLE
CMAKE: Added git ignore for cache files generated by cmake (IDFGH-1356)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,13 @@ test_multi_heap_host
 # VS Code Settings
 .vscode/
 
+# Idea files from Clion
+.idea/
+
+# CMake generated files
+cmake-build-*/
+CMakeFiles/
+CMakeCache.txt
 # Results for the checking of the Python coding style
 flake8_output.txt
 


### PR DESCRIPTION
Hi all,

Added these files to the git ignore, this adds support so that you cannot accidentally publish cmake cache files and also IDE files from CLion's IDE.

Thanks,
Gordon