### PR TITLE
Fix subtype in PartitionTable.find_by_type (IDFGH-2646)

### DIFF
--- a/components/partition_table/gen_esp32part.py
+++ b/components/partition_table/gen_esp32part.py
@@ -160,7 +160,7 @@ class PartitionTable(list):
             subtype = SUBTYPES[int(ptype)][subtype]
         except KeyError:
             try:
-                ptype = int(ptype, 0)
+                subtype = int(subtype, 0)
             except TypeError:
                 pass
 


### PR DESCRIPTION
I was getting odd "Partition not found" results from parttool.py. Tracked it down to this line in gen_esp32part.py where 'ptype' has obviously not been updated to 'subtype'. Results are now as expected with the fix.