### PR TITLE
Add macOS 10.15 JTAG/FTDI details in documentation (IDFGH-4078)

### DIFF
--- a/docs/en/api-guides/jtag-debugging/configure-ft2232h-jtag.rst
+++ b/docs/en/api-guides/jtag-debugging/configure-ft2232h-jtag.rst
@@ -113,8 +113,16 @@ Manually unloading the driver
     sudo kextunload -b com.FTDI.driver.FTDIUSBSerialDriver
 
    In some cases you may need to unload Apple's FTDI driver as well::
-
-    sudo kextunload -b com.apple.driver.AppleUSBFTDI
+    
+    • macOS < 10.15:
+        sudo kextunload -b com.apple.driver.AppleUSBFTDI
+    
+    • macOS 10.15:
+        sudo kextunload -b com.apple.DriverKit-AppleUSBFTDI
+        
+     .. warning:: 
+        Attempting to use serial over the wrong channel with the FTDI driver will cause a kernel panic. The ESP-Wrover-Kit uses channel A for JTAG and channel B for serial.
+        
 
 4. Run OpenOCD:
 


### PR DESCRIPTION
Adds a couple of JTAG usage details in the documentation for macOS 10.15, since pre 10.15 uses a different driver kext.