### PR TITLE
partition_table requires esptool_py for esptool_py_flash_target (IDFGH-4876)

### DIFF
--- a/components/partition_table/CMakeLists.txt
+++ b/components/partition_table/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register()
+idf_component_register(PRIV_REQUIRES esptool_py)
 
 if(BOOTLOADER_BUILD)
     return()


### PR DESCRIPTION
possible fix for #6670 

Not sure if this is the right approach.

A sample project is attached and posted to the issue which shows the behavior.  The project will trigger the issue without this fix.  With this fix, the project will build (but will not compile, which is fine).

Including component app_update triggers the issue, but i believe that's due to alphabetical component building.  The root cause appears to be partition_table doesn't explicitly require esptool_py.

[simple.zip](https://github.com/espressif/esp-idf/files/6096346/simple.zip)
