### PR TITLE
BG96 operator name and access technology (IDFGH-3844)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/include/esp_modem_dce.h
+++ b/examples/protocols/pppos_client/components/modem/include/esp_modem_dce.h
@@ -75,6 +75,7 @@ struct modem_dce {
     char imsi[MODEM_IMSI_LENGTH + 1];                                                 /*!< IMSI number */
     char name[MODEM_MAX_NAME_LENGTH];                                                 /*!< Module name */
     char oper[MODEM_MAX_OPERATOR_LENGTH];                                             /*!< Operator name */
+    uint8_t act;                                                                      /*!< Access technology */
     modem_state_t state;                                                              /*!< Modem working state */
     modem_mode_t mode;                                                                /*!< Working mode */
     modem_dte_t *dte;                                                                 /*!< DTE which connect to DCE */
@@ -86,6 +87,7 @@ struct modem_dce {
     esp_err_t (*get_signal_quality)(modem_dce_t *dce, uint32_t *rssi, uint32_t *ber); /*!< Get signal quality */
     esp_err_t (*get_battery_status)(modem_dce_t *dce, uint32_t *bcs,
                                     uint32_t *bcl, uint32_t *voltage);  /*!< Get battery status */
+    esp_err_t (*get_operator_name)(modem_dce_t *bg96_dce);              /*!< Get operator name */
     esp_err_t (*define_pdp_context)(modem_dce_t *dce, uint32_t cid,
                                     const char *type, const char *apn); /*!< Set PDP Contex */
     esp_err_t (*set_working_mode)(modem_dce_t *dce, modem_mode_t mode); /*!< Set working mode */

--- a/examples/protocols/pppos_client/components/modem/include/esp_modem_dce.h
+++ b/examples/protocols/pppos_client/components/modem/include/esp_modem_dce.h
@@ -87,7 +87,7 @@ struct modem_dce {
     esp_err_t (*get_signal_quality)(modem_dce_t *dce, uint32_t *rssi, uint32_t *ber); /*!< Get signal quality */
     esp_err_t (*get_battery_status)(modem_dce_t *dce, uint32_t *bcs,
                                     uint32_t *bcl, uint32_t *voltage);  /*!< Get battery status */
-    esp_err_t (*get_operator_name)(modem_dce_t *bg96_dce);              /*!< Get operator name */
+    esp_err_t (*get_operator_name)(modem_dce_t *dce);                   /*!< Get operator name */
     esp_err_t (*define_pdp_context)(modem_dce_t *dce, uint32_t cid,
                                     const char *type, const char *apn); /*!< Set PDP Contex */
     esp_err_t (*set_working_mode)(modem_dce_t *dce, modem_mode_t mode); /*!< Set working mode */

--- a/examples/protocols/pppos_client/components/modem/src/bg96.c
+++ b/examples/protocols/pppos_client/components/modem/src/bg96.c
@@ -181,7 +181,7 @@ static esp_err_t bg96_handle_cimi(modem_dce_t *dce, const char *line)
  * @brief Handle response from AT+COPS?
  */
 static esp_err_t bg96_handle_cops(modem_dce_t *dce, const char *line)
-{
+{   
     esp_err_t err = ESP_FAIL;
     if (strstr(line, MODEM_RESULT_CODE_SUCCESS)) {
         err = esp_modem_process_command_done(dce, MODEM_STATE_SUCCESS);
@@ -193,9 +193,9 @@ static esp_err_t bg96_handle_cops(modem_dce_t *dce, const char *line)
         size_t len = strlen(line);
         char *line_copy = malloc(len + 1);
         strcpy(line_copy, line);
-        /* +COPS: <mode>[, <format>[, <oper>]] */
+        /* +COPS: <mode>[, <format>[, <oper>][, <Act>]] */
         char *str_ptr = NULL;
-        char *p[3];
+        char *p[5];
         uint8_t i = 0;
         /* strtok will broke string by replacing delimiter with '\0' */
         p[i] = strtok_r(line_copy, ",", &str_ptr);
@@ -209,6 +209,11 @@ static esp_err_t bg96_handle_cops(modem_dce_t *dce, const char *line)
                 strip_cr_lf_tail(dce->oper, len);
                 err = ESP_OK;
             }
+        }
+        if (i >= 4) {
+            char act_str[3] = {0};
+            int len = snprintf(act_str, 3, "%s", p[3]);
+            dce->act = (uint8_t)atoi(act_str);
         }
         free(line_copy);
     }
@@ -400,14 +405,15 @@ err:
 /**
  * @brief Get Operator's name
  *
- * @param bg96_dce bg96 object
+ * @param dce Modem DCE object
  * @return esp_err_t
  *      - ESP_OK on success
  *      - ESP_FAIL on error
  */
-static esp_err_t bg96_get_operator_name(bg96_modem_dce_t *bg96_dce)
+static esp_err_t bg96_get_operator_name(modem_dce_t *dce)
 {
-    modem_dte_t *dte = bg96_dce->parent.dte;
+    modem_dte_t *dte = dce->dte;
+    bg96_modem_dce_t *bg96_dce = __containerof(dce, bg96_modem_dce_t, parent);
     bg96_dce->parent.handle_line = bg96_handle_cops;
     DCE_CHECK(dte->send_cmd(dte, "AT+COPS?\r", MODEM_COMMAND_TIMEOUT_OPERATOR) == ESP_OK, "send command failed", err);
     DCE_CHECK(bg96_dce->parent.state == MODEM_STATE_SUCCESS, "get network operator failed", err);
@@ -454,6 +460,7 @@ modem_dce_t *bg96_init(modem_dte_t *dte)
     bg96_dce->parent.hang_up = esp_modem_dce_hang_up;
     bg96_dce->parent.get_signal_quality = bg96_get_signal_quality;
     bg96_dce->parent.get_battery_status = bg96_get_battery_status;
+    bg96_dce->parent.get_operator_name = bg96_get_operator_name;
     bg96_dce->parent.set_working_mode = bg96_set_working_mode;
     bg96_dce->parent.power_down = bg96_power_down;
     bg96_dce->parent.deinit = bg96_deinit;
@@ -467,8 +474,6 @@ modem_dce_t *bg96_init(modem_dte_t *dte)
     DCE_CHECK(bg96_get_imei_number(bg96_dce) == ESP_OK, "get imei failed", err_io);
     /* Get IMSI number */
     DCE_CHECK(bg96_get_imsi_number(bg96_dce) == ESP_OK, "get imsi failed", err_io);
-    /* Get operator name */
-    DCE_CHECK(bg96_get_operator_name(bg96_dce) == ESP_OK, "get operator name failed", err_io);
     return &(bg96_dce->parent);
 err_io:
     free(bg96_dce);


### PR DESCRIPTION
This PR adds the following:

- Adds get operator functionality for BG96, currently the COPS command is only called at initialisation, if the modem does not yet have at network connection the operator name will be empty. Calling get operator will update the operator name value.

- Adds the access technology used by the modem, this is required when the application logic is dependent on the access technology used e.g. NB IoT applications need to send messages via COAP and 2G uses MQTT.

- Fixes a stack smashing issue on BG96 