### PR TITLE
Put argument of macro SPI_SWAP_DATA_TX in parentheses

### DIFF
--- a/components/driver/include/driver/spi_common.h
+++ b/components/driver/include/driver/spi_common.h
@@ -45,7 +45,7 @@ extern "C"
  *  len Length of data to be sent, since the SPI peripheral sends from the MSB,
  *  this helps to shift the data to the MSB.
  */
-#define SPI_SWAP_DATA_TX(data, len) __builtin_bswap32((uint32_t)data<<(32-len))
+#define SPI_SWAP_DATA_TX(data, len) __builtin_bswap32((uint32_t)(data)<<(32-len))
 
 /**
  * Transform received data of length <= 32 bits to the format of an unsigned integer.


### PR DESCRIPTION
For "obvious" reasons - `SPI_SWAP_DATA_TX(val & 0x1ff, 9)` didn't quite do what I expected...