### PR TITLE
Fix crash due to modbus responses after timeout (IDFGH-2830)

### DIFF
--- a/components/freemodbus/port/portevent_m.c
+++ b/components/freemodbus/port/portevent_m.c
@@ -167,6 +167,8 @@ BOOL xMBMasterRunResTake( LONG lTimeOut )
  */
 void vMBMasterRunResRelease( void )
 {
+    // Check if the semaphore is not released already
+    if (uxSemaphoreGetCount(xSemaphorMasterHdl) == 1) return;
     BaseType_t xStatus = pdFALSE;
     xStatus = xSemaphoreGive(xSemaphorMasterHdl);
     MB_PORT_CHECK((xStatus == pdTRUE), ; , "%s: resource release failure.", __func__);


### PR DESCRIPTION
When a modbus response is received after the timeout period, they are processed and lead to second call of `vMBMasterRunResRelease`. This seems to crash the ESP, because `xSemaphoreGive` is called while the semaphore is not taken. 
I don't know if this fix is the right approach, however it seems to involve the least amount of code and makes the call to `vMBMasterRunResRelease` more robust.