### PR TITLE
Linker script fix (IDFGH-3938)

### DIFF
--- a/components/esp_event/linker.lf
+++ b/components/esp_event/linker.lf
@@ -1,6 +1,6 @@
-if ESP_EVENT_POST_FROM_IRAM_ISR = y:
-    [mapping:esp_event]
-    archive: libesp_event.a
-    entries:
+[mapping:esp_event]
+archive: libesp_event.a
+entries:
+    if ESP_EVENT_POST_FROM_IRAM_ISR = y:
         esp_event:esp_event_isr_post_to (noflash)
         default_event_loop:esp_event_isr_post (noflash)


### PR DESCRIPTION
Update to linker script that was fixed by m/r #3335
For ref. see:
https://github.com/espressif/esp-idf/pull/3335/commits/7bf0a17d14bc69811d1c88fc06bc58dd1adb2197

Affects:
- current master
- tags from v4.0 to v4.3-dev