### PR TITLE
Fixed error in "touch_ll_get_sleep_time" function for ESP32 (IDFGH-5111)

### DIFF
--- a/components/hal/esp32/include/hal/touch_sensor_ll.h
+++ b/components/hal/esp32/include/hal/touch_sensor_ll.h
@@ -96,7 +96,7 @@ static inline void touch_ll_set_sleep_time(uint16_t sleep_time)
  */
 static inline void touch_ll_get_sleep_time(uint16_t *sleep_time)
 {
-    *sleep_time = SENS.sar_touch_ctrl1.touch_meas_delay;
+    *sleep_time = SENS.sar_touch_ctrl2.touch_sleep_cycles;
 }
 
 /**


### PR DESCRIPTION
Because of this bug touch_hal_get_sleep_time() returns wrong value (both, sleep_cycle and meas_cycle filled with meas_cycle). As result, touch_pad_get_meas_time returns wrong sleep_cycle too.
Additional, bad side effect, touch_pad_config() makes wrong vTaskDelay() (because delay based on values returned by touch_pad_get_meas_time())