### PR TITLE
sdspi: allow skipping spi bus initialization (IDFGH-1909)

### DIFF
--- a/components/driver/include/driver/sdspi_host.h
+++ b/components/driver/include/driver/sdspi_host.h
@@ -62,6 +62,7 @@ typedef struct {
     gpio_num_t gpio_wp;     ///< GPIO number of write protect signal
     gpio_num_t gpio_int;    ///< GPIO number of interrupt line (input) for SDIO card.
     int dma_channel;        ///< DMA channel to be used by SPI driver (1 or 2)
+    bool skip_bus_init;     ///< skip spi bus initialization
 } sdspi_slot_config_t;
 
 #define SDSPI_SLOT_NO_CD    GPIO_NUM_NC ///< indicates that card detect line is not used
@@ -79,7 +80,8 @@ typedef struct {
     .gpio_cd   = SDSPI_SLOT_NO_CD, \
     .gpio_wp   = SDSPI_SLOT_NO_WP, \
     .gpio_int  = GPIO_NUM_NC, \
-    .dma_channel = 1 \
+    .dma_channel = 1, \
+    .skip_bus_init = false \
 }
 
 /**

--- a/components/driver/sdspi_host.c
+++ b/components/driver/sdspi_host.c
@@ -287,20 +287,24 @@ esp_err_t sdspi_host_init_slot(int slot, const sdspi_slot_config_t* slot_config)
         return ESP_ERR_INVALID_ARG;
     }
 
-    spi_bus_config_t buscfg = {
-        .miso_io_num = slot_config->gpio_miso,
-        .mosi_io_num = slot_config->gpio_mosi,
-        .sclk_io_num = slot_config->gpio_sck,
-        .quadwp_io_num = GPIO_NUM_NC,
-        .quadhd_io_num = GPIO_NUM_NC
-    };
+    esp_err_t ret;
 
-    // Initialize SPI bus
-    esp_err_t ret = spi_bus_initialize((spi_host_device_t)slot, &buscfg,
-            slot_config->dma_channel);
-    if (ret != ESP_OK) {
-        ESP_LOGD(TAG, "spi_bus_initialize failed with rc=0x%x", ret);
-        return ret;
+    if (!slot_config->skip_bus_init) {
+        spi_bus_config_t buscfg = {
+            .miso_io_num = slot_config->gpio_miso,
+            .mosi_io_num = slot_config->gpio_mosi,
+            .sclk_io_num = slot_config->gpio_sck,
+            .quadwp_io_num = GPIO_NUM_NC,
+            .quadhd_io_num = GPIO_NUM_NC
+        };
+
+        // Initialize SPI bus
+        ret = spi_bus_initialize((spi_host_device_t)slot, &buscfg,
+                slot_config->dma_channel);
+        if (ret != ESP_OK) {
+            ESP_LOGD(TAG, "spi_bus_initialize failed with rc=0x%x", ret);
+            return ret;
+        }
     }
 
     // Attach the SD card to the SPI bus


### PR DESCRIPTION
This solves bus initialization issues on targets like the Odroid-Go where the SPI bus is shared between multiple slave by adding a skip_bus_init flag within sdspi_slot_config_t.

@OtherCrashOverride this might be of interest to you.