### PR TITLE
Improve error log description UART rx buffer size. (IDFGH-3579)

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1277,7 +1277,7 @@ esp_err_t uart_driver_install(uart_port_t uart_num, int rx_buffer_size, int tx_b
 {
     esp_err_t r;
     UART_CHECK((uart_num < UART_NUM_MAX), "uart_num error", ESP_FAIL);
-    UART_CHECK((rx_buffer_size > UART_FIFO_LEN), "uart rx buffer length error(>128)", ESP_FAIL);
+    UART_CHECK((rx_buffer_size > UART_FIFO_LEN), "uart rx buffer length error(<=128)", ESP_FAIL);
     UART_CHECK((tx_buffer_size > UART_FIFO_LEN) || (tx_buffer_size == 0), "uart tx buffer length error(>128 or 0)", ESP_FAIL);
 #if CONFIG_UART_ISR_IN_IRAM
     if ((intr_alloc_flags & ESP_INTR_FLAG_IRAM) == 0) {


### PR DESCRIPTION
The under the error condition of rx buffer size is <=128 an error log is printed that reads uart rx buffer length error(>128). Propose an update to better describe the error condition as uart rx buffer length error(<=128).