### PR TITLE
esp_modem: Ensure uart_param_config and uart pins are set before uart… (IDFGH-2844)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/src/esp_modem.c
+++ b/examples/protocols/pppos_client/components/modem/src/esp_modem.c
@@ -383,11 +383,6 @@ modem_dte_t *esp_modem_dte_init(const esp_modem_dte_config_t *config)
         .source_clk = UART_SCLK_APB,
         .flow_ctrl = (config->flow_control == MODEM_FLOW_CONTROL_HW) ? UART_HW_FLOWCTRL_CTS_RTS : UART_HW_FLOWCTRL_DISABLE
     };
-    /* Install UART driver and get event queue used inside driver */
-    res = uart_driver_install(esp_dte->uart_port, CONFIG_EXAMPLE_UART_RX_BUFFER_SIZE, CONFIG_EXAMPLE_UART_TX_BUFFER_SIZE,
-                              CONFIG_EXAMPLE_UART_EVENT_QUEUE_SIZE, &(esp_dte->event_queue), 0);
-    MODEM_CHECK(res == ESP_OK, "install uart driver failed", err_uart_config);
-
     MODEM_CHECK(uart_param_config(esp_dte->uart_port, &uart_config) == ESP_OK, "config uart parameter failed", err_uart_config);
     if (config->flow_control == MODEM_FLOW_CONTROL_HW) {
         res = uart_set_pin(esp_dte->uart_port, CONFIG_EXAMPLE_UART_MODEM_TX_PIN, CONFIG_EXAMPLE_UART_MODEM_RX_PIN,
@@ -404,6 +399,11 @@ modem_dte_t *esp_modem_dte_init(const esp_modem_dte_config_t *config)
         res = uart_set_sw_flow_ctrl(esp_dte->uart_port, true, 8, UART_FIFO_LEN - 8);
     }
     MODEM_CHECK(res == ESP_OK, "config uart flow control failed", err_uart_config);
+    /* Install UART driver and get event queue used inside driver */
+    res = uart_driver_install(esp_dte->uart_port, CONFIG_EXAMPLE_UART_RX_BUFFER_SIZE, CONFIG_EXAMPLE_UART_TX_BUFFER_SIZE,
+                              CONFIG_EXAMPLE_UART_EVENT_QUEUE_SIZE, &(esp_dte->event_queue), 0);
+    MODEM_CHECK(res == ESP_OK, "install uart driver failed", err_uart_config);
+
     /* Set pattern interrupt, used to detect the end of a line. */
     res = uart_enable_pattern_det_baud_intr(esp_dte->uart_port, '\n', 1, MIN_PATTERN_INTERVAL, MIN_POST_IDLE, MIN_PRE_IDLE);
     /* Set pattern queue size */


### PR DESCRIPTION
…_driver_install

Fixes Guru Meditation Error: Core 0 panic'ed (LoadProhibited) when config with
CONFIG_PM_ENABLE=y && CONFIG_PM_DFS_INIT_AUTO=y.

Signed-off-by: Axel Lin <axel.lin@gmail.com>