### PR TITLE
Fix error when `ZSH_VERSION` is unset. (IDFGH-4784)

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -137,7 +137,7 @@ idf_export_main() {
 }
 
 enable_autocomplete() {
-    if [ -n "$ZSH_VERSION" ]
+    if [ -n "${ZSH_VERSION-}" ]
     then
         autoload -Uz compinit && compinit -u
         eval "$(env _IDF.PY_COMPLETE=source_zsh idf.py)" || echo "WARNING: Failed to load shell autocompletion!"


### PR DESCRIPTION
When `set -u` is specified, `export.sh` currently fails in `bash`.