### PR TITLE
freertos_hooks: Fix unbalance lock in deregistration for cpu functions (IDFGH-4472)

### DIFF
--- a/components/esp_common/src/freertos_hooks.c
+++ b/components/esp_common/src/freertos_hooks.c
@@ -109,10 +109,10 @@ esp_err_t esp_register_freertos_tick_hook(esp_freertos_tick_cb_t new_tick_cb)
 
 void esp_deregister_freertos_idle_hook_for_cpu(esp_freertos_idle_cb_t old_idle_cb, UBaseType_t cpuid)
 {
-    portENTER_CRITICAL(&hooks_spinlock);
     if(cpuid >= portNUM_PROCESSORS){
         return;
     }
+    portENTER_CRITICAL(&hooks_spinlock);
     for(int n = 0; n < MAX_HOOKS; n++){
         if(idle_cb[cpuid][n] == old_idle_cb) idle_cb[cpuid][n] = NULL;
     }
@@ -130,10 +130,10 @@ void esp_deregister_freertos_idle_hook(esp_freertos_idle_cb_t old_idle_cb)
 
 void esp_deregister_freertos_tick_hook_for_cpu(esp_freertos_tick_cb_t old_tick_cb, UBaseType_t cpuid)
 {
-    portENTER_CRITICAL(&hooks_spinlock);
     if(cpuid >= portNUM_PROCESSORS){
         return;
     }
+    portENTER_CRITICAL(&hooks_spinlock);
     for(int n = 0; n < MAX_HOOKS; n++){
         if(tick_cb[cpuid][n] == old_tick_cb) tick_cb[cpuid][n] = NULL;
     }


### PR DESCRIPTION
Current code exits the deregistration for cpu functions with spinlock held when
cpuid >= portNUM_PROCESSORS. Fix it.

Fixes: 9d63e1da4a23 ("New Task Watchdog API (Revert of Revert)")
Signed-off-by: Axel Lin <axel.lin@gmail.com>