### PR TITLE
Fixed register to RTC_CNTL_ULP_CP_TIMER_1_REG in ulp.c (IDFGH-4398)

### DIFF
--- a/components/ulp/ulp.c
+++ b/components/ulp/ulp.c
@@ -82,7 +82,7 @@ esp_err_t ulp_run(uint32_t entry_point)
     // ULP FSM sends the DONE signal.
     CLEAR_PERI_REG_MASK(RTC_CNTL_COCPU_CTRL_REG, RTC_CNTL_COCPU_DONE_FORCE);
     /* Set the number of cycles of ULP_TIMER sleep, the wait time required to start ULP */
-    REG_SET_FIELD(RTC_CNTL_ULP_CP_TIMER_REG, RTC_CNTL_ULP_CP_TIMER_SLP_CYCLE, 100);
+    REG_SET_FIELD(RTC_CNTL_ULP_CP_TIMER_1_REG, RTC_CNTL_ULP_CP_TIMER_SLP_CYCLE, 100);
     /* Clear interrupt COCPU status */
     REG_WRITE(RTC_CNTL_INT_CLR_REG, RTC_CNTL_COCPU_INT_CLR | RTC_CNTL_COCPU_TRAP_INT_CLR | RTC_CNTL_ULP_CP_INT_CLR);
     // 1: start with timer. wait ULP_TIMER cnt timer.


### PR DESCRIPTION
I was initially working on release 4.2 and noticed that ULP example doesn't work. One of the main reasons was that the RTC_CNTL_ULP_CP_TIMER_REG was rewritten with a constant value so that the start address of the ULP program was corrupt. This happened on two places in 4.2. 

I managed to get it working in version 4.2. However, the master version has so many changes that it broke the example again. I'm still struggling to find the reason why it fails. 
Unfortunately, this correction is not enough to fix the problem, but at least it's one bug less :) Maybe some of you folks will figure it out.