### PR TITLE
reset DCE pointer in DTE if we failed to init modem (IDFGH-4936)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/src/bg96.c
+++ b/examples/protocols/pppos_client/components/modem/src/bg96.c
@@ -178,6 +178,7 @@ modem_dce_t *bg96_init(modem_dte_t *dte)
     return &(esp_modem_dce->parent);
 err_io:
     free(esp_modem_dce);
+    dte->dce = NULL;
 err:
     return NULL;
 }

--- a/examples/protocols/pppos_client/components/modem/src/sim800.c
+++ b/examples/protocols/pppos_client/components/modem/src/sim800.c
@@ -176,6 +176,7 @@ modem_dce_t *sim800_init(modem_dte_t *dte)
     return &(esp_modem_dce->parent);
 err_io:
     free(esp_modem_dce);
+    dte->dce = NULL;
 err:
     return NULL;
 }


### PR DESCRIPTION
so we can e.g. retry later