### PR TITLE
Set pxStackBase value in TaskStatus_t when filling task info (IDFGH-3258)

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3730,6 +3730,7 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 				pxTaskStatusArray[ uxTask ].xTaskNumber = pxNextTCB->uxTCBNumber;
 				pxTaskStatusArray[ uxTask ].eCurrentState = eState;
 				pxTaskStatusArray[ uxTask ].uxCurrentPriority = pxNextTCB->uxPriority;
+				pxTaskStatusArray[ uxTask ].pxStackBase = pxNextTCB->pxStack;
 
 				#if ( configTASKLIST_INCLUDE_COREID == 1 )
 				pxTaskStatusArray[ uxTask ].xCoreID = pxNextTCB->xCoreID;


### PR DESCRIPTION
The value was never set, thus resulting in garbage when accessed.