### PR TITLE
Changed ParseException message argument (IDFGH-3360)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -151,6 +151,7 @@ exclude =
         components/tinyusb,
         components/unity/unity,
         examples/build_system/cmake/import_lib/main/lib/tinyxml2,
+        examples/peripherals/secure_element/atecc608_ecdsa/components/esp-cryptoauthlib,
     # other third-party libraries
         tools/kconfig_new/kconfiglib.py,
         tools/kconfig_new/menuconfig.py,

--- a/tools/ldgen/generation.py
+++ b/tools/ldgen/generation.py
@@ -591,7 +591,7 @@ class SectionsInfo(dict):
         try:
             results = parser.parseString(first_line)
         except ParseException as p:
-            raise ParseException("Parsing sections info for library " + sections_info_dump.name + " failed. " + p.message)
+            raise ParseException("Parsing sections info for library " + sections_info_dump.name + " failed. " + p.msg)
 
         archive = os.path.basename(results.archive_path)
         self.sections[archive] = SectionsInfo.__info(sections_info_dump.name, sections_info_dump.read())


### PR DESCRIPTION
The 'message' attribute seems to be not usable since python 3.0 (see PEP #352 : https://www.python.org/dev/peps/pep-0352/#exception-hierarchy-changes)
but 'msg' is a valid attribute for pyparsing.ParseException.