### PR TITLE
fix initializer order for BT_CONTROLLER_INIT_CONFIG_DEFAULT (IDFGH-2655)

### DIFF
--- a/components/bt/include/esp_bt.h
+++ b/components/bt/include/esp_bt.h
@@ -124,8 +124,8 @@ the adv packet will be discarded until the memory is restored. */
     .ble_max_conn = CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN_EFF,               \
     .bt_max_acl_conn = CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_ACL_CONN_EFF,     \
     .bt_sco_datapath = CONFIG_BTDM_CTRL_BR_EDR_SCO_DATA_PATH_EFF,          \
-    .bt_max_sync_conn = CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_SYNC_CONN_EFF,   \
     .auto_latency = BTDM_CTRL_AUTO_LATENCY_EFF,                            \
+    .bt_max_sync_conn = CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_SYNC_CONN_EFF,   \
     .magic = ESP_BT_CONTROLLER_CONFIG_MAGIC_VAL,                           \
 };
 


### PR DESCRIPTION
Using macro BT_CONTROLLER_INIT_CONFIG_DEFAULT throws the following error because initializer order does not match order of variables defined in the esp_bt_controller_config_t struct.    Fixed declaration order.

esp/esp-idf/components/bt/include/esp_bt.h:130:1: sorry, unimplemented: non-trivial designated initializers not supported
