### PR TITLE
Changed from sending NULL to send bd_addr (IDFGH-2576)

### DIFF
--- a/components/bt/host/bluedroid/btc/profile/std/hf_ag/btc_hf_ag.c
+++ b/components/bt/host/bluedroid/btc/profile/std/hf_ag/btc_hf_ag.c
@@ -461,7 +461,7 @@ static bt_status_t btc_hf_unat_response(bt_bdaddr_t *bd_addr, const char *unat)
         return BT_STATUS_FAIL;
     }
 
-    if (is_connected(NULL) && (idx != BTC_HF_INVALID_IDX))
+    if (is_connected(bd_addr) && (idx != BTC_HF_INVALID_IDX))
     {
         tBTA_AG_RES_DATA    ag_res;
         /* Format the response and send */


### PR DESCRIPTION
"Resolves #4660 " 
NULL sent to is_connected() is causing crashing.