### PR TITLE
Fix UART RS485 Failing to Enable Transmitter After Some Time (IDFGH-1983) (IDFGH-1987)

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -836,6 +836,7 @@ static void uart_rx_intr_handler_default(void *param)
                         if (UART_IS_MODE_SET(uart_num, UART_MODE_RS485_HALF_DUPLEX)) {
                             UART_ENTER_CRITICAL_ISR(&uart_spinlock[uart_num]);
                             uart_reg->conf0.sw_rts = 0;
+							uart_reg->int_clr.tx_done = 1;
                             uart_reg->int_ena.tx_done = 1;
                             UART_EXIT_CRITICAL_ISR(&uart_spinlock[uart_num]);
                         }
@@ -1113,7 +1114,7 @@ static int uart_fill_fifo(uart_port_t uart_num, const char* buffer, uint32_t len
     // Set the RTS pin if RS485 mode is enabled
     if (UART_IS_MODE_SET(uart_num, UART_MODE_RS485_HALF_DUPLEX)) {
         UART[uart_num]->conf0.sw_rts = 0;
-        uart_clear_intr_status(uart_num, UART_TX_DONE_INT_CLR_M);	// Clear interrupt before enabling to fix (IDFGH-1983)
+		UART[uart_num]->int_clr.tx_done = 1;
         UART[uart_num]->int_ena.tx_done = 1;
     }
     for (i = 0; i < copy_cnt; i++) {

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1113,7 +1113,7 @@ static int uart_fill_fifo(uart_port_t uart_num, const char* buffer, uint32_t len
     // Set the RTS pin if RS485 mode is enabled
     if (UART_IS_MODE_SET(uart_num, UART_MODE_RS485_HALF_DUPLEX)) {
         UART[uart_num]->conf0.sw_rts = 0;
-		uart_clear_intr_status(uart_num, UART_TX_DONE_INT_CLR_M);	// Clear interrupt before enabling to fix (IDFGH-1983)
+        uart_clear_intr_status(uart_num, UART_TX_DONE_INT_CLR_M);	// Clear interrupt before enabling to fix (IDFGH-1983)
         UART[uart_num]->int_ena.tx_done = 1;
     }
     for (i = 0; i < copy_cnt; i++) {

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1113,6 +1113,7 @@ static int uart_fill_fifo(uart_port_t uart_num, const char* buffer, uint32_t len
     // Set the RTS pin if RS485 mode is enabled
     if (UART_IS_MODE_SET(uart_num, UART_MODE_RS485_HALF_DUPLEX)) {
         UART[uart_num]->conf0.sw_rts = 0;
+		uart_clear_intr_status(uart_num, UART_TX_DONE_INT_CLR_M);	// Clear interrupt before enabling to fix (IDFGH-1983)
         UART[uart_num]->int_ena.tx_done = 1;
     }
     for (i = 0; i < copy_cnt; i++) {


### PR DESCRIPTION
Added the code to clear the tx done interrupt before enabling the interrupt to fix the issue of the transceiver not being enabled after some time of running in RS485 mode. I suspect an interrupt is being missed for some reason, which causes the interrupt and fifo fill to get out of sync. By clearing the interrupt before enabling it and writing to the fifo, we make sure it will always stay in sync