### PR TITLE
ble_hid_device_demo: fix build if building with c++ (IDFGH-3182)

### DIFF
--- a/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/main/hid_dev.h
+++ b/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/main/hid_dev.h
@@ -253,5 +253,9 @@ void hid_keyboard_build_report(uint8_t *buffer, keyboard_cmd_t cmd);
 
 void hid_mouse_build_report(uint8_t *buffer, mouse_cmd_t cmd);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* HID_DEV_H__ */
 


### PR DESCRIPTION
Fixed missing closing bracket in the header file