### PR TITLE
option to configure runtime type information (IDFGH-2495)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -137,6 +137,18 @@ mainmenu "Espressif IoT Development Framework Configuration"
                 Size (in bytes) of the emergency memory pool for C++ exceptions. This pool will be used to allocate
                 memory for thrown exceptions when there is not enough memory on the heap.
 
+        config CXX_ENABLE_RTTI
+		    bool "Enable C++ Runtime Type Information"
+			default n
+			help
+			    Enabling this option compiles all IDF C++ files with runtime type information (rtti) support enabled.
+				
+				Disabling this option disables C++ runtime type information support and some features like
+				dynamic_cast<> can not be used.
+				
+				Enabling this option will add a small memory overhead to each class or struct that contains virtual
+				functions.
+
         choice STACK_CHECK_MODE
             prompt "Stack smashing protection mode"
             default STACK_CHECK_NONE

--- a/make/project.mk
+++ b/make/project.mk
@@ -391,7 +391,6 @@ CXXFLAGS ?=
 EXTRA_CXXFLAGS ?=
 CXXFLAGS := $(strip \
 	-std=gnu++11 \
-	-fno-rtti \
 	$(OPTIMIZATION_FLAGS) $(DEBUG_FLAGS) \
 	$(COMMON_FLAGS) \
 	$(COMMON_WARNING_FLAGS) \
@@ -402,6 +401,12 @@ ifdef CONFIG_CXX_EXCEPTIONS
 CXXFLAGS += -fexceptions
 else
 CXXFLAGS += -fno-exceptions
+endif
+
+ifdef CONFIG_CXX_ENABLE_RTTI
+CXXFLAGS += -frtti
+else
+CXXFLAGS += -fno-rtti
 endif
 
 ARFLAGS := cru


### PR DESCRIPTION
To allow dynamic_cast<> in C++ the runtime type information needs to be enabled. This can be done via menuconfig. It slightly increases the virtual table of all classes and structs that have virtual functions.

Maybe this change can be cherry-picked to master. I cannot get the the needed Toolchain for master compiling on my Raspberry Pi (assembler error in gmp).