### PR TITLE
Provide optional callback for wakeup from automatic light sleep (IDFGH-2200)

### DIFF
--- a/components/esp32/pm_esp32.c
+++ b/components/esp32/pm_esp32.c
@@ -565,8 +565,7 @@ void IRAM_ATTR vApplicationSleep( TickType_t xExpectedIdleTime )
         }
     }
     portEXIT_CRITICAL(&s_switch_lock);
-    if(went_to_sleep && s_light_sleep_wakeup_cb != NULL)
-    {
+    if (went_to_sleep && s_light_sleep_wakeup_cb != NULL) {
         s_light_sleep_wakeup_cb();
     }
 }

--- a/components/esp_common/include/esp_pm.h
+++ b/components/esp_common/include/esp_pm.h
@@ -59,17 +59,27 @@ typedef enum {
  */
 esp_err_t esp_pm_configure(const void* config);
 
+#if CONFIG_FREERTOS_USE_TICKLESS_IDLE
+/**
+ * @brief Automatic light sleep wakeup callback function type
+ */
+typedef void  (*esp_pm_light_sleep_wakeup_callback)(void* ctx);
+
+/**
+ * @brief Set an optional callback function to be invoked on wakeup from automatic light sleep.
+ *
+ * No blocking functions may be called from this callback, including printf and ESP_LOG functions.
+ *
+ * @param cb callback function
+ * @param ctx argument to be passed to the callback
+ */
+void esp_pm_set_light_sleep_wakeup_cb(esp_pm_light_sleep_wakeup_callback cb, void* ctx);
+#endif // CONFIG_FREERTOS_USE_TICKLESS_IDLE
 
 /**
  * @brief Opaque handle to the power management lock
  */
 typedef struct esp_pm_lock* esp_pm_lock_handle_t;
-
-/**
- * @brief Automatic light sleep wakeup callback function type
- */
-typedef void  (*esp_pm_light_sleep_wakeup_callback)();
-
 
 /**
  * @brief Initialize a lock handle for certain power management parameter
@@ -179,14 +189,6 @@ esp_err_t esp_pm_lock_delete(esp_pm_lock_handle_t handle);
  *      - ESP_ERR_NOT_SUPPORTED if CONFIG_PM_ENABLE is not enabled in sdkconfig
  */
 esp_err_t esp_pm_dump_locks(FILE* stream);
-
-#if CONFIG_FREERTOS_USE_TICKLESS_IDLE
-/**
- * Set an optional callback function to be invoked on wakeup from automatic light sleep.
- */
-void esp_pm_set_light_sleep_wakeup_cb(esp_pm_light_sleep_wakeup_callback cb);
-#endif
-
 
 
 #ifdef __cplusplus

--- a/components/esp_common/include/esp_pm.h
+++ b/components/esp_common/include/esp_pm.h
@@ -65,6 +65,11 @@ esp_err_t esp_pm_configure(const void* config);
  */
 typedef struct esp_pm_lock* esp_pm_lock_handle_t;
 
+/**
+ * @brief Automatic light sleep wakeup callback function type
+ */
+typedef void  (*esp_pm_light_sleep_wakeup_callback)();
+
 
 /**
  * @brief Initialize a lock handle for certain power management parameter
@@ -174,6 +179,13 @@ esp_err_t esp_pm_lock_delete(esp_pm_lock_handle_t handle);
  *      - ESP_ERR_NOT_SUPPORTED if CONFIG_PM_ENABLE is not enabled in sdkconfig
  */
 esp_err_t esp_pm_dump_locks(FILE* stream);
+
+#if CONFIG_FREERTOS_USE_TICKLESS_IDLE
+/**
+ * Set an optional callback function to be invoked on wakeup from automatic light sleep.
+ */
+void esp_pm_set_light_sleep_wakeup_cb(esp_pm_light_sleep_wakeup_callback cb);
+#endif
 
 
 


### PR DESCRIPTION
Unless I'm missing something, it seems often impossible to be notified of a wakeup from automatic light sleep.

Consider this typical scenario:
An ISR (that gives a semaphore) is configured to trigger on a GPIO falling edge. PM config is set. When tasks are idle, the ESP32 automatically enters light sleep.
Later, a falling edge occurs -> the ESP32 begins to wake up from light sleep -> the falling edge ends -> the ESP32 is ready -> <???> -> No tasks are ready to run -> the ESP32 re-enters light sleep. 
The ISR never runs, the semaphore is never given, the app is blissfully unaware that the ESP32 even woke up.

This PR allows inserting an optional callback where <???> is so that the app is notified when a wakeup occurs, and can handle it accordingly. Consider it a light sleep 'wakeup stub'.

eg.
```
void myLightSleepWakeupHandler()
{
    if(gpio_get_level(GPIO_NUM_0) == 0) {
        xSemaphoreGive(someSemaphore);
    }
    xTaskNotifyGive(someTaskHandle);
    ++lightSleepWakeupCount;
}

esp_pm_set_light_sleep_wakeup_cb(myLightSleepWakeupHandler);
```

If there's an existing way to do this, please let me know!

Additionally, when WiFi is enabled, this may be used to synchronise tasks with WiFi-related wakeups in order to maximise the potential power savings of automatic light sleep.