### PR TITLE
httpd_resp_send: use `HTTPD_RESP_USE_STRLEN` when possible (IDFGH-3268)

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -1047,7 +1047,7 @@ esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len
  *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
  */
 static inline esp_err_t httpd_resp_sendstr(httpd_req_t *r, const char *str) {
-    return httpd_resp_send(r, str, (str == NULL) ? 0 : strlen(str));
+    return httpd_resp_send(r, str, (str == NULL) ? 0 : HTTPD_RESP_USE_STRLEN);
 }
 
 /**
@@ -1068,7 +1068,7 @@ static inline esp_err_t httpd_resp_sendstr(httpd_req_t *r, const char *str) {
  *  - ESP_ERR_HTTPD_INVALID_REQ : Invalid request
  */
 static inline esp_err_t httpd_resp_sendstr_chunk(httpd_req_t *r, const char *str) {
-    return httpd_resp_send_chunk(r, str, (str == NULL) ? 0 : strlen(str));
+    return httpd_resp_send_chunk(r, str, (str == NULL) ? 0 : HTTPD_RESP_USE_STRLEN);
 }
 
 /* Some commonly used status codes */

--- a/components/esp_http_server/src/httpd_txrx.c
+++ b/components/esp_http_server/src/httpd_txrx.c
@@ -451,7 +451,7 @@ esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const ch
 #endif
 
     /* Send HTTP error message */
-    ret = httpd_resp_send(req, msg, strlen(msg));
+    ret = httpd_resp_send(req, msg, HTTPD_RESP_USE_STRLEN);
 
 #ifdef CONFIG_HTTPD_ERR_RESP_NO_DELAY
     /* If TCP_NODELAY was set successfully above, time to disable it */

--- a/docs/en/api-reference/protocols/esp_http_server.rst
+++ b/docs/en/api-reference/protocols/esp_http_server.rst
@@ -23,7 +23,7 @@ Application Example
         {
             /* Send a simple response */
             const char resp[] = "URI GET Response";
-            httpd_resp_send(req, resp, strlen(resp));
+            httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
             return ESP_OK;
         }
 
@@ -56,7 +56,7 @@ Application Example
 
             /* Send a simple response */
             const char resp[] = "URI POST Response";
-            httpd_resp_send(req, resp, strlen(resp));
+            httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
             return ESP_OK;
         }
 

--- a/docs/zh_CN/api-reference/protocols/esp_http_server.rst
+++ b/docs/zh_CN/api-reference/protocols/esp_http_server.rst
@@ -23,7 +23,7 @@ HTTP Server 组件提供了在 ESP32 上运行轻量级 Web 服务器的功能�
         {
             /* 发送回简单的响应数据包 */
             const char[] resp = "URI GET Response";
-            httpd_resp_send(req, resp, strlen(resp));
+            httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
             return ESP_OK;
         }
 
@@ -52,7 +52,7 @@ HTTP Server 组件提供了在 ESP32 上运行轻量级 Web 服务器的功能�
 
             /* 发送简单的响应数据包 */
             const char[] resp = "URI POST Response";
-            httpd_resp_send(req, resp, strlen(resp));
+            httpd_resp_send(req, resp, HTTPD_RESP_USE_STRLEN);
             return ESP_OK;
         }
 

