### PR TITLE
Fix for #6633 (IDFGH-4835)

### DIFF
--- a/components/driver/esp32s2/include/driver/touch_sensor.h
+++ b/components/driver/esp32s2/include/driver/touch_sensor.h
@@ -13,11 +13,11 @@
 
 #pragma once
 
+#include "driver/touch_sensor_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "driver/touch_sensor_common.h"
 
 /**
  * @brief Set touch sensor FSM start

--- a/components/esp_adc_cal/include/esp_adc_cal.h
+++ b/components/esp_adc_cal/include/esp_adc_cal.h
@@ -15,13 +15,13 @@
 #ifndef __ESP_ADC_CAL_H__
 #define __ESP_ADC_CAL_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include "esp_err.h"
 #include "driver/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Type of calibration value used in characterization


### PR DESCRIPTION
Moving #includes above #ifdef __cplusplus extern "C" { #endif
So that we can compile with CPP.

This is a fix for https://github.com/espressif/esp-idf/issues/6633
NB this PR fixes in the v4.3 branch. I presume there are other branches (like master) to which this should also be applied.
