### PR TITLE
Add event stack size option to esp_hidh_config_t and increase default event stack size in esp_hid_host example (IDFGH-4568)

### DIFF
--- a/components/esp_hid/include/esp_hidh.h
+++ b/components/esp_hid/include/esp_hidh.h
@@ -100,6 +100,7 @@ typedef union {
 
 typedef struct {
     esp_event_handler_t callback;
+    uint16_t event_stack_size;
 } esp_hidh_config_t;
 
 /**

--- a/components/esp_hid/src/ble_hidh.c
+++ b/components/esp_hid/src/ble_hidh.c
@@ -617,7 +617,7 @@ esp_err_t esp_ble_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_ble_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = config->event_stack_size > 0 ? config->event_stack_size : 2048,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &event_loop_handle);

--- a/components/esp_hid/src/bt_hidh.c
+++ b/components/esp_hid/src/bt_hidh.c
@@ -325,7 +325,7 @@ esp_err_t esp_bt_hidh_init(const esp_hidh_config_t *config)
         .queue_size = 5,
         .task_name = "esp_bt_hidh_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = config->event_stack_size > 0 ? config->event_stack_size : 2048,
         .task_core_id = tskNO_AFFINITY
     };
     esp_err_t ret = esp_event_loop_create(&event_task_args, &event_loop_handle);

--- a/examples/bluetooth/esp_hid_host/main/esp_hid_host_main.c
+++ b/examples/bluetooth/esp_hid_host/main/esp_hid_host_main.c
@@ -127,6 +127,7 @@ void app_main(void)
     ESP_ERROR_CHECK( esp_ble_gattc_register_callback(esp_hidh_gattc_event_handler) );
     esp_hidh_config_t config = {
         .callback = hidh_callback,
+        .event_stack_size = 4096
     };
     ESP_ERROR_CHECK( esp_hidh_init(&config) );
 


### PR DESCRIPTION
The default stack size value of 2048 given to the "esp_bt_hidh_events" and "esp_ble_hidh_events" tasks make them prone to stack overflows on rapid events. The new value of 4096 seems to mitigate this issue for human-speed mouse and keyboard inputs, however may be insufficient for other cases, e.g., HID scanners, emulated HID devices, etc. Adding the event stack size as an option to the existing config struct allows for flexibility.

Resolves #6380