### PR TITLE
tcp_transport: Fix NULL pointer dereference if esp_transport_init ret… (IDFGH-5201)

### DIFF
--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -365,6 +365,10 @@ void esp_transport_ssl_set_interface_name(esp_transport_handle_t t, struct ifreq
 esp_transport_handle_t esp_transport_ssl_init(void)
 {
     esp_transport_handle_t t = esp_transport_init();
+    if (t == NULL) {
+        return NULL;
+    }
+
     esp_transport_set_func(t, ssl_connect, ssl_read, ssl_write, ssl_close, ssl_poll_read, ssl_poll_write, ssl_destroy);
     esp_transport_set_async_connect_func(t, ssl_connect_async);
     t->_get_socket = ssl_get_socket;
@@ -385,6 +389,9 @@ void esp_transport_esp_tls_destroy(struct transport_esp_tls* transport_esp_tls)
 esp_transport_handle_t esp_transport_tcp_init(void)
 {
     esp_transport_handle_t t = esp_transport_init();
+    if (t == NULL) {
+        return NULL;
+    }
     esp_transport_set_func(t, tcp_connect, ssl_read, ssl_write, ssl_close, ssl_poll_read, ssl_poll_write, ssl_destroy);
     esp_transport_set_async_connect_func(t, tcp_connect_async);
     t->_get_socket = ssl_get_socket;

--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -580,6 +580,9 @@ static int ws_get_socket(esp_transport_handle_t t)
 esp_transport_handle_t esp_transport_ws_init(esp_transport_handle_t parent_handle)
 {
     esp_transport_handle_t t = esp_transport_init();
+    if (t == NULL) {
+        return NULL;
+    }
     transport_ws_t *ws = calloc(1, sizeof(transport_ws_t));
     ESP_TRANSPORT_MEM_CHECK(TAG, ws, return NULL);
     ws->parent = parent_handle;


### PR DESCRIPTION
…urns NULL

Add missing NULL test for esp_transport_init() call.
Otherwise, it will hit NULL pointer dereference when assign t->_get_socket.

Signed-off-by: Axel Lin <axel.lin@gmail.com>