### PR TITLE
Prepend (esp-idf) to shell prompt when the idf is entered. (IDFGH-4523)

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -146,8 +146,13 @@ enable_autocomplete() {
     fi
 }
 
+update_prompt() {
+	export PS1="(esp-idf) ${PS1}"
+}
+
 idf_export_main
 enable_autocomplete
+update_prompt
 
 unset realpath_int
 unset idf_export_main

--- a/export.sh
+++ b/export.sh
@@ -146,13 +146,10 @@ enable_autocomplete() {
     fi
 }
 
-update_prompt() {
-    export PS1="(esp-idf) ${PS1}"
-}
-
 idf_export_main
 enable_autocomplete
-update_prompt
+
+export PS1="(esp-idf) ${PS1}"
 
 unset realpath_int
 unset idf_export_main

--- a/export.sh
+++ b/export.sh
@@ -147,7 +147,7 @@ enable_autocomplete() {
 }
 
 update_prompt() {
-	export PS1="(esp-idf) ${PS1}"
+    export PS1="(esp-idf) ${PS1}"
 }
 
 idf_export_main


### PR DESCRIPTION
Added function in `export.sh` to update the shell prompt such that the
programmer knows that they are in an esp-idf environment. This works
just like when you enter a python virtual environment and the name of
the virtualenv is prepended to your shell PS1 in parens.

![esp-idf_prompt_pr_example](https://user-images.githubusercontent.com/73897725/103448316-9c20d900-4c5d-11eb-9ab5-e509bc3f06de.png)