### PR TITLE
Implement esp_log_level_get(TAG) (IDFGH-4770)

### DIFF
--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -69,6 +69,16 @@ typedef int (*vprintf_like_t)(const char *, va_list);
 void esp_log_level_set(const char* tag, esp_log_level_t level);
 
 /**
+ * @brief Get log level for given tag, can be used to avoid expensive log statements
+ *
+ * @param tag Tag of the log to query current level. Must be a non-NULL zero terminated
+ *            string.
+ *
+ * @return func the current log level for the given tag
+ */
+esp_log_level_t esp_log_level_get(const char* tag);
+
+/**
  * @brief Set function used to output log entries
  *
  * By default, log output goes to UART0. This function can be used to redirect log

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -148,6 +148,25 @@ void esp_log_level_set(const char *tag, esp_log_level_t level)
     esp_log_impl_unlock();
 }
 
+esp_log_level_t esp_log_level_get(const char* tag)
+{
+    esp_log_impl_lock();
+    esp_log_level_t level_for_tag;
+    // Look for the tag in cache first, then in the linked list of all tags
+    if (!get_cached_log_level(tag, &level_for_tag)) {
+        if (!get_uncached_log_level(tag, &level_for_tag)) {
+            level_for_tag = s_log_default_level;
+        }
+        add_to_cache(tag, level_for_tag);
+#ifdef LOG_BUILTIN_CHECKS
+        ++s_log_cache_misses;
+#endif
+    }
+    esp_log_impl_unlock();
+
+    return level_for_tag;
+}
+
 void clear_log_level_list(void)
 {
     uncached_tag_entry_t *it;


### PR DESCRIPTION
Add simple getter for current log level to skip expensive log construction.

example usage:

```
#include <string>
#include <esp_log.h>

extern std::string slowLogBuilder();

namespace {
constexpr const char TAG[] = "MAIN";
}

void someMethod()
{
    if (esp_log_level_get(TAG) >= ESP_LOG_DEBUG)
        ESP_LOGD(TAG, "current log status=%s", slowLogBuilder().c_str());
}
}