### PR TITLE
Explain how to fix 'httpd_parse: header too long' (IDFGH-4741)

### DIFF
--- a/examples/protocols/http_server/simple/README.md
+++ b/examples/protocols/http_server/simple/README.md
@@ -20,5 +20,7 @@ The Example consists of HTTPD server demo with demostration of URI handling :
                 * since the server echoes back the request body, the two files should be same, as can be confirmed using : "cmp anyfile tmpfile"
             3. "curl -X PUT -d "0" 192.168.43.130:80/ctrl" - disable /hello and /echo handlers
             4. "curl -X PUT -d "1" 192.168.43.130:80/ctrl" -  enable /hello and /echo handlers
+            
+* If the server log shows "httpd_parse: parse_block: request URI/header too long", especially when handling POST requests, then you probably need to increase HTTPD_MAX_REQ_HDR_LEN, which you can find in the project configuration menu (`idf.py menuconfig`): Component config -> HTTP Server -> Max HTTP Request Header Length
 
 See the README.md file in the upper level 'examples' directory for more information about examples.


### PR DESCRIPTION
Small change to the README, explaining what to do if you see "httpd_parse: parse_block: request URI/header too long". This can easily  which can easily happen if (e.g.) they POST an HTML form with a modern browser.

Experienced users will probably work this out - but because this is the 'simple' server example, it is probably where new users will start out or come if they are having problems.