### PR TITLE
export: put old path to front of new path export (IDFGH-2467)

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -57,7 +57,7 @@ function idf_export_main() {
     IDF_ADD_PATHS_EXTRAS="${IDF_PATH}/components/esptool_py/esptool"
     IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/espcoredump"
     IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/partition_table/"
-    export PATH="${IDF_ADD_PATHS_EXTRAS}:${PATH}"
+    export PATH="${PATH}:${IDF_ADD_PATHS_EXTRAS}"
 
     if [[ -n "$BASH" ]]
     then

--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1041,7 +1041,7 @@ def action_export(args):
         raise NotImplementedError('unsupported export format {}'.format(args.format))
 
     if paths_to_export:
-        export_vars['PATH'] = path_sep.join(to_shell_specific_paths(paths_to_export) + [old_path])
+        export_vars['PATH'] = path_sep.join([old_path] + to_shell_specific_paths(paths_to_export))
 
     export_statements = export_sep.join([export_format.format(k, v) for k, v in export_vars.items()])
 


### PR DESCRIPTION
In case of using of ccache, the entry of ccache have to be on front of
path exports. At least before the toolchain paths. This patch change the
order of new and old paths, so that the old paths are at front. This
avoid disabling of ccache functionality.

Signed-off-by: Andreas Schmidt <mail@schmidt-andreas.de>