### PR TITLE
Fix missing path to arch-specific definitions of espcoredump functions (IDFGH-4958)

### DIFF
--- a/components/espcoredump/component.mk
+++ b/components/espcoredump/component.mk
@@ -5,8 +5,10 @@ COMPONENT_ADD_LDFRAGMENTS += linker.lf
 
 ifdef CONFIG_IDF_TARGET_ARCH_XTENSA
 	COMPONENT_PRIV_INCLUDEDIRS += include_core_dump/port/xtensa
+	COMPONENT_SRCDIRS += src/port/xtensa
 endif
 
 ifdef CONFIG_IDF_TARGET_ARCH_RISCV
 	COMPONENT_PRIV_INCLUDEDIRS += include_core_dump/port/riscv
+	COMPONENT_SRCDIRS += src/port/riscv
 endif


### PR DESCRIPTION
Fix for the undefined reference to arch-specific
part of the coredump component when compiling
using make.