### PR TITLE
Prevent linker error with duplicate symbol  (IDFGH-1811)

### DIFF
--- a/components/newlib/syscalls.c
+++ b/components/newlib/syscalls.c
@@ -27,6 +27,7 @@ int _system_r(struct _reent *r, const char *str)
     return -1;
 }
 
+int _raise_r(struct _reent *r, int sig) __attribute__((weak));
 int _raise_r(struct _reent *r, int sig)
 {
     abort();


### PR DESCRIPTION
Found in both the cross compiler's libnano library and newlib library.

This fix #4017