### PR TITLE
refactor: shortened expression (IDFGH-3357)

### DIFF
--- a/tools/idf_py_actions/serial_ext.py
+++ b/tools/idf_py_actions/serial_ext.py
@@ -85,12 +85,7 @@ def action_extensions(base_actions, project_path):
             monitor_args += ["-p", args.port]
 
         if not monitor_baud:
-            if os.getenv("IDF_MONITOR_BAUD"):
-                monitor_baud = os.getenv("IDF_MONITOR_BAUD", None)
-            elif os.getenv("MONITORBAUD"):
-                monitor_baud = os.getenv("MONITORBAUD", None)
-            else:
-                monitor_baud = project_desc["monitor_baud"]
+            monitor_baud = os.getenv("IDF_MONITOR_BAUD") or os.getenv("MONITORBAUD") or project_desc["monitor_baud"]
 
         monitor_args += ["-b", monitor_baud]
         monitor_args += ["--toolchain-prefix", project_desc["monitor_toolprefix"]]


### PR DESCRIPTION
- replaced with oneliner
- removed default arguments

I replaced the nested if statement with an "or assignment". This also reduces calling method getenv.  I also removed argument None, since it is default in getenv. 