### PR TITLE
pthread: fix pthread_mutex_destroy() breaking priority inheritance (IDFGH-3764)

### DIFF
--- a/components/pthread/pthread.c
+++ b/components/pthread/pthread.c
@@ -593,7 +593,12 @@ int pthread_mutex_destroy(pthread_mutex_t *mutex)
         return EBUSY;
     }
 
+    // FreeRTOS mutex must not be deleted while taken (breaks priority inheritance):
+    vTaskSuspendAll();
+    pthread_mutex_unlock(mutex);
     vSemaphoreDelete(mux->sem);
+    xTaskResumeAll();
+
     free(mux);
 
     return 0;


### PR DESCRIPTION
Using https://github.com/espressif/esp-idf/pull/5682, I found this bug in the POSIX thread mutex implementation: `pthread_mutex_destroy()` locks the mutex prior to deleting it, without doing an unlock before deletion. This behaviour breaks the FreeRTOS mutex priority disinheritance, the mutex hold count will get stuck.