### PR TITLE
Explain the need to enable BT and BTDM BLE in SDK (IDFGH-4854)

### DIFF
--- a/examples/provisioning/wifi_prov_mgr/README.md
+++ b/examples/provisioning/wifi_prov_mgr/README.md
@@ -22,6 +22,8 @@ Right after provisioning is complete, BLE is turned off and disabled to free the
 
 This example can be used, as it is, for adding a provisioning service to any application intended for IoT.
 
+> Note: If you use this example code in your own project, in BLE mode, then remember to enable the BT stack and BTDM BLE control settings in your SDK configuration (e.g. by using the `sdkconfig.defaults` file from this project).
+
 ## How to use example
 
 ### Hardware Required

--- a/examples/provisioning/wifi_prov_mgr/main/app_main.c
+++ b/examples/provisioning/wifi_prov_mgr/main/app_main.c
@@ -237,6 +237,10 @@ void app_main(void)
             0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
             0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02,
         };
+        
+        /* if your build fails with linker errors at this point, then you may have
+         * forgotten to enable the BT stack or BTDM BLE settings in the SDK (e.g. see
+         * the sdkconfig.defaults in the example project) */
         wifi_prov_scheme_ble_set_service_uuid(custom_service_uuid);
 #endif /* CONFIG_EXAMPLE_PROV_TRANSPORT_BLE */
 


### PR DESCRIPTION
If users may try to use this (excellent) example code in their own projects, without understanding the need to enable the BT stack and BTDM settings in the SDK. If they do that then their builds will fail with linker errors but they may not understand why.