### PR TITLE
add missing gatt descriptors (IDFGH-2339)

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_gatt_defs.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatt_defs.h
@@ -34,7 +34,7 @@ extern "C" {
  * All "ESP_GATT_UUID_xxx" is attribute types
  */
 #define ESP_GATT_UUID_IMMEDIATE_ALERT_SVC           0x1802          /*  Immediate alert Service*/
-#define ESP_GATT_UUID_LINK_LOSS_SVC                 0x1803          /*  Link Loss Service*/                             
+#define ESP_GATT_UUID_LINK_LOSS_SVC                 0x1803          /*  Link Loss Service*/
 #define ESP_GATT_UUID_TX_POWER_SVC                  0x1804          /*  TX Power Service*/
 #define ESP_GATT_UUID_CURRENT_TIME_SVC              0x1805          /*  Current Time Service Service*/
 #define ESP_GATT_UUID_REF_TIME_UPDATE_SVC           0x1806          /*  Reference Time Update Service*/
@@ -75,6 +75,12 @@ extern "C" {
 #define ESP_GATT_UUID_CHAR_VALID_RANGE              0x2906          /*  Characteristic Valid Range */
 #define ESP_GATT_UUID_EXT_RPT_REF_DESCR             0x2907
 #define ESP_GATT_UUID_RPT_REF_DESCR                 0x2908
+#define ESP_GATT_UUID_NUM_DIGITALS_DESCR            0x2909
+#define ESP_GATT_UUID_VALUE_TRIGGER_DESCR           0x290A
+#define ESP_GATT_UUID_ENV_SENS_CONFIG_DESCR         0x290B
+#define ESP_GATT_UUID_ENV_SENS_MEAS_DESCR           0x290C
+#define ESP_GATT_UUID_ENV_SENS_TRIGGER_DESCR        0x290D
+#define ESP_GATT_UUID_TIME_TRIGGER_DESCR            0x290E
 
 /* GAP Profile Attributes */
 #define ESP_GATT_UUID_GAP_DEVICE_NAME               0x2A00
@@ -304,7 +310,7 @@ typedef enum {
  * @brief Attribute description (used to create database)
  */
  typedef struct
- {   
+ {
      uint16_t uuid_length;              /*!< UUID length */
      uint8_t  *uuid_p;                  /*!< UUID value */
      uint16_t perm;                     /*!< Attribute permission */
@@ -353,7 +359,7 @@ typedef struct
 /**
   * @brief Gatt  include service entry element
   */
-typedef struct 
+typedef struct
 {
     uint16_t start_hdl;                                     /*!< Gatt  start handle value of included service */
     uint16_t end_hdl;                                       /*!< Gatt  end handle value of included service */
@@ -363,13 +369,13 @@ typedef struct
 /**
   * @brief Gatt  include 128 bit service entry element
   */
-typedef struct 
+typedef struct
 {
     uint16_t start_hdl;                                     /*!< Gatt  start handle value of included 128 bit service */
     uint16_t end_hdl;                                       /*!< Gatt  end handle value of included 128 bit service */
 } esp_gatts_incl128_svc_desc_t;                             /*!< Gatt  include 128 bit service entry element */
 
-/// Gatt attribute value 
+/// Gatt attribute value
 typedef struct {
     uint8_t           value[ESP_GATT_MAX_ATTR_LEN];         /*!< Gatt attribute value */
     uint16_t          handle;                               /*!< Gatt attribute handle */
@@ -442,7 +448,7 @@ typedef struct {
 /**
   * @brief service element
   */
-typedef struct { 
+typedef struct {
     bool                        is_primary;                 /*!< The service flag, true if the service is primary service, else is secondly service */
     uint16_t                    start_handle;               /*!< The start handle of the service */
     uint16_t                    end_handle;                 /*!< The end handle of the service */

--- a/components/bt/host/bluedroid/btc/profile/std/gatt/btc_gatts.c
+++ b/components/bt/host/bluedroid/btc/profile/std/gatt/btc_gatts.c
@@ -381,7 +381,13 @@ static void btc_gatts_act_create_attr_tab(esp_gatts_attr_db_t *gatts_attr_db,
             case ESP_GATT_UUID_CHAR_AGG_FORMAT:
             case ESP_GATT_UUID_CHAR_VALID_RANGE:
             case ESP_GATT_UUID_EXT_RPT_REF_DESCR:
-            case ESP_GATT_UUID_RPT_REF_DESCR:{
+            case ESP_GATT_UUID_RPT_REF_DESCR:
+            case ESP_GATT_UUID_NUM_DIGITALS_DESCR:
+            case ESP_GATT_UUID_VALUE_TRIGGER_DESCR:
+            case ESP_GATT_UUID_ENV_SENS_CONFIG_DESCR:
+            case ESP_GATT_UUID_ENV_SENS_MEAS_DESCR:
+            case ESP_GATT_UUID_ENV_SENS_TRIGGER_DESCR:
+            case ESP_GATT_UUID_TIME_TRIGGER_DESCR: {
                 uint16_t svc_hal = btc_creat_tab_env.svc_start_hdl;
                 tBT_UUID bta_char_uuid;
                 esp_bt_uuid_t uuid_temp;


### PR DESCRIPTION
Hello -

This PR adds definitions for GATT descriptors 0x2909 (Number of Digitals) through 0x290E (Time Trigger Setting) as defined by the current Bluetooth GATT Descriptors specification:

https://www.bluetooth.com/specifications/gatt/descriptors/

In addition, the new descriptors are added to the btc_gatts_act_create_attr_tab() function, so that server applications can deploy services that include these descriptors, e.g. AIOS service. Without this change, it is not possible to deploy an AIOS service on ESP32/Bluedroid, because some of the required descriptors are missing and hence not added to the attribute table.

Regards,
Brian