### PR TITLE
driver/gpio: Change log level to debug for gpio_config() (IDFGH-2959)

### DIFF
--- a/components/driver/gpio.c
+++ b/components/driver/gpio.c
@@ -361,7 +361,7 @@ esp_err_t gpio_config(const gpio_config_t *pGPIOConfig)
                 gpio_pulldown_dis(io_num);
             }
 
-            ESP_LOGI(GPIO_TAG, "GPIO[%d]| InputEn: %d| OutputEn: %d| OpenDrain: %d| Pullup: %d| Pulldown: %d| Intr:%d ", io_num, input_en, output_en, od_en, pu_en, pd_en, pGPIOConfig->intr_type);
+            ESP_LOGD(GPIO_TAG, "GPIO[%d]| InputEn: %d| OutputEn: %d| OpenDrain: %d| Pullup: %d| Pulldown: %d| Intr:%d ", io_num, input_en, output_en, od_en, pu_en, pd_en, pGPIOConfig->intr_type);
             gpio_set_intr_type(io_num, pGPIOConfig->intr_type);
 
             if (pGPIOConfig->intr_type) {


### PR DESCRIPTION
Some applications need a frequent reconfiguration of gpios via
gpio_config(), for example to switch between input and output, etc.
In that case the console is spammed with debug messages. Silence
these message by changing the log level to "debug".