### PR TITLE
Fix Modbus - add compile time checks for MB_MASTER_TCP_ENABLED (IDFGH-5019)

### DIFF
--- a/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
+++ b/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
@@ -717,4 +717,4 @@ esp_err_t mbc_tcp_master_create(void** handler)
     return ESP_OK;
 }
 
-#endif
+#endif //#if MB_MASTER_TCP_ENABLED

--- a/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
+++ b/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
@@ -33,6 +33,8 @@
 #include "mbc_tcp_master.h"         // for tcp master create function and types
 #include "port_tcp_master.h"        // for tcp master port defines and types
 
+#if MB_MASTER_TCP_ENABLED
+
 /*-----------------------Master mode use these variables----------------------*/
 
 // The response time is average processing time + data transmission
@@ -714,3 +716,5 @@ esp_err_t mbc_tcp_master_create(void** handler)
 
     return ESP_OK;
 }
+
+#endif

--- a/components/freemodbus/tcp_master/port/port_tcp_master.c
+++ b/components/freemodbus/tcp_master/port/port_tcp_master.c
@@ -947,4 +947,4 @@ xMBMasterTCPTimerExpired(void)
     return xNeedPoll;
 }
 
-#endif
+#endif //#if MB_MASTER_TCP_ENABLED

--- a/components/freemodbus/tcp_master/port/port_tcp_master.c
+++ b/components/freemodbus/tcp_master/port/port_tcp_master.c
@@ -52,6 +52,8 @@
 #include "mbframe.h"
 #include "port_tcp_master.h"
 
+#if MB_MASTER_TCP_ENABLED
+
 /* ----------------------- Defines  -----------------------------------------*/
 #define MB_TCP_CONNECTION_TIMEOUT_MS    ( 20 )      // Connection timeout in mS
 #define MB_TCP_RECONNECT_TIMEOUT        ( 5000000 ) // Connection timeout in uS
@@ -944,3 +946,5 @@ xMBMasterTCPTimerExpired(void)
 
     return xNeedPoll;
 }
+
+#endif

--- a/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
@@ -223,4 +223,4 @@ esp_err_t mbc_tcp_slave_create(void** handler)
     return ESP_OK;
 }
 
-#endif
+#endif //#if MB_MASTER_TCP_ENABLED

--- a/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
@@ -28,6 +28,8 @@
 #include "mbc_tcp_slave.h"          // for tcp slave mb controller defines
 #include "port_tcp_slave.h"         // for tcp slave port defines
 
+#if MB_MASTER_TCP_ENABLED
+
 // Shared pointer to interface structure
 static mb_slave_interface_t* mbs_interface_ptr = NULL;
 
@@ -220,3 +222,5 @@ esp_err_t mbc_tcp_slave_create(void** handler)
 
     return ESP_OK;
 }
+
+#endif

--- a/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
@@ -28,7 +28,7 @@
 #include "mbc_tcp_slave.h"          // for tcp slave mb controller defines
 #include "port_tcp_slave.h"         // for tcp slave port defines
 
-#if MB_MASTER_TCP_ENABLED
+#if CONFIG_FMB_COMM_MODE_TCP_EN
 
 // Shared pointer to interface structure
 static mb_slave_interface_t* mbs_interface_ptr = NULL;
@@ -223,4 +223,4 @@ esp_err_t mbc_tcp_slave_create(void** handler)
     return ESP_OK;
 }
 
-#endif //#if MB_MASTER_TCP_ENABLED
+#endif //#if CONFIG_FMB_COMM_MODE_TCP_EN

--- a/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
@@ -28,7 +28,7 @@
 #include "mbc_tcp_slave.h"          // for tcp slave mb controller defines
 #include "port_tcp_slave.h"         // for tcp slave port defines
 
-#if CONFIG_FMB_COMM_MODE_TCP_EN
+#if MB_TCP_ENABLED
 
 // Shared pointer to interface structure
 static mb_slave_interface_t* mbs_interface_ptr = NULL;
@@ -223,4 +223,4 @@ esp_err_t mbc_tcp_slave_create(void** handler)
     return ESP_OK;
 }
 
-#endif //#if CONFIG_FMB_COMM_MODE_TCP_EN
+#endif //#if MB_TCP_ENABLED

--- a/components/freemodbus/tcp_slave/port/port_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/port/port_tcp_slave.c
@@ -731,4 +731,4 @@ xMBTCPPortSendResponse( UCHAR * pucMBTCPFrame, USHORT usTCPLength )
     return bFrameSent;
 }
 
-#endif
+#endif //#if MB_MASTER_TCP_ENABLED

--- a/components/freemodbus/tcp_slave/port/port_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/port/port_tcp_slave.c
@@ -55,6 +55,8 @@
 #include "port_tcp_slave.h"
 #include "esp_modbus_common.h"      // for common types for network options
 
+#if MB_MASTER_TCP_ENABLED
+
 /* ----------------------- Defines  -----------------------------------------*/
 #define MB_TCP_DISCONNECT_TIMEOUT       ( CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000000 ) // disconnect timeout in uS
 #define MB_TCP_RESP_TIMEOUT_MS          ( MB_MASTER_TIMEOUT_MS_RESPOND - 2 ) // slave response time limit
@@ -728,3 +730,5 @@ xMBTCPPortSendResponse( UCHAR * pucMBTCPFrame, USHORT usTCPLength )
     }
     return bFrameSent;
 }
+
+#endif

--- a/components/freemodbus/tcp_slave/port/port_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/port/port_tcp_slave.c
@@ -55,7 +55,7 @@
 #include "port_tcp_slave.h"
 #include "esp_modbus_common.h"      // for common types for network options
 
-#if CONFIG_FMB_COMM_MODE_TCP_EN
+#if MB_TCP_ENABLED
 
 /* ----------------------- Defines  -----------------------------------------*/
 #define MB_TCP_DISCONNECT_TIMEOUT       ( CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000000 ) // disconnect timeout in uS
@@ -731,4 +731,4 @@ xMBTCPPortSendResponse( UCHAR * pucMBTCPFrame, USHORT usTCPLength )
     return bFrameSent;
 }
 
-#endif //#if CONFIG_FMB_COMM_MODE_TCP_EN
+#endif //#if MB_TCP_ENABLED

--- a/components/freemodbus/tcp_slave/port/port_tcp_slave.c
+++ b/components/freemodbus/tcp_slave/port/port_tcp_slave.c
@@ -55,7 +55,7 @@
 #include "port_tcp_slave.h"
 #include "esp_modbus_common.h"      // for common types for network options
 
-#if MB_MASTER_TCP_ENABLED
+#if CONFIG_FMB_COMM_MODE_TCP_EN
 
 /* ----------------------- Defines  -----------------------------------------*/
 #define MB_TCP_DISCONNECT_TIMEOUT       ( CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000000 ) // disconnect timeout in uS
@@ -731,4 +731,4 @@ xMBTCPPortSendResponse( UCHAR * pucMBTCPFrame, USHORT usTCPLength )
     return bFrameSent;
 }
 
-#endif //#if MB_MASTER_TCP_ENABLED
+#endif //#if CONFIG_FMB_COMM_MODE_TCP_EN


### PR DESCRIPTION
Currently the build fails if you compile with CONFIG_FMB_COMM_MODE_TCP_EN disabled.

Disabling tcp saves significant ram.