### PR TITLE
Error if attempting to use APLL for I2S clock source in ADC/DAC mode (IDFGH-1425)

### DIFF
--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -1046,6 +1046,7 @@ esp_err_t i2s_driver_install(i2s_port_t i2s_num, const i2s_config_t *i2s_config,
     I2S_CHECK((i2s_config != NULL), "I2S configuration must not NULL", ESP_ERR_INVALID_ARG);
     I2S_CHECK((i2s_config->dma_buf_count >= 2 && i2s_config->dma_buf_count <= 128), "I2S buffer count less than 128 and more than 2", ESP_ERR_INVALID_ARG);
     I2S_CHECK((i2s_config->dma_buf_len >= 8 && i2s_config->dma_buf_len <= 1024), "I2S buffer length at most 1024 and more than 8", ESP_ERR_INVALID_ARG);
+    I2S_CHECK(!(i2s_config->mode & (I2S_MODE_DAC_BUILT_IN | I2S_MODE_ADC_BUILT_IN)) != !(i2s_config->use_apll), "APLL cannot be used as I2S clock source in ADC or DAC mode", ESP_ERR_INVALID_ARG);
     if (p_i2s_obj[i2s_num] == NULL) {
         p_i2s_obj[i2s_num] = (i2s_obj_t*) malloc(sizeof(i2s_obj_t));
         if (p_i2s_obj[i2s_num] == NULL) {

--- a/components/driver/include/driver/i2s.h
+++ b/components/driver/include/driver/i2s.h
@@ -136,7 +136,7 @@ typedef struct {
     int                     intr_alloc_flags;       /*!< Flags used to allocate the interrupt. One or multiple (ORred) ESP_INTR_FLAG_* values. See esp_intr_alloc.h for more info */
     int                     dma_buf_count;          /*!< I2S DMA Buffer Count */
     int                     dma_buf_len;            /*!< I2S DMA Buffer Length */
-    bool                    use_apll;              /*!< I2S using APLL as main I2S clock, enable it to get accurate clock */
+    bool                    use_apll;               /*!< I2S using APLL as main I2S clock, enable it to get accurate clock (cannot use with built-in ADC or DAC mode) */
     bool                    tx_desc_auto_clear;     /*!< I2S auto clear tx descriptor if there is underflow condition (helps in avoiding noise in case of data unavailability) */
     int                     fixed_mclk;             /*!< I2S using fixed MCLK output. If use_apll = true and fixed_mclk > 0, then the clock output for i2s is fixed and equal to the fixed_mclk value.*/
 } i2s_config_t;


### PR DESCRIPTION
The technical manual (12.5) says:

> In the ADC/DAC mode, use PLL_D2_CLK as the clock source.

I added an error check (maybe it should be a warning?) and a note in the I2S header about this.