### PR TITLE
putchar is not thread safe and eventually halts the ESP32 under certa… (IDFGH-1842)

### DIFF
--- a/examples/protocols/https_request/main/https_request_example_main.c
+++ b/examples/protocols/https_request/main/https_request_example_main.c
@@ -129,7 +129,7 @@ static void https_get_task(void *pvParameters)
             ESP_LOGD(TAG, "%d bytes read", len);
             /* Print response directly to stdout as it is read */
             for(int i = 0; i < len; i++) {
-                putchar(buf[i]);
+                printf("%c", buf[i]);
             }
         } while(1);
 


### PR DESCRIPTION
…in conditions. No WDT or task WDT work in that situation nor crash report is displayed. The device freezes for good.