### PR TITLE
components/bt: Fix GATTC double free error (IDFGH-3783)

### DIFF
--- a/components/bt/host/bluedroid/bta/gatt/bta_gattc_utils.c
+++ b/components/bt/host/bluedroid/bta/gatt/bta_gattc_utils.c
@@ -306,7 +306,9 @@ void bta_gattc_clcb_dealloc(tBTA_GATTC_CLCB *p_clcb)
                 p_srcb->p_srvc_cache = NULL;
             }
         }
-        osi_free(p_clcb->p_q_cmd);
+        if (!list_contains(p_clcb->p_cmd_list, p_clcb->p_q_cmd)) {
+            osi_free(p_clcb->p_q_cmd);
+        }
         p_clcb->p_q_cmd = NULL;
         // don't forget to clear the command queue before dealloc the clcb.
         list_clear(p_clcb->p_cmd_list);


### PR DESCRIPTION
This change fixes a potential double free error that occurs when calling esp_ble_gattc_close() while unacknowedged commands remain in the client command queue.
