### PR TITLE
tools/docker: Add libpython2.7 in order to satisfy GDB dependencies (IDFGH-3925)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# We need libpython2.7 due to GDB tools
 RUN apt-get update && apt-get install -y \
     apt-utils \
     bison \
@@ -17,6 +18,7 @@ RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     make \
     ninja-build \
+    libpython2.7 \
     python3 \
     python3-pip \
     unzip \

--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1206,7 +1206,10 @@ def action_install_python_env(args):
 
         subprocess.check_call([sys.executable, '-m', 'virtualenv', idf_python_env_path],
                               stdout=sys.stdout, stderr=sys.stderr)
-    run_args = [virtualenv_python, '-m', 'pip', 'install', '--no-warn-script-location']
+    # Need to update resolver otherwise gdbgui dependency is not possible
+    # satisfy
+    run_args = [virtualenv_python, '-m', 'pip', 'install',
+                '--no-warn-script-location', '--use-feature=2020-resolver']
     requirements_txt = os.path.join(global_idf_path, 'requirements.txt')
     run_args += ['-r', requirements_txt]
     if args.extra_wheels_dir:

--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1206,10 +1206,7 @@ def action_install_python_env(args):
 
         subprocess.check_call([sys.executable, '-m', 'virtualenv', idf_python_env_path],
                               stdout=sys.stdout, stderr=sys.stderr)
-    # Need to update resolver otherwise gdbgui dependency is not possible
-    # satisfy
-    run_args = [virtualenv_python, '-m', 'pip', 'install',
-                '--no-warn-script-location', '--use-feature=2020-resolver']
+    run_args = [virtualenv_python, '-m', 'pip', 'install', '--no-warn-script-location']
     requirements_txt = os.path.join(global_idf_path, 'requirements.txt')
     run_args += ['-r', requirements_txt]
     if args.extra_wheels_dir:


### PR DESCRIPTION
It was not possible to run xtensa-esp32-elf-gdb from container due to
missing libpython2.7 library.
In order to satisfy Python dependencies for IDF tools it was required to
change resolver behavior otherwise pip did not installed proper version
of gdbgui which caused failure when initializing IDF.