### PR TITLE
Allow KConfig to configure LWIP checksum validation (IDFGH-4349)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -574,13 +574,13 @@ menu "LWIP"
 
     config LWIP_CHECKSUM_CHECK_IP
         bool "Enable LWIP IP checksums"
-        default y
+        default n
         help
             Enable checksum checking for received IP messages
 
     config LWIP_CHECKSUM_CHECK_UDP
         bool "Enable LWIP UDP checksums"
-        default y
+        default n
         help
             Enable checksum checking for received UDP messages
 

--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -570,6 +570,28 @@ menu "LWIP"
 
     endmenu # UDP
 
+    menu "Checksums"
+
+    config LWIP_CHECKSUM_CHECK_IP
+        bool "Enable LWIP IP checksums"
+        default y
+        help
+            Enable checksum checking for received IP messages
+
+    config LWIP_CHECKSUM_CHECK_UDP
+        bool "Enable LWIP UDP checksums"
+        default y
+        help
+            Enable checksum checking for received UDP messages
+
+    config LWIP_CHECKSUM_CHECK_ICMP
+        bool "Enable LWIP ICMP checksums"
+        default y
+        help
+            Enable checksum checking for received ICMP messages
+
+    endmenu # Checksums
+
     config LWIP_TCPIP_TASK_STACK_SIZE
         int "TCP/IP Task Stack Size"
         default 3072
@@ -780,12 +802,20 @@ menu "LWIP"
             bool "Enable ICMP debug messages"
             default n
 
+        config LWIP_DHCP_DEBUG
+            bool "Enable DHCP debug messages"
+            default n
+
         config LWIP_IP6_DEBUG
             bool "Enable IP6 debug messages"
             default n
 
         config LWIP_ICMP6_DEBUG
             bool "Enable ICMP6 debug messages"
+            default n
+
+        config LWIP_TCP_DEBUG
+            bool "Enable TCP debug messages"
             default n
 
     endmenu #debug

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -753,6 +753,25 @@ u32_t lwip_hook_tcp_isn(const struct ip_addr *local_ip, u16_t local_port,
    --------------------------------------
 */
 
+
+#ifdef CONFIG_LWIP_CHECKSUM_CHECK_UDP
+#define CHECKSUM_CHECK_UDP 1
+#else
+#define CHECKSUM_CHECK_UDP 0
+#endif
+
+#ifdef CONFIG_LWIP_CHECKSUM_CHECK_IP
+#define CHECKSUM_CHECK_IP 1
+#else
+#define CHECKSUM_CHECK_IP 0
+#endif
+
+#ifdef CONFIG_LWIP_CHECKSUM_CHECK_ICMP
+#define CHECKSUM_CHECK_ICMP 1
+#else
+#define CHECKSUM_CHECK_ICMP 0
+#endif
+
 /*
    ---------------------------------------
    ---------- IPv6 options ---------------
@@ -847,6 +866,15 @@ u32_t lwip_hook_tcp_isn(const struct ip_addr *local_ip, u16_t local_port,
 #endif
 
 /**
+ * DHCP_DEBUG: Enable debugging in dhcp.c.
+ */
+#ifdef CONFIG_LWIP_DHCP_DEBUG
+#define DHCP_DEBUG                      LWIP_DBG_ON
+#else
+#define DHCP_DEBUG                      LWIP_DBG_OFF
+#endif
+
+/**
  * IP_DEBUG: Enable debugging for IP.
  */
 #ifdef CONFIG_LWIP_IP_DEBUG
@@ -856,12 +884,21 @@ u32_t lwip_hook_tcp_isn(const struct ip_addr *local_ip, u16_t local_port,
 #endif
 
 /**
- * IP_DEBUG: Enable debugging for IP.
+ * IP6_DEBUG: Enable debugging for IP6.
  */
 #ifdef CONFIG_LWIP_IP6_DEBUG
 #define IP6_DEBUG                        LWIP_DBG_ON
 #else
 #define IP6_DEBUG                        LWIP_DBG_OFF
+#endif
+
+/**
+ * TCP_DEBUG: Enable debugging for TCP.
+ */
+#ifdef CONFIG_LWIP_TCP_DEBUG
+#define TCP_DEBUG                        LWIP_DBG_ON
+#else
+#define TCP_DEBUG                        LWIP_DBG_OFF
 #endif
 
 /**
@@ -968,12 +1005,7 @@ u32_t lwip_hook_tcp_isn(const struct ip_addr *local_ip, u16_t local_port,
 /**
  * DHCP_DEBUG: Enable debugging in dhcp.c.
  */
-#define DHCP_DEBUG                      LWIP_DBG_OFF
 #define LWIP_DEBUG                      LWIP_DBG_OFF
-#define TCP_DEBUG                       LWIP_DBG_OFF
-
-#define CHECKSUM_CHECK_UDP              0
-#define CHECKSUM_CHECK_IP               0
 
 #define LWIP_NETCONN_FULLDUPLEX         1
 #define LWIP_NETCONN_SEM_PER_THREAD     1


### PR DESCRIPTION
for some reason (?!) the ESP LWIP configuration defaults to disabling checksum validation for IP, UDP, and ICMP packets. this PR adds KConfig options to configure LWIP checksums and passes these through to the platform config.

the `Checksums` submenu is there because while there are `ICMP` and `UDP` menus that these could be nested under, there is not one for `IP`.


cc. @webworxshop 