### PR TITLE
Call uart_param_config before uart_driver_install (IDFGH-2985)

### DIFF
--- a/components/driver/test/test_uart.c
+++ b/components/driver/test/test_uart.c
@@ -34,8 +34,8 @@ static void uart_config(uint32_t baud_rate, bool use_ref_tick)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
     };
     uart_config.source_clk = use_ref_tick ? UART_SCLK_REF_TICK : UART_SCLK_APB;
-    uart_driver_install(UART_NUM1, BUF_SIZE * 2, BUF_SIZE * 2, 20, NULL, 0);
     uart_param_config(UART_NUM1, &uart_config);
+    uart_driver_install(UART_NUM1, BUF_SIZE * 2, BUF_SIZE * 2, 20, NULL, 0);
     TEST_ESP_OK(uart_set_loop_back(UART_NUM1, true));
 }
 

--- a/components/vfs/test/test_vfs_select.c
+++ b/components/vfs/test/test_vfs_select.c
@@ -105,8 +105,8 @@ static void uart1_init(void)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
-    uart_driver_install(UART_NUM_1, 256, 256, 0, NULL, 0);
     uart_param_config(UART_NUM_1, &uart_config);
+    uart_driver_install(UART_NUM_1, 256, 256, 0, NULL, 0);
 }
 
 static void send_task(void *param)

--- a/examples/bluetooth/bluedroid/ble/ble_spp_client/main/spp_client_demo.c
+++ b/examples/bluetooth/bluedroid/ble/ble_spp_client/main/spp_client_demo.c
@@ -596,10 +596,10 @@ static void spp_uart_init(void)
         .source_clk = UART_SCLK_APB,
     };
 
-    //Install UART driver, and get the queue.
-    uart_driver_install(UART_NUM_0, 4096, 8192, 10, &spp_uart_queue, 0);
     //Set UART parameters
     uart_param_config(UART_NUM_0, &uart_config);
+    //Install UART driver, and get the queue.
+    uart_driver_install(UART_NUM_0, 4096, 8192, 10, &spp_uart_queue, 0);
     //Set UART pins
     uart_set_pin(UART_NUM_0, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     xTaskCreate(uart_task, "uTask", 2048, (void*)UART_NUM_0, 8, NULL);

--- a/examples/bluetooth/bluedroid/ble/ble_spp_server/main/ble_spp_server_demo.c
+++ b/examples/bluetooth/bluedroid/ble/ble_spp_server/main/ble_spp_server_demo.c
@@ -401,10 +401,10 @@ static void spp_uart_init(void)
         .source_clk = UART_SCLK_APB,
     };
 
-    //Install UART driver, and get the queue.
-    uart_driver_install(UART_NUM_0, 4096, 8192, 10,&spp_uart_queue,0);
     //Set UART parameters
     uart_param_config(UART_NUM_0, &uart_config);
