### PR TITLE
component: adc/i2s: support multi channel ADC DMA

### DIFF
--- a/components/driver/esp32/adc.c
+++ b/components/driver/esp32/adc.c
@@ -84,19 +84,22 @@ esp_err_t adc_set_i2s_data_source(adc_i2s_source_t src)
     return ESP_OK;
 }
 
-esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, adc_channel_t channel)
+esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns)
 {
+    ADC_CHECK(pattern_count <= 16, "ADC only supports max 16 patterns", ESP_ERR_INVALID_ARG);
     if (adc_unit & ADC_UNIT_1) {
         ADC_CHECK((SOC_ADC_SUPPORT_DMA_MODE(ADC_NUM_1)), "ADC1 not support DMA for now.", ESP_ERR_INVALID_ARG);
-        ADC_CHANNEL_CHECK(ADC_NUM_1, channel);
+        for (int i = 0; i < pattern_count; i++) {
+            ADC_CHANNEL_CHECK(ADC_NUM_1, patterns[i].channel);
+        }
     }
     if (adc_unit & ADC_UNIT_2) {
         ADC_CHECK((SOC_ADC_SUPPORT_DMA_MODE(ADC_NUM_2)), "ADC2 not support DMA for now.", ESP_ERR_INVALID_ARG);
-        ADC_CHANNEL_CHECK(ADC_NUM_2, channel);
+        for (int i = 0; i < pattern_count; i++) {
+            ADC_CHANNEL_CHECK(ADC_NUM_2, patterns[i].channel);
+        }
     }
 
-    adc_digi_pattern_table_t adc1_pattern[1];
-    adc_digi_pattern_table_t adc2_pattern[1];
     adc_digi_config_t dig_cfg = {
         .conv_limit_en = ADC_MEAS_NUM_LIM_DEFAULT,
         .conv_limit_num = ADC_MAX_MEAS_NUM_DEFAULT,
@@ -105,20 +108,16 @@ esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, adc_channel_t channel)
     };
 
     if (adc_unit & ADC_UNIT_1) {
-        adc1_pattern[0].atten = DIG_ADC_ATTEN_DEFUALT;
-        adc1_pattern[0].bit_width = DIG_ADC_BIT_WIDTH_DEFUALT;
-        adc1_pattern[0].channel = channel;
-        dig_cfg.adc1_pattern_len = 1;
-        dig_cfg.adc1_pattern = adc1_pattern;
+        dig_cfg.adc1_pattern_len = pattern_count;
+        dig_cfg.adc1_pattern = patterns;
     }
     if (adc_unit & ADC_UNIT_2) {
-        adc2_pattern[0].atten = DIG_ADC_ATTEN_DEFUALT;
-        adc2_pattern[0].bit_width = DIG_ADC_BIT_WIDTH_DEFUALT;
-        adc2_pattern[0].channel = channel;
-        dig_cfg.adc2_pattern_len = 1;
-        dig_cfg.adc2_pattern = adc2_pattern;
+        dig_cfg.adc2_pattern_len = pattern_count;
+        dig_cfg.adc2_pattern = patterns;
     }
-    adc_gpio_init(adc_unit, channel);
+    for (int i = 0; i < pattern_count; i++) {
+        adc_gpio_init(adc_unit, patterns[i].channel);
+    }
     ADC_ENTER_CRITICAL();
     adc_hal_digi_init();
     adc_hal_digi_controller_config(&dig_cfg);

