### PR TITLE
[mbedtls] add configuration options for EC-JPAKE (IDFGH-3085)

### DIFF
--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -389,6 +389,13 @@ menu "mbedTLS"
             help
                 Enable to support ciphersuites with prefix TLS-ECDHE-RSA-WITH-
 
+        config MBEDTLS_KEY_EXCHANGE_ECJPAKE
+            bool "Enable ECJPAKE based ciphersuite modes"
+            depends on MBEDTLS_ECJPAKE_C && MBEDTLS_ECP_DP_SECP256R1_ENABLED
+            default n
+            help
+                Enable to support ciphersuites with prefix TLS-ECJPAKE-WITH-
+
     endmenu # TLS key exchange modes
 
     config MBEDTLS_SSL_RENEGOTIATION
@@ -585,6 +592,13 @@ menu "mbedTLS"
         default y
         help
             Enable ECDSA. Needed to use ECDSA-xxx TLS ciphersuites.
+
+    config MBEDTLS_ECJPAKE_C
+        bool "Elliptic curve J-PAKE"
+        depends on MBEDTLS_ECP_C
+        default n
+        help
+            Enable ECJPAKE. Needed to use ECJPAKE-xxx TLS ciphersuites.
 
     config MBEDTLS_ECP_DP_SECP192R1_ENABLED
         bool "Enable SECP192R1 curve"

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -685,6 +685,29 @@
 #endif
 
 /**
+ * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+ *
+ * Enable the ECJPAKE based ciphersuite modes in SSL / TLS.
+ *
+ * \warning This is currently experimental. EC J-PAKE support is based on the
+ * Thread v1.0.0 specification; incompatible changes to the specification
+ * might still happen. For this reason, this is disabled by default.
+ *
+ * Requires: MBEDTLS_ECJPAKE_C
+ *           MBEDTLS_SHA256_C
+ *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
+ *
+ * This enables the following ciphersuites (if other requisites are
+ * enabled as well):
+ *      MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+ */
+#ifdef CONFIG_MBEDTLS_KEY_EXCHANGE_ECJPAKE
+#define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#else
+#undef MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
+#endif
+
+/**
  * \def MBEDTLS_PK_PARSE_EC_EXTENDED
  *
  * Enhance support for reading EC keys using variants of SEC1 not allowed by
@@ -1594,7 +1617,11 @@
  *
  * Requires: MBEDTLS_ECP_C, MBEDTLS_MD_C
  */
-//#define MBEDTLS_ECJPAKE_C
+#ifdef CONFIG_MBEDTLS_ECJPAKE_C
+#define MBEDTLS_ECJPAKE_C
+#else
+#undef MBEDTLS_ECJPAKE_C
+#endif
 
 /**
  * \def MBEDTLS_ECP_C


### PR DESCRIPTION
This PR adds mbedTLS component configuration for `EC-JPAKE`. The `EC-JPAKE` definitions are by default commented out in mbedTLS's [default config.h](https://github.com/ARMmbed/mbedtls/blob/e62bdefce164cbdd44bcc8cacff5ee7d92819c40/include/mbedtls/config.h#L1107-L1124), but it is still able to turn it on with a user config file.

For the mbedTLS component built with esp-idf, we need the kconfig options.

## Background
EC-JAPKE stuffs are needed by the [Thread protocol](https://www.threadgroup.org/), and this PR helps support Thread on ESP32 boards.