### PR TITLE
component: adc/i2s: new api for multi channel ADC DMA

### DIFF
--- a/components/driver/esp32/include/driver/adc.h
+++ b/components/driver/esp32/include/driver/adc.h
@@ -33,12 +33,24 @@ extern "C" {
 esp_err_t adc_set_i2s_data_source(adc_i2s_source_t src);
 
 /**
- * @brief Initialize I2S ADC mode
+ * @brief Initialize I2S ADC mode for multiple channels
+ * @param adc_unit ADC unit index
+ * @param pattern_count count of ADC channels to sample
+ * @param patterns pointer to an array of `pattern_count` channel patterns
+ * @return
+ *     - ESP_OK success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ */
+esp_err_t adc_i2s_mode_init_multi(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns);
+
+/**
+ * @brief Initialize I2S ADC mode for a single channel
  * @param adc_unit ADC unit index
  * @param channel ADC channel index
  * @return
  *     - ESP_OK success
  *     - ESP_ERR_INVALID_ARG Parameter error
+ * @sa adc_i2s_mode_init_multi
  */
 esp_err_t adc_i2s_mode_init(adc_unit_t adc_unit, adc_channel_t channel);
 

--- a/components/driver/i2s.c
+++ b/components/driver/i2s.c
@@ -100,7 +100,9 @@ static i2s_obj_t *p_i2s_obj[I2S_NUM_MAX] = {0};
 static portMUX_TYPE i2s_spinlock[I2S_NUM_MAX];
 #if SOC_I2S_SUPPORTS_ADC_DAC
 static int _i2s_adc_unit = -1;
-static int _i2s_adc_channel = -1;
+static int _i2s_adc_pattern_count = -1;
+static adc_digi_pattern_table_t *_i2s_adc_patterns = NULL;
+static adc1_channel_t _i2s_adc_single_channel;
 #endif
 
 static i2s_dma_t *i2s_create_dma_queue(i2s_port_t i2s_num, int dma_buf_count, int dma_buf_len);
@@ -720,16 +722,31 @@ esp_err_t i2s_set_dac_mode(i2s_dac_mode_t dac_mode)
 
 static esp_err_t _i2s_adc_mode_recover(void)
 {
-    I2S_CHECK(((_i2s_adc_unit != -1) && (_i2s_adc_channel != -1)), "i2s ADC recover error, not initialized...", ESP_ERR_INVALID_ARG);
-    return adc_i2s_mode_init(_i2s_adc_unit, _i2s_adc_channel);
+    I2S_CHECK((_i2s_adc_unit != -1), "i2s ADC recover error, not initialized...", ESP_ERR_INVALID_ARG);
+    if (_i2s_adc_patterns && _i2s_adc_pattern_count > 0) {
+        return adc_i2s_mode_init_multi(_i2s_adc_unit, _i2s_adc_pattern_count, _i2s_adc_patterns);
+    } else {
+        return adc_i2s_mode_init(_i2s_adc_unit, _i2s_adc_single_channel);
+    }
+}
+
+
+esp_err_t i2s_set_adc_mode_multi(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns)
+{
+    I2S_CHECK((adc_unit < ADC_UNIT_2), "i2s ADC unit error, only support ADC1 for now", ESP_ERR_INVALID_ARG);
+    // For now, we only support SAR ADC1.
+    _i2s_adc_unit = adc_unit;
+    _i2s_adc_pattern_count = pattern_count;
+    _i2s_adc_patterns = patterns;
+    return adc_i2s_mode_init_multi(adc_unit, pattern_count, patterns);
 }
 
 esp_err_t i2s_set_adc_mode(adc_unit_t adc_unit, adc1_channel_t adc_channel)
 {
     I2S_CHECK((adc_unit < ADC_UNIT_2), "i2s ADC unit error, only support ADC1 for now", ESP_ERR_INVALID_ARG);
-    // For now, we only support SAR ADC1.
-    _i2s_adc_unit = adc_unit;
-    _i2s_adc_channel = adc_channel;
+    _i2s_adc_single_channel = adc_channel;
+    _i2s_adc_patterns = NULL;
+    _i2s_adc_pattern_count = 0;
     return adc_i2s_mode_init(adc_unit, adc_channel);
 }
 #endif

--- a/components/driver/include/driver/i2s.h
+++ b/components/driver/include/driver/i2s.h
@@ -301,6 +301,19 @@ float i2s_get_clk(i2s_port_t i2s_num);
  *        and set ADC parameters.
  * @note  In this mode, the ADC maximum sampling rate is 150KHz. Set the sampling rate through ``i2s_config_t``.
  * @param adc_unit    SAR ADC unit index
+ * @param pattern_count count of ADC channels to sample
+ * @param patterns pointer to an array of `pattern_count` channel patterns
+ * @return
+ *     - ESP_OK              Success
+ *     - ESP_ERR_INVALID_ARG Parameter error
+ */
+esp_err_t i2s_set_adc_mode_multi(adc_unit_t adc_unit, size_t pattern_count, adc_digi_pattern_table_t *patterns);
+
+/**
+ * @brief Set built-in ADC mode for I2S DMA, this function will initialize ADC pad,
+ *        and set ADC parameters, for a single channel.
+ * @sa  i2s_set_adc_mode_multi
+ * @param adc_unit    SAR ADC unit index
  * @param adc_channel ADC channel index
  * @return
  *     - ESP_OK              Success

--- a/examples/peripherals/i2s_adc_dac/main/app_main.c
+++ b/examples/peripherals/i2s_adc_dac/main/app_main.c
@@ -76,8 +76,11 @@ void example_i2s_init(void)
      i2s_driver_install(i2s_num, &i2s_config, 0, NULL);
      //init DAC pad
      i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
-     //init ADC pad
-     i2s_set_adc_mode(I2S_ADC_UNIT, I2S_ADC_CHANNEL);
+     //init ADC pad(s)
+     adc_digi_pattern_table_t patterns[] = {
+         {.atten = ADC_ATTEN_DB_11, .bit_width = ADC_WIDTH_BIT_12, .channel = I2S_ADC_CHANNEL},
+     };
+     i2s_set_adc_mode(I2S_ADC_UNIT, 1, patterns);
 }
 
 /*


### PR DESCRIPTION
Add a new API for configuring ADC DMA via the i2s peripheral for
multiple channels, but leave the existing API for a single channel
in place.

Inspired by: https://github.com/espressif/esp-idf/pull/1991

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

This is an alternative to https://github.com/espressif/esp-idf/pull/6665 that provides a new API to avoid any compatibility concerns