### PR TITLE
ESP SPI Master with two devices on one bus does not work (IDFGH-2652) (IDFGH-3538)

### DIFF
--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -430,6 +430,8 @@ esp_err_t spi_bus_add_device(spi_host_device_t host, const spi_device_interface_
     //Set CS pin, CS options
     if (dev_config->spics_io_num >= 0) {
         spicommon_cs_initialize(host, dev_config->spics_io_num, freecs, !(spihost[host]->flags&SPICOMMON_BUSFLAG_IOMUX_PINS));
+        hal->positive_cs = dev_config->flags & SPI_DEVICE_POSITIVE_CS ? 1 : 0;
+        spi_ll_master_set_pos_cs(hal->hw, freecs, hal->positive_cs);
     }
 
     *handle=dev;
@@ -504,6 +506,7 @@ static void SPI_MASTER_ISR_ATTR spi_setup_device(spi_host_t *host, int dev_id)
     hal->rx_lsbfirst = dev->cfg.flags & SPI_DEVICE_RXBIT_LSBFIRST ? 1 : 0;
     hal->no_compensate = dev->cfg.flags & SPI_DEVICE_NO_DUMMY ? 1 : 0;
     hal->sio = dev->cfg.flags & SPI_DEVICE_3WIRE ? 1 : 0;
+    hal->positive_cs = dev->cfg.flags & SPI_DEVICE_POSITIVE_CS ? 1 : 0;
     hal->dummy_bits = dev->cfg.dummy_bits;
     hal->cs_setup = dev->cfg.cs_ena_pretrans;
     hal->cs_hold =dev->cfg.cs_ena_posttrans;

--- a/components/soc/include/hal/spi_ll.h
+++ b/components/soc/include/hal/spi_ll.h
@@ -275,7 +275,7 @@ static inline void spi_ll_master_set_pos_cs(spi_dev_t *hw, int cs, uint32_t pos_
     if (pos_cs) {
         hw->pin.master_cs_pol |= (1 << cs);
     } else {
-        hw->pin.master_cs_pol &= (1 << cs);
+        hw->pin.master_cs_pol &= ~(1 << cs);
     }
 }
 


### PR DESCRIPTION
Fixing the problem with devices with different polarities of cs line
All devices must be added to the same spi line before use.