### PR TITLE
esp_modem.c: post PPP stop event when requested (IDFGH-2557)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/src/esp_modem.c
+++ b/examples/protocols/pppos_client/components/modem/src/esp_modem.c
@@ -478,6 +478,10 @@ esp_err_t esp_modem_stop_ppp(modem_dte_t *dte)
 {
     modem_dce_t *dce = dte->dce;
     MODEM_CHECK(dce, "DTE has not yet bind with DCE", err);
+    esp_modem_dte_t *esp_dte = __containerof(dte, esp_modem_dte_t, parent);
+
+    /* post PPP mode stopped event */
+    esp_event_post_to(esp_dte->event_loop_hdl, ESP_MODEM_EVENT, ESP_MODEM_EVENT_PPP_STOP, NULL, 0, 0);
     /* Enter command mode */
     MODEM_CHECK(dte->change_mode(dte, MODEM_COMMAND_MODE) == ESP_OK, "enter command mode failed", err);
     /* Hang up */


### PR DESCRIPTION
When library users call `esp_stop_ppp()`, it is expected that the PPP link
is closed and the DCE is moved into command mode.

If the STOP event is not posted into the event loop, then the PPP stack
would not be turned off, resulting in the impossibility to switch into
command mode, as the modem is still sending PPP binary data.

Signed-off-by: Francesco Giancane <francesco.giancane@accenture.com>