### PR TITLE
esp_http_client: fix truncated headers (IDFGH-4552)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -205,7 +205,19 @@ static int http_on_status(http_parser *parser, const char *at, size_t length)
 static int http_on_header_field(http_parser *parser, const char *at, size_t length)
 {
     esp_http_client_t *client = parser->data;
-    http_utils_assign_string(&client->current_header_key, at, length);
+
+    if (client->current_header_key != NULL && client->current_header_value != NULL) {
+        ESP_LOGD(TAG, "HEADER=%s:%s", client->current_header_key, client->current_header_value);
+        client->event.header_key = client->current_header_key;
+        client->event.header_value = client->current_header_value;
+        http_dispatch_event(client, HTTP_EVENT_ON_HEADER, NULL, 0);
+        free(client->current_header_key);
+        free(client->current_header_value);
+        client->current_header_key = NULL;
+        client->current_header_value = NULL;
+    }
+
+    http_utils_append_string(&client->current_header_key, at, length);
 
     return 0;
 }
@@ -217,29 +229,32 @@ static int http_on_header_value(http_parser *parser, const char *at, size_t leng
         return 0;
     }
     if (strcasecmp(client->current_header_key, "Location") == 0) {
-        http_utils_assign_string(&client->location, at, length);
+        http_utils_append_string(&client->location, at, length);
     } else if (strcasecmp(client->current_header_key, "Transfer-Encoding") == 0
                && memcmp(at, "chunked", length) == 0) {
         client->response->is_chunked = true;
     } else if (strcasecmp(client->current_header_key, "WWW-Authenticate") == 0) {
-        http_utils_assign_string(&client->auth_header, at, length);
+        http_utils_append_string(&client->auth_header, at, length);
     }
-    http_utils_assign_string(&client->current_header_value, at, length);
-
-    ESP_LOGD(TAG, "HEADER=%s:%s", client->current_header_key, client->current_header_value);
-    client->event.header_key = client->current_header_key;
-    client->event.header_value = client->current_header_value;
-    http_dispatch_event(client, HTTP_EVENT_ON_HEADER, NULL, 0);
-    free(client->current_header_key);
-    free(client->current_header_value);
-    client->current_header_key = NULL;
-    client->current_header_value = NULL;
+    http_utils_append_string(&client->current_header_value, at, length);
     return 0;
 }
 
 static int http_on_headers_complete(http_parser *parser)
 {
     esp_http_client_handle_t client = parser->data;
+
+    if (client->current_header_key != NULL && client->current_header_value != NULL) {
+        ESP_LOGD(TAG, "HEADER=%s:%s", client->current_header_key, client->current_header_value);
+        client->event.header_key = client->current_header_key;
+        client->event.header_value = client->current_header_value;
+        http_dispatch_event(client, HTTP_EVENT_ON_HEADER, NULL, 0);
+        free(client->current_header_key);
+        free(client->current_header_value);
+        client->current_header_key = NULL;
+        client->current_header_value = NULL;
+    }
+
     client->response->status_code = parser->status_code;
     client->response->data_offset = parser->nread;
     client->response->content_length = parser->content_length;

--- a/components/esp_http_client/lib/http_utils.c
+++ b/components/esp_http_client/lib/http_utils.c
@@ -61,6 +61,30 @@ char *http_utils_assign_string(char **str, const char *new_str, int len)
     return old_str;
 }
 
+char *http_utils_append_string(char **str, const char *new_str, int len)
+{
+    if (new_str == NULL) {
+        return NULL;
+    }
+    char *old_str = *str;
+    if (len <= 0) {
+        len = strlen(new_str);
+    }
+    if (old_str) {
+        int old_len = strlen(old_str);
+        old_str = realloc(old_str, old_len + len + 1);
+        mem_check(old_str);
+        memcpy(old_str + old_len, new_str, len);
+        old_str[old_len + len] = 0;
+    } else {
+        old_str = calloc(1, len + 1);
+        mem_check(old_str);
+        memcpy(old_str, new_str, len);
+    }
+    *str = old_str;
+    return old_str;
+}
+
 void http_utils_trim_whitespace(char **str)
 {
     char *end, *start;

--- a/components/esp_http_client/lib/include/http_utils.h
+++ b/components/esp_http_client/lib/include/http_utils.h
@@ -31,6 +31,19 @@
 char *http_utils_assign_string(char **str, const char *new_str, int len);
 
 /**
+ * @brief      Realloc *str and append new_str to it, if not NULL; assign new_str to *str pointer if NULL
+ *
+ * @param      str      pointer to string pointer
+ * @param      new_str  assign this string to str
+ * @param      len      length of string, 0 if new_str is zero terminated
+ *
+ * @return
+ *  - new_str pointer
+ *  - NULL
+ */
+char *http_utils_append_string(char **str, const char *new_str, int len);
+
+/**
  * @brief      Remove white space at begin and end of string
  *
  * @param[in]  str   The string


### PR DESCRIPTION
When not all response headers fit into the buffer, process them properly.
Fixes #6157 (IDFGH-4315).