### PR TITLE
Fixed rights for entrypoint.sh (IDFGH-2727)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN $IDF_PATH/tools/idf_tools.py --non-interactive install required \
 # Ccache is installed, enable it by default
 ENV IDF_CCACHE_ENABLE=1
 
-COPY entrypoint.sh /opt/esp/entrypoint.sh
+COPY entrypoint.sh $IDF_TOOLS_PATH/entrypoint.sh
 RUN chmod u+x $IDF_TOOLS_PATH/entrypoint.sh
 
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -62,6 +62,7 @@ RUN $IDF_PATH/tools/idf_tools.py --non-interactive install required \
 ENV IDF_CCACHE_ENABLE=1
 
 COPY entrypoint.sh /opt/esp/entrypoint.sh
+RUN chmod u+x $IDF_TOOLS_PATH/entrypoint.sh
 
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
docker: Error response from daemon: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/opt/esp/entrypoint.sh\": permission denied": unknown.