### PR TITLE
Do not #define bool when compiling in C++ (IDFGH-3078)

### DIFF
--- a/components/bt/esp_ble_mesh/mesh_common/include/mesh_types.h
+++ b/components/bt/esp_ble_mesh/mesh_common/include/mesh_types.h
@@ -27,6 +27,7 @@ typedef unsigned long long  u64_t;
 
 typedef int         bt_mesh_atomic_t;
 
+#ifndef __cplusplus
 #ifndef bool
 #define bool        int8_t
 #endif
@@ -37,6 +38,7 @@ typedef int         bt_mesh_atomic_t;
 
 #ifndef true
 #define true        1
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Redefining bool, true and false breaks C++ builds which include BLE mesh headers. Guarding with #ifdef resolves the problem.