### PR TITLE
component/bt: allow setting a higher baudrate in UART HCI mode

### DIFF
--- a/components/bt/Kconfig
+++ b/components/bt/Kconfig
@@ -160,7 +160,7 @@ menu "Bluetooth"
             config BT_HCI_UART_BAUDRATE
                 int "UART Baudrate for HCI"
                 depends on BTDM_CTRL_HCI_MODE_UART_H4
-                range 115200 921600
+                range 115200 4000000
                 default 921600
                 help
                     UART Baudrate for HCI. Please use standard baudrate.


### PR DESCRIPTION
The ESP32 datasheet specifies that the internal Bluetooth UART HCI baudrate can reach up to 4 Mbps, but the baudrate range is limited to 921600 bps in Kconfig.

I tried to use a FT232R usb serial converter to communicate with the Bluetooth controller at 3 Mbps baudrate (the maximum baudrate supported by the FT232R chip), and it worked as expected.

When using 921600 bps baudrate the SPP speed is limited to 90 KB/s, after changing the baudrate to 3 Mbps the SPP speed is increased to 260 KB/s, so just allow users to set a higher baudrate as the hardware does support it.

Example: [controller_hci_uart](https://github.com/espressif/esp-idf/tree/master/examples/bluetooth/hci/controller_hci_uart)

![ESP32](https://user-images.githubusercontent.com/9910809/75382174-eede8580-5914-11ea-827f-7009e103a87e.png)
