### PR TITLE
[mdns] fix wrong mdns source address (IDFGH-4196)

### DIFF
--- a/components/mdns/mdns_networking.c
+++ b/components/mdns/mdns_networking.c
@@ -127,7 +127,8 @@ static void _udp_recv(void *arg, struct udp_pcb *upcb, struct pbuf *pb, const ip
         packet->tcpip_if = MDNS_IF_MAX;
         packet->pb = this_pb;
         packet->src_port = rport;
-        memcpy(&packet->src, raddr, sizeof(ip_addr_t));
+        packet->src.type = raddr->type;
+        memcpy(&packet->src.u_addr, raddr->u_addr, sizeof(ip6_addr_t));
         packet->dest.type = packet->src.type;
 
         if (packet->src.type == IPADDR_TYPE_V4) {


### PR DESCRIPTION
The struct definition of ip6_addr_t in lwip and esp_ip6_addr_t
differs since zone is not enabled in lwip. Using `memcpy` to copy the
address will cause wrong source address. Copy the entries manually
instead.