### PR TITLE
Allow setting NETIF_PPP_AUTHTYPE_NONE (IDFGH-2553)

### DIFF
--- a/components/esp_netif/include/esp_netif_ppp.h
+++ b/components/esp_netif/include/esp_netif_ppp.h
@@ -74,6 +74,7 @@ typedef enum {
  *
  */
 typedef enum {
+    NETIF_PPP_AUTHTYPE_NONE =      0x00,
     NETIF_PPP_AUTHTYPE_PAP =       0x01,
     NETIF_PPP_AUTHTYPE_CHAP =      0x02,
     NETIF_PPP_AUTHTYPE_MSCHAP =    0x04,

--- a/components/esp_netif/lwip/esp_netif_lwip_ppp.c
+++ b/components/esp_netif/lwip/esp_netif_lwip_ppp.c
@@ -207,10 +207,8 @@ esp_err_t esp_netif_ppp_set_auth(esp_netif_t *netif, esp_netif_auth_type_t autht
     if (netif == NULL || !netif->is_ppp_netif) {
         return ESP_ERR_ESP_NETIF_INVALID_PARAMS;
     }
+#if PPP_AUTH_SUPPORT
     struct lwip_ppp_ctx *obj =  netif->lwip_ppp_ctx;
-#if PAP_SUPPORT
-    pppapi_set_auth(obj->ppp, authtype, user, passwd);
-#elif CHAP_SUPPORT
     pppapi_set_auth(obj->ppp, authtype, user, passwd);
 #else
 #error "Unsupported AUTH Negotiation"


### PR DESCRIPTION
Add NETIF_PPP_AUTHTYPE_NONE to esp_netif_auth_type_t and allow
esp_netif_ppp_set_auth to set auth_type with NETIF_PPP_AUTHTYPE_NONE.