### PR TITLE
Update rtc_io_periph.h (IDFGH-4374)

### DIFF
--- a/components/soc/include/soc/rtc_io_periph.h
+++ b/components/soc/include/soc/rtc_io_periph.h
@@ -100,7 +100,7 @@ typedef struct {
  * This is an internal function of the driver, and is not usually useful
  * for external use.
  */
-extern const rtc_gpio_desc_t rtc_gpio_desc[GPIO_PIN_COUNT];
+extern const rtc_gpio_desc_t rtc_gpio_desc[SOC_GPIO_PIN_COUNT];
 
 #endif // CONFIG_IDF_TARGET_ESP32
 


### PR DESCRIPTION
solves undefined GPIO_PIN_COUNT error when compiling ulp component.