### PR TITLE
Typo fix (IDFGH-1899)

### DIFF
--- a/components/ulp/include/esp32/ulp.h
+++ b/components/ulp/include/esp32/ulp.h
@@ -240,7 +240,7 @@ typedef union {
         uint32_t unused : 8;        /*!< Unused */
         uint32_t low : 5;           /*!< Low bit */
         uint32_t high : 5;          /*!< High bit */
-        uint32_t opcode : 4;        /*!< Opcode (OPCODE_WR_REG) */
+        uint32_t opcode : 4;        /*!< Opcode (OPCODE_RD_REG) */
     } rd_reg;                       /*!< Format of RD_REG instruction */
 
     struct {


### PR DESCRIPTION
rd_reg comment references incorrect OPCODE ("OPCODE_WR_REG"); amended to "OPCODE_RD_REG".