### PR TITLE
Add aditional uint32_t object to `ulp_insn_t` to get the encoded instruction from bit-field structs

### DIFF
--- a/components/ulp/include/esp32/ulp.h
+++ b/components/ulp/include/esp32/ulp.h
@@ -262,6 +262,8 @@ typedef union {
         uint32_t opcode: 4;         /*!< Opcode (OPCODE_MACRO) */
     } macro;                        /*!< Format of tokens used by LABEL and BRANCH macros */
 
+    uint32_t instruction;           /*!< Encoded instruction for ULP coprocessor */
+
 } ulp_insn_t;
 
 _Static_assert(sizeof(ulp_insn_t) == 4, "ULP coprocessor instruction size should be 4 bytes");


### PR DESCRIPTION
This allows users to quickly get the encoded instruction that can be assigned rather than needing `memcpy` to assign.

Current way of assignment looks bad :
```
ulp_insn_t wr_inst = I_WR_REG(DAC_REG, 19, 26, i);
*inst_p = *(uint32_t *)&wr_inst
```
