### PR TITLE
4.0 bugfix - don't try to atomic-load a device if its a null pointer in the host array

### DIFF
--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -593,6 +593,12 @@ static SPI_MASTER_ISR_ATTR void device_release_bus_internal(spi_host_t *host)
     atomic_store(&host->acquire_cs, NO_CS);
     //first try to restore the acquiring device
     for (int i = 0; i < NO_CS; i++) {
+
+        //don't try to atomic-load a device below if its a null pointer in the host array
+        spi_host_t* h = atomic_load(&host);
+        spi_device_t* devt = h->device[i];
+        if ( (int)devt < NO_CS+5 ) return; // disallow null pointer, but also pointer/s to memory 0x01 ,0x02, 0x03 etc
+
         //search for all registered devices
         spi_device_t* dev = atomic_load(&host->device[i]);
         if (dev && dev->waiting) {


### PR DESCRIPTION

without this, I get exception:

0x4008481b: device_release_bus_internal at /home/buzz/ardupilot/modules/esp_idf/components/driver/spi_master.c line 598
0x40084da8: spi_device_release_bus at /home/buzz/ardupilot/modules/esp_idf/components/driver/spi_master.c line 1015
0x4014763f: ESP32::SPIDevice::acquire_bus(bool) at ../../libraries/AP_HAL_ESP32/SPIDevice.cpp line 165
0x40147677: ESP32::SPIDevice::transfer_fullduplex(unsigned char const*, unsigned char*, unsigned int) at ../../libraries/AP_HAL_ESP32/SPIDevice.cpp line 151
0x401473cb: ESP32::SPIDevice::transfer(unsigned char const*, unsigned int, unsigned char*, unsigned int) at ../../libraries/AP_HAL_ESP32/SPIDevice.cpp line 131
0x401b22fa: AP_HAL::Device::read_registers(unsigned char, unsigned char*, unsigned int) at ../../libraries/AP_HAL/Device.h line 120
0x4014f11a: AP_Baro_BMP280::_timer() at ../../libraries/AP_Baro/AP_Baro_BMP280.cpp line 148
0x4014f165: Functor ::method_wrapper (void*) at ../../libraries/AP_HAL/utility/functor.h line 85
0x4008303b: ESP32::DeviceBus::bus_thread(void*) at ../../libraries/AP_HAL/utility/functor.h line 52