### PR TITLE
Use C++20 by default instead of C++11 (IDFGH-2781)

### DIFF
--- a/make/project.mk
+++ b/make/project.mk
@@ -467,7 +467,7 @@ CFLAGS := $(strip \
 CXXFLAGS ?=
 EXTRA_CXXFLAGS ?=
 CXXFLAGS := $(strip \
-	-std=gnu++11 \
+	-std=gnu++17 \
 	$(OPTIMIZATION_FLAGS) $(DEBUG_FLAGS) \
 	$(COMMON_FLAGS) \
 	$(COMMON_WARNING_FLAGS) \

--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -113,7 +113,7 @@ function(__build_set_default_build_specifications)
     list(APPEND c_compile_options   "-std=gnu99"
                                     "-Wno-old-style-declaration")
 
-    list(APPEND cxx_compile_options "-std=gnu++11")
+    list(APPEND cxx_compile_options "-std=gnu++17")
 
     idf_build_set_property(COMPILE_DEFINITIONS "${compile_definitions}" APPEND)
     idf_build_set_property(COMPILE_OPTIONS "${compile_options}" APPEND)


### PR DESCRIPTION
The toolchain uses the recent gcc 8.2 which supports C++17. There are many useful features for embedded development like string_view, constexpr lambda and if, binary and utf8 literals, std::optional, many template and syntax improvements.