### PR TITLE
Fix format string in websocket example (IDFGH-3025)

### DIFF
--- a/examples/protocols/websocket/example_test.py
+++ b/examples/protocols/websocket/example_test.py
@@ -82,7 +82,7 @@ class Websocket:
                     return
 
             except socket.error as err:
-                print("Unable to establish a websocket connection: {}, {}".format(err))
+                print("Unable to establish a websocket connection: {}".format(err))
                 raise
 
     def handshake(self, data):


### PR DESCRIPTION
Remove duplicate format character from websocket example_test python script.