### PR TITLE
Added missing ESP32-S3 target for /rom/gpio.h include (IDFGH-4870)

### DIFF
--- a/components/driver/include/driver/gpio.h
+++ b/components/driver/include/driver/gpio.h
@@ -31,6 +31,8 @@
 #include "esp32/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #include "esp32s2/rom/gpio.h"
+#elif CONFIG_IDF_TARGET_ESP32S3
+#include "esp32s3/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #include "esp32c3/rom/gpio.h"
 #endif


### PR DESCRIPTION
I know this is being depreciated in 5, but we need it working for S3 in 4.x :)