+    //Install UART driver, and get the queue.
+    uart_driver_install(UART_NUM_0, 4096, 8192, 10,&spp_uart_queue,0);
     //Set UART pins
     uart_set_pin(UART_NUM_0, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     xTaskCreate(uart_task, "uTask", 2048, (void*)UART_NUM_0, 8, NULL);

--- a/examples/peripherals/uart/nmea0183_parser/main/nmea_parser.c
+++ b/examples/peripherals/uart/nmea0183_parser/main/nmea_parser.c
@@ -685,14 +685,14 @@ nmea_parser_handle_t nmea_parser_init(const nmea_parser_config_t *config)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
+    if (uart_param_config(esp_gps->uart_port, &uart_config) != ESP_OK) {
+        ESP_LOGE(GPS_TAG, "config uart parameter failed");
+        goto err_uart_config;
+    }
     if (uart_driver_install(esp_gps->uart_port, CONFIG_NMEA_PARSER_RING_BUFFER_SIZE, 0,
                             config->uart.event_queue_size, &esp_gps->event_queue, 0) != ESP_OK) {
         ESP_LOGE(GPS_TAG, "install uart driver failed");
         goto err_uart_install;
-    }
-    if (uart_param_config(esp_gps->uart_port, &uart_config) != ESP_OK) {
-        ESP_LOGE(GPS_TAG, "config uart parameter failed");
-        goto err_uart_config;
     }
     if (uart_set_pin(esp_gps->uart_port, UART_PIN_NO_CHANGE, config->uart.rx_pin,
                      UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) != ESP_OK) {

--- a/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
+++ b/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
@@ -29,8 +29,8 @@ void init(void) {
         .source_clk = UART_SCLK_APB,
     };
     // We won't use a buffer for sending data.
-    uart_driver_install(UART_NUM_1, RX_BUF_SIZE * 2, 0, 0, NULL, 0);
     uart_param_config(UART_NUM_1, &uart_config);
+    uart_driver_install(UART_NUM_1, RX_BUF_SIZE * 2, 0, 0, NULL, 0);
     uart_set_pin(UART_NUM_1, TXD_PIN, RXD_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
 }
 

--- a/examples/peripherals/uart/uart_echo/main/uart_echo_example_main.c
+++ b/examples/peripherals/uart/uart_echo/main/uart_echo_example_main.c
@@ -43,8 +43,8 @@ static void echo_task(void *arg)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
-    uart_driver_install(UART_NUM_1, BUF_SIZE * 2, 0, 0, NULL, 0);
     uart_param_config(UART_NUM_1, &uart_config);
+    uart_driver_install(UART_NUM_1, BUF_SIZE * 2, 0, 0, NULL, 0);
     uart_set_pin(UART_NUM_1, ECHO_TEST_TXD, ECHO_TEST_RXD, ECHO_TEST_RTS, ECHO_TEST_CTS);
 
     // Configure a temporary buffer for the incoming data

--- a/examples/peripherals/uart/uart_echo_rs485/main/rs485_example.c
+++ b/examples/peripherals/uart/uart_echo_rs485/main/rs485_example.c
@@ -70,12 +70,13 @@ static void echo_task(void *arg)
     
     ESP_LOGI(TAG, "Start RS485 application test and configure UART.");
 
+    // Configure UART parameters
+    uart_param_config(uart_num, &uart_config);
+
     // Install UART driver (we don't need an event queue here)
     // In this example we don't even use a buffer for sending data.
     uart_driver_install(uart_num, BUF_SIZE * 2, 0, 0, NULL, 0);
-    // Configure UART parameters
-    uart_param_config(uart_num, &uart_config);
-    
+
     ESP_LOGI(TAG, "UART set pins, mode and install driver.");
     // Set UART1 pins(TX: IO23, RX: I022, RTS: IO18, CTS: IO19)
     uart_set_pin(uart_num, ECHO_TEST_TXD, ECHO_TEST_RXD, ECHO_TEST_RTS, ECHO_TEST_CTS);

--- a/examples/peripherals/uart/uart_events/main/uart_events_example_main.c
+++ b/examples/peripherals/uart/uart_events/main/uart_events_example_main.c
@@ -132,8 +132,8 @@ void app_main(void)
         .source_clk = UART_SCLK_APB,
     };
     //Install UART driver, and get the queue.
-    uart_driver_install(EX_UART_NUM, BUF_SIZE * 2, BUF_SIZE * 2, 20, &uart0_queue, 0);
     uart_param_config(EX_UART_NUM, &uart_config);
+    uart_driver_install(EX_UART_NUM, BUF_SIZE * 2, BUF_SIZE * 2, 20, &uart0_queue, 0);
 
     //Set UART log level
     esp_log_level_set(TAG, ESP_LOG_INFO);

--- a/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
+++ b/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
@@ -30,8 +30,8 @@ static void uart_select_task(void *arg)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
-    uart_driver_install(UART_NUM_0, 2*1024, 0, 0, NULL, 0);
     uart_param_config(UART_NUM_0, &uart_config);
+    uart_driver_install(UART_NUM_0, 2*1024, 0, 0, NULL, 0);
 
     while (1) {
         int fd;

--- a/examples/protocols/pppos_client/components/modem/src/esp_modem.c
+++ b/examples/protocols/pppos_client/components/modem/src/esp_modem.c
@@ -383,10 +383,6 @@ modem_dte_t *esp_modem_dte_init(const esp_modem_dte_config_t *config)
         .source_clk = UART_SCLK_APB,
         .flow_ctrl = (config->flow_control == MODEM_FLOW_CONTROL_HW) ? UART_HW_FLOWCTRL_CTS_RTS : UART_HW_FLOWCTRL_DISABLE
     };
-    /* Install UART driver and get event queue used inside driver */
-    res = uart_driver_install(esp_dte->uart_port, CONFIG_EXAMPLE_UART_RX_BUFFER_SIZE, CONFIG_EXAMPLE_UART_TX_BUFFER_SIZE,
-                              CONFIG_EXAMPLE_UART_EVENT_QUEUE_SIZE, &(esp_dte->event_queue), 0);
-    MODEM_CHECK(res == ESP_OK, "install uart driver failed", err_uart_config);
 
     MODEM_CHECK(uart_param_config(esp_dte->uart_port, &uart_config) == ESP_OK, "config uart parameter failed", err_uart_config);
     if (config->flow_control == MODEM_FLOW_CONTROL_HW) {
@@ -404,6 +400,10 @@ modem_dte_t *esp_modem_dte_init(const esp_modem_dte_config_t *config)
         res = uart_set_sw_flow_ctrl(esp_dte->uart_port, true, 8, UART_FIFO_LEN - 8);
     }
     MODEM_CHECK(res == ESP_OK, "config uart flow control failed", err_uart_config);
+    /* Install UART driver and get event queue used inside driver */
+    res = uart_driver_install(esp_dte->uart_port, CONFIG_EXAMPLE_UART_RX_BUFFER_SIZE, CONFIG_EXAMPLE_UART_TX_BUFFER_SIZE,
+                              CONFIG_EXAMPLE_UART_EVENT_QUEUE_SIZE, &(esp_dte->event_queue), 0);
+    MODEM_CHECK(res == ESP_OK, "install uart driver failed", err_uart_config);
     /* Set pattern interrupt, used to detect the end of a line. */
     res = uart_enable_pattern_det_baud_intr(esp_dte->uart_port, '\n', 1, MIN_PATTERN_INTERVAL, MIN_POST_IDLE, MIN_PRE_IDLE);
     /* Set pattern queue size */

--- a/examples/system/select/main/select_example.c
+++ b/examples/system/select/main/select_example.c
@@ -98,8 +98,8 @@ static void uart1_init(void)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
-    uart_driver_install(UART_NUM_1, 256, 0, 0, NULL, 0);
     uart_param_config(UART_NUM_1, &uart_config);
+    uart_driver_install(UART_NUM_1, 256, 0, 0, NULL, 0);
     uart_set_loop_back(UART_NUM_1, true);
 
     if ((uart_fd = open("/dev/uart/1", O_RDWR | O_NONBLOCK)) == -1) {


### PR DESCRIPTION
In many examples, uart_driver_install is called before uart_param_config.
This leads to problems as can be seen in issues like #4830.

This will close PR #4904