### PR TITLE
Allow processing of ULP macro array in RTC slow mem (IDFGH-2172)

### DIFF
--- a/components/ulp/include/ulp_common.h
+++ b/components/ulp/include/ulp_common.h
@@ -47,6 +47,17 @@ typedef union ulp_insn ulp_insn_t;
 esp_err_t ulp_process_macros_and_load(uint32_t load_addr, const ulp_insn_t* program, size_t* psize);
 
 /**
+ * @brief Resolve all macro references in a program in RTC memory, overwriting it with the result
+ * @param program  ulp_insn_t array (in RTC_SLOW_MEM) with the program
+ * @param psize  size of the program, expressed in 32-bit words
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_NO_MEM if auxiliary temporary structure can not be allocated
+ *      - one of ESP_ERR_ULP_xxx if program is not valid or can not be loaded
+ */
+esp_err_t ulp_process_macros_in_place(const ulp_insn_t* program, size_t* psize);
+
+/**
  * @brief Load ULP program binary into RTC memory
  *
  * ULP program binary should have the following format (all values little-endian):

--- a/components/ulp/ulp_macro.c
+++ b/components/ulp/ulp_macro.c
@@ -313,16 +313,15 @@ esp_err_t ulp_process_macros_and_load(uint32_t load_addr, const ulp_insn_t* prog
 esp_err_t ulp_process_macros_in_place(const ulp_insn_t* program, size_t* psize)
 {
     size_t macro_count = count_ulp_macros(program, *psize);
-    size_t real_program_size = *psize - macro_count;
     const size_t ulp_mem_end = 0x1000 / sizeof(ulp_insn_t);
     uint32_t load_addr = program - (ulp_insn_t*)RTC_SLOW_MEM;
     if (program < RTC_SLOW_MEM || load_addr >= ulp_mem_end) {
         ESP_LOGW(TAG, "program in invalid location in memory, check attributes");
         return ESP_ERR_ULP_INVALID_LOAD_ADDR;
     }
-    if (real_program_size + load_addr > ulp_mem_end) {
+    if (*psize + load_addr > ulp_mem_end) {
         ESP_LOGE(TAG, "program too big: %d words, max is %d words",
-                real_program_size, ulp_mem_end - load_addr);
+                *psize, ulp_mem_end - load_addr);
         return ESP_ERR_ULP_SIZE_TOO_BIG;
     }
     // If no macros found, return

--- a/components/ulp/ulp_macro.c
+++ b/components/ulp/ulp_macro.c
@@ -315,7 +315,6 @@ esp_err_t ulp_process_macros_in_place(const ulp_insn_t* program, size_t* psize)
     size_t macro_count = count_ulp_macros(program, *psize);
     size_t real_program_size = *psize - macro_count;
     const size_t ulp_mem_end = 0x1000 / sizeof(ulp_insn_t);
-    // const uint32_t* program_addr = program;
     uint32_t load_addr = program - (ulp_insn_t*)RTC_SLOW_MEM;
     if (program < RTC_SLOW_MEM || load_addr >= ulp_mem_end) {
         ESP_LOGW(TAG, "program in invalid location in memory, check attributes");


### PR DESCRIPTION
This adds **ulp_process_macros_in_place()**, a variant of ulp_process_macros_and_load(). It takes a ULP macro array that is already in RTC slow memory and _replaces_ it with the output program.

```
RTC_DATA_ATTR const ulp_insn_t program[] = { M_LABEL(1), M_BX(1), };
size_t programSize = sizeof(program) / sizeof(ulp_insn_t);
ulp_process_macros_in_place(program, &programSize);
ulp_run((uint32_t*)program - RTC_SLOW_MEM);
```

The underlying processing functions are already safe (read_ptr>=write_ptr) so there isn't much to it.

By initialising directly in RTC memory, flash and/or dram usage is reduced.

Incidentally, this will also permit bypassing the restrictive pre-compiled ULP reserved memory size in the Arduino environment. (For greater flexibility, this value may even be reduced to 0 so that the full RTC slow memory is available for use, with only a minor inconvenience to those needing ULP memory.)

Of course it does mean more RTC memory is used, proportional to the number of macros in the program. A motivated programmer could repurpose this memory, if necessary, after processing is complete, by using the program size returned from ulp_process_macros_in_place() to determine the offset and size of unused memory. 
