### PR TITLE
Allow to fully integrate the esptool-ftdi utility in the idf.py build/flash system (IDFGH-5095)

### DIFF
--- a/components/esptool_py/project_include.cmake
+++ b/components/esptool_py/project_include.cmake
@@ -12,7 +12,7 @@ if(target STREQUAL "esp32s3")
     endif()
 endif()
 
-set(ESPTOOLPY ${python} "$ENV{ESPTOOL_FTDI}" "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip ${chip_model})
+set(ESPTOOLPY ${python} "$ENV{ESPTOOL_WRAPPER}" "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip ${chip_model})
 set(ESPSECUREPY ${python} "${CMAKE_CURRENT_LIST_DIR}/esptool/espsecure.py")
 set(ESPEFUSEPY ${python} "${CMAKE_CURRENT_LIST_DIR}/esptool/espefuse.py")
 set(ESPMONITOR ${python} "${idf_path}/tools/idf_monitor.py")

--- a/components/esptool_py/project_include.cmake
+++ b/components/esptool_py/project_include.cmake
@@ -12,7 +12,7 @@ if(target STREQUAL "esp32s3")
     endif()
 endif()
 
-set(ESPTOOLPY ${python} "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip ${chip_model})
+set(ESPTOOLPY ${python} "$ENV{ESPTOOL_FTDI}" "${CMAKE_CURRENT_LIST_DIR}/esptool/esptool.py" --chip ${chip_model})
 set(ESPSECUREPY ${python} "${CMAKE_CURRENT_LIST_DIR}/esptool/espsecure.py")
 set(ESPEFUSEPY ${python} "${CMAKE_CURRENT_LIST_DIR}/esptool/espefuse.py")
 set(ESPMONITOR ${python} "${idf_path}/tools/idf_monitor.py")

--- a/tools/idf_py_actions/serial_ext.py
+++ b/tools/idf_py_actions/serial_ext.py
@@ -37,12 +37,12 @@ def action_extensions(base_actions, project_path):
 
     def _get_esptool_args(args):
         esptool_path = os.path.join(os.environ['IDF_PATH'], 'components/esptool_py/esptool/esptool.py')
-        esptool_ftdi_path = os.environ.get("ESPTOOL_FTDI", "")
+        esptool_wrapper_path = os.environ.get("ESPTOOL_WRAPPER", "")
         if args.port is None:
             args.port = _get_default_serial_port(args)
         result = [PYTHON]
-        if os.path.exists(esptool_ftdi_path):
-            result += [esptool_ftdi_path]
+        if os.path.exists(esptool_wrapper_path):
+            result += [esptool_wrapper_path]
         result += [esptool_path]
         result += ['-p', args.port]
         result += ['-b', str(args.baud)]

--- a/tools/idf_py_actions/serial_ext.py
+++ b/tools/idf_py_actions/serial_ext.py
@@ -37,9 +37,13 @@ def action_extensions(base_actions, project_path):
 
     def _get_esptool_args(args):
         esptool_path = os.path.join(os.environ['IDF_PATH'], 'components/esptool_py/esptool/esptool.py')
+        esptool_ftdi_path = os.environ.get("ESPTOOL_FTDI", "")
         if args.port is None:
             args.port = _get_default_serial_port(args)
-        result = [PYTHON, esptool_path]
+        result = [PYTHON]
+        if os.path.exists(esptool_ftdi_path):
+            result += [esptool_ftdi_path]
+        result += [esptool_path]
         result += ['-p', args.port]
         result += ['-b', str(args.baud)]
 


### PR DESCRIPTION
To use this set the environment variable ESPTOOL_FTDI to the path to the utility.

This utility allows to flash an ESP event simpler/cheaper with a standard FTDI USB-serial cable.
The lack of RTS/DTR is compensated by bitbanging RTS/CTS.

Implements https://github.com/jimparis/esptool-ftdi/issues/3

I am not sure, if you like this hacky approach. But after all, it _is_ very comfortable to use a simple FTDI cable for flashing.