### PR TITLE
Fix multiple definition linker error for operators for C++  (IDFGH-1810)

### DIFF
--- a/components/esp32/include/esp_attr.h
+++ b/components/esp32/include/esp_attr.h
@@ -80,18 +80,19 @@
 // Format: FLAG_ATTR(flag_enum_t)
 #ifdef __cplusplus
 
+// Inline is required here to avoid multiple definition error in linker
 #define FLAG_ATTR_IMPL(TYPE, INT_TYPE) \
-constexpr TYPE operator~ (TYPE a) { return (TYPE)~(INT_TYPE)a; } \
-constexpr TYPE operator| (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a | (INT_TYPE)b); } \
-constexpr TYPE operator& (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a & (INT_TYPE)b); } \
-constexpr TYPE operator^ (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a ^ (INT_TYPE)b); } \
-constexpr TYPE operator>> (TYPE a, int b) { return (TYPE)((INT_TYPE)a >> b); } \
-constexpr TYPE operator<< (TYPE a, int b) { return (TYPE)((INT_TYPE)a << b); } \
-TYPE& operator|=(TYPE& a, TYPE b) { a = a | b; return a; } \
-TYPE& operator&=(TYPE& a, TYPE b) { a = a & b; return a; } \
-TYPE& operator^=(TYPE& a, TYPE b) { a = a ^ b; return a; } \
-TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
-TYPE& operator<<=(TYPE& a, int b) { a <<= b; return a; }
+inline constexpr TYPE operator~ (TYPE a) { return (TYPE)~(INT_TYPE)a; } \
+inline constexpr TYPE operator| (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a | (INT_TYPE)b); } \
+inline constexpr TYPE operator& (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a & (INT_TYPE)b); } \
+inline constexpr TYPE operator^ (TYPE a, TYPE b) { return (TYPE)((INT_TYPE)a ^ (INT_TYPE)b); } \
+inline constexpr TYPE operator>> (TYPE a, int b) { return (TYPE)((INT_TYPE)a >> b); } \
+inline constexpr TYPE operator<< (TYPE a, int b) { return (TYPE)((INT_TYPE)a << b); } \
+inline TYPE& operator|=(TYPE& a, TYPE b) { a = a | b; return a; } \
+inline TYPE& operator&=(TYPE& a, TYPE b) { a = a & b; return a; } \
+inline TYPE& operator^=(TYPE& a, TYPE b) { a = a ^ b; return a; } \
+inline TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
+inline TYPE& operator<<=(TYPE& a, int b) { a <<= b; return a; }
 
 #define FLAG_ATTR_U32(TYPE) FLAG_ATTR_IMPL(TYPE, uint32_t)
 #define FLAG_ATTR FLAG_ATTR_U32


### PR DESCRIPTION
In build including FLAG_ATTR'ed enum.

This fix #4016