### PR TITLE
Extend lwip compatibility with sys sockets (IDFGH-2551)

### DIFF
--- a/components/lwip/port/esp32/include/netinet/tcp.h
+++ b/components/lwip/port/esp32/include/netinet/tcp.h
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TCP_H_
-#define TCP_H_
+#ifndef _NETINET_TCP_H 
+#define _NETINET_TCP_H 
 
 #include "lwip/tcp.h"
 
-#endif /* TCP_H_ */
+#endif /* _NETINET_TCP_H  */

--- a/components/lwip/port/esp32/include/netinet/tcp.h
+++ b/components/lwip/port/esp32/include/netinet/tcp.h
@@ -1,0 +1,21 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2020 Francesco Giancane <francesco.giancane@accenture.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TCP_H_
+#define TCP_H_
+
+#include "lwip/tcp.h"
+
+#endif /* TCP_H_ */

--- a/components/lwip/port/esp32/include/sys/socket.h
+++ b/components/lwip/port/esp32/include/sys/socket.h
@@ -31,3 +31,8 @@
  */
 
 #include "lwip/sockets.h"
+/*
+	SOMAXCONN is expected to be found in this header too,
+	while for ESP32 port is defined in net/if.h
+*/
+#include <net/if.h>


### PR DESCRIPTION
Hi,

I found that some compatibility headers were missing, and some symbols could not be found in places where they are expected to be.

In particular, trying to compile newest version of `azure-iot-sdk-c` would fail (in AMQP module) with errors.
* Header `netinet/tcp.h` was not found
* symbol `SOMAXCONN` was not defined

wrapping `lwip/tcp.h` with `netinet/tcp.h` and including `net/if.h` in `sys/socket.h` solved those issues.