### PR TITLE
Make the UserAgent string in esp-http-client configurable (IDFGH-4184)

### DIFF
--- a/components/esp_http_client/Kconfig
+++ b/components/esp_http_client/Kconfig
@@ -14,4 +14,10 @@ menu "ESP HTTP client"
             This option will enable HTTP Basic Authentication. It is disabled by default as Basic
             auth uses unencrypted encoding, so it introduces a vulnerability when not using TLS
 
+    config ESP_HTTP_CLIENT_USER_AGENT
+        string "User Agent"
+        default "ESP32 HTTP Client/1.0"
+        help
+            The User Agent string to send with Http requests.
+
 endmenu

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -136,7 +136,7 @@ static esp_err_t _clear_connection_info(esp_http_client_handle_t client);
 #define ASYNC_TRANS_CONNECTING 0
 #define ASYNC_TRANS_CONNECT_PASS 1
 
-static const char *DEFAULT_HTTP_USER_AGENT = "ESP32 HTTP Client/1.0";
+static const char *DEFAULT_HTTP_USER_AGENT = CONFIG_ESP_HTTP_CLIENT_USER_AGENT;
 static const char *DEFAULT_HTTP_PROTOCOL = "HTTP/1.1";
 static const char *DEFAULT_HTTP_PATH = "/";
 static const int DEFAULT_MAX_REDIRECT = 10;


### PR DESCRIPTION
This change creates a new configurable parameter (through idf.py menuconfig), which is able to change the Http user agent string in esp_http_client.

The default value of the config parameter is exactly the same as the previous hard coded value, so people who don't change the config will see no difference in behavior.