### PR TITLE
Implemented esp_core_dump_image_erase() (IDFGH-4832)

### DIFF
--- a/components/espcoredump/include/esp_core_dump.h
+++ b/components/espcoredump/include/esp_core_dump.h
@@ -92,6 +92,6 @@ esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size);
  *
  * @return ESP_OK on success, otherwise \see esp_err_t
  */
-esp_err_t esp_core_dump_image_erase();
+esp_err_t esp_core_dump_image_erase(void);
 
 #endif

--- a/components/espcoredump/include/esp_core_dump.h
+++ b/components/espcoredump/include/esp_core_dump.h
@@ -85,4 +85,13 @@ void esp_core_dump_to_uart(panic_info_t *info);
  */
 esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size);
 
+/**
+ * @brief  Erases coredump data in flash. esp_core_dump_image_get() will then return
+ *         ESP_ERR_NOT_FOUND. Can be used after a coredump has been transmitted successfully.
+ *         This function is always available, even when core dump is disabled in menuconfig.
+ *
+ * @return ESP_OK on success, otherwise \see esp_err_t
+ */
+esp_err_t esp_core_dump_image_erase();
+
 #endif

--- a/components/espcoredump/src/core_dump_flash.c
+++ b/components/espcoredump/src/core_dump_flash.c
@@ -19,6 +19,8 @@
 #include "esp_flash_encrypt.h"
 #include "esp_rom_crc.h"
 
+#define BLANK_COREDUMP_SIZE 0xFFFFFFFF
+
 const static DRAM_ATTR char TAG[] __attribute__((unused)) = "esp_core_dump_flash";
 
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
@@ -389,7 +391,7 @@ esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size)
     }
 
     /* Verify that the size read from the flash is not corrupted. */
-    if (size == 0xFFFFFFFF) {
+    if (size == BLANK_COREDUMP_SIZE) {
         ESP_LOGD(TAG, "Coredump not found, blank core dump partition!");
         err = ESP_ERR_NOT_FOUND;
     } else if ((size < sizeof(uint32_t)) || (size > core_part->size)) {
@@ -456,7 +458,7 @@ esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size)
     return ESP_OK;
 }
 
-esp_err_t esp_core_dump_image_erase()
+esp_err_t esp_core_dump_image_erase(void)
 {
     /* Find the partition that could potentially contain a (previous) core dump. */
     const esp_partition_t *core_part = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
@@ -478,11 +480,9 @@ esp_err_t esp_core_dump_image_erase()
         return err;
     }
 
-    // on encrypted flash esp_partition_erase_range will leave encrypted
-    // garbage instead of 0xFFFFFFFF so overwriting again to safely signalize
-    // deleted coredumps
-    const uint32_t invalid_size = 0xFFFFFFFF;
-    err = esp_partition_write(core_part, 0, &invalid_size, sizeof(invalid_size));
+    // Mark core dump as deleted by setting field size
+    const uint32_t blank_size = BLANK_COREDUMP_SIZE;
+    err = esp_partition_write(core_part, 0, &blank_size, sizeof(blank_size));
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to write core dump partition size (%d)!", err);
     }

--- a/components/espcoredump/src/core_dump_flash.c
+++ b/components/espcoredump/src/core_dump_flash.c
@@ -390,8 +390,8 @@ esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size)
 
     /* Verify that the size read from the flash is not corrupted. */
     if (size == 0xFFFFFFFF) {
-        ESP_LOGD(TAG, "Blank core dump partition!");
-        err = ESP_ERR_INVALID_SIZE;
+        ESP_LOGD(TAG, "Coredump not found, blank core dump partition!");
+        err = ESP_ERR_NOT_FOUND;
     } else if ((size < sizeof(uint32_t)) || (size > core_part->size)) {
         ESP_LOGE(TAG, "Incorrect size of core dump image: %d", size);
         err = ESP_ERR_INVALID_SIZE;
@@ -454,4 +454,38 @@ esp_err_t esp_core_dump_image_get(size_t* out_addr, size_t *out_size)
 
     *out_addr = core_part->address;
     return ESP_OK;
+}
+
+esp_err_t esp_core_dump_image_erase()
+{
+    /* Find the partition that could potentially contain a (previous) core dump. */
+    const esp_partition_t *core_part = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
+                                                                ESP_PARTITION_SUBTYPE_DATA_COREDUMP,
+                                                                NULL);
+    if (!core_part) {
+        ESP_LOGE(TAG, "No core dump partition found!");
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (core_part->size < sizeof(uint32_t)) {
+        ESP_LOGE(TAG, "Too small core dump partition!");
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    esp_err_t err = ESP_OK;
+    err = esp_partition_erase_range(core_part, 0, core_part->size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to erase core dump partition (%d)!", err);
+        return err;
+    }
+
+    // on encrypted flash esp_partition_erase_range will leave encrypted
+    // garbage instead of 0xFFFFFFFF so overwriting again to safely signalize
+    // deleted coredumps
+    const uint32_t invalid_size = 0xFFFFFFFF;
+    err = esp_partition_write(core_part, 0, &invalid_size, sizeof(invalid_size));
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to write core dump partition size (%d)!", err);
+    }
+
+    return err;
 }


### PR DESCRIPTION
Implemented esp_core_dump_image_erase() and esp_core_dump_image_get() now returns ESP_ERR_NOT_FOUND when partition is blank/erased.

esp_core_dump_image_erase() calls esp_partition_erase_range() and additionally writes size 0xFFFFFFFF to avoid problems when flash encryption is enabled. Without explicitly writing 0xFFFFFFFF for size, esp_core_dump_image_get() will read a garbage size when the erased bytes are being decrypted.

With size 0xFFFFFFFF esp_core_dump_image_get() now returns ESP_ERR_NOT_FOUND instead of ESP_ERR_INVALID_SIZE

I needed to know if an error happened during reading the coredump or if it has simply been not found / been invalid or erased (because never crashed or coredump has been transmitted already successfully)