### PR TITLE
Avoid compiler error (IDFGH-2485)

### DIFF
--- a/components/heap/multi_heap_platform.h
+++ b/components/heap/multi_heap_platform.h
@@ -29,14 +29,14 @@ typedef portMUX_TYPE multi_heap_lock_t;
 /* Because malloc/free can happen inside an ISR context,
    we need to use portmux spinlocks here not RTOS mutexes */
 #define MULTI_HEAP_LOCK(PLOCK) do {                         \
-        if((PLOCK) != NULL) {                               \
+        if((PLOCK) != (void*)NULL) {                               \
             portENTER_CRITICAL((PLOCK));                    \
         }                                                   \
     } while(0)
 
 
 #define MULTI_HEAP_UNLOCK(PLOCK) do {                       \
-        if ((PLOCK) != NULL) {                              \
+        if ((PLOCK) != (void*)NULL) {                              \
             portEXIT_CRITICAL((PLOCK));                     \
         }                                                   \
     } while(0)


### PR DESCRIPTION
Compiler errors saying always true in some uses of this macro.