### PR TITLE
Allow to find any partition type (app and data) with iterator (IDFGH-4783)

### DIFF
--- a/components/spi_flash/include/esp_partition.h
+++ b/components/spi_flash/include/esp_partition.h
@@ -45,6 +45,8 @@ extern "C" {
 typedef enum {
     ESP_PARTITION_TYPE_APP = 0x00,       //!< Application partition type
     ESP_PARTITION_TYPE_DATA = 0x01,      //!< Data partition type
+
+    ESP_PARTITION_TYPE_ANY = 0xff,       //!< Used to search for partitions with any type
 } esp_partition_type_t;
 
 /**

--- a/components/spi_flash/partition.c
+++ b/components/spi_flash/partition.c
@@ -108,10 +108,10 @@ esp_partition_iterator_t esp_partition_next(esp_partition_iterator_t it)
     _lock_acquire(&s_partition_list_lock);
     for (; it->next_item != NULL; it->next_item = SLIST_NEXT(it->next_item, next)) {
         esp_partition_t* p = &it->next_item->info;
-        if (it->type != p->type) {
+        if (it->type != ESP_PARTITION_TYPE_ANY && it->type != p->type) {
             continue;
         }
-        if (it->subtype != 0xff && it->subtype != p->subtype) {
+        if (it->subtype != ESP_PARTITION_SUBTYPE_ANY && it->subtype != p->subtype) {
             continue;
         }
         if (it->label != NULL && strcmp(it->label, p->label) != 0) {


### PR DESCRIPTION
I tried to build an remove partition browser tool which lists all types and subtypes of partitions and I was missing the partition type "ANY".

Example usage:

        JsonDocument doc;
        auto iter = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, nullptr);

        while (iter)
        {
            auto part = esp_partition_get(iter);
            if (!part)
                break;

            auto obj = doc.createNestedObject();
            obj["type"] = part->type;
            obj["subtype"] = part->subtype;
            obj["address"] = part->address;
            obj["size"] = part->size;
            obj["label"] = std::string{part->label};
            obj["encrypted"] = part->encrypted;

            iter = esp_partition_next(iter);
        }

        if (iter)
            esp_partition_iterator_release(iter);