### PR TITLE
esp-netif: esp_netif_is_netif_up should also check netif_is_link_up (IDFGH-3171)

### DIFF
--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -1141,7 +1141,7 @@ bool esp_netif_is_netif_up(esp_netif_t *esp_netif)
 {
     ESP_LOGV(TAG, "%s esp_netif:%p", __func__, esp_netif);
 
-    if (esp_netif != NULL && esp_netif->lwip_netif != NULL && netif_is_up(esp_netif->lwip_netif)) {
+    if (esp_netif != NULL && esp_netif->lwip_netif != NULL && netif_is_up(esp_netif->lwip_netif) && netif_is_link_up(esp_netif->lwip_netif)) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
Otherwise esp_netif_update_default_netif_lwip() may select wrong interface
as default route. e.g. calling esp_netif_is_netif_up() for ppp interface before
dialing up returns true without this patch then it's selected as the default
route due to higher priority.

Signed-off-by: Axel Lin <axel.lin@gmail.com>