### PR TITLE
Fix ignored return value. (IDFGH-4976)

### DIFF
--- a/components/hal/sdio_slave_hal.c
+++ b/components/hal/sdio_slave_hal.c
@@ -91,7 +91,7 @@ static esp_err_t sdio_ringbuf_send(sdio_ringbuf_t *buf, esp_err_t (*copy_callbac
     uint8_t* get_ptr = sdio_ringbuf_offset_ptr(buf, RINGBUF_WRITE_PTR, SDIO_SLAVE_SEND_DESC_SIZE);
     esp_err_t err = ESP_OK;
     if (copy_callback) {
-        (*copy_callback)(get_ptr, arg);
+        err = (*copy_callback)(get_ptr, arg);
     }
     if (err != ESP_OK) return err;
 


### PR DESCRIPTION
sdio_ringbuf_send ignores the return value of the callback.