### PR TITLE
mdns: Remove mbedtls dependency (IDFGH-3177)

### DIFF
--- a/components/mdns/CMakeLists.txt
+++ b/components/mdns/CMakeLists.txt
@@ -3,6 +3,6 @@ idf_component_register(SRCS "mdns.c"
                             "mdns_networking.c"
                     INCLUDE_DIRS "include"
                     PRIV_INCLUDE_DIRS "private_include"
-                    REQUIRES lwip mbedtls console esp_netif
+                    REQUIRES lwip console esp_netif
                     PRIV_REQUIRES esp_timer)
 


### PR DESCRIPTION
mdns does not use mbedtls, so remove mbedtls dependency.

Signed-off-by: Axel Lin <axel.lin@gmail.com>