### PR TITLE
Added configuration option to select base clock of rmt peripheral (IDFGH-1715)

### DIFF
--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -49,7 +49,7 @@ typedef enum {
 }rmt_mem_owner_t;
 
 typedef enum {
-    RMT_BASECLK_REF = 0,   /*!< RMT source clock system reference tick, 1MHz by default (not supported in this version) */
+    RMT_BASECLK_REF = 0,   /*!< RMT source clock system reference tick, 1MHz by default */
     RMT_BASECLK_APB,       /*!< RMT source clock is APB CLK, 80Mhz by default */
     RMT_BASECLK_MAX,
 } rmt_source_clk_t;
@@ -119,6 +119,7 @@ typedef struct {
 typedef struct {
     rmt_mode_t rmt_mode;               /*!< RMT mode: transmitter or receiver */
     rmt_channel_t channel;             /*!< RMT channel */
+    rmt_source_clk_t clock;            /*!< RMT base clock */
     uint8_t clk_div;                   /*!< RMT channel counter divider */
     gpio_num_t gpio_num;               /*!< RMT GPIO number */
     uint8_t mem_block_num;             /*!< RMT memory block number */

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -413,6 +413,7 @@ esp_err_t rmt_config(const rmt_config_t* rmt_param)
     uint8_t channel = rmt_param->channel;
     uint8_t gpio_num = rmt_param->gpio_num;
     uint8_t mem_cnt = rmt_param->mem_block_num;
+    uint8_t clock = rmt_param->clock;
     int clk_div = rmt_param->clk_div;
     uint32_t carrier_freq_hz = rmt_param->tx_config.carrier_freq_hz;
     bool carrier_en = rmt_param->tx_config.carrier_en;
@@ -446,9 +447,9 @@ esp_err_t rmt_config(const rmt_config_t* rmt_param)
         /*Memory set block number*/
         RMT.conf_ch[channel].conf0.mem_size = mem_cnt;
         RMT.conf_ch[channel].conf1.mem_owner = RMT_MEM_OWNER_TX;
-        /*We use APB clock in this version, which is 80Mhz, later we will release system reference clock*/
-        RMT.conf_ch[channel].conf1.ref_always_on = RMT_BASECLK_APB;
-        rmt_source_clk_hz = RMT_SOURCE_CLK(RMT_BASECLK_APB);
+        /*Select peripheral base clock */
+        RMT.conf_ch[channel].conf1.ref_always_on = clock;
+        rmt_source_clk_hz = RMT_SOURCE_CLK(clock);
         /*Set idle level */
         RMT.conf_ch[channel].conf1.idle_out_en = rmt_param->tx_config.idle_output_en;
         RMT.conf_ch[channel].conf1.idle_out_lv = idle_level;
@@ -479,8 +480,8 @@ esp_err_t rmt_config(const rmt_config_t* rmt_param)
 
         portENTER_CRITICAL(&rmt_spinlock);
         /*clock init*/
-        RMT.conf_ch[channel].conf1.ref_always_on = RMT_BASECLK_APB;
-        uint32_t rmt_source_clk_hz = RMT_SOURCE_CLK(RMT_BASECLK_APB);
+        RMT.conf_ch[channel].conf1.ref_always_on = clock;
+        uint32_t rmt_source_clk_hz = RMT_SOURCE_CLK(clock);
         /*memory set block number and owner*/
         RMT.conf_ch[channel].conf0.mem_size = mem_cnt;
         RMT.conf_ch[channel].conf1.mem_owner = RMT_MEM_OWNER_RX;

--- a/examples/peripherals/rmt_nec_tx_rx/main/infrared_nec_main.c
+++ b/examples/peripherals/rmt_nec_tx_rx/main/infrared_nec_main.c
@@ -242,6 +242,7 @@ static void nec_tx_init(void)
     rmt_tx.gpio_num = RMT_TX_GPIO_NUM;
     rmt_tx.mem_block_num = 1;
     rmt_tx.clk_div = RMT_CLK_DIV;
+    rmt_tx.clock = RMT_BASECLK_APB;
     rmt_tx.tx_config.loop_en = false;
     rmt_tx.tx_config.carrier_duty_percent = 50;
     rmt_tx.tx_config.carrier_freq_hz = 38000;
@@ -262,6 +263,7 @@ static void nec_rx_init(void)
     rmt_config_t rmt_rx;
     rmt_rx.channel = RMT_RX_CHANNEL;
     rmt_rx.gpio_num = RMT_RX_GPIO_NUM;
+    rmt_rx.clock = RMT_BASECLK_APB;
     rmt_rx.clk_div = RMT_CLK_DIV;
     rmt_rx.mem_block_num = 1;
     rmt_rx.rmt_mode = RMT_MODE_RX;

--- a/examples/peripherals/rmt_tx/main/rmt_tx_main.c
+++ b/examples/peripherals/rmt_tx/main/rmt_tx_main.c
@@ -91,6 +91,7 @@ static void rmt_tx_int(void)
     config.channel = RMT_TX_CHANNEL;
     config.gpio_num = RMT_TX_GPIO;
     config.mem_block_num = 1;
+    config.clock = RMT_BASECLK_APB;
     config.tx_config.loop_en = 0;
     // enable the carrier to be able to hear the Morse sound
     // if the RMT_TX_GPIO is connected to a speaker


### PR DESCRIPTION
While creating a program to encode and decode 433 MHZ transmissions via the RMT peripheral I needed to use the REF clock instead of the APB clock. So I wrote this small patch to enable selecting the clock source of the peripheral and also update the example code to include this configuration option.