### PR TITLE
Support loading CA certs with unsupported extensions (IDFGH-2307)

### DIFF
--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -486,7 +486,7 @@ menu "mbedTLS"
             help
                 Support for parsing X.509 Certifificate Signing Requests
 
-        config MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+        config MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXT
             bool "X.509 CRT parsing with unsupported critical extensions"
             default n
             help

--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -486,14 +486,19 @@ menu "mbedTLS"
             help
                 Support for parsing X.509 Certifificate Signing Requests
 
-        config MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXT
-            bool "X.509 CRT parsing with unsupported critical extensions"
-            default n
-            help
-                Allow the X.509 certificate parser to load certificates
-                with unsupported critical extensions
-
     endmenu # Certificates
+
+    menuconfig MBEDTLS_SECURITY_RISKS
+        bool  "Show configurations with potential security risks"
+        default n
+
+    config MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXT
+        bool "X.509 CRT parsing with unsupported critical extensions"
+        depends on MBEDTLS_SECURITY_RISKS
+        default n
+        help
+            Allow the X.509 certificate parser to load certificates
+            with unsupported critical extensions
 
     menuconfig MBEDTLS_ECP_C
         bool  "Elliptic Curve Ciphers"

--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -486,6 +486,13 @@ menu "mbedTLS"
             help
                 Support for parsing X.509 Certifificate Signing Requests
 
+        config MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+            bool "X.509 CRT parsing with unsupported critical extensions"
+            default n
+            help
+                Allow the X.509 certificate parser to load certificates
+                with unsupported critical extensions
+
     endmenu # Certificates
 
     menuconfig MBEDTLS_ECP_C

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -2227,7 +2227,7 @@
  * This module is supports loading of certificates with extensions that
  * may not be supported by mbedtls.
  */
-#ifdef CONFIG_MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+#ifdef CONFIG_MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXT
 #define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
 #else
 #undef MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -2215,6 +2215,25 @@
 #define MBEDTLS_X509_CRT_WRITE_C
 
 /**
+ * \def MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+ *
+  * Alow the X509 parser to not break-off when parsing an X509 certificate
+ * and encountering an unknown critical extension.
+ *
+ * Module:  library/x509_crt.c
+ *
+ * Requires: MBEDTLS_X509_CRT_PARSE_C
+ *
+ * This module is supports loading of certificates with extensions that
+ * may not be supported by mbedtls.
+ */
+#ifdef CONFIG_MBEDTLS_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+#else
+#undef MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+#endif
+
+/**
  * \def MBEDTLS_X509_CSR_WRITE_C
  *
  * Enable creating X.509 Certificate Signing Requests (CSR).


### PR DESCRIPTION
Hey hi,

This PR adds support for CA certificates with critical extensions unsupported by mbedtls (fixes `esp-tls: mbedtls_x509_crt_parse returned -0x2562` when loading CA certificates with critical Name Constraints).

- Added KConfig to mbedtls module
- Added config option to mbedtls/esp_config.h

(It's be awesome if it was possible to land this in 4.0 but I wasn't sure what to open the PR against)