### PR TITLE
Fix standard NEC IR transmission (IDFGH-2676)

### DIFF
--- a/examples/peripherals/rmt/ir_protocols/components/infrared_tools/src/ir_builder_rmt_nec.c
+++ b/examples/peripherals/rmt/ir_protocols/components/infrared_tools/src/ir_builder_rmt_nec.c
@@ -102,10 +102,10 @@ static esp_err_t nec_build_frame(ir_builder_t *builder, uint32_t address, uint32
     if (!nec_builder->flags & IR_TOOLS_FLAGS_PROTO_EXT) {
         uint8_t low_byte = address & 0xFF;
         uint8_t high_byte = (address >> 8) & 0xFF;
-        NEC_CHECK(low_byte == ~high_byte, "address not match standard NEC protocol", err, ESP_ERR_INVALID_ARG);
+        NEC_CHECK(low_byte == (~high_byte & 0xFF), "address not match standard NEC protocol", err, ESP_ERR_INVALID_ARG);
         low_byte = command & 0xFF;
         high_byte = (command >> 8) & 0xFF;
-        NEC_CHECK(low_byte == ~high_byte, "command not match standard NEC protocol", err, ESP_ERR_INVALID_ARG);
+        NEC_CHECK(low_byte == (~high_byte & 0xFF), "command not match standard NEC protocol", err, ESP_ERR_INVALID_ARG);
     }
     builder->make_head(builder);
     // LSB -> MSB

--- a/examples/peripherals/rmt/ir_protocols/main/ir_protocols_main.c
+++ b/examples/peripherals/rmt/ir_protocols/main/ir_protocols_main.c
@@ -99,12 +99,12 @@ static void example_ir_tx_task(void *arg)
         ESP_ERROR_CHECK(ir_builder->build_frame(ir_builder, addr, cmd));
         ESP_ERROR_CHECK(ir_builder->get_result(ir_builder, &items, &length));
         //To send data according to the waveform items.
-        rmt_write_items(example_tx_channel, items, length, true);
+        rmt_write_items(example_tx_channel, items, length, false);
         // Send repeat code
         vTaskDelay(pdMS_TO_TICKS(ir_builder->repeat_period_ms));
         ESP_ERROR_CHECK(ir_builder->build_repeat_frame(ir_builder));
         ESP_ERROR_CHECK(ir_builder->get_result(ir_builder, &items, &length));
-        rmt_write_items(example_tx_channel, items, length, true);
+        rmt_write_items(example_tx_channel, items, length, false);
         cmd++;
     }
     ir_builder->del(ir_builder);


### PR DESCRIPTION
There are some oversights in the RMT IR example that might break the functionallity of it.
One problem were the blocking RMT writes which elongated the delay between message and repeat frame to increase.
The other issue had to do with integer promotion which prevented the use of the utility in non-extended mode.