### PR TITLE
Added the option to print system time rather than RTOS time in ESP_LOGx functions (IDFGH-1773)

### DIFF
--- a/components/esp_wifi/include/esp_private/wifi_os_adapter.h
+++ b/components/esp_wifi/include/esp_private/wifi_os_adapter.h
@@ -104,11 +104,7 @@ typedef struct {
     int32_t (* _get_time)(void *t);
     unsigned long (* _random)(void);
     void (* _log_write)(uint32_t level, const char* tag, const char* format, ...);
-#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
-    char* (* _log_timestamp)(void);
-#else
     uint32_t (* _log_timestamp)(void);
-#endif
     void * (* _malloc_internal)(size_t size);
     void * (* _realloc_internal)(void *ptr, size_t size);
     void * (* _calloc_internal)(size_t n, size_t size);

--- a/components/esp_wifi/include/esp_private/wifi_os_adapter.h
+++ b/components/esp_wifi/include/esp_private/wifi_os_adapter.h
@@ -104,7 +104,11 @@ typedef struct {
     int32_t (* _get_time)(void *t);
     unsigned long (* _random)(void);
     void (* _log_write)(uint32_t level, const char* tag, const char* format, ...);
+#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
+    char* (* _log_timestamp)(void);
+#else
     uint32_t (* _log_timestamp)(void);
+#endif
     void * (* _malloc_internal)(size_t size);
     void * (* _realloc_internal)(void *ptr, size_t size);
     void * (* _calloc_internal)(size_t n, size_t size);

--- a/components/log/Kconfig
+++ b/components/log/Kconfig
@@ -44,17 +44,30 @@ menu "Log output"
 
             In order to view these, your terminal program must support ANSI color codes.
 
-    config LOG_SYSTEM_TIME
-        bool "Use system time in log output"
-        default "n"
+    choice LOG_TIMESTAMP_SOURCE
+        prompt "Log Timestamps"
+        default LOG_TIMESTAMP_SOURCE_RTOS
         help
-            Display the system time (HH:MM:SS.sss) in the log output rather than the 
-            RTOS time. Currently this will not get used in logging from binary blobs
-			(i.e WiFi & Bluetooth libraries), these will still print the RTOS tick time.
+            Choose what sort of timestamp is displayed in the log output:
 
-            The system time is initialized to 0 on startup, this can be set to 
-            the correct time with an SNTP sync, or manually with standard 
-            POSIX time functions.
+            - Milliseconds since boot is calulated from the RTOS tick count multiplied
+              by the tick period. This time will reset after a software reboot.
+              e.g. (90000)
+            
+            - System time is taken from POSIX time functions which use the ESP32's
+              RTC and FRC1 timers to maintain an accurate time. The system time is 
+              initialized to 0 on startup, it can be set with an SNTP sync, or with 
+              POSIX time functions. This time will not reset after a software reboot.
+              e.g. (00:01:30.000)
 
+            - NOTE: Currently this will not get used in logging from binary blobs
+              (i.e WiFi & Bluetooth libraries), these will always print 
+              milliseconds since boot.
+
+        config LOG_TIMESTAMP_SOURCE_RTOS
+            bool "Milliseconds Since Boot"
+        config LOG_TIMESTAMP_SOURCE_SYSTEM
+            bool "System Time"
+    endchoice
 
 endmenu

--- a/components/log/Kconfig
+++ b/components/log/Kconfig
@@ -44,5 +44,15 @@ menu "Log output"
 
             In order to view these, your terminal program must support ANSI color codes.
 
+    config LOG_SYSTEM_TIME
+        bool "Use system time in log output"
+        default "n"
+        help
+            Display the system time (HH:MM:SS.sss) in the log output rather than the 
+            RTOS time.
+
+            In order for this time to be correct, you must do an SNTP time sync,
+            otherwise this time will start from 0.
+
 
 endmenu

--- a/components/log/Kconfig
+++ b/components/log/Kconfig
@@ -49,10 +49,12 @@ menu "Log output"
         default "n"
         help
             Display the system time (HH:MM:SS.sss) in the log output rather than the 
-            RTOS time.
+            RTOS time. Currently this will not get used in logging from binary blobs
+			(i.e WiFi & Bluetooth libraries), these will still print the RTOS tick time.
 
-            In order for this time to be correct, you must do an SNTP time sync,
-            otherwise this time will start from 0.
+            The system time is initialized to 0 on startup, this can be set to 
+            the correct time with an SNTP sync, or manually with standard 
+            POSIX time functions.
 
 
 endmenu

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -311,15 +311,7 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
  *
  * @see ``printf``
  */
-#if CONFIG_LOG_SYSTEM_TIME
-#define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
-        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-    } while(0)
-#else
+#if CONFIG_LOG_TIMESTAMP_SOURCE_RTOS
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
@@ -327,7 +319,15 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
     } while(0)
