### PR TITLE
Release/v4.0 (IDFGH-3698)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 [submodule "components/coap/libcoap"]
 	path = components/coap/libcoap
 	url = ../../elasticdotventures/libcoap.git
-        branch = dtls
+        branch = release-4.2.0
 
 [submodule "components/nghttp/nghttp2"]
 	path = components/nghttp/nghttp2

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,7 @@
 [submodule "components/coap/libcoap"]
 	path = components/coap/libcoap
 	url = ../../elasticdotventures/libcoap.git
+        branch = dtls
 
 [submodule "components/nghttp/nghttp2"]
 	path = components/nghttp/nghttp2

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 
 [submodule "components/coap/libcoap"]
 	path = components/coap/libcoap
-	url = ../../obgm/libcoap.git
+	url = ../../elasticdotventures/libcoap.git
 
 [submodule "components/nghttp/nghttp2"]
 	path = components/nghttp/nghttp2


### PR DESCRIPTION
A repository referenced by libcoap hosted by eclipse is broken/down (for the past 23 days or so)
The libcoap repository needs to be fixed, however since the esp-idf release v4.0 points at a specific commit, even IF the repo is fixed it won't fix the IDF.

The esp-idf v4 needs to update it's reference to libcoap (which in turn needs to update it's reference to tinydtls)

https://github.com/eclipse/tinydtls

as a work around, i've forked the libcoap repo and fixed the upstread tinydtls url. 

