### PR TITLE
fix compiler warning: comparison of integer expressions of different … (IDFGH-3767)

### DIFF
--- a/components/soc/esp32/include/soc/cpu.h
+++ b/components/soc/esp32/include/soc/cpu.h
@@ -74,7 +74,7 @@ static inline void cpu_init_memctl()
 static inline void cpu_configure_region_protection()
 {
     const uint32_t pages_to_protect[] = {0x00000000, 0x80000000, 0xa0000000, 0xc0000000, 0xe0000000};
-    for (int i = 0; i < sizeof(pages_to_protect)/sizeof(pages_to_protect[0]); ++i) {
+    for (size_t i = 0; i < sizeof(pages_to_protect)/sizeof(pages_to_protect[0]); ++i) {
         cpu_write_dtlb(pages_to_protect[i], 0xf);
         cpu_write_itlb(pages_to_protect[i], 0xf);
     }


### PR DESCRIPTION
+ Fix compiler warnings in 'components/soc/esp32/include/soc/cpu.h'
  + unsigned and signed comparison