### PR TITLE
tcpip_adapter: declare functions extern "C" (IDFGH-2265)

### DIFF
--- a/components/tcpip_adapter/include/tcpip_adapter.h
+++ b/components/tcpip_adapter/include/tcpip_adapter.h
@@ -23,6 +23,10 @@
 
 #include "tcpip_adapter_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief tcpip adapter legacy init. It is used only to set the compatibility mode of esp-netif, which
  * will enable backward compatibility of esp-netif.
@@ -244,5 +248,9 @@ esp_err_t tcpip_adapter_get_hostname(tcpip_adapter_if_t tcpip_if, const char **h
  * @return ESP_OK on success
  */
 esp_err_t tcpip_adapter_set_default_wifi_handlers(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif //_TCPIP_ADAPTER_H_

--- a/components/tcpip_adapter/include/tcpip_adapter_compatible/tcpip_adapter_compat.h
+++ b/components/tcpip_adapter/include/tcpip_adapter_compatible/tcpip_adapter_compat.h
@@ -15,6 +15,10 @@
 #ifndef _TCPIP_ADAPTER_COMPAT_H_
 #define _TCPIP_ADAPTER_COMPAT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief This function is called from ethernet driver init code to facilitate
  * autostart fo the driver in backward compatible tcpip_adapter way
@@ -53,5 +57,9 @@ esp_err_t tcpip_adapter_set_default_wifi_handlers(void);
  * @return ESP_OK on success
  */
 esp_err_t tcpip_adapter_clear_default_wifi_handlers(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif //_TCPIP_ADAPTER_COMPAT_H_


### PR DESCRIPTION
I had a linker error (undefined reference) when calling those functions from C++.