### PR TITLE
Ensure serial break event is generated in the correct place in the serial byte stream

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -799,10 +799,11 @@ static void UART_ISR_ATTR uart_rx_intr_handler_default(void *param)
                 }
             }
         }
-        else if ((uart_intr_status & UART_INTR_RXFIFO_TOUT)
+        else if (((uart_intr_status & UART_INTR_RXFIFO_TOUT)
                 || (uart_intr_status & UART_INTR_RXFIFO_FULL)
                 || (uart_intr_status & UART_INTR_CMD_CHAR_DET)
-                ) {
+                ) || ( (uart_intr_status & UART_INTR_BRK_DET) 
+                      && (uart_ll_get_rxfifo_len(uart_context[uart_num].hal.dev) > 0) )) {
             if(pat_flg == 1) {
                 uart_intr_status |= UART_INTR_CMD_CHAR_DET;
                 pat_flg = 0;


### PR DESCRIPTION
Currently the UART_BREAK event generated upon detection of a serial break is delivered asynchronously to the bytes received by the UART. An event containing bytes received following a serial break is sent prior to the event for the corresponding break. If the serial break is used as a frame delimiter, as it is in many protocols, this makes determining where to delineate frames challenging.

This patch was proposed by @negativekelvin in #4537, and ensures UART_BREAK events are delivered in the correct place in the stream.