### PR TITLE
Fixed syntax error in esp_http_server.rst (IDFGH-1701)

### DIFF
--- a/docs/en/api-reference/protocols/esp_http_server.rst
+++ b/docs/en/api-reference/protocols/esp_http_server.rst
@@ -22,7 +22,7 @@ Application Example
         esp_err_t get_handler(httpd_req_t *req)
         {
             /* Send a simple response */
-            const char[] resp = "URI GET Response";
+            const char resp[] = "URI GET Response";
             httpd_resp_send(req, resp, strlen(resp));
             return ESP_OK;
         }
@@ -55,7 +55,7 @@ Application Example
             }
 
             /* Send a simple response */
-            const char[] resp = "URI POST Response";
+            const char resp[] = "URI POST Response";
             httpd_resp_send(req, resp, strlen(resp));
             return ESP_OK;
         }


### PR DESCRIPTION
Changed the "const char[] name" into "const char name[]", so now the code doesn't produce the "expected identifier or '(' before '[' token" error.