### PR TITLE
Use CONFIG_BTU_TASK_STACK_SIZE instead of hard-coded value in Bluedroid component (IDFGH-1757)

### DIFF
--- a/components/bt/host/bluedroid/common/include/common/bluedroid_user_config.h
+++ b/components/bt/host/bluedroid/common/include/common/bluedroid_user_config.h
@@ -33,6 +33,12 @@
 #else
 #define UC_A2DP_SOURCE_TASK_STACK_SIZE      2048
 #endif
+#ifdef CONFIG_BT_BTU_TASK_STACK_SIZE
+#define UC_BT_BTU_TASK_STACK_SIZE           CONFIG_BT_BTU_TASK_STACK_SIZE
+#else
+#define UC_BT_BTU_TASK_STACK_SIZE           4096
+#endif
+
 
 /**********************************************************
  * Profile reference

--- a/components/bt/host/bluedroid/common/include/common/bt_target.h
+++ b/components/bt/host/bluedroid/common/include/common/bt_target.h
@@ -45,6 +45,7 @@
 /* OS Configuration from User config (eg: sdkconfig) */
 #define A2DP_SINK_TASK_STACK_SIZE   UC_A2DP_SINK_TASK_STACK_SIZE
 #define A2DP_SOURCE_TASK_STACK_SIZE UC_A2DP_SOURCE_TASK_STACK_SIZE
+#define BT_BTU_TASK_STACK_SIZE      UC_BT_BTU_TASK_STACK_SIZE
 
 /******************************************************************************
 **

--- a/components/bt/host/bluedroid/stack/btu/btu_init.c
+++ b/components/bt/host/bluedroid/stack/btu/btu_init.c
@@ -45,7 +45,7 @@
 #endif
 
 #define BTU_TASK_PINNED_TO_CORE         (TASK_PINNED_TO_CORE)
-#define BTU_TASK_STACK_SIZE             (4096 + BT_TASK_EXTRA_STACK_SIZE)
+#define BTU_TASK_STACK_SIZE             (BT_BTU_TASK_STACK_SIZE + BT_TASK_EXTRA_STACK_SIZE)
 #define BTU_TASK_PRIO                   (BT_TASK_MAX_PRIORITIES - 5)
 #define BTU_TASK_NAME                   "btuT"
 


### PR DESCRIPTION
I simply replaced a hard-coded stack size with the value pulled from the configuration, which is how it worked in the past.  Without this, I can't use Bluetooth at all without getting stack overflows.

I logged [IDFGH-1702](https://github.com/espressif/esp-idf/issues/3941) for this last week, and it seems to be a very simple fix.