### PR TITLE
Init phy data to default if invalid in flash partition to avoid bootloops (IDFGH-4812)

### DIFF
--- a/components/esp_wifi/Kconfig
+++ b/components/esp_wifi/Kconfig
@@ -406,6 +406,16 @@ menu "PHY"
 
             If unsure, choose 'n'.
 
+    config ESP32_PHY_DEFAULT_INIT_IF_INVALID
+        bool "Reset default PHY init data if invalid"
+        default n
+        depends on ESP32_PHY_INIT_DATA_IN_PARTITION
+        help
+            If enabled, PHY init data will be restored to default if
+            it cannot be verified successfully to avoid endless bootloops.
+
+            If unsure, choose 'n'.
+
     if ESP32_PHY_INIT_DATA_IN_PARTITION
         config ESP32_SUPPORT_MULTIPLE_PHY_INIT_DATA_BIN
             bool "Support multiple PHY init data bin"

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -340,40 +340,14 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
         memcpy(init_data_store + sizeof(phy_init_magic_pre) + sizeof(phy_init_data),
                PHY_INIT_MAGIC, sizeof(phy_init_magic_post));
 
+        assert(memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) == 0);
+        assert(memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
+                      PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) == 0);
+
         // write default data
         err = esp_partition_write(partition, 0, init_data_store, init_data_store_length);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "failed to write default PHY data partition (0x%x)", err);
-            free(init_data_store);
-            return NULL;
-        }
-
-        memset(init_data_store, 0, init_data_store_length);
-
-        // verify by reading again from flash
-        esp_err_t err = esp_partition_read(partition, 0, init_data_store, init_data_store_length);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "failed to read PHY data partition second time (0x%x)", err);
-            free(init_data_store);
-            return NULL;
-        }
-
-        if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) != 0)
-        {
-            ESP_LOGE(TAG, "failed to validate PHY data partition second time PRE");
-        }
-
-        if (memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
-                   PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0)
-        {
-            ESP_LOGE(TAG, "failed to validate PHY data partition second time POST");
-        }
-
-        // if still not valid flash might be damaged
-        if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) != 0 ||
-            memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
-                    PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0) {
-            ESP_LOGE(TAG, "failed to validate PHY data partition second time");
             free(init_data_store);
             return NULL;
         }

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -316,16 +316,68 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
         ESP_LOGE(TAG, "failed to allocate memory for PHY init data");
         return NULL;
     }
+    // read phy data from flash
     esp_err_t err = esp_partition_read(partition, 0, init_data_store, init_data_store_length);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "failed to read PHY data partition (0x%x)", err);
+        free(init_data_store);
         return NULL;
     }
