### PR TITLE
Fixed TLS 1.1 still being enables even if disabled via config. (IDFGH-3755)

### DIFF
--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -976,6 +976,8 @@
  */
 #ifdef CONFIG_MBEDTLS_SSL_PROTO_TLS1_1
 #define MBEDTLS_SSL_PROTO_TLS1_1
+#else
+#undef MBEDTLS_SSL_PROTO_TLS1_1
 #endif
 
 /**


### PR DESCRIPTION
Fixed `MBEDTLS_SSL_PROTO_TLS1_1` still being defined even if `CONFIG_MBEDTLS_SSL_PROTO_TLS1_1` is not