### PR TITLE
Add missing static qualifier in esp_hid (IDFGH-3877)

### DIFF
--- a/components/esp_hid/src/esp_hid_common.c
+++ b/components/esp_hid/src/esp_hid_common.c
@@ -19,7 +19,7 @@
 #if (CONFIG_GATTS_ENABLE || CONFIG_GATTC_ENABLE)
 #include "esp_gatt_defs.h"
 #endif
-const char *TAG = "hid_parser";
+static const char *TAG = "hid_parser";
 
 typedef struct {
     uint16_t appearance;


### PR DESCRIPTION
This caused linkage error in my project. Seems to be a simple oversight.