### PR TITLE
idf_monitor: only mangle /dev/tty.* on Darwin (IDFGH-3507)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -944,7 +944,7 @@ def main():
         args.port = args.port.replace('COM', r'\\.\COM')
         yellow_print("--- WARNING: GDB cannot open serial ports accessed as COMx")
         yellow_print("--- Using %s instead..." % args.port)
-    elif args.port.startswith("/dev/tty."):
+    elif args.port.startswith("/dev/tty.") and sys.platform == 'darwin':
         args.port = args.port.replace("/dev/tty.", "/dev/cu.")
         yellow_print("--- WARNING: Serial ports accessed as /dev/tty.* will hang gdb if launched.")
         yellow_print("--- Using %s instead..." % args.port)


### PR DESCRIPTION
On my Linux system, I use udev rules to be able to easily identify serial ports based on their USB bus path, for example

    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="tty.cp2102-%s{devpath}"

So it took me a while to figure out why the tools were looking for `/dev/cu.` devices. This fixes it for me.