### PR TITLE
Change Ubuntu/Debian command to `apt` (IDFGH-2536)

### DIFF
--- a/docs/en/get-started/linux-setup.rst
+++ b/docs/en/get-started/linux-setup.rst
@@ -15,7 +15,7 @@ To compile with ESP-IDF you need to get the following packages:
 
 - Ubuntu and Debian::
 
-    sudo apt-get install git wget flex bison gperf python python-pip python-setuptools python-serial python-click python-cryptography python-future python-pyparsing python-pyelftools cmake ninja-build ccache libffi-dev libssl-dev
+    sudo apt install git wget flex bison gperf python python-pip python-setuptools python-serial python-click python-cryptography python-future python-pyparsing python-pyelftools cmake ninja-build ccache libffi-dev libssl-dev
 
 - Arch::
 


### PR DESCRIPTION
`apt` is the preferred installation method, I gather, from all the recent Ubuntu tutorials I've been reading. Moreover `apt-get` threw a weird error about some `libssh` package that didn't occur for me under `apt`.