### PR TITLE
Bug with input parametr enum in function esp_wifi_80211_tx (IDFGH-4007)

### DIFF
--- a/components/esp_wifi/include/esp_wifi.h
+++ b/components/esp_wifi/include/esp_wifi.h
@@ -992,7 +992,7 @@ esp_err_t esp_wifi_get_event_mask(uint32_t *mask);
   *    - ESP_ERR_WIFI_NO_MEM: out of memory
   */
 
-esp_err_t esp_wifi_80211_tx(wifi_interface_t ifx, const void *buffer, int len, bool en_sys_seq);
+esp_err_t esp_wifi_80211_tx(esp_interface_t ifx, const void *buffer, int len, bool en_sys_seq);
 
 /**
   * @brief The RX callback function of Channel State Information(CSI)  data. 


### PR DESCRIPTION
You have an error in input parametr in function "esp_wifi_80211_tx".
The docs say, that input parametr may be "WIFI_IF_STA" ( = 0 ) . But it parameter staying into enum: esp_interface_t. I use the parametr "WIFI_MODE_STA" ( = 1 ), that staying into wifi_interface_t, and have an error while use this function. Please apply this change in DOCs, i don't find document inc/esp_wifi.inc.