### PR TITLE
Update idf_tools.py - double negation in info (IDFGH-3116)

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1005,7 +1005,7 @@ def action_export(args):
                 continue
 
         if tool.version_in_path and tool.version_in_path not in tool.versions:
-            info('Not using an unsupported version of tool {} found in PATH: {}.'.format(
+            info('Not using a supported version of tool {} found in PATH: {}.'.format(
                  tool.name, tool.version_in_path) + prefer_system_hint, f=sys.stderr)
 
         version_to_use = tool.get_preferred_installed_version()


### PR DESCRIPTION
Remove double negation in warning that tool is not supported.

(for me that is currently: "Not using an unsupported version of tool openocd-esp32 found in PATH: v0.10.0-esp32-20200309" after pulling from git today and ./install.sh)