### PR TITLE
export.fish: Remove source check (IDFGH-3976)

### DIFF
--- a/export.fish
+++ b/export.fish
@@ -1,15 +1,6 @@
 # This script should be sourced, not executed.
 
 function idf_export_main
-    # The file doesn't have executable permissions, so this shouldn't really happen.
-    # Doing this in case someone tries to chmod +x it and execute...
-    set cmd (status current-command)
-    if test $cmd != source -a $cmd != .
-        echo "his script should be sourced, not executed:"
-        echo . (realpath (status --current-filename)/..)
-        return 1
-    end
-
     if not set -q IDF_PATH
         echo "IDF_PATH must be set before sourcing this script"
         return 1


### PR DESCRIPTION
This prevents starting a new shell with the IDF environment like this:

    env IDF_PATH=/my/idf/path fish -C 'source "$IDF_PATH"/export.fish'

as `status current-command` returns `fish` in this case, but this check expects
`source`.

This check does nothing anyway, as you can't even execute that file even if it
was marked executable, as fish rejects files without a shebang, and it's not
valid bash.