### PR TITLE
tinyusb: add 'extern C' bit to tusb_console.h (IDFGH-4641)

### DIFF
--- a/components/tinyusb/additions/include/tusb_console.h
+++ b/components/tinyusb/additions/include/tusb_console.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_err.h"
 
 /**
@@ -31,3 +35,7 @@ esp_err_t esp_tusb_init_console(int cdc_intf);
  * @return esp_err_t
  */
 esp_err_t esp_tusb_deinit_console(int cdc_intf);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Public headers need the "if __cplusplus, extern C" boilerplate. Otherwise, C++
sources which include the header will look for a name-mangled symbol and fail
at link time.