### PR TITLE
Fix websocket frame handling in components/tcp_transport (IDFGH-1882)

### DIFF
--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -171,6 +171,15 @@ static esp_err_t esp_websocket_client_set_config(esp_websocket_client_handle_t c
         free(cfg->path);
         cfg->path = strdup(config->path);
         ESP_WS_CLIENT_MEM_CHECK(TAG, cfg->path, return ESP_ERR_NO_MEM);
+
+        esp_transport_handle_t trans = esp_transport_list_get_transport(client->transport_list, "ws");
+        if (trans) {
+            esp_transport_ws_set_path(trans, cfg->path);
+        }
+        trans = esp_transport_list_get_transport(client->transport_list, "wss");
+        if (trans) {
+            esp_transport_ws_set_path(trans, cfg->path);
+        }
     }
 
     cfg->network_timeout_ms = WEBSOCKET_NETWORK_TIMEOUT_MS;

--- a/components/esp_websocket_client/esp_websocket_client.c
+++ b/components/esp_websocket_client/esp_websocket_client.c
@@ -460,7 +460,7 @@ static void esp_websocket_client_task(void *pv)
                     esp_transport_write(client->transport, NULL, 0, client->config->network_timeout_ms);
                 }
                 if (read_select == 0) {
-                    ESP_LOGD(TAG, "Timeout...");
+                    ESP_LOGD(TAG, "Keep waiting for new message...");
                     continue;
                 }
                 client->ping_tick_ms = _tick_get_ms();


### PR DESCRIPTION
The _components/esp_websocket_client_ sends PING frame to server every 10 seconds by default, this usually triggers the server replying with a PONG frame, which could trigger a read error. This pull request fixed this issue, and made the following minor changes in _components/tcp_transport_:
1. Reply with PONG frame when a PING frame from server is received. This prevent timeout if server has a keep-alive mechanism.
2. Handle websocket frame with size over buffer size without error.

While using _components/esp_websocket_client_ to test, also fixed the following issue:
1. Fix path in client config is not being applied.
2. Rephrasing debug message prevent misunderstanding.