### PR TITLE
Add include guards gatt mtu size (IDFGH-3327)

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_gatt_common_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatt_common_api.h
@@ -26,10 +26,14 @@ extern "C" {
 #endif
 
 // Maximum Transmission Unit used in GATT
+#ifndef ESP_GATT_DEF_BLE_MTU_SIZE
 #define ESP_GATT_DEF_BLE_MTU_SIZE   23   /* relate to GATT_DEF_BLE_MTU_SIZE in stack/gatt_api.h */
+#endif
 
 // Maximum Transmission Unit allowed in GATT
+#ifndef ESP_GATT_MAX_MTU_SIZE
 #define ESP_GATT_MAX_MTU_SIZE       517  /* relate to GATT_MAX_MTU_SIZE in stack/gatt_api.h */
+#endif
 
 /**
  * @brief           This function is called to set local MTU,

--- a/components/bt/host/bluedroid/stack/include/stack/gatt_api.h
+++ b/components/bt/host/bluedroid/stack/include/stack/gatt_api.h
@@ -139,7 +139,9 @@ typedef UINT16 tGATT_DISCONN_REASON;
 
 /* default GATT MTU size over LE link
 */
+#ifndef GATT_DEF_BLE_MTU_SIZE
 #define GATT_DEF_BLE_MTU_SIZE               23
+#endif
 
 /* invalid connection ID
 */


### PR DESCRIPTION
I'm working on a bluetooth mesh application with the ESP32 (wroom32).
Because the app I am using does not handle segmentation properly during the provisioning I needed to change GATT_DEF_BLE_MTU_SIZE.

This was not possible without include guards.