### PR TITLE
Fix ccache documentation: environment variable is IDF_CCACHE_ENABLE (IDFGH-3847)

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -113,7 +113,7 @@ Here is a list of some useful options:
 - ``-B <dir>`` allows overriding the build directory from the default ``build`` subdirectory of the project directory.
 - ``--ccache`` flag can be used to enable CCache_ when compiling source files, if the CCache_ tool is installed. This can dramatically reduce some build times.
 
-Note that some older versions of CCache may exhibit bugs on some platforms, so if files are not rebuilt as expected then try disabling ccache and build again. CCache can be enabled by default by setting the ``IDF_ENABLE_CCACHE`` environment variable to a non-zero value.
+Note that some older versions of CCache may exhibit bugs on some platforms, so if files are not rebuilt as expected then try disabling ccache and build again. CCache can be enabled by default by setting the ``IDF_CCACHE_ENABLE`` environment variable to a non-zero value.
 - ``-v`` flag causes both ``idf.py`` and the build system to produce verbose build output. This can be useful for debugging build problems.
 
 Using CMake Directly


### PR DESCRIPTION
The documentation states a wrong environment variable when trying to enable `ccache`.

See: 
- https://github.com/espressif/esp-idf/blob/master/tools/idf_py_actions/core_ext.py#L244-L248
- https://www.esp32.com/viewtopic.php?f=13&p=63928#p63978

The releases notes are also wrong; they state `IDF_ENABLE_CCACHE` instead of `IDF_CCACHE_ENABLE`