### PR TITLE
nvs: allow to specify custom partition (IDFGH-3159)

### DIFF
--- a/components/nvs_flash/include/nvs_flash.h
+++ b/components/nvs_flash/include/nvs_flash.h
@@ -62,6 +62,20 @@ esp_err_t nvs_flash_init(void);
 esp_err_t nvs_flash_init_partition(const char *partition_label);
 
 /**
+ * @brief Initialize NVS flash storage for the partition specified by partition pointer.
+ *
+ * @param[in] partition pointer to a partition obtained by the ESP partition API.
+ *
+ * @return
+ *      - ESP_OK if storage was successfully initialized
+ *      - ESP_ERR_NVS_NO_FREE_PAGES if the NVS storage contains no empty pages
+ *        (which may happen if NVS partition was truncated)
+ *      - ESP_ERR_INVALID_ARG in case partition or partition->label is NULL
+ *      - one of the error codes from the underlying flash storage driver
+ */
+esp_err_t nvs_flash_init_partition_ptr(const esp_partition_t *partition);
+
+/**
  * @brief Deinitialize NVS storage for the default NVS partition
  *
  * Default NVS partition is the partition with "nvs" label in the partition table.
@@ -117,6 +131,26 @@ esp_err_t nvs_flash_erase(void);
  *      - different error in case de-initialization fails (shouldn't happen)
  */
 esp_err_t nvs_flash_erase_partition(const char *part_name);
+
+/**
+ * @brief Erase custom partition.
+ *
+ * Erase all content of specified custom partition.
+ *
+ * @note
+ *  If the partition is initialized, this function first de-initializes it.
+ *  Afterwards, the partition has to be initialized again to be used.
+ *
+ * @param[in] partition pointer to a partition obtained by the ESP partition API.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_NOT_FOUND if there is no partition with the specified
+ *        parameters in the partition table
+ *      - ESP_ERR_INVALID_ARG in case partition or partition->label is NULL
+ *      - one of the error codes from the underlying flash storage driver
+ */
+esp_err_t nvs_flash_erase_partition_ptr(const esp_partition_t *partition);
 
 /**
  * @brief Initialize the default NVS partition.

--- a/components/nvs_flash/src/nvs_api.cpp
+++ b/components/nvs_flash/src/nvs_api.cpp
@@ -136,6 +136,24 @@ extern "C" esp_err_t nvs_flash_init_partition(const char *part_name)
     return NVSPartitionManager::get_instance()->init_partition(part_name);
 }
 
+extern "C" esp_err_t nvs_flash_init_partition_ptr(const esp_partition_t *partition)
+{
+    Lock::init();
+    Lock lock;
+
+    if (!partition) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!partition->label) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return nvs_flash_init_custom(partition->label,
+                                 partition->address / SPI_FLASH_SEC_SIZE,
+                                 partition->size / SPI_FLASH_SEC_SIZE);
+}
+
 extern "C" esp_err_t nvs_flash_init(void)
 {
     return nvs_flash_init_partition(NVS_DEFAULT_PART_NAME);
@@ -188,6 +206,32 @@ extern "C" esp_err_t nvs_flash_erase_partition(const char *part_name)
             ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_NVS, part_name);
     if (partition == NULL) {
         return ESP_ERR_NOT_FOUND;
+    }
+
+    return esp_partition_erase_range(partition, 0, partition->size);
+}
+
+extern "C" esp_err_t nvs_flash_erase_partition_ptr(const esp_partition_t *partition)
+{
+    Lock::init();
+    Lock lock;
+
+    if (!partition) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!partition->label) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // if the partition is initialized, uninitialize it first
+    if (NVSPartitionManager::get_instance()->lookup_storage_from_name(partition->label)) {
+        const esp_err_t err = close_handles_and_deinit(partition->label);
+
+        // only hypothetical/future case, deinit_partition() only fails if partition is uninitialized
+        if (err != ESP_OK) {
+            return err;
+        }
     }
 
     return esp_partition_erase_range(partition, 0, partition->size);


### PR DESCRIPTION
Link: #5130

According to the discussion from #5130

> Perhaps we can create new functions nvs_flash_init_partition_ptr and nvs_flash_erase_partition_ptr which would take const esp_partition_t*. I don't know how widely useful this will be, though.

I've decided not to accept `const esp_partition_t*` because:

- All operations with low-level partition API is synced with storage lock;
- All operations check if the corresponding storage handle was created or not.

----

@igrr could you please take a look?