### PR TITLE
Update main.c (IDFGH-3769)

### DIFF
--- a/examples/system/ulp_riscv/main/ulp/main.c
+++ b/examples/system/ulp_riscv/main/ulp/main.c
@@ -33,7 +33,6 @@ int main (void)
         if(gpio_level != gpio_level_previous) {
             gpio_level_previous = gpio_level;
             ulp_riscv_wakeup_main_processor();
-            break;
         }
 
     }


### PR DESCRIPTION
Fix to make example work multiple times, i.e. every time GPIO0 changes from low to high or high to low the main processor wakes from deep sleep