### PR TITLE
install.sh: use python3 (IDFGH-2718) (IDFGH-2719)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,10 @@ set -u
 export IDF_PATH=$(cd $(dirname $0); pwd)
 
 echo "Installing ESP-IDF tools"
-${IDF_PATH}/tools/idf_tools.py install
+python3 ${IDF_PATH}/tools/idf_tools.py install
 
 echo "Installing Python environment and packages"
-${IDF_PATH}/tools/idf_tools.py install-python-env
+python3 ${IDF_PATH}/tools/idf_tools.py install-python-env
 
 basedir="$(dirname $0)"
 echo "All done! You can now run:"


### PR DESCRIPTION
In some cases python3 is not default python library so probably it's better to use python3.