### PR TITLE
Fix invalid clock source in i2c_self_test example (IDFGH-4382)

### DIFF
--- a/examples/peripherals/i2c/i2c_self_test/main/i2c_example_main.c
+++ b/examples/peripherals/i2c/i2c_self_test/main/i2c_example_main.c
@@ -151,6 +151,7 @@ static esp_err_t i2c_master_init(void)
     conf.scl_io_num = I2C_MASTER_SCL_IO;
     conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
     conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
+    conf.clk_flags = 0;
     i2c_param_config(i2c_master_port, &conf);
     return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
 }


### PR DESCRIPTION
Fixed issue where the check at `components/driver/i2c.c:667` would fail due to `clk_flags` not being specified in the self test example