### PR TITLE
fix a bug when calculating i2s apll parameters. (IDFGH-1365)

### DIFF
--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -268,6 +268,16 @@ static esp_err_t i2s_apll_calculate_fi2s(int rate, int bits_per_sample, int *sdm
             *odir = _odir;
         }
     }
+    min_diff = APLL_MAX_FREQ;
+    for (_sdm2 = 4; _sdm2 < 9; _sdm2 ++) {
+        max_rate = i2s_apll_get_fi2s(bits_per_sample, 255, 255, _sdm2, *odir);
+        min_rate = i2s_apll_get_fi2s(bits_per_sample, 0, 0, _sdm2, *odir);
+        avg = (max_rate + min_rate)/2;
+        if(abs(avg - rate) < min_diff) {
+            min_diff = abs(avg - rate);
+            *sdm2 = _sdm2;
+        }
+    }
 
     min_diff = APLL_MAX_FREQ;
     for (_sdm1 = 0; _sdm1 < 256; _sdm1 ++) {


### PR DESCRIPTION
fix #2634, #3380
improve #3407

Tested with IDF v3.2:
```
I (527) I2S: APLL: Req RATE: 10675, real rate: 10675.000, BITS: 16, ERROR: 0.000000%
I (538) I2S: APLL: Req RATE: 10675, real rate: 10675.003, BITS: 24, ERROR: 0.000030%
I (554) I2S: APLL: Req RATE: 10675, real rate: 10675.006, BITS: 32, ERROR: 0.000055%

I (569) I2S: APLL: Req RATE: 11025, real rate: 11024.991, BITS: 16, ERROR: 0.000080%
I (585) I2S: APLL: Req RATE: 11025, real rate: 11024.992, BITS: 24, ERROR: 0.000071%
I (600) I2S: APLL: Req RATE: 11025, real rate: 11024.991, BITS: 32, ERROR: 0.000080%

I (616) I2S: APLL: Req RATE: 16000, real rate: 15999.986, BITS: 16, ERROR: 0.000085%
I (631) I2S: APLL: Req RATE: 16000, real rate: 15999.987, BITS: 24, ERROR: 0.000081%
I (646) I2S: APLL: Req RATE: 16000, real rate: 16000.003, BITS: 32, ERROR: 0.000018%

I (662) I2S: APLL: Req RATE: 22050, real rate: 22049.982, BITS: 16, ERROR: 0.000080%
I (677) I2S: APLL: Req RATE: 22050, real rate: 22049.984, BITS: 24, ERROR: 0.000071%
I (693) I2S: APLL: Req RATE: 22050, real rate: 22049.994, BITS: 32, ERROR: 0.000027%

I (708) I2S: APLL: Req RATE: 32000, real rate: 32000.006, BITS: 16, ERROR: 0.000018%
I (724) I2S: APLL: Req RATE: 32000, real rate: 31999.974, BITS: 24, ERROR: 0.000081%
I (739) I2S: APLL: Req RATE: 32000, real rate: 32000.006, BITS: 32, ERROR: 0.000018%

I (755) I2S: APLL: Req RATE: 44100, real rate: 44099.988, BITS: 16, ERROR: 0.000027%
I (770) I2S: APLL: Req RATE: 44100, real rate: 44099.969, BITS: 24, ERROR: 0.000071%
I (786) I2S: APLL: Req RATE: 44100, real rate: 44099.988, BITS: 32, ERROR: 0.000027%

I (801) I2S: APLL: Req RATE: 48000, real rate: 47999.961, BITS: 16, ERROR: 0.000081%
I (816) I2S: APLL: Req RATE: 48000, real rate: 48000.016, BITS: 24, ERROR: 0.000033%
I (832) I2S: APLL: Req RATE: 48000, real rate: 47999.992, BITS: 32, ERROR: 0.000016%

I (847) I2S: APLL: Req RATE: 96000, real rate: 95999.984, BITS: 16, ERROR: 0.000016%
I (863) I2S: APLL: Req RATE: 96000, real rate: 96000.031, BITS: 24, ERROR: 0.000033%
I (878) I2S: APLL: Req RATE: 96000, real rate: 95999.984, BITS: 32, ERROR: 0.000016%
```
Previous version:
```
I (516) I2S: APLL: Req RATE: 10675, real rate: 10675.000, BITS: 16, ERROR: 0.000000%
I (527) I2S: APLL: Req RATE: 10675, real rate: 10675.003, BITS: 24, ERROR: 0.000030%
I (543) I2S: APLL: Req RATE: 10675, real rate: 10675.006, BITS: 32, ERROR: 0.000055%

I (558) I2S: APLL: Req RATE: 11025, real rate: 11024.991, BITS: 16, ERROR: 0.000080%
I (573) I2S: APLL: Req RATE: 11025, real rate: 11024.992, BITS: 24, ERROR: 0.000071%
I (589) I2S: APLL: Req RATE: 11025, real rate: 11024.991, BITS: 32, ERROR: 0.000080%

I (604) I2S: APLL: Req RATE: 16000, real rate: 15999.986, BITS: 16, ERROR: 0.000085%
I (620) I2S: APLL: Req RATE: 16000, real rate: 15999.987, BITS: 24, ERROR: 0.000081%
I (635) I2S: APLL: Req RATE: 16000, real rate: 16000.003, BITS: 32, ERROR: 0.000018%

I (651) I2S: APLL: Req RATE: 22050, real rate: 22049.982, BITS: 16, ERROR: 0.000080%
I (666) I2S: APLL: Req RATE: 22050, real rate: 22049.984, BITS: 24, ERROR: 0.000071%
I (682) I2S: APLL: Req RATE: 22050, real rate: 21972.619, BITS: 32, ERROR: 0.350934%

I (697) I2S: APLL: Req RATE: 32000, real rate: 32000.006, BITS: 16, ERROR: 0.000018%
I (712) I2S: APLL: Req RATE: 32000, real rate: 31999.974, BITS: 24, ERROR: 0.000081%
I (728) I2S: APLL: Req RATE: 32000, real rate: 32000.006, BITS: 32, ERROR: 0.000018%

I (743) I2S: APLL: Req RATE: 44100, real rate: 43945.238, BITS: 16, ERROR: 0.350934%
I (759) I2S: APLL: Req RATE: 44100, real rate: 44099.969, BITS: 24, ERROR: 0.000071%
I (774) I2S: APLL: Req RATE: 44100, real rate: 43945.238, BITS: 32, ERROR: 0.350934%

I (790) I2S: APLL: Req RATE: 48000, real rate: 47999.961, BITS: 16, ERROR: 0.000081%
I (805) I2S: APLL: Req RATE: 48000, real rate: 46874.922, BITS: 24, ERROR: 2.343913%
I (821) I2S: APLL: Req RATE: 48000, real rate: 43945.238, BITS: 32, ERROR: 8.447420%

I (836) I2S: APLL: Req RATE: 96000, real rate: 87890.477, BITS: 16, ERROR: 8.447420%
I (852) I2S: APLL: Req RATE: 96000, real rate: 96000.031, BITS: 24, ERROR: 0.000033%
I (867) I2S: APLL: Req RATE: 96000, real rate: 107421.875, BITS: 32, ERROR: 11.897786%
```