### PR TITLE
Fix overriding of PYTHON variable (IDFGH-2602)

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -2,7 +2,7 @@
 # and component makefiles (component_wrapper.mk)
 #
 
-PYTHON=$(call dequote,$(CONFIG_SDK_PYTHON))
+PYTHON ?= $(call dequote,$(CONFIG_SDK_PYTHON))
 
 # Include project config makefile, if it exists.
 #


### PR DESCRIPTION
Making this variable existentially conditional allows for overriding `PYTHON` and `CONFIG_SDK_PYTHON` without side effects