### PR TITLE
Add KConfig option to allow using other Bluetooth Host Stack (IDFGH-2062)

### DIFF
--- a/components/bt/Kconfig
+++ b/components/bt/Kconfig
@@ -378,6 +378,11 @@ menu "Bluetooth"
             help
                 This option is recommended for BLE only usecases to save on memory
 
+        config BT_OTHER_ENABLED
+            bool "Other Host Stack"
+            help
+                This option is recommended to use with other Bluetooth Host stack
+
     endchoice
 
     menu "Bluedroid Options"


### PR DESCRIPTION
With the current KConfig for the Bluetooth component, it is not possible to select neither Bluedroid nor NimBLE. If disabling both, the default (Bluedroid) is activated. 

The pull request adds an "Other" option that allows use a different Bluetooth Stack, e.g. [BTstack](https://github.com/bluekitchen/btstack/tree/master/port/esp32).