### PR TITLE
Fix Cmake compilation for OTA (IDFGH-2066)

### DIFF
--- a/components/esp_https_ota/CMakeLists.txt
+++ b/components/esp_https_ota/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "src/esp_https_ota.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES esp_http_client
+                    REQUIRES esp_http_client app_update
                     PRIV_REQUIRES log app_update)


### PR DESCRIPTION
In some cases Cmake hits  fatal error: esp_ota_ops.h: No such file or directory, this fix this issue