### PR TITLE
Add config option for LWIP TCP_TMR_INTERVAL (IDFGH-2041)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -318,6 +318,14 @@ menu "LWIP"
                 IPv4 TCP_MSS Range: 576 <= TCP_MSS <= 1460
                 IPv6 TCP_MSS Range: 1220<= TCP_mSS <= 1440
 
+        config TCP_TMR_INTERVAL
+            int "TCP timer interval"
+            default 250
+            help
+                Set TCP timer interval in milliseconds.
+
+                Can be used to speed connections on bad networks. A lower value will redeliver unacked packets faster.
+
         config LWIP_TCP_MSL
             int "Maximum segment lifetime (MSL)"
             default 60000

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -326,6 +326,11 @@
 #define TCP_MSS                         CONFIG_LWIP_TCP_MSS
 
 /**
+ * TCP_TMR_INTERVAL: TCP timer interval
+ */
+#define TCP_TMR_INTERVAL                CONFIG_TCP_TMR_INTERVAL
+
+/**
  * TCP_MSL: The maximum segment lifetime in milliseconds
  */
 #define TCP_MSL                         CONFIG_LWIP_TCP_MSL


### PR DESCRIPTION
This is the same change from https://github.com/espressif/esp-idf/pull/3365

I haven't tested it though; since I'm still on the 3.2 branch, but it should do the same thing.