### PR TITLE
bt_mesh_generic_server received message recv_rssi is always 0. (IDFGH-3556)

### DIFF
--- a/components/bt/esp_ble_mesh/btc/btc_ble_mesh_generic_model.c
+++ b/components/bt/esp_ble_mesh/btc/btc_ble_mesh_generic_model.c
@@ -742,6 +742,7 @@ void bt_mesh_generic_server_cb_evt_to_btc(u8_t evt_type,
     cb_params.ctx.recv_ttl = ctx->recv_ttl;
     cb_params.ctx.recv_op = ctx->recv_op;
     cb_params.ctx.recv_dst = ctx->recv_dst;
+    cb_params.ctx.recv_rssi = ctx->recv_rssi;
 
     if (val && len) {
         length = (len <= sizeof(cb_params.value)) ? len : sizeof(cb_params.value);


### PR DESCRIPTION
When a generic mesh model message is received "bt_mesh_generic_server_cb_evt_to_btc" copies the

ctx values to cb_params for the mesh stack.

recv_rssi was not copied.

This means the rssi could not be read when receiving generic server messages using ble_mesh.