### PR TITLE
Modify the OTA implementation to incrementally erase flash (IDFGH-3250)

### DIFF
--- a/components/app_update/esp_ota_ops.c
+++ b/components/app_update/esp_ota_ops.c
@@ -48,7 +48,6 @@
 typedef struct ota_ops_entry_ {
     uint32_t handle;
     const esp_partition_t *part;
-    uint32_t erased_size;
     uint32_t wrote_size;
     uint8_t partial_bytes;
     uint8_t partial_data[16];
@@ -131,7 +130,6 @@ static esp_ota_img_states_t set_new_state_otadata(void)
 esp_err_t esp_ota_begin(const esp_partition_t *partition, size_t image_size, esp_ota_handle_t *out_handle)
 {
     ota_ops_entry_t *new_entry;
-    esp_err_t ret = ESP_OK;
 
     if ((partition == NULL) || (out_handle == NULL)) {
         return ESP_ERR_INVALID_ARG;
@@ -161,30 +159,12 @@ esp_err_t esp_ota_begin(const esp_partition_t *partition, size_t image_size, esp
     }
 #endif
 
-    // If input image size is 0 or OTA_SIZE_UNKNOWN, erase entire partition
-    if ((image_size == 0) || (image_size == OTA_SIZE_UNKNOWN)) {
-        ret = esp_partition_erase_range(partition, 0, partition->size);
-    } else {
-        const int aligned_erase_size = (image_size + SPI_FLASH_SEC_SIZE - 1) & ~(SPI_FLASH_SEC_SIZE - 1);
-        ret = esp_partition_erase_range(partition, 0, aligned_erase_size);
-    }
-
-    if (ret != ESP_OK) {
-        return ret;
-    }
-
     new_entry = (ota_ops_entry_t *) calloc(sizeof(ota_ops_entry_t), 1);
     if (new_entry == NULL) {
         return ESP_ERR_NO_MEM;
     }
 
     LIST_INSERT_HEAD(&s_ota_ops_entries_head, new_entry, entries);
-
-    if ((image_size == 0) || (image_size == OTA_SIZE_UNKNOWN)) {
-        new_entry->erased_size = partition->size;
-    } else {
-        new_entry->erased_size = image_size;
-    }
 
     new_entry->part = partition;
     new_entry->handle = ++s_ota_ops_last_handle;
@@ -207,7 +187,20 @@ esp_err_t esp_ota_write(esp_ota_handle_t handle, const void *data, size_t size)
     for (it = LIST_FIRST(&s_ota_ops_entries_head); it != NULL; it = LIST_NEXT(it, entries)) {
         if (it->handle == handle) {
             // must erase the partition before writing to it
-            assert(it->erased_size > 0 && "must erase the partition before writing to it");
+			uint32_t first_sector = it->wrote_size / SPI_FLASH_SEC_SIZE;
+			uint32_t last_sector = (it->wrote_size + size) / SPI_FLASH_SEC_SIZE;
+
+			ret = ESP_OK;
+			if (0 == (it->wrote_size % SPI_FLASH_SEC_SIZE)) {
+				ret = esp_partition_erase_range(it->part, it->wrote_size, ((last_sector - first_sector) + 1) * SPI_FLASH_SEC_SIZE);
+			}
+			else if (first_sector != last_sector) {
+				ret = esp_partition_erase_range(it->part, (first_sector + 1) * SPI_FLASH_SEC_SIZE, (last_sector - first_sector) * SPI_FLASH_SEC_SIZE);
+			}
+			if (ret != ESP_OK) {
+				return ret;
+			}
+
             if (it->wrote_size == 0 && it->partial_bytes == 0 && size > 0 && data_bytes[0] != ESP_IMAGE_HEADER_MAGIC) {
                 ESP_LOGE(TAG, "OTA image has invalid magic byte (expected 0xE9, saw 0x%02x)", data_bytes[0]);
                 return ESP_ERR_OTA_VALIDATE_FAILED;
@@ -276,7 +269,7 @@ esp_err_t esp_ota_end(esp_ota_handle_t handle)
     /* 'it' holds the ota_ops_entry_t for 'handle' */
 
     // esp_ota_end() is only valid if some data was written to this handle
-    if ((it->erased_size == 0) || (it->wrote_size == 0)) {
+    if (it->wrote_size == 0) {
         ret = ESP_ERR_INVALID_ARG;
         goto cleanup;
     }

--- a/components/app_update/include/esp_ota_ops.h
+++ b/components/app_update/include/esp_ota_ops.h
@@ -29,6 +29,7 @@ extern "C"
 #endif
 
 #define OTA_SIZE_UNKNOWN 0xffffffff /*!< Used for esp_ota_begin() if new image size is unknown */
+#define OTA_WITH_SEQUENTIAL_WRITES 0xfffffffe /*!< Used for esp_ota_begin() if all writes are in a continuous sequence */
 
 #define ESP_ERR_OTA_BASE                         0x1500                     /*!< Base error code for ota_ops api */
 #define ESP_ERR_OTA_PARTITION_CONFLICT           (ESP_ERR_OTA_BASE + 0x01)  /*!< Error if request was to write or erase the current running partition */


### PR DESCRIPTION
This patch modifies the OTA implementation to incremental erase flash sectors as they are written, rather than bulk erasing them all at once when OT begins. This solves several problems:

- The bulk flash erase can take so long that it triggers the watchdog timer. Disabling the watchdog is an undesirable risk.
- The bulk erase interferes with the responsiveness of the system to user input.
- Incremental erasing eliminates the need to pass the firmware image size to esp_ota_begin to avoid erasing more flash sectors than required.
- When installing an OTA received via HTTP, the size of the firmware image is known when the content-length header is received. Calling esp_ota_begin at that time causes a long delay to do the bulk erase which causes the TCP transfer speed to be measurably slowed when the transfer resumes after the erase. Incremental erasing eliminates this TCP slowdown.