### PR TITLE
Removed relative path for lwip/arpa/inet.h (IDFGH-2153)

### DIFF
--- a/components/lwip/port/esp32/include/arpa/inet.h
+++ b/components/lwip/port/esp32/include/arpa/inet.h
@@ -15,6 +15,6 @@
 #ifndef INET_H_
 #define INET_H_
 
-#include "../../../lwip/src/include/lwip/inet.h"
+#include "lwip/inet.h"
 
 #endif /* INET_H_ */


### PR DESCRIPTION
The relative path breaks compatibility with arduino-esp32 as the path doesn't exist in arduino-esp32.
https://github.com/espressif/arduino-esp32/pull/3425