### PR TITLE
Fix for compiling with configTASKLIST_INCLUDE_COREID active (IDFGH-4197)

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -4134,7 +4134,7 @@ static void prvCheckTasksWaitingTermination( void )
 		pxTaskStatus->xTaskNumber = pxTCB->uxTCBNumber;
 
 		#if ( configTASKLIST_INCLUDE_COREID == 1 )
-		pxTaskStatus.xCoreID = pxTCB->xCoreID;
+		pxTaskStatus->xCoreID = pxTCB->xCoreID;
 		#endif /* configTASKLIST_INCLUDE_COREID */
 
 		#if ( configUSE_MUTEXES == 1 )


### PR DESCRIPTION
Does not compile otherwise if `configTASKLIST_INCLUDE_COREID ` is enabled.