### PR TITLE
Weak linkage for esp_phy_load_cal_and_init (IDFGH-4605)

### DIFF
--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -523,7 +523,7 @@ static void __attribute((unused)) esp_phy_reduce_tx_power(esp_phy_init_data_t* i
 }
 #endif
 
-void esp_phy_load_cal_and_init(void)
+__attribute__((weak)) void esp_phy_load_cal_and_init(void)
 {
     char * phy_version = get_phy_version_str();
     ESP_LOGI(TAG, "phy_version %s", phy_version);


### PR DESCRIPTION
Weakly link esp_phy_load_cal_and_init so that the application can optionally override initialisation/loading/storing of calibration data.

nb: esp_phy_rf_init previously offered this functionality but this API has been removed in 4.3 (and was probably not the intended usage regardless)