### PR TITLE
newlib: fix compile error of toupper/tolower (IDFGH-1975)

### DIFF
--- a/components/newlib/include/ctype.h
+++ b/components/newlib/include/ctype.h
@@ -54,7 +54,7 @@ extern	__IMPORT char	* _CONST __ctype_ptr__;
    Meanwhile, the real index to __ctype_ptr__+1 must be cast to int,
    since isalpha(0x100000001LL) must equal isalpha(1), rather than being
    an out-of-bounds reference on a 64-bit machine.  */
-#define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
+#define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[(int)(__c)]))[(int)(__c)])
 
 #define	isalpha(__c)	(__ctype_lookup(__c)&(_U|_L))
 #define	isupper(__c)	((__ctype_lookup(__c)&(_U|_L))==_U)


### PR DESCRIPTION
otherwise, error will occured as follows:

...
ctype.h:57:54: error: array subscript has type 'char' [-Werror=char-subscripts]