### PR TITLE
Build fix ESP_BLE_MESH. (IDFGH-2596)

### DIFF
--- a/components/bt/esp_ble_mesh/mesh_core/include/mesh_bearer_adapt.h
+++ b/components/bt/esp_ble_mesh/mesh_core/include/mesh_bearer_adapt.h
@@ -34,6 +34,10 @@
 
 #endif
 
+#if !defined(ADV_TASK_CORE)
+#define ADV_TASK_CORE TASK_PINNED_TO_CORE
+#endif
+
 #define BLE_MESH_GAP_ADV_MAX_LEN    31
 
 #define BLE_MESH_GATT_DEF_MTU_SIZE  23


### PR DESCRIPTION
Revert partially commit f58d7d14c7e264375b6824dceb742f553b51269c to
define ADV_TASK_CORE if CONFIG_BT_{BLUEDROID,NIMBLE}_ENABLED are not
set.