### PR TITLE
Support for more Bluetooth HID devices (IDFGH-3529)

### DIFF
--- a/components/bt/host/bluedroid/stack/btm/btm_acl.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_acl.c
@@ -1115,7 +1115,6 @@ void btm_read_remote_ext_features_complete (UINT8 *p)
 
     if (max_page > HCI_EXT_FEATURES_PAGE_MAX) {
         BTM_TRACE_ERROR("btm_read_remote_ext_features_complete page=%d unknown", max_page);
-        return;
     }
 
     p_acl_cb = &btm_cb.acl_db[acl_idx];


### PR DESCRIPTION
Some Bluetooth devices - such as an Xbox One S controller (model 1708) - report more than two external features pages and are rejected immediately. Pages 1 and 2 are marked as unhandled in btm_devctl.c anyway, so there is no reason to block devices with more pages.
(IDFGH-3515)