### PR TITLE
Linenoise don't return NULL on 0 length input (IDFGH-2869)

### DIFF
--- a/components/console/Kconfig
+++ b/components/console/Kconfig
@@ -1,0 +1,10 @@
+menu "Linenoise"
+
+    config ESP_LINENOISE_RETURN_ZERO_STRING
+        bool "Return 0 length strings"
+        default n
+        help
+            If enabled linenoise will return 0 length strings if the user presses enter with out typing 
+            a command, if disabled NULL will be returned instead.
+
+endmenu

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -979,11 +979,11 @@ char *linenoise(const char *prompt) {
     } else {
         count = linenoiseDumb(buf, LINENOISE_MAX_LINE, prompt);
     }
-    if (count > 0) {
+    if (count >= 0) {
         sanitize(buf);
         count = strlen(buf);
     }
-    if (count <= 0) {
+    if (count < 0) {
         free(buf);
         return NULL;
     }

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -116,6 +116,7 @@
 #include <sys/fcntl.h>
 #include <unistd.h>
 #include "linenoise.h"
+#include "sdkconfig.h"
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
@@ -979,11 +980,14 @@ char *linenoise(const char *prompt) {
     } else {
         count = linenoiseDumb(buf, LINENOISE_MAX_LINE, prompt);
     }
+#ifdef CONFIG_ESP_LINENOISE_RETURN_ZERO_STRING
     if (count >= 0) {
+#else
+    if (count > 0) {
+#endif
         sanitize(buf);
         count = strlen(buf);
-    }
-    if (count < 0) {
+    } else {
         free(buf);
         return NULL;
     }

--- a/examples/system/console/main/console_example_main.c
+++ b/examples/system/console/main/console_example_main.c
@@ -170,8 +170,8 @@ void app_main(void)
          * The line is returned when ENTER is pressed.
          */
         char* line = linenoise(prompt);
-        if (line == NULL) { /* Ignore empty lines */
-            continue;
+        if (line == NULL) { /* Break on EOF or error */
+            break;
         }
         /* Add the command to the history */
         linenoiseHistoryAdd(line);
@@ -195,4 +195,8 @@ void app_main(void)
         /* linenoise allocates line buffer on the heap, so need to free it */
         linenoiseFree(line);
     }
+    
+    ESP_LOGE(TAG, "Error or end-of-input, terminating console");
+    esp_console_deinit();
+    vTaskDelete(NULL); /* terminate app_main */
 }

--- a/examples/system/console/main/console_example_main.c
+++ b/examples/system/console/main/console_example_main.c
@@ -173,12 +173,14 @@ void app_main(void)
         if (line == NULL) { /* Break on EOF or error */
             break;
         }
-        /* Add the command to the history */
-        linenoiseHistoryAdd(line);
+        /* Add the command to the history if not empty*/
+        if(strlen(line) > 0) {
+            linenoiseHistoryAdd(line);
 #if CONFIG_STORE_HISTORY
-        /* Save command history to filesystem */
-        linenoiseHistorySave(HISTORY_PATH);
+            /* Save command history to filesystem */
+            linenoiseHistorySave(HISTORY_PATH);
 #endif
+        }
 
         /* Try to run the command */
         int ret;


### PR DESCRIPTION
Linenoise should only return NULL if there's been an error on input or if EOF is reached (user enters Ctrl-D)  0 length inputs are still valid and should be treated and returned as such.