### PR TITLE
mdns: Allow config mDNS task stack size (IDFGH-3219)

### DIFF
--- a/components/mdns/Kconfig
+++ b/components/mdns/Kconfig
@@ -19,6 +19,12 @@ menu "mDNS"
             higher than priorities of system tasks. Compile time warning/error
             would be emitted if the chosen task priority were too high.
 
+    config MDNS_TASK_STACK_SIZE
+        int "mDNS task stack size"
+        default 4096
+        help
+            Allows setting mDNS task stacksize.
+
     choice MDNS_TASK_AFFINITY
         prompt "mDNS task affinity"
         default MDNS_TASK_AFFINITY_CPU0

--- a/components/mdns/private_include/mdns_private.h
+++ b/components/mdns/private_include/mdns_private.h
@@ -56,7 +56,7 @@
 #define MDNS_ANSWER_AAAA_SIZE       16
 
 #define MDNS_SERVICE_PORT           5353                    // UDP port that the server runs on
-#define MDNS_SERVICE_STACK_DEPTH    4096                    // Stack size for the service thread
+#define MDNS_SERVICE_STACK_DEPTH    CONFIG_MDNS_TASK_STACK_SIZE
 #define MDNS_TASK_PRIORITY          CONFIG_MDNS_TASK_PRIORITY
 #if (MDNS_TASK_PRIORITY > ESP_TASK_PRIO_MAX)
 #error "mDNS task priority is higher than ESP_TASK_PRIO_MAX"


### PR DESCRIPTION
When I check uxTaskGetStackHighWaterMark with my application I found mdns
task wastes some memory but the stack size is not configurable now.
Thus add this patch to allow config mdns task stack size.

Signed-off-by: Axel Lin <axel.lin@gmail.com>