### PR TITLE
esp_partition_erase_range(): rename parameter "start_addr" to "offset" (IDFGH-1484)

### DIFF
--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -245,8 +245,8 @@ esp_err_t esp_partition_write(const esp_partition_t* partition,
  * @param partition Pointer to partition structure obtained using
  *                  esp_partition_find_first or esp_partition_get.
  *                  Must be non-NULL.
- * @param start_addr Address where erase operation should start. Must be aligned
- *                   to 4 kilobytes.
+ * @param offset Offset from the beginning of partition where erase operation
+ *               should start. Must be aligned to 4 kilobytes.
  * @param size Size of the range which should be erased, in bytes.
  *                   Must be divisible by 4 kilobytes.
  *
@@ -256,7 +256,7 @@ esp_err_t esp_partition_write(const esp_partition_t* partition,
  *         or one of error codes from lower-level flash driver.
  */
 esp_err_t esp_partition_erase_range(const esp_partition_t* partition,
-                                    uint32_t start_addr, uint32_t size);
+                                    uint32_t offset, uint32_t size);
 
 /**
  * @brief Configure MMU to map partition into data memory

--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -276,22 +276,22 @@ esp_err_t esp_partition_write(const esp_partition_t* partition,
 }
 
 esp_err_t esp_partition_erase_range(const esp_partition_t* partition,
-                                    size_t start_addr, size_t size)
+                                    size_t offset, size_t size)
 {
     assert(partition != NULL);
-    if (start_addr > partition->size) {
+    if (offset > partition->size) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (start_addr + size > partition->size) {
+    if (offset + size > partition->size) {
         return ESP_ERR_INVALID_SIZE;
     }
     if (size % SPI_FLASH_SEC_SIZE != 0) {
         return ESP_ERR_INVALID_SIZE;
     }
-    if (start_addr % SPI_FLASH_SEC_SIZE != 0) {
+    if (offset % SPI_FLASH_SEC_SIZE != 0) {
         return ESP_ERR_INVALID_ARG;
     }
-    return spi_flash_erase_range(partition->address + start_addr, size);
+    return spi_flash_erase_range(partition->address + offset, size);
 
 }
 


### PR DESCRIPTION
The name "start_addr" (which goes straight into the docs) implies
it's an absolute address while in fact it's an offset into the
partition like what's used in all the other esp_partition_*
functions.

So in order to avoid confusion make the name consistent with the
parameter names used for the other partition functions and call it
"offset".