### PR TITLE
fix buffer overrun bug (IDFGH-5150)

### DIFF
--- a/examples/protocols/esp_http_client/main/esp_http_client_example.c
+++ b/examples/protocols/esp_http_client/main/esp_http_client_example.c
@@ -603,7 +603,7 @@ static void http_native_request(void)
                 ESP_LOGI(TAG, "HTTP GET Status = %d, content_length = %d",
                 esp_http_client_get_status_code(client),
                 esp_http_client_get_content_length(client));
-                ESP_LOG_BUFFER_HEX(TAG, output_buffer, strlen(output_buffer));
+                ESP_LOG_BUFFER_HEX(TAG, output_buffer, data_read);
             } else {
                 ESP_LOGE(TAG, "Failed to read response");
             }


### PR DESCRIPTION
`output_buffer` isn't necessarily NUL-terminated