### PR TITLE
esp_https_ota: Fix build warning when CONFIG_OTA_ALLOW_HTTP is set (IDFGH-5098)

### DIFF
--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -162,11 +162,13 @@ static esp_err_t _ota_write(esp_https_ota_t *https_ota_handle, const void *buffe
     return err;
 }
 
+#if !CONFIG_OTA_ALLOW_HTTP
 static bool is_server_verification_enabled(esp_https_ota_config_t *ota_config) {
     return  (ota_config->http_config->cert_pem
             || ota_config->http_config->use_global_ca_store
-            || !(ota_config->http_config->crt_bundle_attach == NULL));
+            || ota_config->http_config->crt_bundle_attach != NULL);
 }
+#endif
 
 esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_handle_t *handle)
 {


### PR DESCRIPTION
Fix below build warning when CONFIG_OTA_ALLOW_HTTP is set:
esp_https_ota.c:165:13: warning: 'is_server_verification_enabled' defined but not used [-Wunused-function]

While at it, also simplify the is_server_verification_enabled logic.

Fixes: 48987ad9df35 ("esp_https_ota: Enable option of using global_ca_store and x509_crt_bundle")
Signed-off-by: Axel Lin <axel.lin@gmail.com>