### PR TITLE
Accept relative path as env variable - CMake

### DIFF
--- a/tools/check_python_dependencies.py
+++ b/tools/check_python_dependencies.py
@@ -52,7 +52,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     not_satisfied = []
-    with open(args.requirements) as f:
+
+    absolute_path = os.path.expanduser(args.requirements)
+    with open(absolute_path) as f:
         for line in f:
             line = line.strip()
             try:


### PR DESCRIPTION
When I tried to set up CMake and defined IDF_PATH relative to user's home `~/esp/esp-idf'` I got an error:  `No such file or directory: '~/esp/esp-idf/requirements.txt'` in check_python_dependencies.py as `with open("~/esp/esp-idf)` requires full file path. 

Fix expands IDF_PATH with user home if it starts with ~