### PR TITLE
kconfig: fix `unexpected operator` error on Linux (IDFGH-1742)

### DIFF
--- a/tools/kconfig/lxdialog/check-lxdialog.sh
+++ b/tools/kconfig/lxdialog/check-lxdialog.sh
@@ -4,10 +4,10 @@
 # What library to link
 ldflags()
 {
-	if [ $(uname -s) == "Darwin" ]; then 
+	if [ `uname -s` = "Darwin" ]; then
 		#OSX seems to need ncurses too
 		echo -n "-lncurses "
-	elif [ $(uname -s) == "FreeBSD" ]; then
+	elif [ `uname -s` = "FreeBSD" ]; then
 		# On FreeBSD, the linker needs to know to search port libs for
 		# libintl
 		echo -n "-L/usr/local/lib -lintl "
@@ -45,10 +45,10 @@ ccflags()
 	else
 		echo '-DCURSES_LOC="<curses.h>"'
 	fi
-	if [ $(uname -s) == "Darwin" ]; then
+	if [ `uname -s` = "Darwin" ]; then
 		#OSX doesn't have libintl
 		echo -n "-DKBUILD_NO_NLS -Wno-format-security "
-	elif [ $(uname -s) == "FreeBSD" ]; then
+	elif [ `uname -s` = "FreeBSD" ]; then
 		# FreeBSD gettext port has libintl.h, but the compiler needs
 		# to know to search port includes
 		echo -n "-I/usr/local/include "


### PR DESCRIPTION
and use portable backticks

introduced by me, d296aad causes `unexpected operator` warning during the build on Linux machine, which is harmless, but confuses users.