### PR TITLE
Match designator order of HTTPD_SSL_CONFIG_DEFAULT and httpd_ssl_config (IDFGH-3008)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -110,10 +110,10 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     },                                            \
     .cacert_pem = NULL,                           \
     .cacert_len = 0,                              \
-    .prvtkey_pem = NULL,                          \
-    .prvtkey_len = 0,                             \
     .client_verify_cert_pem = NULL,               \
     .client_verify_cert_len = 0,                  \
+    .prvtkey_pem = NULL,                          \
+    .prvtkey_len = 0,                             \
     .transport_mode = HTTPD_SSL_TRANSPORT_SECURE, \
     .port_secure = 443,                           \
     .port_insecure = 80,                          \


### PR DESCRIPTION
The designator order of `HTTPD_SSL_CONFIG_DEFAULT` and the configuration struct `httpd_ssl_config` do not match. When compiling an C++ object:

```
../../../../components/esp_https_server/include/esp_https_server.h:120:1: error: designator order for field 'httpd_ssl_config::client_verify_cert_pem' does not match declaration order in 'httpd_ssl_config_t' {aka 'httpd_ssl_config'}
 }
 ^
../main/main.cpp:52:31: note: in expansion of macro 'HTTPD_SSL_CONFIG_DEFAULT'
     httpd_ssl_config_t conf = HTTPD_SSL_CONFIG_DEFAULT();
```

This fixes the issue by reordering the default configuration macro to match the declaration order in `httpd_ssl_config_t` struct.