### PR TITLE
Changed to C linkage in netdb.h for fixing bug when using mixed C/C++ code (IDFGH-4027)

### DIFF
--- a/components/lwip/port/esp32/include/netdb.h
+++ b/components/lwip/port/esp32/include/netdb.h
@@ -32,9 +32,17 @@
 
 #include "lwip/netdb.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
 #ifdef ESP_PLATFORM
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
                 char *host, socklen_t hostlen,
                 char *serv, socklen_t servlen, int flags);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif


### PR DESCRIPTION
I got an error when trying to compile a project with mixed C/C++ code. This fixes the linkage issues. The error message is:
```
error: conflicting declaration of 'int getnameinfo(const sockaddr*, socklen_t, char*, socklen_t, char*, socklen_t, int)' with 'C' linkage
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
     ^~~~~~~~~~~
```