### PR TITLE
BT HFP: Add AT+NREC=0 command for disabling AG echo cancellation. (IDFGH-1385)

### DIFF
--- a/components/bt/host/bluedroid/api/esp_hf_client_api.c
+++ b/components/bt/host/bluedroid/api/esp_hf_client_api.c
@@ -432,6 +432,22 @@ esp_err_t esp_hf_client_request_last_voice_tag_number(void)
     return (stat == BT_STATUS_SUCCESS) ? ESP_OK : ESP_FAIL;
 }
 
+esp_err_t esp_hf_client_send_nrec(void)
+{
+    if (esp_bluedroid_get_status() != ESP_BLUEDROID_STATUS_ENABLED) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    btc_msg_t msg;
+    msg.sig = BTC_SIG_API_CALL;
+    msg.pid = BTC_PID_HF_CLIENT;
+    msg.act = BTC_HF_CLIENT_SEND_NREC_EVT;
+
+    /* Switch to BTC context */
+    bt_status_t stat = btc_transfer_context(&msg, NULL, 0, NULL);
+    return (stat == BT_STATUS_SUCCESS) ? ESP_OK : ESP_FAIL;
+}
+
 esp_err_t esp_hf_client_register_data_callback(esp_hf_client_incoming_data_cb_t recv,
                                                esp_hf_client_outgoing_data_cb_t send)
 {

--- a/components/bt/host/bluedroid/api/include/api/esp_hf_client_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_hf_client_api.h
@@ -579,6 +579,20 @@ esp_err_t esp_hf_client_send_dtmf(char code);
 esp_err_t esp_hf_client_request_last_voice_tag_number(void);
 
 /**
+ *
+ * @brief           Disable echo cancellation and noise reduction in the AG (use AT+NREC=0 command)
+ *                  As a precondition to use this API, Service Level Connection shall exist with AG
+ *
+ * @return
+ *                  - ESP_OK: NREC=0 request is sent to lower layer
+ *                  - ESP_INVALID_STATE: if bluetooth stack is not yet enabled
+ *                  - ESP_FAIL: others
+ *
+ */
+esp_err_t esp_hf_client_send_nrec(void);
+
+
+/**
  * @brief           Register HFP client data output function; the callback is only used in
  *                  the case that Voice Over HCI is enabled.
  *

--- a/components/bt/host/bluedroid/btc/profile/std/hf_client/btc_hf_client.c
+++ b/components/bt/host/bluedroid/btc/profile/std/hf_client/btc_hf_client.c
@@ -632,6 +632,27 @@ static bt_status_t btc_hf_client_request_last_voice_tag_number(void)
 
 /*******************************************************************************
 **
+** Function         btc_hf_client_send_nrec
+**
+** Description      Request AG to disable echo cancellation & noise reduction
+**
+** Returns          bt_status_t
+**
+*******************************************************************************/
+static bt_status_t btc_hf_client_send_nrec(void)
+{
+    CHECK_HF_CLIENT_SLC_CONNECTED();
+
+    if (hf_client_local_param.btc_hf_client_cb.peer_feat & BTA_HF_CLIENT_PEER_FEAT_ECNR)
+    {
+        BTA_HfClientSendAT(hf_client_local_param.btc_hf_client_cb.handle, BTA_HF_CLIENT_AT_CMD_NREC, 0, 0, NULL);
+        return BT_STATUS_SUCCESS;
+    }
+    return BT_STATUS_UNSUPPORTED;
+}
+
+/*******************************************************************************
+**
 ** Function         bte_hf_client_evt
 **
 ** Description      Switches context from BTE to BTIF for all HF Client events
@@ -1072,6 +1093,9 @@ void btc_hf_client_call_handler(btc_msg_t *msg)
         break;
     case BTC_HF_CLIENT_REGISTER_DATA_CALLBACK_EVT:
         btc_hf_client_reg_data_cb(arg->reg_data_cb.recv, arg->reg_data_cb.send);
+        break;
+    case BTC_HF_CLIENT_SEND_NREC_EVT:
+        btc_hf_client_send_nrec();
         break;
     default:
         BTC_TRACE_WARNING("%s : unhandled event: %d\n", __FUNCTION__, msg->act);

--- a/components/bt/host/bluedroid/btc/profile/std/include/btc_hf_client.h
+++ b/components/bt/host/bluedroid/btc/profile/std/include/btc_hf_client.h
@@ -57,6 +57,7 @@ typedef enum {
     BTC_HF_CLIENT_SEND_DTMF_EVT,
     BTC_HF_CLIENT_REQUEST_LAST_VOICE_TAG_NUMBER_EVT,
     BTC_HF_CLIENT_REGISTER_DATA_CALLBACK_EVT,
+    BTC_HF_CLIENT_SEND_NREC_EVT,
 } btc_hf_client_act_t;
 
 /* btc_hf_client_args_t */


### PR DESCRIPTION
For testing HFP Client in the case where audio is routed via HCI, it is practical to route the incoming audio from the AG to the outgoing audio via a buffer. However, if the AG has echo cancellation (EC) enabled, the EC will suppress the audio from the HF.

This PR adds an API to use the AT+NREC command for disabling echo cancellation in the AG.
This is probably also needed if the HF has it's own echo canceller.
