### PR TITLE
tcp transport ssl DER-support (IDFGH-1518)

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -90,22 +90,28 @@ typedef struct esp_tls_cfg {
                                                  - where 'h2' is the protocol name */
  
     const unsigned char *cacert_pem_buf;    /*!< Certificate Authority's certificate in a buffer.
-                                                 This buffer should be NULL terminated */
+                                                 Format may be PEM or DER, depending on mbedtls-support
+                                                 This buffer should be NULL terminated in case of PEM */
  
     unsigned int cacert_pem_bytes;          /*!< Size of Certificate Authority certificate
-                                                 pointed to by cacert_pem_buf */
+                                                 pointed to by cacert_pem_buf
+                                                 (including NULL-terminator in case of PEM format) */
 
     const unsigned char *clientcert_pem_buf;/*!< Client certificate in a buffer
-                                                 This buffer should be NULL terminated */
+                                                 Format may be PEM or DER, depending on mbedtls-support
+                                                 This buffer should be NULL terminated in case of PEM */
 
     unsigned int clientcert_pem_bytes;      /*!< Size of client certificate pointed to by
-                                                 clientcert_pem_buf */
+                                                 clientcert_pem_buf
+                                                 (including NULL-terminator in case of PEM format) */
 
     const unsigned char *clientkey_pem_buf; /*!< Client key in a buffer
-                                                 This buffer should be NULL terminated */
+                                                 Format may be PEM or DER, depending on mbedtls-support
+                                                 This buffer should be NULL terminated in case of PEM */
 
     unsigned int clientkey_pem_bytes;       /*!< Size of client key pointed to by
-                                                 clientkey_pem_buf */
+                                                 clientkey_pem_buf
+                                                 (including NULL-terminator in case of PEM format) */
 
     const unsigned char *clientkey_password;/*!< Client key decryption password string */
 

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -41,6 +41,17 @@ esp_transport_handle_t esp_transport_ssl_init();
 void esp_transport_ssl_set_cert_data(esp_transport_handle_t t, const char *data, int len);
 
 /**
+ * @brief      Set SSL certificate data (as DER format).
+ *             Note that, this function stores the pointer to data, rather than making a copy.
+ *             So this data must remain valid until after the connection is cleaned up
+ *
+ * @param      t     ssl transport
+ * @param[in]  data  The der data
+ * @param[in]  len   The length
+ */
+void esp_transport_ssl_set_cert_data_der(esp_transport_handle_t t, const char *data, int len);
+
+/**
  * @brief      Enable global CA store for SSL connection
  *
  * @param      t    ssl transport
@@ -59,6 +70,17 @@ void esp_transport_ssl_enable_global_ca_store(esp_transport_handle_t t);
 void esp_transport_ssl_set_client_cert_data(esp_transport_handle_t t, const char *data, int len);
 
 /**
+ * @brief      Set SSL client certificate data for mutual authentication (as DER format).
+ *             Note that, this function stores the pointer to data, rather than making a copy.
+ *             So this data must remain valid until after the connection is cleaned up
+ *
+ * @param      t     ssl transport
+ * @param[in]  data  The der data
+ * @param[in]  len   The length
+ */
+void esp_transport_ssl_set_client_cert_data_der(esp_transport_handle_t t, const char *data, int len);
+
+/**
  * @brief      Set SSL client key data for mutual authentication (as PEM format).
  *             Note that, this function stores the pointer to data, rather than making a copy.
  *             So this data must remain valid until after the connection is cleaned up
@@ -68,6 +90,17 @@ void esp_transport_ssl_set_client_cert_data(esp_transport_handle_t t, const char
  * @param[in]  len   The length
  */
 void esp_transport_ssl_set_client_key_data(esp_transport_handle_t t, const char *data, int len);
+
+/**
+ * @brief      Set SSL client key data for mutual authentication (as DER format).
+ *             Note that, this function stores the pointer to data, rather than making a copy.
+ *             So this data must remain valid until after the connection is cleaned up
+ *
+ * @param      t     ssl transport
+ * @param[in]  data  The der data
+ * @param[in]  len   The length
+ */
+void esp_transport_ssl_set_client_key_data_der(esp_transport_handle_t t, const char *data, int len);
 
 /**
  * @brief      Skip validation of certificate's common name field

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -178,6 +178,15 @@ void esp_transport_ssl_set_cert_data(esp_transport_handle_t t, const char *data,
     }
 }
 
+void esp_transport_ssl_set_cert_data_der(esp_transport_handle_t t, const char *data, int len)
+{
+    transport_ssl_t *ssl = esp_transport_get_context_data(t);
+    if (t && ssl) {
+        ssl->cfg.cacert_pem_buf = (void *)data;
+        ssl->cfg.cacert_pem_bytes = len;
+    }
+}
+
 void esp_transport_ssl_set_client_cert_data(esp_transport_handle_t t, const char *data, int len)
 {
     transport_ssl_t *ssl = esp_transport_get_context_data(t);
@@ -187,12 +196,30 @@ void esp_transport_ssl_set_client_cert_data(esp_transport_handle_t t, const char
     }
 }
 
+void esp_transport_ssl_set_client_cert_data_der(esp_transport_handle_t t, const char *data, int len)
+{
+    transport_ssl_t *ssl = esp_transport_get_context_data(t);
+    if (t && ssl) {
+        ssl->cfg.clientcert_pem_buf = (void *)data;
+        ssl->cfg.clientcert_pem_bytes = len;
+    }
+}
+
 void esp_transport_ssl_set_client_key_data(esp_transport_handle_t t, const char *data, int len)
 {
     transport_ssl_t *ssl = esp_transport_get_context_data(t);
     if (t && ssl) {
         ssl->cfg.clientkey_pem_buf = (void *)data;
         ssl->cfg.clientkey_pem_bytes = len + 1;
+    }
+}
+
+void esp_transport_ssl_set_client_key_data_der(esp_transport_handle_t t, const char *data, int len)
+{
+    transport_ssl_t *ssl = esp_transport_get_context_data(t);
+    if (t && ssl) {
+        ssl->cfg.clientkey_pem_buf = (void *)data;
+        ssl->cfg.clientkey_pem_bytes = len;
     }
 }
 


### PR DESCRIPTION
This pull-request is to add der-support to esp_transport_ssl. Or to be more precise, to clarify the already existing possibility to use der format for certificates and keys courtesy of mbedtls.
mbedtls supports der format just as well as pem format, assuming it is not disabled at compile time. The relevant functions autodetect the format, so all that is necessary is to pass the correct certificate-/key- length.
Unfortunately the existing esp_transport_ssl_set_client_cert etc. functions assume NULL-terminated pem, and (because mbedlts requires the NULL-byte to be included in the key-/cert-length parameter) add 1 to the length. This is wrong for DER, so I added _der variants that don't add 1 to the length back. (that's literally the only difference).
Ideally I'd also like to rename all *_pem_* variables, to reflect that they in fact don't need to be in PEM format, but since they are part of the public api of the libraries this would break existing code.