### PR TITLE
esp_event_loop_deinit() should declare in esp_event_legacy.h file. (IDFGH-2367)

### DIFF
--- a/components/bootloader_support/src/bootloader_common.c
+++ b/components/bootloader_support/src/bootloader_common.c
@@ -64,14 +64,17 @@ esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, ui
     }
     gpio_pad_pullup(num_pin);
     uint32_t tm_start = esp_log_early_timestamp();
-    if (GPIO_INPUT_GET(num_pin) == 1) {
+    if (GPIO_INPUT_GET(num_pin) == 0) {
+        ESP_LOGI(TAG, "<-----------GPIO_NOT_HOLD------------->");
         return GPIO_NOT_HOLD;
     }
     do {
-        if (GPIO_INPUT_GET(num_pin) != 0) {
+        if (GPIO_INPUT_GET(num_pin) != 1) {
+	    ESP_LOGI(TAG, "<-----------GPIO_SHORT_HOLD------------->");
             return GPIO_SHORT_HOLD;
         }
     } while (delay_sec > ((esp_log_early_timestamp() - tm_start) / 1000L));
+    ESP_LOGI(TAG, "<-----------GPIO_LONG_HOLD------------->");
     return GPIO_LONG_HOLD;
 }
 

--- a/components/esp_event/include/esp_event_legacy.h
+++ b/components/esp_event/include/esp_event_legacy.h
@@ -227,6 +227,15 @@ typedef esp_err_t (*system_event_cb_t)(void *ctx, system_event_t *event);
 esp_err_t esp_event_loop_init(system_event_cb_t cb, void *ctx) __attribute__ ((deprecated));
 
 /**
+ * @brief Deinitializes the event loop library
+ *
+ * @return 
+ *  - ESP_OK: Success
+ *  - Others: Fail
+ */
+esp_err_t esp_event_loop_deinit();
+
+/**
  * @brief  Set application specified event callback function
  *
  * @note This API is part of the legacy event system. New code should use event library API in esp_event.h


### PR DESCRIPTION
I am getting this error when using esp_event_loop_deinit() function. Once I declare in esp_event_legacy.h, the error get resolved. Technically it should be declare in esp_event_legacy.h because the definition of this function is in event_loop_legacy.c 