### PR TITLE
app_update: fix incorrect first byte from esp_ota_get_app_elf_sha256 (IDFGH-4572)

### DIFF
--- a/components/app_update/esp_app_desc.c
+++ b/components/app_update/esp_app_desc.c
@@ -89,7 +89,7 @@ int IRAM_ATTR esp_ota_get_app_elf_sha256(char* dst, size_t size)
     static bool first_call = true;
     if (first_call) {
         first_call = false;
-        const uint8_t* src = esp_app_desc.app_elf_sha256;
+        const volatile uint8_t* src = (const volatile uint8_t*)esp_app_desc.app_elf_sha256;
         for (size_t i = 0; i < sizeof(s_app_elf_sha256); ++i) {
             s_app_elf_sha256[i] = src[i];
         }


### PR DESCRIPTION
At -O2 optimization level, GCC seems to optimize out the copying of the
first byte of the checksum, assuming it is zero. This "miscompilation"
happens because the esp_app_desc struct is declared const, but then modified
post-compilation. Casting to volatile disables the optimization.