--- a/components/driver/esp32/include/driver/adc.h
+++ b/components/driver/esp32/include/driver/adc.h
@@ -35,12 +35,14 @@ esp_err_t adc_set_i2s_data_source(adc_i2s_source_t src);
 /**
  * @brief Initialize I2S ADC mode
  * @param adc_unit ADC unit index
- * @param channel ADC channel index
+ * @param pattern_count count of ADC channels to sample
+ * @param patterns pointer to an array of `pattern_count` channel patterns
  * @return
  *     - ESP_OK success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, adc_channel_t channel);
+esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns);
+
 
 /*---------------------------------------------------------------
                     RTC controller setting

--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -100,7 +100,8 @@ static i2s_obj_t *p_i2s_obj[I2S_NUM_MAX] = {0};
 static portMUX_TYPE i2s_spinlock[I2S_NUM_MAX];
 #if SOC_I2S_SUPPORTS_ADC_DAC
 static int _i2s_adc_unit = -1;
-static int _i2s_adc_channel = -1;
+static int _i2s_adc_pattern_count = -1;
+static adc_digi_pattern_table_t *_i2s_adc_patterns = NULL;
 #endif
 
 static i2s_dma_t *i2s_create_dma_queue(i2s_port_t i2s_num, int dma_buf_count, int dma_buf_len);
@@ -720,17 +721,19 @@ esp_err_t i2s_set_dac_mode(i2s_dac_mode_t dac_mode)
 
 static esp_err_t _i2s_adc_mode_recover(void)
 {
-    I2S_CHECK(((_i2s_adc_unit != -1) && (_i2s_adc_channel != -1)), "i2s ADC recover error, not initialized...", ESP_ERR_INVALID_ARG);
-    return adc_i2s_mode_init(_i2s_adc_unit, _i2s_adc_channel);
+    I2S_CHECK(((_i2s_adc_unit != -1) && (_i2s_adc_pattern_count != -1)), "i2s ADC recover error, not initialized...", ESP_ERR_INVALID_ARG);
+    return adc_i2s_mode_init(_i2s_adc_unit, _i2s_adc_pattern_count, _i2s_adc_patterns);
 }
 
-esp_err_t i2s_set_adc_mode(adc_unit_t adc_unit, adc1_channel_t adc_channel)
+
+esp_err_t i2s_set_adc_mode(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns)
 {
     I2S_CHECK((adc_unit < ADC_UNIT_2), "i2s ADC unit error, only support ADC1 for now", ESP_ERR_INVALID_ARG);
     // For now, we only support SAR ADC1.
     _i2s_adc_unit = adc_unit;
-    _i2s_adc_channel = adc_channel;
-    return adc_i2s_mode_init(adc_unit, adc_channel);
+    _i2s_adc_pattern_count = pattern_count;
+    _i2s_adc_patterns = patterns;
+    return adc_i2s_mode_init(adc_unit, pattern_count, patterns);
 }
 #endif
 

--- a/components/driver/include/driver/i2s.h
+++ b/components/driver/include/driver/i2s.h
@@ -301,12 +301,14 @@ float i2s_get_clk(i2s_port_t i2s_num);
  *        and set ADC parameters.
  * @note  In this mode, the ADC maximum sampling rate is 150KHz. Set the sampling rate through ``i2s_config_t``.
  * @param adc_unit    SAR ADC unit index
- * @param adc_channel ADC channel index
+ * @param pattern_count count of ADC channels to sample
+ * @param patterns pointer to an array of `pattern_count` channel patterns
  * @return
  *     - ESP_OK              Success
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
-esp_err_t i2s_set_adc_mode(adc_unit_t adc_unit, adc1_channel_t adc_channel);
+esp_err_t i2s_set_adc_mode(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns);
+
 
 /**
  * @brief Start to use I2S built-in ADC mode

--- a/examples/peripherals/i2s_adc_dac/main/app_main.c
+++ b/examples/peripherals/i2s_adc_dac/main/app_main.c
@@ -76,8 +76,11 @@ void example_i2s_init(void)
      i2s_driver_install(i2s_num, &i2s_config, 0, NULL);
      //init DAC pad
      i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
-     //init ADC pad
-     i2s_set_adc_mode(I2S_ADC_UNIT, I2S_ADC_CHANNEL);
+     //init ADC pad(s)
+     adc_digi_pattern_table_t patterns[] = {
+         {.atten = ADC_ATTEN_DB_11, .bit_width = ADC_WIDTH_BIT_12, .channel = I2S_ADC_CHANNEL},
+     };
+     i2s_set_adc_mode(I2S_ADC_UNIT, 1, patterns);
 }
 
 /*


### PR DESCRIPTION
Allow configuring ADC DMA via the i2s peripheral for multiple channels,
instead of hard limiting it to a single channel.

See-also: https://github.com/espressif/esp-idf/pull/1991

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

This is very heavily inspired by #1991, simply updated to current 4.2 release.  Should we leave the original single channel API in place and add a _new_ api? or change it like this?