### PR TITLE
example/wifi/scan: fix README grammar (IDFGH-1400)

### DIFF
--- a/examples/wifi/scan/README.md
+++ b/examples/wifi/scan/README.md
@@ -1,11 +1,11 @@
 # Wifi SCAN Example
 
-This example shows how to use the scan functionality of ESP32.
+This example shows how to use the scan functionality of the Wi-Fi driver of ESP32.
 
 Two scan methods are supported: fast scan and all channel scan.
 
-* fast scan: in this mode, scan finishes right after a matching AP is detected, even if channels are not completely scanned. You can set thresholds for signal strength, as well as select desired authmodes provided by the AP's. The board will ignore AP's that fail to meet mentioned criteria.
+* fast scan: in this mode, scan finishes right after a matching AP is detected, even if channels are not completely scanned. You can set thresholds for signal strength, as well as select desired authmodes provided by the AP's. The Wi-Fi driver will ignore AP's that fail to meet mentioned criteria.
 
-* all channel scan: scan will end only after all channel are scanned; the board will store 4 of the fully matching AP's. Sort methods for AP's include rssi and authmode. After the scan, the board selects the AP that fits best based on the sort.
+* all channel scan: scan will end only after all channel are scanned; the Wi-Fi driver will store 4 of the fully matching AP's. Sort methods for AP's include rssi and authmode. After the scan, the Wi-Fi driver selects the AP that fits best based on the sort.
 
-After the scan, the board will try to connect. Because it needs to malloc precious dynamic memory to store matching AP's, and, most of the cases, connect to the AP with the strongest reception, it does not need to record all the AP's matched. The number of matches stored is limited to 4 in order to limit dynamic memory usage. Among the 4 matches,  AP's are allowed to carry the same SSID name and all possible auth modes - Open, WEP, WPA and WPA2.
+After the scan, the Wi-Fi driver will try to connect. Because it needs to malloc precious dynamic memory to store matching AP's, and, most of the cases, connect to the AP with the strongest reception, it does not need to record all the AP's matched. The number of matches stored is limited to 4 in order to limit dynamic memory usage. Among the 4 matches,  AP's are allowed to carry the same SSID name and all possible auth modes - Open, WEP, WPA and WPA2.

--- a/examples/wifi/scan/README.md
+++ b/examples/wifi/scan/README.md
@@ -1,11 +1,11 @@
 # Wifi SCAN Example
 
-This example shows how to use scan of ESP32.
+This example shows how to use the scan functionality of ESP32.
 
-We have two way to scan, fast scan and all channel scan:
+Two scan methods are supported: fast scan and all channel scan.
 
-* fast scan: in this mode, scan will finish after find match AP even didn't scan all the channel, you can set thresholds for signal and authmode, it will ignore the AP which below the thresholds.
+* fast scan: in this mode, scan finishes right after a matching AP is detected, even if channels are not completely scanned. You can set thresholds for signal strength, as well as select desired authmodes provided by the AP's. The board will ignore AP's that fail to meet mentioned criteria.
 
-* all channel scan : scan will end after checked all the channel, it will store four of the whole matched AP, you can set the sort method base on rssi or authmode, after scan, it will choose the best one 
+* all channel scan: scan will end only after all channel are scanned; the board will store 4 of the fully matching AP's. Sort methods for AP's include rssi and authmode. After the scan, the board selects the AP that fits best based on the sort.
 
-and try to connect. Because it need malloc dynamic memory to store match AP, and most of cases is to connect to better signal AP, so it needn't record all the AP matched. The number of matches is limited to 4 in order to limit dynamic memory usage. Four matches allows APs with the same SSID name and all possible auth modes - Open, WEP, WPA and WPA2.
+After the scan, the board will try to connect. Because it needs to malloc precious dynamic memory to store matching AP's, and, most of the cases, connect to the AP with the strongest reception, it does not need to record all the AP's matched. The number of matches stored is limited to 4 in order to limit dynamic memory usage. Among the 4 matches,  AP's are allowed to carry the same SSID name and all possible auth modes - Open, WEP, WPA and WPA2.


### PR DESCRIPTION
example/wifi/scan/README.md is currently holding grammatical imperfections. This pull request improves this document.