### PR TITLE
Add extern qualifier to variables in tinyusb/.../usb_descriptors.h (IDFGH-3505)

### DIFF
--- a/components/tinyusb/port/common/include/usb_descriptors.h
+++ b/components/tinyusb/port/common/include/usb_descriptors.h
@@ -23,8 +23,8 @@
 #define USB_STRING_DESCRIPTOR_ARRAY_SIZE 7
 typedef char *tusb_desc_strarray_device_t[USB_STRING_DESCRIPTOR_ARRAY_SIZE];
 
-tusb_desc_device_t descriptor_tinyusb;
-tusb_desc_strarray_device_t descriptor_str_tinyusb;
+extern tusb_desc_device_t descriptor_tinyusb;
+extern tusb_desc_strarray_device_t descriptor_str_tinyusb;
 
-tusb_desc_device_t descriptor_kconfig;
-tusb_desc_strarray_device_t descriptor_str_kconfig;
+extern tusb_desc_device_t descriptor_kconfig;
+extern tusb_desc_strarray_device_t descriptor_str_kconfig;


### PR DESCRIPTION
As described in #5459, the tinyusb port does not correctly support c++ source files. Specifically, the linking stage fails due to duplicate symbols from usb_descriptors.h.

This change adds the extern qualifier to all variables in usb_descriptors.h to clarify that all definitions come from elsewhere (specifically, usb_descriptors.c). This is not required when all includers of usb_descriptors.h are c files, as c is compiled with -fcommon, but is required if any includer of usb_descriptors.h is a cc file, which is compiled with -fnocommon.