### PR TITLE
Fix bug: Avoid sbc_plc_deinit(...) on unallocated memory. (IDFGH-1535)

### DIFF
--- a/components/bt/host/bluedroid/btc/profile/std/hf_client/bta_hf_client_co.c
+++ b/components/bt/host/bluedroid/btc/profile/std/hf_client/bta_hf_client_co.c
@@ -254,12 +254,13 @@ void bta_hf_client_sco_co_close(void)
 
     if (hf_air_mode == BTM_SCO_AIR_MODE_TRANSPNT) {
 #if (PLC_INCLUDED == TRUE)
-        sbc_plc_deinit(&(bta_hf_ct_plc.plc_state));
-        bta_hf_ct_plc.first_good_frame_found = FALSE;
 
 #if (HFP_DYNAMIC_MEMORY == TRUE)
         osi_free(bta_hf_ct_plc_ptr);
         bta_hf_ct_plc_ptr = NULL;
+#else
+        sbc_plc_deinit(&(bta_hf_ct_plc.plc_state));
+        bta_hf_ct_plc.first_good_frame_found = FALSE;
 #endif  /// (HFP_DYNAMIC_MEMORY == TRUE)
 
 #endif  ///(PLC_INCLUDED == TRUE)


### PR DESCRIPTION
Once in a while, usually in situations when a "Peer connection failed (res: 16)" error is observed, it seems that ```sbc_plc_deinit(...)``` is called on unallocated memory. This causes a core panic due to an unhandled ```StoreProhibited``` exception. This happens when Bluedroid is using dynamic allocation.

```sbc_plc_deinit(...)``` just clears the ```plc_state``` instance memory and does not (currently) have any side-effects.

In any case, I think that ```bta_hf_client_sco_co_close()``` should be written so that it is safe to call it, even if initialisation/allocation has not been completed.

