### PR TITLE
malloc memory request size is updated (IDFGH-1490)

### DIFF
--- a/examples/peripherals/mcpwm/mcpwm_basic_config/main/mcpwm_basic_config_example.c
+++ b/examples/peripherals/mcpwm/mcpwm_basic_config/main/mcpwm_basic_config_example.c
@@ -137,8 +137,8 @@ static void gpio_test_signal(void *arg)
  */
 static void disp_captured_signal(void *arg)
 {
-    uint32_t *current_cap_value = (uint32_t *)malloc(sizeof(CAP_SIG_NUM));
-    uint32_t *previous_cap_value = (uint32_t *)malloc(sizeof(CAP_SIG_NUM));
+    uint32_t *current_cap_value = (uint32_t *)malloc(CAP_SIG_NUM*sizeof(uint32_t));
+    uint32_t *previous_cap_value = (uint32_t *)malloc(CAP_SIG_NUM*sizeof(uint32_t));
     capture evt;
     while (1) {
         xQueueReceive(cap_queue, &evt, portMAX_DELAY);


### PR DESCRIPTION
sizeof(CAP_SIG_NUM) will return only 4 bytes. However, we need 3*4 = 12 for three signals capture. So, CAP_SIG_NUM*sizeof(uint32_t) is valid for memory allocation. Otherwise, it will access out-of boundary memory.