### PR TITLE
fix(FreeRTOS): Initialize uxTaskNumber at task initialization (IDFGH-1815)

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -887,6 +887,13 @@ UBaseType_t x;
 	}
 	#endif /* ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) || ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) ) ) */
 
+	#if( configUSE_TRACE_FACILITY == 1 )
+	{
+		/* Zero the uxTaskNumber TCB member to avoid random value from dynamically allocated TCBs */
+		pxNewTCB->uxTaskNumber = 0;
+	}
+	#endif  /* ( configUSE_TRACE_FACILITY == 1 ) */
+
 	/* Calculate the top of stack address.  This depends on whether the stack
 	grows from high memory to low (as per the 80x86) or vice versa.
 	portSTACK_GROWTH is used to make the result positive or negative as required


### PR DESCRIPTION
```uxTaskNumber``` member of ```struct tskTaskControlBlock``` is not initialized at thread creation.
As the TCB can be dynamically allocated, ```uxTaskNumber``` might then get a value from the heap.
As a result, the user might get a seems-valid value when calling ```uxTaskGetTaskNumber()``` and then take wrong decisions.

This fix zeroes ```uxTaskNumber``` when the task is initialized.