### PR TITLE
Update linenoise.c: calloc returning NULL is not handled (IDFGH-3144)

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1119,6 +1119,9 @@ int linenoiseHistoryLoad(const char *filename) {
         if (p) *p = '\0';
         linenoiseHistoryAdd(buf);
     }
+
+    free(buf);
     fclose(fp);
+    
     return 0;
 }

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1102,9 +1102,14 @@ int linenoiseHistorySave(const char *filename) {
  * on error -1 is returned. */
 int linenoiseHistoryLoad(const char *filename) {
     FILE *fp = fopen(filename,"r");
-    char buf[LINENOISE_MAX_LINE];
+    if (fp == NULL) {
+        return -1;
+    }
 
-    if (fp == NULL) return -1;
+    char *buf = calloc(1, LINENOISE_MAX_LINE);
+    if (buf == NULL) {
+        return -1;
+    }
 
     while (fgets(buf,LINENOISE_MAX_LINE,fp) != NULL) {
         char *p;

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1108,6 +1108,7 @@ int linenoiseHistoryLoad(const char *filename) {
 
     char *buf = calloc(1, LINENOISE_MAX_LINE);
     if (buf == NULL) {
+        fclose(fp);
         return -1;
     }
 
@@ -1122,6 +1123,6 @@ int linenoiseHistoryLoad(const char *filename) {
 
     free(buf);
     fclose(fp);
-    
+
     return 0;
 }

--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -974,6 +974,9 @@ static void sanitize(char* src) {
 char *linenoise(const char *prompt) {
     char *buf = calloc(1, LINENOISE_MAX_LINE);
     int count = 0;
+    if (buf == NULL) {
+        return NULL;
+    }
     if (!dumbmode) {
         count = linenoiseRaw(buf, LINENOISE_MAX_LINE, prompt);
     } else {


### PR DESCRIPTION
Calloc function tries to allocate 4096 bytes.
If such memory is not available, it returns NULL pointer.
This exception was not handled in the code, causing a dirty crash.