### PR TITLE
Timeout for TCP connect (IDFGH-1541)

### DIFF
--- a/components/tcp_transport/transport_tcp.c
+++ b/components/tcp_transport/transport_tcp.c
@@ -52,7 +52,6 @@ static int resolve_dns(const char *host, struct sockaddr_in *ip) {
 static int tcp_connect(esp_transport_handle_t t, const char *host, int port, int timeout_ms)
 {
     struct sockaddr_in remote_ip;
-    struct timeval tv;
     transport_tcp_t *tcp = esp_transport_get_context_data(t);
 
     bzero(&remote_ip, sizeof(struct sockaddr_in));
@@ -74,13 +73,82 @@ static int tcp_connect(esp_transport_handle_t t, const char *host, int port, int
     remote_ip.sin_family = AF_INET;
     remote_ip.sin_port = htons(port);
 
-    esp_transport_utils_ms_to_timeval(timeout_ms, &tv);
+    // Set socket to non-blocking
+    int flags;
+    if ((flags = fcntl(tcp->sock, F_GETFL, NULL)) < 0) {
+        ESP_LOGE(TAG, "[sock=%d] set fcntl(F_GETFL) error: %s", tcp->sock, strerror(errno));
+        tcp->sock = -1;
+        return -1;
+    }
+    flags |= O_NONBLOCK; 
+    if (fcntl(tcp->sock, F_SETFL, flags) < 0) { 
+        ESP_LOGE(TAG, "[sock=%d] set fcntl(F_SETFL) error: %s", tcp->sock, strerror(errno));
+        tcp->sock = -1;
+        return -1;
+    }
 
-    setsockopt(tcp->sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ESP_LOGD(TAG, "[sock=%d] Connecting to server. IP: %s, Port: %d",
+             tcp->sock, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), port); 
 
-    ESP_LOGD(TAG, "[sock=%d],connecting to server IP:%s,Port:%d...",
-             tcp->sock, ipaddr_ntoa((const ip_addr_t*)&remote_ip.sin_addr.s_addr), port);
-    if (connect(tcp->sock, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)) != 0) {
+    int res = connect(tcp->sock, (struct sockaddr *)(&remote_ip), sizeof(struct sockaddr)); 
+    if (res < 0) {
+        if (errno == EINPROGRESS) {
+            ESP_LOGD(TAG, "[sock=%d] EINPROGRESS in connect(), selecting...", tcp->sock); 
+            struct timeval tv;
+            fd_set fdset;
+            do {
+                esp_transport_utils_ms_to_timeval(timeout_ms, &tv);
+                FD_ZERO(&fdset);
+                FD_SET(tcp->sock, &fdset);
+                res = select(tcp->sock+1, NULL, &fdset, NULL, &tv);
+                if (res < 0 && errno != EINTR) {
+                    ESP_LOGE(TAG, "[sock=%d] select() error: %s", tcp->sock, strerror(errno));
+                    close(tcp->sock);
+                    tcp->sock = -1;
+                    return -1;
+                }
+                else if (res > 0) {
+                    int sockerr;
+                    socklen_t len = (socklen_t)sizeof(int);
+                    if (getsockopt(tcp->sock, SOL_SOCKET, SO_ERROR, (void*)(&sockerr), &len) < 0) {
+                        ESP_LOGE(TAG, "[sock=%d] getsockopt() error: %s", tcp->sock, strerror(errno));
+                        close(tcp->sock);
+                        tcp->sock = -1;
+                        return -1;
+                    }
+                    if (sockerr) {
+                        ESP_LOGE(TAG, "[sock=%d] delayed connect error: %s", tcp->sock, strerror(sockerr));
+                        close(tcp->sock);
+                        tcp->sock = -1;
+                        return -1;
+                    }
+                    break; 
+                }
+                else {
+                    ESP_LOGE(TAG, "[sock=%d] select() timeout", tcp->sock);
+                    close(tcp->sock);
+                    tcp->sock = -1;
+                    return -1;
+                }
+            } while (1);
+        }
+        else { 
+            ESP_LOGE(TAG, "[sock=%d] connect() error: %s", tcp->sock, strerror(errno));
+            close(tcp->sock);
+            tcp->sock = -1;
+            return -1;
+        }
+    }
+    // Reset socket to blocking
+    if ((flags = fcntl(tcp->sock, F_GETFL, NULL)) < 0) {
+        ESP_LOGE(TAG, "[sock=%d] reset fcntl(F_GETFL) error: %s", tcp->sock, strerror(errno));
+        close(tcp->sock);
+        tcp->sock = -1;
+        return -1;
+    } 
+    flags &= (~O_NONBLOCK); 
+    if (fcntl(tcp->sock, F_SETFL, flags) < 0) {
+        ESP_LOGE(TAG, "[sock=%d] reset fcntl(F_SETFL) error: %s", tcp->sock, strerror(errno));
         close(tcp->sock);
         tcp->sock = -1;
         return -1;


### PR DESCRIPTION
Currently, the timeout_ms parameter is actually used for the SO_RCVTIMEO option rather than for the socket connection. Therefore, regardless of the timeout_ms value, connect() will block for a long time (~20 seconds) if a connection cannot be established (eg. the server is offline). This is very inefficient, especially in the common case of battery-powered devices connecting to a local server, where <100ms might be enough to determine if the server is online. 

Efficiency aside, I think it's far more intuitive for a 'timeout_ms' parameter of 'tcp_connect' to actually be the connection timeout. 

With this, tcp_connect will return an error if the socket is not write-able before timeout_ms expires. I've tested via esp_http_client.

- It gets kinda if-if-iffy. Is "goto error" preferred style? (edit: updated to goto)
- Also I'm unsure if there's anything that is dependent on SO_RCVTIMEO being set to timeout_ms here. I know that esp_http_client is fine (it passes timeout_ms separately to read) but tcp_connect might be called elsewhere. Should SO_RCVTIMEO still be timeout_ms? 