### PR TITLE
Fix typo with sigmadelta.h #ifdef (IDFGH-3129)

### DIFF
--- a/components/driver/include/driver/sigmadelta.h
+++ b/components/driver/include/driver/sigmadelta.h
@@ -81,6 +81,6 @@ esp_err_t sigmadelta_set_prescale(sigmadelta_channel_t channel, uint8_t prescale
  */
 esp_err_t sigmadelta_set_pin(sigmadelta_channel_t channel, gpio_num_t gpio_num);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I was experiencing a build error with an unmatched { bracket when including the sigmadelta.h file on a C++ project. It looks like a simple typo where instead of two underscores only one was provided. 

A quick scan of the rest of the esp-idf revealed this was the only occurrence of the typo.