### PR TITLE
Fix eclipse build error on Windows: “UnicodeDecodeError: 'ascii' codec can't decode byte” (IDFGH-4693)

### DIFF
--- a/tools/windows/eclipse_make.py
+++ b/tools/windows/eclipse_make.py
@@ -20,7 +20,7 @@ def check_path(path):
         pass
     paths[path] = path  # cache as failed, replace with success if it works
     try:
-        winpath = subprocess.check_output(["cygpath", "-w", path]).decode().strip()
+        winpath = subprocess.check_output(["cygpath", "-w", path]).decode("utf-8").strip()
     except subprocess.CalledProcessError:
         return path  # something went wrong running cygpath, assume this is not a path!
     if not os.path.exists(winpath):


### PR DESCRIPTION
After commit 2e9561d252b7a84bfe2644f17b2f58c747b19416 build in Eclipse was failed.