### PR TITLE
Fix typo in smartconfig_ack.h (IDFGH-4483)

### DIFF
--- a/components/esp_wifi/include/smartconfig_ack.h
+++ b/components/esp_wifi/include/smartconfig_ack.h
@@ -28,7 +28,7 @@ extern "C" {
   *         token: token from the cellphone;
   *         cellphone_ip: IP address of the cellphone;
   *
-  * @retuen ESP_OK: succeed
+  * @return ESP_OK: succeed
   *         others: fail
   */
 esp_err_t sc_send_ack_start(smartconfig_type_t type, uint8_t token, uint8_t *cellphone_ip);


### PR DESCRIPTION
correct spelling of @return ( was @retuen )