### PR TITLE
Missing SENDER_EMAIL in snprintf (428) (IDFGH-3088)

### DIFF
--- a/examples/protocols/smtp_client/main/smtp_client_example_main.c
+++ b/examples/protocols/smtp_client/main/smtp_client_example_main.c
@@ -425,7 +425,7 @@ static void smtp_client_task(void *pvParameters)
                    "From: %s\r\nSubject: mbed TLS Test mail\r\n"
                    "To: %s\r\n"
                    "MIME-Version: 1.0 (mime-construct 1.9)\n",
-                   "ESP32 SMTP Client", RECIPIENT_MAIL);
+                   "ESP32 SMTP Client", SENDER_MAIL, RECIPIENT_MAIL);
 
     /**
      * Note: We are not validating return for some ssl_writes.


### PR DESCRIPTION
I did not try the example, but snprintf should crash!