### PR TITLE
LwIP: Make IP_PKTINFO support configurable (IDFGH-1758)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -90,6 +90,13 @@ menu "LWIP"
         help
             Enabling this option allows checking for available data on a netconn.
 
+    config LWIP_NETBUF_RECVINFO
+        bool "Enable IP_PKTINFO option"
+        default n
+        help
+            Enabling this option allows checking for the destination address
+            of a received IPv4 Packet.
+
     config LWIP_IP_FRAG
         bool "Enable fragment outgoing IP packets"
         default n

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -556,6 +556,12 @@
  */
 #define SO_REUSE_RXTOALL                CONFIG_LWIP_SO_REUSE_RXTOALL
 
+/**
+ * LWIP_NETBUF_RECVINFO==1: Enable IP_PKTINFO option.
+ * This option is set via menuconfig.
+ */
+#define LWIP_NETBUF_RECVINFO            CONFIG_LWIP_NETBUF_RECVINFO
+
 /*
    ----------------------------------------
    ---------- Statistics options ----------


### PR DESCRIPTION
LwIP has support for IP_PKTINFO, but it cannot be activated as it is
not configurable.  This fix adds in the ability to configure it.