### PR TITLE
Added esp_https_ota_get_image_size() to retrieve total size of OTA update (IDFGH-5096)

### DIFF
--- a/components/esp_https_ota/include/esp_https_ota.h
+++ b/components/esp_https_ota/include/esp_https_ota.h
@@ -199,6 +199,21 @@ esp_err_t esp_https_ota_get_img_desc(esp_https_ota_handle_t https_ota_handle, es
 */
 int esp_https_ota_get_image_len_read(esp_https_ota_handle_t https_ota_handle);
 
+
+/**
+* @brief  This function returns OTA image total size.
+*
+* @note   This API should be called only if `esp_https_ota_perform()` has been called atleast once or
+*         if `esp_https_ota_get_img_desc` has been called before. This can be used to create some sort
+*         of progress indication (in combination with esp_https_ota_get_image_len_read())
+*
+* @param[in]   https_ota_handle   pointer to esp_https_ota_handle_t structure
+*
+* @return
+*    - -1    On failure or chunked encoding
+*    - total bytes of image
+*/
+int esp_https_ota_get_image_size(esp_https_ota_handle_t https_ota_handle);
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -427,6 +427,14 @@ int esp_https_ota_get_image_len_read(esp_https_ota_handle_t https_ota_handle)
     return handle->binary_file_len;
 }
 
+int esp_https_ota_get_image_size(esp_https_ota_handle_t https_ota_handle)
+{
+    esp_https_ota_t *handle = (esp_https_ota_t *)https_ota_handle;
+    return esp_http_client_is_chunked_response(handle->http_client) ?
+                -1 :
+                esp_http_client_get_content_length(handle->http_client);
+}
+
 esp_err_t esp_https_ota(const esp_http_client_config_t *config)
 {
     if (!config) {


### PR DESCRIPTION
I use `esp_https_ota_get_image_len_read()` to retrieve the succeeded progress of the update and now I can use the new method `esp_https_ota_get_image_size()` get the total size and create some sort of progress indication.

When the OTA update uses chunked encoding I think there is no way of telling the total size so I return -1 instead.