### PR TITLE
Allow for slip input of longer than 256 bytes (alternative fix) (IDFGH-4057)

### DIFF
--- a/components/esp_netif/lwip/esp_netif_lwip_slip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip_slip.c
@@ -165,7 +165,7 @@ void esp_netif_lwip_slip_input(void *h, void *buffer, unsigned int len, void *eb
     const int max_batch = 255;
     int sent = 0;
     while(sent < len) {
-        int batch = len > max_batch ? max_batch : len;
+        int batch = (len - sent) > max_batch ? max_batch : (len - sent);
         slipif_received_bytes(slip_ctx->esp_netif->lwip_netif, buffer+sent, batch);
         sent += batch;
     }

--- a/components/esp_netif/lwip/esp_netif_lwip_slip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip_slip.c
@@ -162,7 +162,13 @@ void esp_netif_lwip_slip_input(void *h, void *buffer, unsigned int len, void *eb
     ESP_LOG_BUFFER_HEXDUMP(TAG, buffer, len, ESP_LOG_DEBUG);
 
     // Update slip netif with data
-    slipif_received_bytes(netif->lwip_netif, buffer, len);
+    const int max_batch = 255;
+    int sent = 0;
+    while(sent < len) {
+        int batch = len > max_batch ? max_batch : len;
+        slipif_received_bytes(slip_ctx->esp_netif->lwip_netif, buffer+sent, batch);
+        sent += batch;
+    }
 
     // Process incoming bytes
     for (int i = 0; i < len; i++) {


### PR DESCRIPTION
Alternative fix to https://github.com/espressif/esp-lwip/pull/23, which does not change lwip.

Implements batch processing of incoming slip data, with a maximum batch size of 255 bytes.