### PR TITLE
[WIP] Keep PHY calibration data in RTC memory (IDFGH-3790)

### DIFF
--- a/components/esp_wifi/Kconfig
+++ b/components/esp_wifi/Kconfig
@@ -326,7 +326,7 @@ menu "PHY"
         
     config ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC
         bool "Keep PHY calibration data in RTC memory"
-        default y
+        default n
         help
             Enabling this option keeps PHY calibration data in RTC memory where it will persist across deep sleep 
             wakeup cycles, allowing optimization of WiFi initialization upon wakeup by avoiding the need to 

--- a/components/esp_wifi/Kconfig
+++ b/components/esp_wifi/Kconfig
@@ -323,6 +323,35 @@ menu "PHY"
             1.If your board is easy to be booted up with antenna disconnected.
             2.Because of your board design, each time when you do calibration, the result are too unstable.
             If unsure, choose 'y'.
+        
+    config ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC
+        bool "Keep PHY calibration data in RTC memory"
+        default y
+        help
+            Enabling this option keeps PHY calibration data in RTC memory where it will persist across deep sleep 
+            wakeup cycles, allowing optimization of WiFi initialization upon wakeup by avoiding the need to 
+            initialize NVS and load PHY data into memory.
+
+    choice ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC_LOC
+        depends on ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC
+        prompt "PHY calibration RTC memory location"
+        default ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC_LOC_SLOW
+        help
+            Select whether to keep PHY calibration data in RTC Slow Memory or RTC Fast Memory.
+
+            As RTC memory is limited, the region may be selected depending on the pressures of the particular 
+            application:
+
+            - Select RTC Slow Memory if available Fast Memory is low, or APP CPU may require access to PHY data.
+            
+            - Select RTC Fast Memory if available Slow Memory is low (eg. in use by ULP), and/or all accesses
+            (including WiFi initialization) are restricted to PRO CPU.
+
+        config ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC_LOC_SLOW
+            bool "RTC Slow Memory"
+        config ESP32_PHY_CALIBRATION_AND_DATA_IN_RTC_LOC_FAST
+            bool "RTC Fast Memory"
+    endchoice
 
     menuconfig ESP32_PHY_INIT_DATA_IN_PARTITION
         bool "Use a partition to store PHY init data"

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -846,7 +846,7 @@ void esp_phy_load_cal_and_init(phy_rf_module_t module)
     uint8_t sta_mac[6];
 
     bool rtc_cal_data_valid =   rtc_get_reset_reason(0) == DEEPSLEEP_RESET &&
-                                ESP_OK == phy_check_rf_cal_version(&cal_data->version) &&
+                                ESP_OK == phy_check_rf_cal_version((uint32_t*)&cal_data->version) &&
                                 ESP_OK == phy_check_rf_cal_mac(cal_data->mac);
     
 #ifdef CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE // RTC + NVS


### PR DESCRIPTION
In designing an ultra low power sensor node that periodically transmits data to a gateway via ESP-NOW, I found that the active time could be effectively _halved_ by avoiding the need for NVS initialization and/or PHY calibration on wakeup by keeping PHY calibration data in RTC memory. In combination with existing config optimisations, the total time for an ESP-NOW transmission, from deep sleep to deep sleep, can be reduced to as little as 39ms (from 85ms without this change), allowing _up to 50% longer battery life_ (@ 1 Tx/5mins).

ESP-NOW transmission:

![rtc_phy_data](https://user-images.githubusercontent.com/46267286/89598545-6c34fb80-d8a0-11ea-9a81-d252b0a2e387.png)

Applications targeting very fast WiFi connection times could also see some benefit from this.

For demonstration, I've got one implementation here, where esp_wifi claims a chunk of RTC memory internally, however it is incomplete (eg. no way to access the data to save it manually or via esp_phy_store_cal_data_to_nvs) and I'm open to better ways.