### PR TITLE
List ESP32S2 support in README for ADC peripheral example (IDFGH-4375)

### DIFF
--- a/examples/peripherals/adc/README.md
+++ b/examples/peripherals/adc/README.md
@@ -1,4 +1,4 @@
-| Supported Targets | ESP32 |
+| Supported Targets | ESP32 & ESP32S2 |
 | ----------------- | ----- |
 
 # ADC1 Example


### PR DESCRIPTION
There have been PRs to add ESP32S2 support, but the README does not reflect that.