### PR TITLE
Fixed left right key confusion in comments. (IDFGH-2586)

### DIFF
--- a/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/main/hid_dev.h
+++ b/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/main/hid_dev.h
@@ -132,9 +132,9 @@ extern "C" {
 #define HID_KEY_LEFT_SHIFT     225  // Keyboard LeftShift
 #define HID_KEY_LEFT_ALT       226  // Keyboard LeftAlt
 #define HID_KEY_LEFT_GUI       227  // Keyboard LeftGUI
-#define HID_KEY_RIGHT_CTRL     228  // Keyboard LeftContorl
-#define HID_KEY_RIGHT_SHIFT    229  // Keyboard LeftShift
-#define HID_KEY_RIGHT_ALT      230  // Keyboard LeftAlt
+#define HID_KEY_RIGHT_CTRL     228  // Keyboard RightContorl
+#define HID_KEY_RIGHT_SHIFT    229  // Keyboard RightShift
+#define HID_KEY_RIGHT_ALT      230  // Keyboard RightAlt
 #define HID_KEY_RIGHT_GUI      231  // Keyboard RightGUI
 typedef uint8_t keyboard_cmd_t;
 


### PR DESCRIPTION
"Left" and "Right" were swapped in some comments.