--- a/examples/protocols/http_server/advanced_tests/main/tests.c
+++ b/examples/protocols/http_server/advanced_tests/main/tests.c
@@ -22,7 +22,7 @@ static esp_err_t hello_get_handler(httpd_req_t *req)
 {
 #define STR "Hello World!"
     ESP_LOGI(TAG, "Free Stack for server task: '%d'", uxTaskGetStackHighWaterMark(NULL));
-    httpd_resp_send(req, STR, strlen(STR));
+    httpd_resp_send(req, STR, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 #undef STR
 }
@@ -107,7 +107,7 @@ static esp_err_t test_header_get_handler(httpd_req_t *req)
     }
     if (httpd_req_get_hdr_value_str(req, "Header2", buf, buf_len) == ESP_OK) {
         ESP_LOGI(TAG, "Header2 content: %s", buf);
-        httpd_resp_send(req, buf, strlen(buf));
+        httpd_resp_send(req, buf, HTTPD_RESP_USE_STRLEN);
     } else {
         ESP_LOGE(TAG, "Header2 not found");
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Header2 not found");
@@ -121,7 +121,7 @@ static esp_err_t hello_type_get_handler(httpd_req_t *req)
 {
 #define STR "Hello World!"
     httpd_resp_set_type(req, HTTPD_TYPE_TEXT);
-    httpd_resp_send(req, STR, strlen(STR));
+    httpd_resp_send(req, STR, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 #undef STR
 }
@@ -130,7 +130,7 @@ static esp_err_t hello_status_get_handler(httpd_req_t *req)
 {
 #define STR "Hello World!"
     httpd_resp_set_status(req, HTTPD_500);
-    httpd_resp_send(req, STR, strlen(STR));
+    httpd_resp_send(req, STR, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 #undef STR
 }
@@ -228,7 +228,7 @@ static esp_err_t adder_post_handler(httpd_req_t *req)
     *adder += val;
 
     snprintf(outbuf, sizeof(outbuf),"%d", *adder);
-    httpd_resp_send(req, outbuf, strlen(outbuf));
+    httpd_resp_send(req, outbuf, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 
@@ -251,7 +251,7 @@ static esp_err_t leftover_data_post_handler(httpd_req_t *req)
 
     buf[ret] = '\0';
     ESP_LOGI(TAG, "leftover data handler read %s", buf);
-    httpd_resp_send(req, buf, strlen(buf));
+    httpd_resp_send(req, buf, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 
@@ -283,7 +283,7 @@ static void generate_async_resp(void *arg)
 static esp_err_t async_get_handler(httpd_req_t *req)
 {
 #define STR "Hello World!"
-    httpd_resp_send(req, STR, strlen(STR));
+    httpd_resp_send(req, STR, HTTPD_RESP_USE_STRLEN);
     /* Also register a HTTPD Work which sends the same data on the same
      * socket again
      */

--- a/examples/protocols/http_server/persistent_sockets/main/main.c
+++ b/examples/protocols/http_server/persistent_sockets/main/main.c
@@ -71,7 +71,7 @@ static esp_err_t adder_post_handler(httpd_req_t *req)
 
     /* Respond with the accumulated value */
     snprintf(outbuf, sizeof(outbuf),"%d", *adder);
-    httpd_resp_send(req, outbuf, strlen(outbuf));
+    httpd_resp_send(req, outbuf, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 
@@ -95,7 +95,7 @@ static esp_err_t adder_get_handler(httpd_req_t *req)
 
     /* Respond with the accumulated value */
     snprintf(outbuf, sizeof(outbuf),"%d", *((int *)req->sess_ctx));
-    httpd_resp_send(req, outbuf, strlen(outbuf));
+    httpd_resp_send(req, outbuf, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 
@@ -133,7 +133,7 @@ static esp_err_t adder_put_handler(httpd_req_t *req)
 
     /* Respond with the reset value */
     snprintf(outbuf, sizeof(outbuf),"%d", *((int *)req->sess_ctx));
-    httpd_resp_send(req, outbuf, strlen(outbuf));
+    httpd_resp_send(req, outbuf, HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 

--- a/examples/protocols/http_server/simple/main/main.c
+++ b/examples/protocols/http_server/simple/main/main.c
@@ -91,7 +91,7 @@ static esp_err_t hello_get_handler(httpd_req_t *req)
     /* Send response with custom headers and body set as the
      * string passed in user context*/
     const char* resp_str = (const char*) req->user_ctx;
-    httpd_resp_send(req, resp_str, strlen(resp_str));
+    httpd_resp_send(req, resp_str, HTTPD_RESP_USE_STRLEN);
 
     /* After sending the HTTP response the old HTTP request
      * headers are lost. Check if HTTP request headers can be read now. */
@@ -245,7 +245,7 @@ static void stop_webserver(httpd_handle_t server)
     httpd_stop(server);
 }
 
-static void disconnect_handler(void* arg, esp_event_base_t event_base, 
+static void disconnect_handler(void* arg, esp_event_base_t event_base,
                                int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
@@ -256,7 +256,7 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
     }
 }
 
-static void connect_handler(void* arg, esp_event_base_t event_base, 
+static void connect_handler(void* arg, esp_event_base_t event_base,
                             int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;

--- a/examples/protocols/https_server/main/main.c
+++ b/examples/protocols/https_server/main/main.c
@@ -30,7 +30,7 @@ static const char *TAG = "example";
 static esp_err_t root_get_handler(httpd_req_t *req)
 {
     httpd_resp_set_type(req, "text/html");
-    httpd_resp_send(req, "<h1>Hello Secure World!</h1>", -1); // -1 = use strlen()
+    httpd_resp_send(req, "<h1>Hello Secure World!</h1>", HTTPD_RESP_USE_STRLEN);
 
     return ESP_OK;
 }
@@ -79,7 +79,7 @@ static void stop_webserver(httpd_handle_t server)
     httpd_ssl_stop(server);
 }
 
-static void disconnect_handler(void* arg, esp_event_base_t event_base, 
+static void disconnect_handler(void* arg, esp_event_base_t event_base,
                                int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
@@ -89,7 +89,7 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
     }
 }
 
-static void connect_handler(void* arg, esp_event_base_t event_base, 
+static void connect_handler(void* arg, esp_event_base_t event_base,
                             int32_t event_id, void* event_data)
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;


### PR DESCRIPTION
Simplifies code; also avoids sign-conversion warnings.