### PR TITLE
Update native_ota_example.c (IDFGH-4824)

### DIFF
--- a/examples/system/ota/native_ota_example/main/native_ota_example.c
+++ b/examples/system/ota/native_ota_example/main/native_ota_example.c
@@ -132,9 +132,9 @@ static void ota_example_task(void *pvParameter)
     esp_http_client_fetch_headers(client);
 
     update_partition = esp_ota_get_next_update_partition(NULL);
+    assert(update_partition != NULL);
     ESP_LOGI(TAG, "Writing to partition subtype %d at offset 0x%x",
              update_partition->subtype, update_partition->address);
-    assert(update_partition != NULL);
 
     int binary_file_length = 0;
     /*deal with all receive packet*/
@@ -235,7 +235,8 @@ static void ota_example_task(void *pvParameter)
         if (err == ESP_ERR_OTA_VALIDATE_FAILED) {
             ESP_LOGE(TAG, "Image validation failed, image is corrupted");
         }
-        ESP_LOGE(TAG, "esp_ota_end failed (%s)!", esp_err_to_name(err));
+        else
+            ESP_LOGE(TAG, "esp_ota_end failed (%s)!", esp_err_to_name(err));
         http_cleanup(client);
         task_fatal_error();
     }


### PR DESCRIPTION
* `assert(update_partition)` should be before trying to use _update_partition_ in `ESP_LOGI()`.
* if we show detailed description about the error _ESP_ERR_OTA_VALIDATE_FAILED_, why show it again using `esp_err_to_name()` ?