### PR TITLE
Fixed a missed last argument (void *__arg) for pthread_create (IDFGH-4666)

### DIFF
--- a/docs/en/api-reference/system/esp_pthread.rst
+++ b/docs/en/api-reference/system/esp_pthread.rst
@@ -29,7 +29,7 @@ Example to tune the stack size of the pthread:
         cfg.stack_size = (4 * 1024);
         esp_pthread_set_cfg(&cfg);
 
-        pthread_create(&t1, NULL, thread_func);
+        pthread_create(&t1, NULL, thread_func, NULL);
     }
 
 The API can also be used for inheriting the settings across threads. For example:
@@ -48,7 +48,7 @@ The API can also be used for inheriting the settings across threads. For example
     {
         printf("In my_thread1\n");
         pthread_t t2;
-        pthread_create(&t2, NULL, my_thread2);
+        pthread_create(&t2, NULL, my_thread2, NULL);
 
         return NULL;
     }
@@ -62,7 +62,7 @@ The API can also be used for inheriting the settings across threads. For example
         cfg.inherit_cfg = true;
         esp_pthread_set_cfg(&cfg);
 
-        pthread_create(&t1, NULL, my_thread1);
+        pthread_create(&t1, NULL, my_thread1, NULL);
     }
 
 API Reference


### PR DESCRIPTION
**pthread_create()** function definition has 4 arguments, and the last one was missed in examples from documentation.
`int	pthread_create (pthread_t *__pthread, const pthread_attr_t  *__attr, void *(*__start_routine)(void *), void *__arg);`