### PR TITLE
Delete i2c cmd_mux semaphore more cleanly (v4.2 branch)

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -367,7 +367,9 @@ esp_err_t i2c_driver_delete(i2c_port_t i2c_num)
     p_i2c->intr_handle = NULL;
 
     if (p_i2c->cmd_mux) {
+        // Let any command in progress finish.
         xSemaphoreTake(p_i2c->cmd_mux, portMAX_DELAY);
+        xSemaphoreGive(p_i2c->cmd_mux);
         vSemaphoreDelete(p_i2c->cmd_mux);
     }
     if (p_i2c_obj[i2c_num]->cmd_evt_queue) {


### PR DESCRIPTION
Similar to https://github.com/espressif/esp-idf/pull/6846 but on the v4.2 branch.