### PR TITLE
Wifi event sta disconnected reason type (IDFGH-2423)

### DIFF
--- a/components/esp_wifi/include/esp_wifi_types.h
+++ b/components/esp_wifi/include/esp_wifi_types.h
@@ -553,7 +553,7 @@ typedef struct {
     uint8_t ssid[32];         /**< SSID of disconnected AP */
     uint8_t ssid_len;         /**< SSID length of disconnected AP */
     uint8_t bssid[6];         /**< BSSID of disconnected AP */
-    uint8_t reason;           /**< reason of disconnection */
+    wifi_err_reason_t reason;           /**< reason of disconnection */
 } wifi_event_sta_disconnected_t;
 
 /** Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event */


### PR DESCRIPTION
Shouldn't the reason for wifi sta disconnection be the enum wifi_err_reason_t?