### PR TITLE
Add missing extern "C" to rtc_cntl.h (IDFGH-2419)

### DIFF
--- a/components/driver/include/driver/rtc_cntl.h
+++ b/components/driver/include/driver/rtc_cntl.h
@@ -18,6 +18,10 @@
 #include "esp_err.h"
 #include "esp_intr_alloc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Register a handler for specific RTC_CNTL interrupts
  *
@@ -46,3 +50,7 @@ esp_err_t rtc_isr_register(intr_handler_t handler, void* handler_arg,
  *        handler_arg isn't registered
  */
 esp_err_t rtc_isr_deregister(intr_handler_t handler, void* handler_arg);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Related: https://github.com/espressif/arduino-esp32/issues/3149