### PR TITLE
driver/adc: Fix pass wrong parameter to adc_gpio_init (IDFGH-2831)

### DIFF
--- a/components/driver/adc.c
+++ b/components/driver/adc.c
@@ -505,8 +505,8 @@ static int hall_sensor_get_value(void)    //hall sensor without LNA
 
 int hall_sensor_read(void)
 {
-    adc_gpio_init(ADC_NUM_1, ADC1_CHANNEL_0);
-    adc_gpio_init(ADC_NUM_1, ADC1_CHANNEL_3);
+    adc_gpio_init(ADC_UNIT_1, ADC1_CHANNEL_0);
+    adc_gpio_init(ADC_UNIT_1, ADC1_CHANNEL_3);
     adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0);
     adc1_config_channel_atten(ADC1_CHANNEL_3, ADC_ATTEN_DB_0);
     return hall_sensor_get_value();


### PR DESCRIPTION
adc_gpio_init takes adc_unit_t rather than adc_ll_num_t as first parameter.

Fixes: f49b192a5e14 ("refactor the adc driver")
Signed-off-by: Axel Lin <axel.lin@gmail.com>