### PR TITLE
allow for minimal scope of wifi_init_config_t (IDFGH-4750)

### DIFF
--- a/components/esp_wifi/include/esp_wifi.h
+++ b/components/esp_wifi/include/esp_wifi.h
@@ -228,7 +228,7 @@ extern uint64_t g_wifi_feature_caps;
     .mgmt_sbuf_num = WIFI_MGMT_SBUF_NUM, \
     .feature_caps = g_wifi_feature_caps, \
     .magic = WIFI_INIT_CONFIG_MAGIC\
-};
+}
 
 /**
   * @brief  Init WiFi


### PR DESCRIPTION
With this change one can use the default config as a variable with minimal scope directly in the function call:
`esp_wifi_init(&(wifi_init_config_t)WIFI_INIT_CONFIG_DEFAULT());`
All examples or tests that use this macro use it in the form of:
`wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();`
so nothing should break.

Kind Regards
Nik