### PR TITLE
Esp modem fix race condition on exit ppp mode (IDFGH-2786)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/include/esp_modem.h
+++ b/examples/protocols/pppos_client/components/modem/include/esp_modem.h
@@ -36,7 +36,8 @@ ESP_EVENT_DECLARE_BASE(ESP_MODEM_EVENT);
 typedef enum {
     ESP_MODEM_EVENT_PPP_START = 0,       /*!< ESP Modem Start PPP Session */
     ESP_MODEM_EVENT_PPP_STOP  = 3,       /*!< ESP Modem Stop PPP Session*/
-    ESP_MODEM_EVENT_UNKNOWN   = 4        /*!< ESP Modem Unknown Response */
+    ESP_MODEM_EVENT_UNKNOWN   = 4,       /*!< ESP Modem Unknown Response */
+    ESP_MODEM_EVENT_PPP_STOPPED          /*!< ESP Modem PPP Session completely stopped */
 } esp_modem_event_t;
 
 /**

--- a/examples/protocols/pppos_client/main/pppos_client_main.c
+++ b/examples/protocols/pppos_client/main/pppos_client_main.c
@@ -115,6 +115,9 @@ static void modem_event_handler(void *event_handler_arg, esp_event_base_t event_
         ESP_LOGI(TAG, "Modem PPP Started");
         break;
     case ESP_MODEM_EVENT_PPP_STOP:
+        ESP_LOGI(TAG, "Modem PPP Stop Requested");
+        break;
+    case ESP_MODEM_EVENT_PPP_STOPPED:
         ESP_LOGI(TAG, "Modem PPP Stopped");
         xEventGroupSetBits(event_group, STOP_BIT);
         break;


### PR DESCRIPTION
This pull request is a rework of #4642  which I previously provided.

As per the discussion, we saw the possibility to have a race condition between the posting of PPP_CLOSE event and its effective completion, thus calling change_mode() and hangup() without proper synchronization could lead to errors.

The correct solution is to differentiate between the events: PPP_STOP and PPP_STOPPED. The former is to identify the request to stop the PPP session and the latter is to signal that the session has been closed properly.

The discussion was already carried out with @AxelLin and @david-cermak so it may be sound if we review this patch together.

Please let me know if it works properly for you.

I also think that the `esp_event_loop_create_default();` may not be necessary.