### PR TITLE
FreeRTOS: add mutex hold count to task status info (IDFGH-3762)

### DIFF
--- a/components/freertos/include/freertos/task.h
+++ b/components/freertos/include/freertos/task.h
@@ -181,6 +181,7 @@ typedef struct xTASK_STATUS
 	eTaskState eCurrentState;		/*!< The state in which the task existed when the structure was populated. */
 	UBaseType_t uxCurrentPriority;	/*!< The priority at which the task was running (may be inherited) when the structure was populated. */
 	UBaseType_t uxBasePriority;		/*!< The priority to which the task will return if the task's current priority has been inherited to avoid unbounded priority inversion when obtaining a mutex.  Only valid if configUSE_MUTEXES is defined as 1 in FreeRTOSConfig.h. */
+	UBaseType_t uxMutexesHeld;		/*!< The number of mutexes currently held by the task. Only valid if configUSE_MUTEXES is defined as 1 in FreeRTOSConfig.h. */
 	uint32_t ulRunTimeCounter;		/*!< The total run time allocated to the task so far, as defined by the run time stats clock.  See http://www.freertos.org/rtos-run-time-stats.html.  Only valid when configGENERATE_RUN_TIME_STATS is defined as 1 in FreeRTOSConfig.h. */
 	StackType_t *pxStackBase;		/*!< Points to the lowest address of the task's stack area. */
 	uint32_t usStackHighWaterMark;	/*!< The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */

--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3753,10 +3753,12 @@ BaseType_t xTaskGetAffinity( TaskHandle_t xTask )
 				#if ( configUSE_MUTEXES == 1 )
 				{
 					pxTaskStatusArray[ uxTask ].uxBasePriority = pxNextTCB->uxBasePriority;
+					pxTaskStatusArray[ uxTask ].uxMutexesHeld = pxNextTCB->uxMutexesHeld;
 				}
 				#else
 				{
 					pxTaskStatusArray[ uxTask ].uxBasePriority = 0;
+					pxTaskStatusArray[ uxTask ].uxMutexesHeld = 0;
 				}
 				#endif
 


### PR DESCRIPTION
This change enables applications to track down and debug stuck mutex priority inheritance and missing mutex release issues.

If `uxCurrentPriority` != `uxBasePriority` and `uxMutexesHeld` > 0, the task has taken a mutex which was then required by a higher priority task. That's normal FreeRTOS mutex priority inheritance, but should only occur temporarily. If `uxMutexesHeld` continues rising, the application has a bug in mutex management.