### PR TITLE
Remove trailing space in tools.json leading to error on file decompress process (IDFGH-2124)

### DIFF
--- a/tools/tools.json
+++ b/tools/tools.json
@@ -95,7 +95,7 @@
           "macos": {
             "sha256": "e566b9f1288ef3bd89b08e9807e88c37f760d48e74b84eee9e9642bb5c0a0bbd",
             "size": 69793197,
-            "url": " https://dl.espressif.com/dl/toolchains/preview/xtensa-esp32s2-elf-gcc8_2_0-esp32s2-dev-4-g3a626e-macos.tar.gz "
+            "url": " https://dl.espressif.com/dl/toolchains/preview/xtensa-esp32s2-elf-gcc8_2_0-esp32s2-dev-4-g3a626e-macos.tar.gz"
           },
           "name": "esp32s2-dev-4-g3a626e9-8.2.0",
           "status": "recommended",


### PR DESCRIPTION
…ssion in macOS

URL for `xtensa-esp32s2-elf-gcc8_2_0-esp32s2-dev-4-g3a626e-macos.tar.gz` has a trailing space that makes the actual file extension `".tar.gz "` making it not recognizable by the decompress process.