### PR TITLE
Update MQTT-Client example (IDFGH-4679)

### DIFF
--- a/examples/protocols/mqtt/tcp/main/app_main.c
+++ b/examples/protocols/mqtt/tcp/main/app_main.c
@@ -104,9 +104,9 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
 static void mqtt_app_start(void)
 {
-    esp_mqtt_client_config_t mqtt_cfg = {
-        .uri = CONFIG_BROKER_URL,
-    };
+    esp_mqtt_client_config_t mqtt_cfg = {0};
+    mqtt_cfg.uri = CONFIG_BROKER_URL;
+    
 #if CONFIG_BROKER_URL_FROM_STDIN
     char line[128];
 


### PR DESCRIPTION
Fixes possible LoadStoreError by initializing the config-struct in the mqtt-example properly.

If - like now - only the uri field is set, values for other fields are undefined, which ends in a LoadStoreError on my ESP32-WROOM-32 board.  Fixed by initially setting all fields to zero and **then** adding custom configuration (uri, in the case of this example).

See https://github.com/espressif/arduino-esp32/issues/4647 for further information.