### PR TITLE
Fix compiler warning/error when HFP_DYNAMIC_MEMORY is not TRUE. (IDFGH-1378)

### DIFF
--- a/components/bt/bluedroid/btc/profile/std/hf_client/bta_hf_client_co.c
+++ b/components/bt/bluedroid/btc/profile/std/hf_client/bta_hf_client_co.c
@@ -217,8 +217,8 @@ void bta_hf_client_sco_co_open(UINT16 handle, UINT8 air_mode, UINT8 inout_pkt_si
 
     return;
 
-error_exit:;
 #if (HFP_DYNAMIC_MEMORY == TRUE)
+error_exit:;
         if (bta_hf_client_co_cb_ptr) {
             osi_free(bta_hf_client_co_cb_ptr);
             bta_hf_client_co_cb_ptr = NULL;


### PR DESCRIPTION
The ```error_exit``` label is not used in a goto statement unless dynamic memory allocation is enabled. Depending on the setting of compiler flags, this may generate an error during compilation.