### PR TITLE
Context data for RMT translator callback (IDFGH-3237)

### DIFF
--- a/components/driver/include/driver/rmt.h
+++ b/components/driver/include/driver/rmt.h
@@ -159,13 +159,14 @@ typedef struct {
 * @param[out] item_num The number of the rmt format data that actually converted to,
 *             it can be less than wanted_num if there is not enough raw data, but cannot exceed wanted_num.
 *             it should return 0 if no data was converted.
+* @param  ctx Pointer to context data, as supplied to rmt_translator_init
 *
 * @note
 *       In fact, item_num should be a multiple of translated_size, e.g. :
 *       When we convert each byte of uint8_t type data to rmt format data,
 *       the relation between item_num and translated_size should be `item_num = translated_size*8`.
 */
-typedef void (*sample_to_rmt_t)(const void *src, rmt_item32_t *dest, size_t src_size, size_t wanted_num, size_t *translated_size, size_t *item_num);
+typedef void (*sample_to_rmt_t)(const void *src, rmt_item32_t *dest, size_t src_size, size_t wanted_num, size_t *translated_size, size_t *item_num, void *ctx);
 
 /**
 * @brief Set RMT clock divider, channel clock is divided from source clock.
@@ -756,12 +757,13 @@ esp_err_t rmt_get_ringbuf_handle(rmt_channel_t channel, RingbufHandle_t *buf_han
 *
 * @param channel RMT channel .
 * @param fn Point to the data conversion function.
+* @param ctx Pointer to some context data to be available for use inside the callback.
 *
 * @return
 *     - ESP_FAIL Init fail.
 *     - ESP_OK Init success.
 */
-esp_err_t rmt_translator_init(rmt_channel_t channel, sample_to_rmt_t fn);
+esp_err_t rmt_translator_init(rmt_channel_t channel, sample_to_rmt_t fn, void *ctx);
 
 /**
 * @brief Translate uint8_t type of data into rmt format and send it out.

--- a/components/driver/rmt.c
+++ b/components/driver/rmt.c
@@ -86,6 +86,7 @@ typedef struct {
     uint32_t rx_item_start_idx;
 #endif
     sample_to_rmt_t sample_to_rmt;
+    void *ctx;
     size_t sample_size_remain;
     const uint8_t *sample_cur;
 } rmt_obj_t;
@@ -684,7 +685,8 @@ static void IRAM_ATTR rmt_driver_isr_default(void *arg)
                                          p_rmt->sample_size_remain,
                                          p_rmt->tx_sub_len,
                                          &translated_size,
-                                         &p_rmt->tx_len_rem);
+                                         &p_rmt->tx_len_rem,
+                                         p_rmt->ctx);
                     p_rmt->sample_size_remain -= translated_size;
                     p_rmt->sample_cur += translated_size;
                     p_rmt->tx_data = p_rmt->tx_buf;
@@ -873,6 +875,9 @@ esp_err_t rmt_driver_uninstall(rmt_channel_t channel)
     if (p_rmt_obj[channel]->sample_to_rmt) {
         p_rmt_obj[channel]->sample_to_rmt = NULL;
     }
+    if (p_rmt_obj[channel]->ctx) {
+        p_rmt_obj[channel]->ctx = NULL;
+    }
 #if SOC_RMT_SUPPORT_RX_PINGPONG
     if (p_rmt_obj[channel]->rx_item_buf) {
         free(p_rmt_obj[channel]->rx_item_buf);
@@ -925,6 +930,7 @@ esp_err_t rmt_driver_install(rmt_channel_t channel, size_t rx_buf_size, int intr
     p_rmt_obj[channel]->wait_done = false;
     p_rmt_obj[channel]->translator = false;
     p_rmt_obj[channel]->sample_to_rmt = NULL;
+    p_rmt_obj[channel]->ctx = NULL;
     if (p_rmt_obj[channel]->tx_sem == NULL) {
 #if !CONFIG_SPIRAM_USE_MALLOC
         p_rmt_obj[channel]->tx_sem = xSemaphoreCreateBinary();
@@ -1064,7 +1070,7 @@ rmt_tx_end_callback_t rmt_register_tx_end_callback(rmt_tx_end_fn_t function, voi
     return previous;
 }
 
-esp_err_t rmt_translator_init(rmt_channel_t channel, sample_to_rmt_t fn)
+esp_err_t rmt_translator_init(rmt_channel_t channel, sample_to_rmt_t fn, void *ctx)
 {
     RMT_CHECK(fn != NULL, RMT_TRANSLATOR_NULL_STR, ESP_ERR_INVALID_ARG);
     RMT_CHECK(channel < RMT_CHANNEL_MAX, RMT_CHANNEL_ERROR_STR, ESP_ERR_INVALID_ARG);
@@ -1087,6 +1093,7 @@ esp_err_t rmt_translator_init(rmt_channel_t channel, sample_to_rmt_t fn)
         }
     }
     p_rmt_obj[channel]->sample_to_rmt = fn;
+    p_rmt_obj[channel]->ctx = ctx;
     p_rmt_obj[channel]->sample_size_remain = 0;
     p_rmt_obj[channel]->sample_cur = NULL;
     ESP_LOGD(RMT_TAG, "RMT translator init done");
@@ -1112,7 +1119,7 @@ esp_err_t rmt_write_sample(rmt_channel_t channel, const uint8_t *src, size_t src
     const uint32_t item_block_len = rmt_ll_get_mem_blocks(p_rmt_obj[channel]->hal.regs, channel) * RMT_MEM_ITEM_NUM;
     const uint32_t item_sub_len = item_block_len / 2;
     xSemaphoreTake(p_rmt->tx_sem, portMAX_DELAY);
-    p_rmt->sample_to_rmt((void *)src, p_rmt->tx_buf, src_size, item_block_len, &translated_size, &item_num);
+    p_rmt->sample_to_rmt((void *)src, p_rmt->tx_buf, src_size, item_block_len, &translated_size, &item_num, p_rmt->ctx);
     p_rmt->sample_size_remain = src_size - translated_size;
     p_rmt->sample_cur = src + translated_size;
     rmt_fill_memory(channel, p_rmt->tx_buf, item_num, 0);

--- a/examples/peripherals/rmt/led_strip/components/led_strip/src/led_strip_rmt_ws2812.c
+++ b/examples/peripherals/rmt/led_strip/components/led_strip/src/led_strip_rmt_ws2812.c
@@ -155,7 +155,7 @@ led_strip_t *led_strip_new_rmt_ws2812(const led_strip_config_t *config)
     ws2812_t1l_ticks = (uint32_t)(ratio * WS2812_T1L_NS);
 
     // set ws2812 to rmt adapter
-    rmt_translator_init((rmt_channel_t)config->dev, ws2812_rmt_adapter);
+    rmt_translator_init((rmt_channel_t)config->dev, ws2812_rmt_adapter, NULL);
 
     ws2812->rmt_channel = (rmt_channel_t)config->dev;
     ws2812->strip_len = config->max_leds;

--- a/examples/peripherals/rmt/led_strip/components/led_strip/src/led_strip_rmt_ws2812.c
+++ b/examples/peripherals/rmt/led_strip/components/led_strip/src/led_strip_rmt_ws2812.c
@@ -62,7 +62,7 @@ typedef struct {
  * @param[out] item_num: number of RMT items which are converted from source data
  */
 static void IRAM_ATTR ws2812_rmt_adapter(const void *src, rmt_item32_t *dest, size_t src_size,
-        size_t wanted_num, size_t *translated_size, size_t *item_num)
+        size_t wanted_num, size_t *translated_size, size_t *item_num, void *ctx)
 {
     if (src == NULL || dest == NULL) {
         *translated_size = 0;


### PR DESCRIPTION
Allows a pointer to some context data to be supplied to `rmt_translator_init`, which is subsequently made available in the respective callback.