### PR TITLE
Make install.fish not dependent on being run from the root dir (IDFGH-4601)

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 
-set basedir $PWD
+set basedir "$PWD/"(dirname (status -f))
 
 set -x IDF_PATH $basedir
 


### PR DESCRIPTION
Using `$PWD` as the basedir only works when the script is run from the root directory. The Bash version determines the location of the root directory from the script, and this change makes the Fish script behave the same.