### PR TITLE
fix: infinite loop on closed socket (IDFGH-4735)

### DIFF
--- a/components/mbedtls/port/dynamic/esp_ssl_tls.c
+++ b/components/mbedtls/port/dynamic/esp_ssl_tls.c
@@ -89,7 +89,7 @@ int __wrap_mbedtls_ssl_read(mbedtls_ssl_context *ssl, unsigned char *buf, size_t
     ret = esp_mbedtls_add_rx_buffer(ssl);
     if (ret == MBEDTLS_ERR_SSL_CONN_EOF) {
         ESP_LOGD(TAG, "fail, the connection indicated an EOF");
-        return 0;
+        return ret;
     } else if (ret < 0) {
         ESP_LOGD(TAG, "fail, error=-0x%x", -ret);
         return ret;


### PR DESCRIPTION
In some scenarios returning 0 there result in infinite loop on closed socket (esp_http_server in particul).