### PR TITLE
Bugfix: Casting int to size_t (IDFGH-3352)

### DIFF
--- a/components/soc/src/esp32/include/hal/cpu_ll.h
+++ b/components/soc/src/esp32/include/hal/cpu_ll.h
@@ -116,7 +116,7 @@ static inline void cpu_ll_set_watchpoint(int id,
 
     //We support watching 2^n byte values, from 1 to 64. Calculate the mask for that.
     for (int x = 0; x < 7; x++) {
-        if (size == (1 << x)) {
+        if (size == (size_t)(1 << x)) {
             break;
         }
         dbreakc <<= 1;

--- a/components/soc/src/esp32s2/include/hal/cpu_ll.h
+++ b/components/soc/src/esp32s2/include/hal/cpu_ll.h
@@ -110,7 +110,7 @@ static inline void cpu_ll_set_watchpoint(int id,
 
     //We support watching 2^n byte values, from 1 to 64. Calculate the mask for that.
     for (int x = 0; x < 7; x++) {
-        if (size == (1 << x)) {
+        if (size == (size_t)(1 << x)) {
             break;
         }
         dbreakc <<= 1;


### PR DESCRIPTION
Without this patch CMake complains and build fails since x is of type int and size is of type size_t .
See here: [libwebsockets commit](https://github.com/warmcat/libwebsockets/commit/fe7b6179901ddd592294391da5b6957cf8a1c285) 