+    // verify data
     if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) != 0 ||
         memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
                 PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0) {
+#ifndef CONFIG_ESP32_PHY_DEFAULT_INIT_IF_INVALID
         ESP_LOGE(TAG, "failed to validate PHY data partition");
         return NULL;
+#else
+        ESP_LOGE(TAG, "failed to validate PHY data partition, restoring default data into flash...");
+
+        memcpy(init_data_store,
+               PHY_INIT_MAGIC, sizeof(phy_init_magic_pre));
+        memcpy(init_data_store + sizeof(phy_init_magic_pre),
+               &phy_init_data, sizeof(phy_init_data));
+        memcpy(init_data_store + sizeof(phy_init_magic_pre) + sizeof(phy_init_data),
+               PHY_INIT_MAGIC, sizeof(phy_init_magic_post));
+
+        // write default data
+        err = esp_partition_write(partition, 0, init_data_store, init_data_store_length);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to write default PHY data partition (0x%x)", err);
+            free(init_data_store);
+            return NULL;
+        }
+
+        memset(init_data_store, 0, init_data_store_length);
+
+        // verify by reading again from flash
+        esp_err_t err = esp_partition_read(partition, 0, init_data_store, init_data_store_length);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to read PHY data partition second time (0x%x)", err);
+            free(init_data_store);
+            return NULL;
+        }
+
+        if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) != 0)
+        {
+            ESP_LOGE(TAG, "failed to validate PHY data partition second time PRE");
+        }
+
+        if (memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
+                   PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0)
+        {
+            ESP_LOGE(TAG, "failed to validate PHY data partition second time POST");
+        }
+
+        // if still not valid flash might be damaged
+        if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre)) != 0 ||
+            memcmp(init_data_store + init_data_store_length - sizeof(phy_init_magic_post),
+                    PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0) {
+            ESP_LOGE(TAG, "failed to validate PHY data partition second time");
+            free(init_data_store);
+            return NULL;
+        }
+#endif // CONFIG_ESP32_PHY_DEFAULT_INIT_IF_INVALID
     }
 #if CONFIG_ESP32_SUPPORT_MULTIPLE_PHY_INIT_DATA_BIN
     if ((*(init_data_store + (sizeof(phy_init_magic_pre) + PHY_SUPPORT_MULTIPLE_BIN_OFFSET)))) {
@@ -728,8 +780,8 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
 
     err = phy_find_bin_data_according_type(init_data_store, init_data_control_info, init_data_multiple, init_data_type);
     if (err != ESP_OK) {
-		ESP_LOGW(TAG, "%s has not been certified, use DEFAULT PHY init data", s_phy_type[init_data_type]);
-		s_phy_init_data_type = ESP_PHY_INIT_DATA_TYPE_DEFAULT;
+        ESP_LOGW(TAG, "%s has not been certified, use DEFAULT PHY init data", s_phy_type[init_data_type]);
+        s_phy_init_data_type = ESP_PHY_INIT_DATA_TYPE_DEFAULT;
     } else {
         s_phy_init_data_type = init_data_type;
     }


### PR DESCRIPTION
I just had a case of endless bootloop crashes because I enabled the menuconfig option to store PHY init data in a dedicated partition instead of NVS.

This happens because `esp_phy_load_cal_and_init()` calls `abort()` when `esp_phy_get_init_data()` returns a nullptr. I added a menuconfig option to reset invalid PHY init data to default when it cannot be verified successfully to avoid such bootloops.

Also I think I fixed a few memory leaks on the way be deleting the pointer when it was returning NULL;

    I (1553) phy_init: phy_version 4660,0162888,Dec 23 2020
    E (1563) phy_init: failed to validate PHY data partition
    E (1563) phy_init: failed to obtain PHY init data

    abort() was called at PC 0x4014029f on core 0
    0x4014029f: esp_phy_load_cal_and_init at <project-home>/build_hw4/../esp-idf/components/esp_wifi/src/phy_init.c:546 (discriminator 3)

    Backtrace:0x40087ac6:0x3ffd4780 0x4008841d:0x3ffd47a0 0x400901d2:0x3ffd47c0 0x4014029f:0x3ffd4830 0x40140411:0x3ffd4860 0x4018e463:0x3ffd4880 0x4018e78b:0x3ffd48a0 0x4018b4fd:0x3ffd48c0 0x40091d4a:0x3ffd48e0
    0x40087ac6: panic_abort at <project-home>/build_hw4/../esp-idf/components/esp_system/panic.c:367
    0x4008841d: esp_system_abort at <project-home>/build_hw4/../esp-idf/components/esp_system/system_api.c:112
    0x400901d2: abort at <project-home>/build_hw4/../esp-idf/components/newlib/abort.c:46
    0x4014029f: esp_phy_load_cal_and_init at <project-home>/build_hw4/../esp-idf/components/esp_wifi/src/phy_init.c:546 (discriminator 3)
    0x40140411: esp_phy_enable at <project-home>/build_hw4/../esp-idf/components/esp_wifi/src/phy_init.c:215
    0x4018e463: wifi_hw_start at ??:?
    ELF file SHA256: 4366c305673513cc

    I (1400) esp_core_dump_flash: Save core dump to flash...
    I (1406) esp_core_dump_flash: Erase flash 20480 bytes @ 0x961000
    I (1681) esp_core_dump_flash: Write end offset 0x4900, check sum length 32
    I (1681) esp_core_dump_flash: Core dump has been saved to flash.
    Rebooting...