### PR TITLE
ldgen: Support flags on mappings in linker fragments (IDFGH-3362)

### DIFF
--- a/docs/en/api-guides/linker-script-generation.rst
+++ b/docs/en/api-guides/linker-script-generation.rst
@@ -488,6 +488,39 @@ Example:
     entries:
         * (noflash)
 
+.. _ldgen-mapping-flags :
+
+**Mapping flags**
+
+Each mapping entry can be followed by a set of mapping flags, influencing linker script
+generation.
+Supported flags are:
+
+.. code-block:: none
+
+    keep
+    emit(symbol)
+    align(alignment)
+
+The :code:`keep` flag ensures that all sections matched by a mapping will be guarded with a
+:code:`KEEP(...)` in the resulting linker script. This protects the sections from being
+garbage collected, even if they do not specify any symbols required by the application.
+
+The :code:`emit(symbol)` flag causes the generated linker script to emit symbols for start
+and end of a mapping. The symbols will be called :code:`__start_symbol` and
+:code:`__stop_symbol` and can be referenced in the application code.
+
+The :code:`align(alignment)` flag aligns the start of the mapping to :code:`alignment` bytes.
+
+Example:
+
+.. code-block:: none
+
+    [mapping:map]
+    archive: libmain.a
+    entries:
+        initdata (rodata) emit(initdata) align(8) keep
+
 .. _ldgen-symbol-granularity-placements :
 
 On Symbol-Granularity Placements

--- a/tools/ldgen/generation.py
+++ b/tools/ldgen/generation.py
@@ -41,7 +41,7 @@ class PlacementRule():
 
     __metadata = collections.namedtuple("__metadata", "excludes expansions expanded")
 
-    def __init__(self, archive, obj, symbol, sections, target):
+    def __init__(self, archive, obj, symbol, sections, target, emit=None, align=None, keep=False):
         if archive == "*":
             archive = None
 
@@ -52,6 +52,9 @@ class PlacementRule():
         self.obj = obj
         self.symbol = symbol
         self.target = target
+        self.emit = emit
+        self.align = align
+        self.keep = keep
         self.sections = dict()
 
         self.specificity = 0
@@ -202,6 +205,15 @@ class PlacementRule():
         else:
             rule_string = "*%s:%s(%s)" % (archive, obj, sections_string)
 
+        if self.keep:
+            rule_string = "KEEP(%s)" % (rule_string)
+
+        if self.emit:
+            rule_string = "__start_%s = ABSOLUTE(.); %s; __stop_%s = ABSOLUTE(.);" % (self.emit, rule_string, self.emit)
+
+        if self.align:
+            rule_string = ". = ALIGN(%d); %s" % (self.align, rule_string)
+
         return rule_string
 
     def __eq__(self, other):
@@ -259,7 +271,7 @@ class GenerationModel:
         self.sections = {}
         self.mappings = {}
 
-    def _add_mapping_rules(self, archive, obj, symbol, scheme_name, scheme_dict, rules):
+    def _add_mapping_rules(self, archive, obj, symbol, scheme_name, scheme_dict, rules, emit=None, align=None, keep=False):
         # Use an ordinary dictionary to raise exception on non-existing keys
         temp_dict = dict(scheme_dict)
 
@@ -271,7 +283,7 @@ class GenerationModel:
             for section in sections:
                 section_entries.extend(section.entries)
 
-            rule = PlacementRule(archive, obj, symbol, section_entries, target)
+            rule = PlacementRule(archive, obj, symbol, section_entries, target, emit, align, keep)
 
             if rule not in rules:
                 rules.append(rule)
@@ -334,11 +346,11 @@ class GenerationModel:
         for mapping in self.mappings.values():
             archive = mapping.archive
             mapping_rules = all_mapping_rules[archive]
-            for (obj, symbol, scheme_name) in mapping.entries:
+            for (obj, symbol, scheme_name, emit, align, keep) in mapping.entries:
                 try:
                     if not (obj == Mapping.MAPPING_ALL_OBJECTS and symbol is None and
                             scheme_name == GenerationModel.DEFAULT_SCHEME):
-                        self._add_mapping_rules(archive, obj, symbol, scheme_name, scheme_dictionary, mapping_rules)
+                        self._add_mapping_rules(archive, obj, symbol, scheme_name, scheme_dictionary, mapping_rules, emit, align, keep)
                 except KeyError:
                     message = GenerationException.UNDEFINED_REFERENCE + " to scheme '" + scheme_name + "'."
                     raise GenerationException(message, mapping)


### PR DESCRIPTION
This PR adds support for specifying per mapping flags in linker fragments.

The supported flags are:

* emit(symbol)
* align(alignment)
* keep

The following section describes the effect of each flag during linking:

#### emit(symbol)
Specifying `emit(symbol)` for a mapping causes ld to emit the symbols `__start_<symbol>` and `__stop_<symbol>` for start and end of the mapping, allowing them to be referenced in C source. This is useful for referencing mappings where the size is not known in advance. That could e.g. be a mapping constructed from object sections emitted by the compiler through the use of the `section(sectionname)` attribute.

#### align(alignment)
Adding `align(alignment)` to a mapping will cause its start to be aligned to `alignment` bytes. This is useful for all types of data requiring special alignment. It can also be used in conjunction with `emit` to ensure that an emitted symbol does actually line up with the start of the mappings data.

#### keep
The `keep` flag causes the generated mapping to be guarded by a `KEEP(...)` in the linker script. This can be important since `--gc-sections` will remove sections that do not contain any referenced symbols from the link.

All of the above is particularly useful for implementing dynamic initialization systems. I've set up a sample project showcasing this use here:
https://github.com/TobleMiner/dynamic-init-demo