### PR TITLE
Fix error UnicodeDecodeError in idf_tools.py (IDFGH-1695)

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -442,7 +442,7 @@ class IDFTool(object):
             raise ToolExecError('Command {} has returned non-zero exit code ({})\n'.format(
                 ' '.join(self._current_options.version_cmd), e.returncode))
 
-        in_str = version_cmd_result.decode()
+        in_str = version_cmd_result.decode('utf-8')
         match = re.search(self._current_options.version_regex, in_str)
         if not match:
             return UNKNOWN_VERSION


### PR DESCRIPTION
Fix error `decode()` by adding **utf-8**, just below install.sh with the error.

```
$ ./install
Installing ESP-IDF tools
Installing tools: xtensa-esp32-elf, esp32ulp-elf, openocd-esp32
Skipping xtensa-esp32-elf@esp32-2019r1-8.2.0 (already installed)
Traceback (most recent call last):
  File "/data/sdk/esp/esp-idf/tools/idf_tools.py", line 1317, in <module>
    main(sys.argv[1:])
  File "/data/sdk/esp/esp-idf/tools/idf_tools.py", line 1313, in main
    action_func(args)
  File "/data/sdk/esp/esp-idf/tools/idf_tools.py", line 1098, in action_install
    tool_obj.find_installed_versions()
  File "/data/sdk/esp/esp-idf/tools/idf_tools.py", line 503, in find_installed_versions
    ver_str = self.check_version(self.get_export_paths(version))
  File "/data/sdk/esp/esp-idf/tools/idf_tools.py", line 445, in check_version
    in_str = version_cmd_result.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 110: ordinal not in range(128)
```