### PR TITLE
copy the IDF_PATH to .zshrc (macOS) (IDFGH-2277)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,8 @@ set -e
 set -u
 
 export IDF_PATH=$(cd $(dirname $0); pwd)
+echo "#IDF PATH for ESP-IDF" >> ~/.zshrc
+echo "IDF_PATH=$IDF_PATH" >> ~/.zshrc
 
 echo "Installing ESP-IDF tools"
 ${IDF_PATH}/tools/idf_tools.py install


### PR DESCRIPTION
In macOS, after running `./install.sh`, the `IDF_PATH` did not appeared in the .zshrc file and `. ./export.sh` displayed the following:
"_IDF_PATH must be set before including this script._"

In order to solve the problem, the script appends IDF_PATH to the .zshrc