### PR TITLE
MQTT: Restore default MQTT_OUTBOX_EXPIRED_TIMEOUT_MS to 30 sec (IDFGH-4221)

### DIFF
--- a/components/mqtt/Kconfig
+++ b/components/mqtt/Kconfig
@@ -117,7 +117,7 @@ menu "ESP-MQTT Configurations"
 
     config MQTT_OUTBOX_EXPIRED_TIMEOUT_MS
         int "Outbox message expired timeout[ms]"
-        default 300000
+        default 30000
         depends on MQTT_USE_CUSTOM_CONFIG
         help
             Messages which stays in the outbox longer than this value before being published will be discarded.


### PR DESCRIPTION
The OUTBOX_EXPIRED_TIMEOUT_MS was 30*1000 in original esp-mqtt code.
Don't change the default OUTBOX_EXPIRED_TIMEOUT_MS without good reason,
which may has impact on memory usage for existing applications.

Fixes: 0ea20bed439d ("MQTT: add configurable msg expired timeout")
Signed-off-by: Axel Lin <axel.lin@gmail.com>