### PR TITLE
allow unit test of extra-components (IDFGH-3369)

### DIFF
--- a/tools/unit-test-app/CMakeLists.txt
+++ b/tools/unit-test-app/CMakeLists.txt
@@ -2,8 +2,10 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/examples/cxx/experimental/experimental_cpp_component/"
-                         "$ENV{IDF_PATH}/examples/peripherals/rmt/ir_protocols/components")
+set(EXTRA_COMPONENT_DIRS
+    ${EXTRA_COMPONENT_DIRS}
+    "$ENV{IDF_PATH}/examples/cxx/experimental/experimental_cpp_component/"
+    "$ENV{IDF_PATH}/examples/peripherals/rmt/ir_protocols/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(unit-test-app)


### PR DESCRIPTION
The 'unit-test-app' should inherit idf.py "-D EXTRA_COMPONENT_DIRS"

In this way, a project that has non-IDF components can be easily tested.

```shell
PROJECT_DIR=`realpath .`
BUILD_DIR=$PROJECT_DIR/testBuild/
EXTRA_COMPONENT_DIRS=$PROJECT_DIR/components/
pushd "$IDF_PATH/tools/unit-test-app"
idf.py -B "$BUILD_DIR" -D EXTRA_COMPONENT_DIRS="$EXTRA_COMPONENT_DIRS" -T customProject   build flash monitor
popd
```