### PR TITLE
Fix compilation error, add missing gpio_periph.h header (IDFGH-2728)

### DIFF
--- a/components/bootloader_support/src/esp32/bootloader_esp32.c
+++ b/components/bootloader_support/src/esp32/bootloader_esp32.c
@@ -26,6 +26,7 @@
 #include "soc/cpu.h"
 #include "soc/dport_reg.h"
 #include "soc/efuse_reg.h"
+#include "soc/gpio_periph.h"
 #include "soc/gpio_sig_map.h"
 #include "soc/io_mux_reg.h"
 #include "soc/rtc.h"


### PR DESCRIPTION
Fixes following error that was introduced in c1d0daf:

```
In file included from /opt/esp-idf-sdk/components/esp_rom/include/esp32/rom/rtc.h:23,
                 from /opt/esp-idf-sdk/components/bootloader_support/include/bootloader_common.h:21,
                 from /opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c:23:
/opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c: In function 'bootloader_init_uart_console':
/opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c:313:26: error: 'GPIO_PIN_MUX_REG' undeclared (first use in this function); did you mean 'GPIO_INPUT_GET'?
         PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
                          ^~~~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/soc.h:90:34: note: in definition of macro 'ETS_UNCACHED_ADDR'
 #define ETS_UNCACHED_ADDR(addr) (addr)
                                  ^~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/soc.h:191:13: note: in expansion of macro 'WRITE_PERI_REG'
             WRITE_PERI_REG((reg), (READ_PERI_REG(reg)|(mask)));                                                        \
             ^~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/io_mux_reg.h:76:50: note: in expansion of macro 'SET_PERI_REG_MASK'
 #define PIN_INPUT_ENABLE(PIN_NAME)               SET_PERI_REG_MASK(PIN_NAME,FUN_IE)
                                                  ^~~~~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c:313:9: note: in expansion of macro 'PIN_INPUT_ENABLE'
         PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
         ^~~~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c:313:26: note: each undeclared identifier is reported only once for each function it appears in
         PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
                          ^~~~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/soc.h:90:34: note: in definition of macro 'ETS_UNCACHED_ADDR'
 #define ETS_UNCACHED_ADDR(addr) (addr)
                                  ^~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/soc.h:191:13: note: in expansion of macro 'WRITE_PERI_REG'
             WRITE_PERI_REG((reg), (READ_PERI_REG(reg)|(mask)));                                                        \
             ^~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/soc/soc/esp32/include/soc/io_mux_reg.h:76:50: note: in expansion of macro 'SET_PERI_REG_MASK'
 #define PIN_INPUT_ENABLE(PIN_NAME)               SET_PERI_REG_MASK(PIN_NAME,FUN_IE)
                                                  ^~~~~~~~~~~~~~~~~
/opt/esp-idf-sdk/components/bootloader_support/src/esp32/bootloader_esp32.c:313:9: note: in expansion of macro 'PIN_INPUT_ENABLE'
         PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
         ^~~~~~~~~~~~~~~~
```