### PR TITLE
Modify method to get base directory. (IDFGH-4926)

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 
-set basedir $PWD
+set basedir (realpath (dirname (status -f)))
 
 set -x IDF_PATH $basedir
 


### PR DESCRIPTION
Current method assumes that you are in the esp-idf directory when executing install. This method will get the correct path regardless of where you execute from.