### PR TITLE
Created a new unmap to speed up when cache saving is not needed (IDFGH-2395)

### DIFF
--- a/components/esp32/esp_himem.c
+++ b/components/esp32/esp_himem.c
@@ -363,4 +363,25 @@ esp_err_t esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr, size_t len)
     return ESP_OK;
 }
 
+esp_err_t esp_himem_unmap_discard(esp_himem_rangehandle_t range, void *ptr, size_t len)
+{
+    //Note: doesn't actually unmap, just clears cache and marks blocks as unmapped.
+    //Future optimization: could actually lazy-unmap here: essentially, do nothing and only clear the cache when we re-use
+    //the block for a different physical address.
+    int range_offset = (uint32_t)ptr - VIRT_HIMEM_RANGE_START;
+    int range_block = (range_offset / CACHE_BLOCKSIZE) - range->block_start;
+    int blockcount = len / CACHE_BLOCKSIZE;
+    HIMEM_CHECK(range_offset % CACHE_BLOCKSIZE != 0, "range offset not block-aligned", ESP_ERR_INVALID_ARG);
+    HIMEM_CHECK(len % CACHE_BLOCKSIZE != 0, "map length not block-aligned", ESP_ERR_INVALID_ARG);
+    HIMEM_CHECK(range_block + blockcount > range->block_ct, "range out of bounds for handle", ESP_ERR_INVALID_ARG);
 
+    portENTER_CRITICAL(&spinlock);
+    for (int i = 0; i < blockcount; i++) {
+        int ramblock = s_range_descriptor[range->block_start + i + range_block].ram_block;
+        assert(ramblock_idx_valid(ramblock));
+        s_ram_descriptor[ramblock].is_mapped = 0;
+        s_range_descriptor[range->block_start + i + range_block].is_mapped = 0;
+    }
+    portEXIT_CRITICAL(&spinlock);
+    return ESP_OK;
+}

--- a/components/esp32/include/esp32/himem.h
+++ b/components/esp32/include/esp32/himem.h
@@ -44,7 +44,7 @@ esp_err_t esp_himem_alloc(size_t size, esp_himem_handle_t *handle_out);
 
 /**
  * @brief Allocate a memory region to map blocks into
- * 
+ *
  * This allocates a contiguous CPU memory region that can be used to map blocks
  * of physical memory into.
  *
@@ -61,7 +61,7 @@ esp_err_t esp_himem_alloc_map_range(size_t size, esp_himem_rangehandle_t *handle
  * @brief Map a block of high memory into the CPUs address space
  *
  * This effectively makes the block available for read/write operations.
- * 
+ *
  * @note The region to be mapped needs to have offsets and sizes that are aligned to the
  *       SPI RAM MMU block size (32K)
  *
@@ -119,6 +119,16 @@ esp_err_t esp_himem_free_map_range(esp_himem_rangehandle_t handle);
  */
 esp_err_t esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr, size_t len);
 
+/**
+ * @brief Unmap a region without saving cache content
+ *
+ * @param range Range handle
+ * @param ptr Pointer returned by esp_himem_map
+ * @param len Length of the block to be unmapped. Must be aligned to the SPI RAM MMU blocksize (32K)
+ * @returns - ESP_OK if the memory is succesfully unmapped,
+ *          - ESP_ERR_INVALID_ARG if ptr or len are invalid.
+ */
+esp_err_t esp_himem_unmap_discard(esp_himem_rangehandle_t range, void *ptr, size_t len);
 
 /**
  * @brief Get total amount of memory under control of himem API


### PR DESCRIPTION
I'm using the Himem to save time when reading multiple time the same files.  But the esp_himem_unmap function runs esp_spiram_writeback_cache() that kills it for me.  It take almost 5ms to write back the cache !  I don't know why.  So I simply added a new function to simply discard the content of the cache when just needing to reading back the Himem.
