### PR TITLE
esp_ble_mesh: api: fixed comment about autoresp (IDFGH-4096)

### DIFF
--- a/components/bt/esp_ble_mesh/api/esp_ble_mesh_defs.h
+++ b/components/bt/esp_ble_mesh/api/esp_ble_mesh_defs.h
@@ -1975,8 +1975,8 @@ typedef struct {
     int64_t  timestamp; /*!< Time when the last message is received */
 } esp_ble_mesh_last_msg_info_t;
 
-#define ESP_BLE_MESH_SERVER_RSP_BY_APP  0   /*!< Response will be sent internally */
-#define ESP_BLE_MESH_SERVER_AUTO_RSP    1   /*!< Response need to be sent in the application */
+#define ESP_BLE_MESH_SERVER_RSP_BY_APP  0   /*!< Response need to be sent in the application */
+#define ESP_BLE_MESH_SERVER_AUTO_RSP    1   /*!< Response will be sent internally */
 
 /** Parameters of the Server Model response control */
 typedef struct {


### PR DESCRIPTION
Fixed the definition for the autoresp constants