### PR TITLE
esp_crt_bundle: Allow verify_callback to correct BADCERT_BAD_MD (IDFGH-4266)

### DIFF
--- a/components/mbedtls/esp_crt_bundle/esp_crt_bundle.c
+++ b/components/mbedtls/esp_crt_bundle/esp_crt_bundle.c
@@ -97,7 +97,10 @@ int esp_crt_verify_callback(void *buf, mbedtls_x509_crt *crt, int data, uint32_t
 {
     mbedtls_x509_crt *child = crt;
 
-    if (*flags != MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
+    if (!*flags) {
+        return 0;
+    }
+    if (*flags & ~(MBEDTLS_X509_BADCERT_NOT_TRUSTED | MBEDTLS_X509_BADCERT_BAD_MD)) {
         return 0;
     }
 


### PR DESCRIPTION
This allows CircuitPython on ESP32S2 to successfully connect to io.adafruit.com, like standard browsers and desktop https clients like openssl s_client, curl, and mbedtls ssl_client2.  This problem also affects at least api.thingspeak.com.

io.adafruit.com serves up a slightly interesting certificate chain.  The part returned to the client includes 3 certificates, and the third one uses the SHA1 signature algorithm.  Since this has turned up on two IOT platforms, I suspect (but have not verified) that this must be to improve compatibility with some older deployed IOT devices.

In standard Linux SSL implementations which use `ca-certificates.crt` which contains DigiCert Global Root CA, the second certificate is marked as trusted and the SHA1 signature algorithm of the third certificate is not considered.  This is also true of mbedtls when compiled for Linux and using ca-certificates.crt.

esp-idf uses a different method (esp_crt_verify_callback) to determine whether a certificate chain is trusted.  This leads to slightly different semantics when items further into the certificate chain than the first trusted certificate would signal problems.  esp_crt_verify_callback is executed after the whole certificate chain has been considered, and in this case the third certificate in the chain has had the flag MBEDTLS_X509_BADCERT_BAD_MD set.

Update  esp_crt_verify_callback so that it can override either NOT_TRUSTED or BAD_MD results when the certificate is present in the esp crt bundle.  If no flags are set, or flags other than these two are set, then it does not influence the result.

The certificate chain presently served by io.adafruit.com, for posterity: [io.txt](https://github.com/espressif/esp-idf/files/5539403/io.txt)

Our discussion of this issue: https://github.com/adafruit/circuitpython/issues/3424

cc: @ladyada @tannewt