### PR TITLE
Clarify upper bits of ULP store instruction (IDFGH-3224)

### DIFF
--- a/components/ulp/include/esp32/ulp.h
+++ b/components/ulp/include/esp32/ulp.h
@@ -464,10 +464,11 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg) {
  * reg_addr register and offset_ field (this offset is expressed in 32-bit words).
  * 32 bits written to RTC memory are built as follows:
  * - bits [31:21] hold the PC of current instruction, expressed in 32-bit words
- * - bits [20:16] = 5'b1
+ * - bits [20:18] = 3'b0
+ * - bits [17:16] reg_addr (0..3)
  * - bits [15:0] are assigned the contents of reg_val
  *
- * RTC_SLOW_MEM[addr + offset_] = { 5'b0, insn_PC[10:0], val[15:0] }
+ * RTC_SLOW_MEM[addr + offset_] = { insn_PC[10:0], 3'b0, reg_addr, reg_val[15:0] }
  */
 #define I_ST(reg_val, reg_addr, offset_) { .st = { \
     .dreg = reg_val, \

--- a/components/ulp/include/esp32s2/ulp.h
+++ b/components/ulp/include/esp32s2/ulp.h
@@ -430,10 +430,11 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg) {
  * reg_addr register and offset_ field (this offset is expressed in 32-bit words).
  * 32 bits written to RTC memory are built as follows:
  * - bits [31:21] hold the PC of current instruction, expressed in 32-bit words
- * - bits [20:16] = 5'b1
+ * - bits [20:18] = 3'b0
+ * - bits [17:16] reg_addr (0..3)
  * - bits [15:0] are assigned the contents of reg_val
  *
- * RTC_SLOW_MEM[addr + offset_] = { 5'b0, insn_PC[10:0], val[15:0] }
+ * RTC_SLOW_MEM[addr + offset_] = { insn_PC[10:0], 3'b0, reg_addr, reg_val[15:0] }
  */
 #define I_ST(reg_val, reg_addr, offset_) { .st = { \
     .dreg = reg_val, \

--- a/docs/en/api-guides/ulp_instruction_set.rst
+++ b/docs/en/api-guides/ulp_instruction_set.rst
@@ -364,9 +364,9 @@ Note that when accessing RTC memories and RTC registers, ULP coprocessor has low
   4 cycles to execute, 4 cycles to fetch next instruction
 
 **Description**
-  The instruction stores the 16-bit value of Rsrc to the lower half-word of memory with address Rdst+offset. The upper half-word is written with the current program counter (PC), expressed in words, shifted left by 5 bits::
+  The instruction stores the 16-bit value of Rsrc to the lower half-word of memory with address Rdst+offset. The upper half-word is written with the current program counter (PC) (expressed in words, shifted left by 5 bits) OR'd with Rdst (0..3)::
 
-    Mem[Rdst + offset / 4]{31:0} = {PC[10:0], 5'b0, Rsrc[15:0]}
+    Mem[Rdst + offset / 4]{31:0} = {PC[10:0], 3'b0, Rdst, Rsrc[15:0]}
 
   The application can use higher 16 bits to determine which instruction in the ULP program has written any particular word into memory.
 


### PR DESCRIPTION
- Improves consistency across references to the upper bits of a memory address written to by the ULP CP. 

- Documents [17:16] as the address register used.