### PR TITLE
Fix double free error when using signed images without a secure boot. (IDFGH-4376)

### DIFF
--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -232,6 +232,12 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
             if (true) {
 #endif // end checking for JTAG
                 err = verify_secure_boot_signature(sha_handle, data, image_digest, verified_digest);
+#ifndef BOOTLOADER_BUILD
+                // sha_handle is freed in verify_secure_boot_signature() by using bootloader_sha256_finish().
+                // If we don't NULL it here then in case invalid boot signature (err is not ESP_OK), sha_handle
+                // will be freed again because it's not NULL (see lines after err label below).
+                sha_handle = NULL;
+#endif // BOOTLOADER_BUILD
             }
 #else // SECURE_BOOT_CHECK_SIGNATURE
             // No secure boot, but SHA-256 can be appended for basic corruption detection


### PR DESCRIPTION
- If the signed images are enabled and image verification occurrs after an upgrade in the app itself the the doulbe free takes place.
- Double free occurs due to the fact that `verify_secure_boot_signature()` already frees the `sha_handle` pointer.
- If the `verify_secure_boot_signature()` does not return `ESP_OK` (for example, when new image is not signed) then the code jumps to the `err` label which basically frees the `sha_handle` if it's not NULL causing a double-free.
- I've decided to set the `sha_handle` to NULL after `verify_secure_boot_signature()` in the non-bootloader mode fixing the double-free. I didn't do this change for bootloader build because all the bootloader functions that use `sha_handle` expect it to be non-NULL.
- I think the better solution is to pass a `sha_handle` by reference and NULL it inside the `verify_secure_boot_signature()` if needed but it's a risky change and I don't have all the required hardware to test it.