### PR TITLE
Support MutualAuthentication in HTTPS-Server (IDFGH-2004)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -47,6 +47,12 @@ struct httpd_ssl_config {
     /** CA certificate byte length */
     size_t cacert_len;
 
+    /** Server certificate */
+    const uint8_t *servercert_pem;
+
+    /** Server certificate byte length */
+    size_t servercert_len;
+
     /** Private key */
     const uint8_t *prvtkey_pem;
 
@@ -100,6 +106,8 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     },                                            \
     .cacert_pem = NULL,                           \
     .cacert_len = 0,                              \
+    .servercert_pem = NULL,                       \
+    .servercert_len = 0,                          \
     .prvtkey_pem = NULL,                          \
     .prvtkey_len = 0,                             \
     .transport_mode = HTTPD_SSL_TRANSPORT_SECURE, \


### PR DESCRIPTION
The ESP-TLS-Server supports client verification in mutual authentication. This adds functionality to the `esp_https_server` for setting the required certificates.
In this way the https server is able to verify a client's certificate using the given ca certificate.