-#endif // CONFIG_LOG_SYSTEM_TIME
+#elif CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM
+#define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+    } while(0)
+#endif //CONFIG_LOG_TIMESTAMP_SOURCE_xxx
 
 /** runtime macro to output logs at a specified level. Also check the level with ``LOG_LOCAL_LEVEL``.
  *

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -84,7 +84,11 @@ vprintf_like_t esp_log_set_vprintf(vprintf_like_t func);
  *
  * @return timestamp, in milliseconds
  */
+#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
+char* esp_log_timestamp(void);
+#else
 uint32_t esp_log_timestamp(void);
+#endif
 
 /**
  * @brief Function which returns timestamp to be used in log output
@@ -241,7 +245,11 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
 #define LOG_RESET_COLOR
 #endif //CONFIG_LOG_COLORS
 
+#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
+#define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%s) %s: " format LOG_RESET_COLOR "\n"
+#else
 #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%d) %s: " format LOG_RESET_COLOR "\n"
+#endif
 
 /** @endcond */
 

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -84,11 +84,22 @@ vprintf_like_t esp_log_set_vprintf(vprintf_like_t func);
  *
  * @return timestamp, in milliseconds
  */
-#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
-char* esp_log_timestamp(void);
-#else
 uint32_t esp_log_timestamp(void);
-#endif
+
+/**
+ * @brief Function which returns system timestamp to be used in log output
+ *
+ * This function is used in expansion of ESP_LOGx macros to print
+ * the system time as "HH:MM:SS.sss". The system time is initialized to
+ * 0 on startup, this can be set to the correct time with an SNTP sync,
+ * or manually with standard POSIX time functions.
+ *
+ * Currently this will not get used in logging from binary blobs
+ * (i.e WiFi & Bluetooth libraries), these will still print the RTOS tick time.
+ *
+ * @return timestamp, in "HH:MM:SS.sss"
+ */
+char* esp_log_system_timestamp(void);
 
 /**
  * @brief Function which returns timestamp to be used in log output
@@ -245,11 +256,8 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
 #define LOG_RESET_COLOR
 #endif //CONFIG_LOG_COLORS
 
-#if defined(CONFIG_LOG_SYSTEM_TIME) && !defined(BOOTLOADER_BUILD)
-#define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%s) %s: " format LOG_RESET_COLOR "\n"
-#else
 #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%d) %s: " format LOG_RESET_COLOR "\n"
-#endif
+#define LOG_SYSTEM_TIME_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%s) %s: " format LOG_RESET_COLOR "\n"
 
 /** @endcond */
 
@@ -303,6 +311,15 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
  *
  * @see ``printf``
  */
+#if CONFIG_LOG_SYSTEM_TIME
+#define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+    } while(0)
+#else
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
@@ -310,6 +327,7 @@ void esp_log_write(esp_log_level_t level, const char* tag, const char* format, .
         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
     } while(0)
