### PR TITLE
Add support for using noinit variables in SPIRAM (IDFGH-2654)

### DIFF
--- a/components/esp32/CMakeLists.txt
+++ b/components/esp32/CMakeLists.txt
@@ -60,6 +60,11 @@ else()
         target_linker_script(${COMPONENT_LIB} INTERFACE "ld/esp32.extram.bss.ld")
     endif()
 
+    if(CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY)
+        # This has to be linked before esp32.project.ld
+        target_linker_script(${COMPONENT_LIB} INTERFACE "ld/esp32.extram.noinit.ld")
+    endif()
+
     # Process the template file through the linker script generation mechanism, and use the output for linking the
     # final binary
     target_linker_script(${COMPONENT_LIB} INTERFACE "${CMAKE_CURRENT_LIST_DIR}/ld/esp32.project.ld.in" 

--- a/components/esp32/component.mk
+++ b/components/esp32/component.mk
@@ -9,6 +9,11 @@ ifdef CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
    LINKER_SCRIPTS += esp32.extram.bss.ld
 endif
 
+ifdef CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+   # This linker script must come before esp32.project.ld
+   LINKER_SCRIPTS += esp32.extram.noinit.ld
+endif
+
 #Linker scripts used to link the final application.
 #Warning: These linker scripts are only used when the normal app is compiled; the bootloader
 #specifies its own scripts.

--- a/components/esp32/cpu_start.c
+++ b/components/esp32/cpu_start.c
@@ -100,6 +100,10 @@ extern int _rtc_bss_end;
 extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
 #endif
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+extern int _ext_ram_noinit_start;
+extern int _ext_ram_noinit_end;
+#endif
 extern int _init_start;
 extern void (*__init_array_start)(void);
 extern void (*__init_array_end)(void);
@@ -238,7 +242,11 @@ void IRAM_ATTR call_start_cpu0(void)
 
 #if CONFIG_SPIRAM_MEMTEST
     if (s_spiram_okay) {
-        bool ext_ram_ok=esp_spiram_test();
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+        bool ext_ram_ok=esp_spiram_test(&_ext_ram_noinit_start, &_ext_ram_noinit_end);
+#else
+        bool ext_ram_ok=esp_spiram_test(0, 0);
+#endif
         if (!ext_ram_ok) {
             ESP_EARLY_LOGE(TAG, "External RAM failed memory test!");
             abort();

--- a/components/esp32/include/esp32/spiram.h
+++ b/components/esp32/include/esp32/spiram.h
@@ -63,7 +63,7 @@ void esp_spiram_init_cache(void);
  *
  * @return true on success, false on failed memory test
  */
-bool esp_spiram_test(void);
+bool esp_spiram_test(const void* keepout_addr_low, const void* keepout_addr_high);
 
 
 /**

--- a/components/esp32/ld/esp32.extram.noinit.ld
+++ b/components/esp32/ld/esp32.extram.noinit.ld
@@ -1,0 +1,14 @@
+/* This section is only included if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+   is set, to link some NOINIT sections in PSRAM */
+
+SECTIONS
+{
+   /* external memory bss, from any global variable with EXT_RAM_NOINIT_ATTR attribute*/
+  .ext_ram.noinit (NOLOAD) :
+  {
+    _ext_ram_noinit_start = ABSOLUTE(.);
+    *(.ext_ram.noinit*)
+    . = ALIGN(4);
+    _ext_ram_noinit_end = ABSOLUTE(.);
+  } > extern_ram_seg
+}

--- a/components/esp32/spiram.c
+++ b/components/esp32/spiram.c
@@ -63,6 +63,10 @@ static const char* TAG = "spiram";
 #if CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
 extern uint8_t _ext_ram_bss_start, _ext_ram_bss_end;
 #endif
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+extern uint8_t _ext_ram_noinit_start, _ext_ram_noinit_end;
+#endif
+
 static bool spiram_inited=false;
 
 
@@ -87,7 +91,7 @@ static int spiram_size_usable_for_malloc(void)
  true when RAM seems OK, false when test fails. WARNING: Do not run this before the 2nd cpu has been
  initialized (in a two-core system) or after the heap allocator has taken ownership of the memory.
 */
-bool esp_spiram_test(void)
+bool esp_spiram_test(const void* keepout_addr_low, const void* keepout_addr_high)
 {
     volatile int *spiram=(volatile int*)SOC_EXTRAM_DATA_LOW;
     size_t p;
@@ -95,9 +99,19 @@ bool esp_spiram_test(void)
     int errct=0;
     int initial_err=-1;
     for (p=0; p<(s/sizeof(int)); p+=8) {
+        if ((keepout_addr_low <= (const void*)&spiram[p]) && ((const void*)&spiram[p] < keepout_addr_high)) {
+            continue;
+        } else if ((keepout_addr_low < (const void*)&spiram[p+1]) && ((const void*)&spiram[p+1] <= keepout_addr_high)) {
+            continue;
+        }
         spiram[p]=p^0xAAAAAAAA;
     }
     for (p=0; p<(s/sizeof(int)); p+=8) {
+        if ((keepout_addr_low <= (const void*)&spiram[p]) && ((const void*)&spiram[p] < keepout_addr_high)) {
+            continue;
+        } else if ((keepout_addr_low < (const void*)&spiram[p+1]) && ((const void*)&spiram[p+1] <= keepout_addr_high)) {
+            continue;
+        }
         if (spiram[p]!=(p^0xAAAAAAAA)) {
             errct++;
             if (errct==1) initial_err=p*4;
@@ -178,13 +192,20 @@ esp_err_t esp_spiram_add_to_heapalloc(void)
 {
     //Add entire external RAM region to heap allocator. Heap allocator knows the capabilities of this type of memory, so there's
     //no need to explicitly specify them.
+    intptr_t mallocable_ram_start = (intptr_t)SOC_EXTRAM_DATA_LOW;
 #if CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
-    ESP_EARLY_LOGI(TAG, "Adding pool of %dK of external SPI memory to heap allocator", (spiram_size_usable_for_malloc() - (&_ext_ram_bss_end - &_ext_ram_bss_start))/1024);
-    return heap_caps_add_region((intptr_t)&_ext_ram_bss_end, (intptr_t)SOC_EXTRAM_DATA_LOW + spiram_size_usable_for_malloc()-1);
-#else
-    ESP_EARLY_LOGI(TAG, "Adding pool of %dK of external SPI memory to heap allocator", spiram_size_usable_for_malloc()/1024);
-    return heap_caps_add_region((intptr_t)SOC_EXTRAM_DATA_LOW, (intptr_t)SOC_EXTRAM_DATA_LOW + spiram_size_usable_for_malloc()-1);
+    if (mallocable_ram_start < (intptr_t)&_ext_ram_bss_end) {
+        mallocable_ram_start = (intptr_t)&_ext_ram_bss_end;
+    }
 #endif
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+    if (mallocable_ram_start < (intptr_t)&_ext_ram_noinit_end) {
+        mallocable_ram_start = (intptr_t)&_ext_ram_noinit_end;
+    }
+#endif
+    intptr_t mallocable_ram_end = (intptr_t)SOC_EXTRAM_DATA_LOW + spiram_size_usable_for_malloc() - 1;
+    ESP_EARLY_LOGI(TAG, "Adding pool of %dK of external SPI memory to heap allocator", (mallocable_ram_end - mallocable_ram_start)/1024);
+    return heap_caps_add_region(mallocable_ram_start, mallocable_ram_end);
 }
 
 

--- a/components/esp32/test/test_spiram_noinit.c
+++ b/components/esp32/test/test_spiram_noinit.c
@@ -1,0 +1,53 @@
+/*
+ * This code tests placing non-initialized, non-zero variables in PSRAM.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "sdkconfig.h"
+#include "esp_attr.h"
+#include "esp32/spiram.h"
+#include "esp_system.h"
+#include "unity.h"
+
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+
+#define TEST_BUFFER_SIZE (16*1024/4)
+static EXT_RAM_NOINIT_ATTR uint32_t s_noinit_buffer[TEST_BUFFER_SIZE];
+
+static void write_spiram_and_reset(void)
+{
+    // Fill the noinit buffer
+    printf("Filling buffer\n");
+    for (uint32_t i = 0; i < TEST_BUFFER_SIZE; i++) {
+        s_noinit_buffer[i] = i ^ 0x55555555U;
+    }
+    printf("Flushing cache\n");
+    // Flush the cache out to SPIRAM before resetting.
+    esp_spiram_writeback_cache();
+
+    printf("Restarting\n");
+    // Reset to test that noinit memory is left intact.
+    esp_restart();
+}
+
+static void check_spiram_contents(void)
+{
+    // Confirm that the memory contents are still what we expect
+    uint32_t error_count = 0;
+    for (uint32_t i = 0; i < TEST_BUFFER_SIZE; i++) {
+        if (s_noinit_buffer[i] != (i ^ 0x55555555U)) {
+            error_count++;
+        }
+    }
+
+    printf("Found %" PRIu32 " memory errors\n", error_count);
+    TEST_ASSERT(error_count == 0);
+}
+
+TEST_CASE_MULTIPLE_STAGES("Spiram test noinit memory", "[spiram]", write_spiram_and_reset, check_spiram_contents);
+
+#endif // CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY

--- a/components/esp_common/Kconfig.spiram.common
+++ b/components/esp_common/Kconfig.spiram.common
@@ -97,3 +97,11 @@ config SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
         If enabled the option,and add EXT_RAM_ATTR defined your variable,then your variable will be placed in
         PSRAM instead of internal memory, and placed most of variables of lwip,net802.11,pp,bluedroid library
         to external memory defaultly.
+
+config SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+    bool "Enable placement of noinit segments in external memory"
+    default n
+    depends on SPIRAM
+    help
+        If enabled, noinit variables can be placed in PSRAM using EXT_RAM_NOINIT_ATTR.
+        If disabled, EXT_RAM_NOINIT_ATTR will act like __NOINIT_ATTR.

--- a/components/xtensa/include/esp_attr.h
+++ b/components/xtensa/include/esp_attr.h
@@ -51,6 +51,14 @@
 #define EXT_RAM_ATTR
 #endif
 
+#if CONFIG_SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY
+// Forces data into external memory noinit section to avoid initialization after restart.
+#define EXT_RAM_NOINIT_ATTR _SECTION_ATTR_IMPL(".ext_ram.noinit", __COUNTER__)
+#else
+// Place in internal noinit section
+#define EXT_RAM_NOINIT_ATTR __NOINIT_ATTR
+#endif
+
 // Forces data into RTC slow memory. See "docs/deep-sleep-stub.rst"
 // Any variable marked with this attribute will keep its value
 // during a deep sleep / wake cycle.


### PR DESCRIPTION
As per #4700, this pull request add support for placing non-initialized variables in SPIRAM.

This includes the following changes:

- There's a new Kconfig option `SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY` which enables the feature.
- When the feature is enabled, `EXT_RAM_NOINIT_ATTR` can be used to place variables into a new non-initialized section in SPIRAM. If `SPIRAM_ALLOW_NOINIT_EXTERNAL_MEMORY` is disabled, it attempts to place it in regular internal RAM instead.
- At startup, the SPIRAM memory test, if enabled, skips over any noinit sections.
- The SPIRAM noinit section is excluded from the SPIRAM memory made available to the heap allocator.

I've tested this internally and I've found it works pretty well (with the caveat that it's important to flush the SPIRAM write-back cache before restarting to ensure everything has been written back) and I've added a simple unit test for it.

Caveats:

- No ESP32S2 support, since I don't have any way to test it.
- No documentation yet