### PR TITLE
Driver/uart: uart_read_bytes should return when no more data in ring buf or timeout

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1240,9 +1240,19 @@ int uart_read_bytes(uart_port_t uart_num, uint8_t* buf, uint32_t length, TickTyp
     if(xSemaphoreTake(p_uart_obj[uart_num]->rx_mux,(portTickType)ticks_to_wait) != pdTRUE) {
         return -1;
     }
+
+    if(p_uart_obj[uart_num]->rx_cur_remain == 0) {
+        data = (uint8_t*) xRingbufferReceive(p_uart_obj[uart_num]->rx_ring_buf, &size, (portTickType) ticks_to_wait);
+        if(data) {
+            p_uart_obj[uart_num]->rx_head_ptr = data;
+            p_uart_obj[uart_num]->rx_ptr = data;
+            p_uart_obj[uart_num]->rx_cur_remain = size;
+        }
+    }
+
     while(length) {
         if(p_uart_obj[uart_num]->rx_cur_remain == 0) {
-            data = (uint8_t*) xRingbufferReceive(p_uart_obj[uart_num]->rx_ring_buf, &size, (portTickType) ticks_to_wait);
+            data = (uint8_t*) xRingbufferReceive(p_uart_obj[uart_num]->rx_ring_buf, &size, (portTickType) 0);
             if(data) {
                 p_uart_obj[uart_num]->rx_head_ptr = data;
                 p_uart_obj[uart_num]->rx_ptr = data;


### PR DESCRIPTION
**The PR is used to fix a bug about uart driver API `uart_read_bytes`:**

int uart_read_bytes(uart_port_t uart_num, uint8_t* buf, uint32_t length, TickType_t ticks_to_wait)
I think the meaning of the last parameter `ticks_to_wait` should be explained as:

- if no data received from driver, the API returns;
- if some data received but less than user buffer length length, it returns too.

**How to reproduce this bug:**
- use example project `examples/peripherals/uart/uart_async_rxtxtasks`
- chang the rx task read timeout to 4000ms
   ```const int rxBytes = uart_read_bytes(UART_NUM_1, data, RX_BUF_SIZE, 4000 / portTICK_RATE_MS);```
- the tx task will send data every 2000ms.
- then rx will not print info durning a long time (the root cause is that the buffer passed to driver is not stuffed then the API will not return).