### PR TITLE
esp_https_server: fix HTTPD_SSL_CONFIG_DEFAULT (IDFGH-2948)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -110,10 +110,10 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     },                                            \
     .cacert_pem = NULL,                           \
     .cacert_len = 0,                              \
-    .prvtkey_pem = NULL,                          \
-    .prvtkey_len = 0,                             \
     .client_verify_cert_pem = NULL,               \
     .client_verify_cert_len = 0,                  \
+    .prvtkey_pem = NULL,                          \
+    .prvtkey_len = 0,                             \
     .transport_mode = HTTPD_SSL_TRANSPORT_SECURE, \
     .port_secure = 443,                           \
     .port_insecure = 80,                          \


### PR DESCRIPTION
This macro didn't compile on C++. Order is fixed now.