### PR TITLE
Ensure that IDF_PATH and IDF_TOOLS_PATH are exported to subshell (IDFGH-1469)

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -28,6 +28,8 @@ function idf_export_main() {
     # Call idf_tools.py to export tool paths
     export IDF_TOOLS_EXPORT_CMD=${IDF_PATH}/export.sh
     export IDF_TOOLS_INSTALL_CMD=${IDF_PATH}/install.sh
+    export IDF_PATH
+    export IDF_TOOLS_PATH
     idf_exports=$(${IDF_PATH}/tools/idf_tools.py export) || return 1
     eval "${idf_exports}"
 


### PR DESCRIPTION
Resolves #3737. This is a naïve approach in that any other environment variables that might need to be exported to the Python tool will need to be added here manually, but it gets the job done.