### PR TITLE
esp_http_client: add flush response (IDFGH-3959)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1374,6 +1374,19 @@ int esp_http_client_read_response(esp_http_client_handle_t client, char *buffer,
     return read_len;
 }
 
+int esp_http_client_flush_response(esp_http_client_handle_t client)
+{
+    int read_len = 0;
+    while (!esp_http_client_is_complete_data_received(client)) {
+        int data_read = esp_http_client_get_data(client);
+        if (data_read < 0) {
+            return -1;
+        }
+        read_len += data_read;
+    }
+    return read_len;
+}
+
 esp_err_t esp_http_client_get_url(esp_http_client_handle_t client, char *url, const int len)
 {
     if (client == NULL || url == NULL) {

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -525,6 +525,20 @@ bool esp_http_client_is_complete_data_received(esp_http_client_handle_t client);
 int esp_http_client_read_response(esp_http_client_handle_t client, char *buffer, int len);
 
 /**
+ * @brief       Process all remaining response data
+ *              This uses an internal buffer to repeatedly receive, parse, and discard response data until complete.
+ *              As no additional user-supplied buffer is required, this may be preferrable to `esp_http_client_read_response` in situations where the content 
+ *              of the response may be ignored, or is processed via the client's event handler.
+ *
+ * @param[in]  client  The esp_http_client handle
+ *
+ * @return
+ *     - (-1) if any errors
+ *     - Length of data read
+ */
+int esp_http_client_flush_response(esp_http_client_handle_t client);
+
+/**
  * @brief          Get URL from client
  *
  * @param[in]      client   The esp_http_client handle


### PR DESCRIPTION
Adds esp_http_client_flush_response so that no additional buffer is required simply to read and discard data from esp_http_client's stream functionality if the response body is already being handled via the event handler (or is of no interest). 

See https://github.com/espressif/esp-idf/issues/5814