### PR TITLE
a2dp_sink example: adds software volume control

### DIFF
--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/Kconfig.projbuild
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/Kconfig.projbuild
@@ -39,4 +39,9 @@ menu "A2DP Example Configuration"
         help
             GPIO number to use for I2S Data Driver.
 
+    config EXAMPLE_A2DP_ENABLE_VOLUME_SIMULATION_TASK
+        bool "Enable volume simulation task"
+        default n
+        help
+            The task increases the volume by 5 every 10 seconds
 endmenu

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_av.c
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_av.c
@@ -163,7 +163,7 @@ static void bt_av_hdl_a2d_evt(uint16_t event, void *p_param)
             } else if (oct0 & (0x01 << 4)) {
                 sample_rate = 48000;
             }
-            i2s_set_clk(0, sample_rate, 16, 2);
+            i2s_set_clk(0, sample_rate, BT_SBC_BITS_PER_SAMPLE, 2);
 
             ESP_LOGI(BT_AV_TAG, "Configure audio player %x-%x-%x-%x",
                      a2d->audio_cfg.mcc.cie.sbc[0],
@@ -284,6 +284,7 @@ static void volume_set_by_controller(uint8_t volume)
     _lock_acquire(&s_volume_lock);
     s_volume = volume;
     _lock_release(&s_volume_lock);
+    bt_i2s_set_volume(volume);
 }
 
 static void volume_set_by_local_host(uint8_t volume)
@@ -313,6 +314,23 @@ static void volume_change_simulation(void *arg)
     }
 }
 
+static void bt_app_volume_sim_task_handler(bool create) {
+    #ifdef CONFIG_EXAMPLE_A2DP_ENABLE_VOLUME_SIMULATION_TASK
+        if (create) {
+            // create task to simulate volume change
+            xTaskCreate(volume_change_simulation, "vcsT", 2048, NULL, 5, &s_vcs_task_hdl);
+        } else {
+            vTaskDelete(s_vcs_task_hdl);
+            ESP_LOGI(BT_RC_TG_TAG, "Stop volume change simulation");
+        }
+    #else
+        // unused variables and functions.
+        (void) create;
+        (void) s_vcs_task_hdl;
+        (void) volume_change_simulation;
+    #endif
+}
+
 static void bt_av_hdl_avrc_tg_evt(uint16_t event, void *p_param)
 {
     ESP_LOGD(BT_RC_TG_TAG, "%s evt %d", __func__, event);
@@ -322,13 +340,8 @@ static void bt_av_hdl_avrc_tg_evt(uint16_t event, void *p_param)
         uint8_t *bda = rc->conn_stat.remote_bda;
         ESP_LOGI(BT_RC_TG_TAG, "AVRC conn_state evt: state %d, [%02x:%02x:%02x:%02x:%02x:%02x]",
                  rc->conn_stat.connected, bda[0], bda[1], bda[2], bda[3], bda[4], bda[5]);
-        if (rc->conn_stat.connected) {
-            // create task to simulate volume change
-            xTaskCreate(volume_change_simulation, "vcsT", 2048, NULL, 5, &s_vcs_task_hdl);
-        } else {
-            vTaskDelete(s_vcs_task_hdl);
-            ESP_LOGI(BT_RC_TG_TAG, "Stop volume change simulation");
-        }
+        
+        bt_app_volume_sim_task_handler(rc->conn_stat.connected);
         break;
     }
     case ESP_AVRC_TG_PASSTHROUGH_CMD_EVT: {

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_av.h
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_av.h
@@ -17,6 +17,7 @@
 #define BT_RC_TG_TAG            "RCTG"
 #define BT_RC_CT_TAG            "RCCT"
 
+#define BT_SBC_BITS_PER_SAMPLE   0x10 /* bit depth */
 /**
  * @brief     callback function for A2DP sink
  */

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_core.c
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_core.c
@@ -29,7 +29,7 @@ static xQueueHandle s_bt_app_task_queue = NULL;
 static xTaskHandle s_bt_app_task_handle = NULL;
 static xTaskHandle s_bt_i2s_task_handle = NULL;
 static RingbufHandle_t s_ringbuf_i2s = NULL;
-static int32_t s_volume = 0;
+static int32_t s_volume = 127;
 
 bool bt_app_work_dispatch(bt_app_cb_t p_cback, uint16_t event, void *p_params, int param_len, bt_app_copy_cb_t p_copy_cback)
 {

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_core.h
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/main/bt_app_core.h
@@ -50,4 +50,9 @@ void bt_i2s_task_shut_down(void);
 
 size_t write_ringbuf(const uint8_t *data, size_t size);
 
+/**
+ * adjusts volume. 0 - 127 levels
+ */
+void bt_i2s_set_volume(uint8_t level);
+
 #endif /* __BT_APP_CORE_H__ */


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-idf/issues/4438
1. Adds a possibility to disable a task that changes a volume periodically.
2. Adds a software volume control.