### PR TITLE
fix windows incompatibility with gdbgui>=0.14 (IDFGH-3896)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ future>=0.15.2
 cryptography>=2.1.4
 pyparsing>=2.0.3,<2.4.0
 pyelftools>=0.22
-gdbgui>=0.13.2.0
+gdbgui<=0.13.2.1,>=0.13.2.0
 pygdbmi<=0.9.0.2
 # The pygdbmi required max version 0.9.0.2 since 0.9.0.3 is not copatible with latest gdbgui (>=0.13.2.0)
 reedsolo>=1.5.3,<=1.5.4


### PR DESCRIPTION
gdbgui intentionally (https://github.com/cs01/gdbgui/pull/346) introduced dependencies that are incompatible with windows, and don't seem to have plans to resolve them anytime soon