+#endif // CONFIG_LOG_SYSTEM_TIME
 
 /** runtime macro to output logs at a specified level. Also check the level with ``LOG_LOCAL_LEVEL``.
  *

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -343,7 +343,7 @@ char* IRAM_ATTR esp_log_system_timestamp(void)
         uint32_t timestamp = esp_log_early_timestamp();
         for (uint8_t i = 0; i < sizeof(buffer); i++) {
             if ((timestamp > 0) || (i == 0)) {
-                for (uint8_t j = sizeof(buffer); j > 0; j--) {
+                for (uint8_t j = sizeof(buffer) - 1; j > 0; j--) {
                     buffer[j] = buffer[j - 1];
                 }
                 buffer[0] = (char) (timestamp % 10) + '0';

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -334,9 +334,7 @@ uint32_t ATTR esp_log_early_timestamp(void)
 
 #ifndef BOOTLOADER_BUILD
 
-#if CONFIG_LOG_SYSTEM_TIME
-
-char* IRAM_ATTR esp_log_timestamp(void)
+char* IRAM_ATTR esp_log_system_timestamp(void)
 {
     static char buffer[15] = {0};
 
@@ -382,8 +380,6 @@ char* IRAM_ATTR esp_log_timestamp(void)
     }
 }
 
-#else
-
 uint32_t IRAM_ATTR esp_log_timestamp(void)
 {
     if (xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED) {
@@ -395,8 +391,6 @@ uint32_t IRAM_ATTR esp_log_timestamp(void)
     }
     return base + xTaskGetTickCount() * (1000 / configTICK_RATE_HZ);
 }
-
-#endif //CONFIG_LOG_SYSTEM_TIME
 
 #else
 

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -367,11 +367,6 @@ char* IRAM_ATTR esp_log_system_timestamp(void)
         struct timespec tv;
         time_t now;
 
-        if (bufferLock == 0)
-        {
-            _lock_init(&bufferLock);
-        }
-
         time(&now);
         localtime_r(&now, &timeinfo);
         clock_gettime(CLOCK_REALTIME, &tv);

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -339,30 +339,22 @@ char* IRAM_ATTR esp_log_system_timestamp(void)
     static char buffer[15] = {0};
     static _lock_t bufferLock = 0;
 
-    if (xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED) 
-    {
+    if (xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED) {
         uint32_t timestamp = esp_log_early_timestamp();
-        for (uint8_t i = 0; i < sizeof(buffer); i++)
-        {
-            if ((timestamp > 0) || (i == 0))
-            {
-                for (uint8_t j = sizeof(buffer); j > 0; j--)
-                {
+        for (uint8_t i = 0; i < sizeof(buffer); i++) {
+            if ((timestamp > 0) || (i == 0)) {
+                for (uint8_t j = sizeof(buffer); j > 0; j--) {
                     buffer[j] = buffer[j - 1];
                 }
                 buffer[0] = (char) (timestamp % 10) + '0';
                 timestamp /= 10;
-            }
-            else
-            {
+            } else {
                 buffer[i] = 0;
                 break;
             }
         }
         return buffer;
-    }
-    else
-    {
+    } else {
         struct tm timeinfo;
         struct timespec tv;
         time_t now;


### PR DESCRIPTION
I mainly wrote this because I wanted to syncronize logs from an ESP32 with logs from a cloud platform that were timestamped in UTC, and I think other people would probably find this option useful too.

Obviously this time will just start from 0 unless you set the system time (with an SNTP sync for example), but assuming you do set the time it makes the logs much more useful when trying to match up events happening on multiple platforms.

Example from the hello world program:

```D (168) efuse: In EFUSE_BLK0__DATA5_REG is used 1 bits starting with 20 bit
I (168) cpu_start: Chip Revision: 1
I (170) cpu_start: Starting scheduler on PRO CPU.
D (0) intr_alloc: Connected src 25 to int 2 (cpu 1)
I (0) cpu_start: Starting scheduler on APP CPU.
D (171) heap_init: New heap initialised at 0x3ffe0440
D (171) heap_init: New heap initialised at 0x3ffe4350
D (171) intr_alloc: Connected src 16 to int 12 (cpu 0)
Hello world!
D (00:00:00.011) efuse: coding scheme 0
D (00:00:00.012) efuse: In EFUSE_BLK0__DATA3_REG is used 1 bits starting with 15 bit
D (00:00:00.013) efuse: coding scheme 0
D (00:00:00.013) efuse: In EFUSE_BLK0__DATA5_REG is used 1 bits starting with 20 bit
This is ESP32 chip with 2 CPU cores, WiFi/BT/BLE, silicon revision 1, 4MB external flash
Restarting in 10 seconds...