### PR TITLE
Add LittleFS port as a component (IDFGH-3514)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,6 @@
 [submodule "examples/peripherals/secure_element/atecc608_ecdsa/components/esp-cryptoauthlib"]
 	path = examples/peripherals/secure_element/atecc608_ecdsa/components/esp-cryptoauthlib
 	url = ../../espressif/esp-cryptoauthlib.git
+[submodule "components/littlefs"]
+	path = components/littlefs
+	url = https://github.com/joltwallet/esp_littlefs.git


### PR DESCRIPTION
Added my port of LittleFS for esp-idf. LittleFS significantly outperforms SPIFFS in most common tasks, and is much more robust when compared to FAT.

Benefits of my port:
* Structured nearly identically to the SPIFFS port, so anyone that was comfortable in that repo should feel comfortable in this repo
* Pretty comprehensive unit tests
* Some systematic improvements/efficiencies such as name-hashing, no-file-limit, nonce-metadata, etc.
* Proper use of submoduling

Some potential areas for improvement:
* Documentation (However the API is the same as SPIFFS with a few exceptions noted in the `README.md`)
* For the `partition_label` required to be specified (instead of allowing it to be `NULL`) in the configuration struct, this could be mitigated by adding a `littlefs` subdatatype to the partition table. [Other ports of LittleFS](https://github.com/nguyen-phuoc-dai/LittleFS) have done this.