### PR TITLE
added esp_ota_abort and created get_ota_ops_entry (IDFGH-3355)

### DIFF
--- a/components/app_update/esp_ota_ops.c
+++ b/components/app_update/esp_ota_ops.c
@@ -250,16 +250,34 @@ esp_err_t esp_ota_write(esp_ota_handle_t handle, const void *data, size_t size)
     return ESP_ERR_INVALID_ARG;
 }
 
-esp_err_t esp_ota_end(esp_ota_handle_t handle)
+static ota_ops_entry_t *get_ota_ops_entry(esp_ota_handle_t handle)
 {
-    ota_ops_entry_t *it;
-    esp_err_t ret = ESP_OK;
-
+    ota_ops_entry_t *it = NULL;
     for (it = LIST_FIRST(&s_ota_ops_entries_head); it != NULL; it = LIST_NEXT(it, entries)) {
         if (it->handle == handle) {
             break;
         }
     }
+   return it;
+}
+
+esp_err_t esp_ota_abort(esp_ota_handle_t handle)
+{
+    ota_ops_entry_t *it = get_ota_ops_entry(handle);
+    esp_err_t ret = ESP_OK;
+
+    if (it == NULL) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    LIST_REMOVE(it, entries);
+    free(it);
+    return ret;
+}
+
+esp_err_t esp_ota_end(esp_ota_handle_t handle)
+{
+    ota_ops_entry_t *it = get_ota_ops_entry(handle);
+    esp_err_t ret = ESP_OK;
 
     if (it == NULL) {
         return ESP_ERR_NOT_FOUND;


### PR DESCRIPTION
This PR should resolve issue #5329.

It would be nice to allow users to abort an ota if they determine it is invalid through their own signature check (or if the signature is valid but fails to pass public key validation). This addition allows an ota to be aborted without the need to validate the image or potentially incorrectly mark the image as bootable should if pass ```esp_image_verify``` but fail other validation(s) by the application.

