### PR TITLE
esp_hid: make stack size adjustable using Kconfig (IDFGH-3889)

### DIFF
--- a/components/esp_hid/Kconfig
+++ b/components/esp_hid/Kconfig
@@ -1,0 +1,7 @@
+menu "HID Support"
+
+    config HID_TASK_STACK_SIZE
+        int "HID event (callback to application) stack size"
+        default 2048
+
+endmenu

--- a/components/esp_hid/Kconfig
+++ b/components/esp_hid/Kconfig
@@ -1,6 +1,6 @@
 menu "HID Support"
 
-    config HID_TASK_STACK_SIZE
+    config HID_EVENT_TASK_STACK_SIZE
         int "HID event (callback to application) stack size"
         default 2048
 

--- a/components/esp_hid/src/ble_hidd.c
+++ b/components/esp_hid/src/ble_hidd.c
@@ -960,7 +960,7 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
         .queue_size = 5,
         .task_name = "ble_hidd_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &s_dev->event_loop_handle);

--- a/components/esp_hid/src/ble_hidd.c
+++ b/components/esp_hid/src/ble_hidd.c
@@ -960,7 +960,7 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
         .queue_size = 5,
         .task_name = "ble_hidd_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
+        .task_stack_size = CONFIG_HID_EVENT_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &s_dev->event_loop_handle);

--- a/components/esp_hid/src/ble_hidh.c
+++ b/components/esp_hid/src/ble_hidh.c
@@ -617,7 +617,7 @@ esp_err_t esp_ble_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_ble_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &event_loop_handle);

--- a/components/esp_hid/src/ble_hidh.c
+++ b/components/esp_hid/src/ble_hidh.c
@@ -617,7 +617,7 @@ esp_err_t esp_ble_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_ble_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
+        .task_stack_size = CONFIG_HID_EVENT_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &event_loop_handle);

--- a/components/esp_hid/src/bt_hidh.c
+++ b/components/esp_hid/src/bt_hidh.c
@@ -320,7 +320,7 @@ esp_err_t esp_bt_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_bt_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     esp_err_t ret = esp_event_loop_create(&event_task_args, &event_loop_handle);

--- a/components/esp_hid/src/bt_hidh.c
+++ b/components/esp_hid/src/bt_hidh.c
@@ -320,7 +320,7 @@ esp_err_t esp_bt_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_bt_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = CONFIG_HID_TASK_STACK_SIZE,
+        .task_stack_size = CONFIG_HID_EVENT_TASK_STACK_SIZE,
         .task_core_id = tskNO_AFFINITY
     };
     esp_err_t ret = esp_event_loop_create(&event_task_args, &event_loop_handle);


### PR DESCRIPTION
This allows users to specify stack size for HID application callbacks. Default value is based on one that previously was hardcoded.

Note: it is possible that default value is too small for esp_hid_host example. I can't test it right now, but it is worth double checking.