### PR TITLE
Adds http_auth empty algorithm header check. (IDFGH-3569)

### DIFF
--- a/components/esp_http_client/lib/http_auth.c
+++ b/components/esp_http_client/lib/http_auth.c
@@ -95,7 +95,7 @@ char *http_auth_digest(const char *username, const char *password, esp_http_auth
     }
 
     ESP_LOGD(TAG, "%s %s %s %s\r\n", "Digest", username, auth_data->realm, password);
-    if (strcasecmp(auth_data->algorithm, "md5-sess") == 0) {
+    if (auth_data->algorithm && strcasecmp(auth_data->algorithm, "md5-sess") == 0) {
         if (md5_printf(ha1, "%s:%s:%016llx", ha1, auth_data->nonce, auth_data->cnonce) <= 0) {
             goto _digest_exit;
         }


### PR DESCRIPTION
Receiving a response without an algorithm header leads to a crash.