### PR TITLE
Implement session ticket support in case mbedtls is used as ssl library (IDFGH-5288)

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -40,9 +40,16 @@ menu "ESP-TLS"
             Enable support for creating server side SSL/TLS session, available for mbedTLS
             as well as wolfSSL TLS library.
 
+    config ESP_TLS_SERVER_SESSION_TICKETS
+        bool "Enable session tickets"
+        depends on ESP_TLS_SERVER && ESP_TLS_USING_MBEDTLS && MBEDTLS_SERVER_SSL_SESSION_TICKETS
+        default n
+        help
+            Enable session ticket support as specified in RFC5077
+
     config ESP_TLS_SERVER_SESSION_TICKET_TIMEOUT
         int "Server session ticket timeout in seconds"
-        depends on ESP_TLS_SERVER && ESP_TLS_USING_MBEDTLS && MBEDTLS_SERVER_SSL_SESSION_TICKETS
+        depends on ESP_TLS_SERVER_SESSION_TICKETS
         default 86400
         help
             Sets the session ticket timeout used in the tls server.

--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -40,6 +40,13 @@ menu "ESP-TLS"
             Enable support for creating server side SSL/TLS session, available for mbedTLS
             as well as wolfSSL TLS library.
 
+    config ESP_TLS_SERVER_SESSION_TICKET_TIMEOUT
+        int "Server session ticket timeout in seconds"
+        depends on ESP_TLS_SERVER && ESP_TLS_USING_MBEDTLS && MBEDTLS_SERVER_SSL_SESSION_TICKETS
+        default 86400
+        help
+            Sets the session ticket timeout used in the tls server.
+
     config ESP_TLS_PSK_VERIFICATION
         bool "Enable PSK verification"
         select MBEDTLS_PSK_MODES if ESP_TLS_USING_MBEDTLS

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -575,17 +575,14 @@ mbedtls_x509_crt *esp_tls_get_global_ca_store(void)
 int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg)
 {
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
-    if (cfg->ticket_ctx) {
+    if (!cfg || cfg->ticket_ctx) {
         return ESP_ERR_INVALID_ARG;
     }
     cfg->ticket_ctx = calloc(1, sizeof(esp_tls_session_ticket_ctx_t));
     if (!cfg->ticket_ctx) {
         return ESP_ERR_NO_MEM;
     }
-    if (_esp_tls_session_ticket_ctx_init(cfg->ticket_ctx) != ESP_OK) {
-        return ESP_FAIL;
-    }
-    return ESP_OK;
+    return _esp_tls_session_ticket_ctx_init(cfg->ticket_ctx);
 #else
     return ESP_ERR_NOT_SUPPORTED;
 #endif
@@ -594,7 +591,9 @@ int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg)
 void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
 {
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
-    _esp_tls_session_ticket_ctx_free(cfg->ticket_ctx);
+    if (cfg && cfg->ticket_ctx) {
+        _esp_tls_session_ticket_ctx_free(cfg->ticket_ctx);
+    }
 #endif
 }
 

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -569,6 +569,54 @@ mbedtls_x509_crt *esp_tls_get_global_ca_store(void)
 
 #endif /* CONFIG_ESP_TLS_USING_MBEDTLS */
 #ifdef CONFIG_ESP_TLS_SERVER
+
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+
+int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * ctx) {
+
+    mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
+    mbedtls_entropy_init(&ctx->entropy);
+    mbedtls_ssl_ticket_init(&ctx->ticket_ctx);
+    int ret;
+    if ((ret = mbedtls_ctr_drbg_seed(&ctx->ctr_drbg,
+                                     mbedtls_entropy_func, &ctx->entropy, NULL, 0)) != 0) {
+        ESP_LOGE(TAG, "mbedtls_ctr_drbg_seed returned -0x%x", -ret);
+        return ESP_ERR_MBEDTLS_CTR_DRBG_SEED_FAILED;
+    }
+
+    if( ( ret = mbedtls_ssl_ticket_setup( &ctx->ticket_ctx,
+                    mbedtls_ctr_drbg_random, &ctx->ctr_drbg,
+                    MBEDTLS_CIPHER_AES_256_GCM,
+                    CONFIG_ESP_TLS_SERVER_SESSION_TICKET_TIMEOUT ) ) != 0 )
+        {
+            ESP_LOGE(TAG, "Failed mbedtls_ssl_ticket_setup with error code %d", ret);
+            return ESP_ERR_MBEDTLS_SSL_SESSION_TICKET_SETUP_FAILED;
+        }
+    return ESP_OK;
+}
+
+void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * ctx) {
+    mbedtls_ssl_ticket_free(&ctx->ticket_ctx);
+    mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
+    mbedtls_entropy_free(&ctx->entropy);
+}
+
+#endif
+
+int esp_tls_cfg_server_init(esp_tls_cfg_server_t * cfg) {
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+    return esp_tls_session_ticket_ctx_init(&cfg->ticket_ctx);
+#else
+    return ESP_OK;
+#endif
+}
+
+void esp_tls_cfg_server_free(esp_tls_cfg_server_t * cfg) {
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+    esp_tls_session_ticket_ctx_free(&cfg->ticket_ctx);
+#endif
+}
+
 /**
  * @brief      Create a server side TLS/SSL connection
  */

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -570,7 +570,7 @@ mbedtls_x509_crt *esp_tls_get_global_ca_store(void)
 #endif /* CONFIG_ESP_TLS_USING_MBEDTLS */
 #ifdef CONFIG_ESP_TLS_SERVER
 
-#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
 
 int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * ctx) {
 
@@ -604,7 +604,7 @@ void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * ctx) {
 #endif
 
 int esp_tls_cfg_server_init(esp_tls_cfg_server_t * cfg) {
-#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
     return esp_tls_session_ticket_ctx_init(&cfg->ticket_ctx);
 #else
     return ESP_OK;
@@ -612,7 +612,7 @@ int esp_tls_cfg_server_init(esp_tls_cfg_server_t * cfg) {
 }
 
 void esp_tls_cfg_server_free(esp_tls_cfg_server_t * cfg) {
-#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
     esp_tls_session_ticket_ctx_free(&cfg->ticket_ctx);
 #endif
 }

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -41,6 +41,8 @@ static const char *TAG = "esp-tls";
 #ifdef CONFIG_ESP_TLS_SERVER
 #define _esp_tls_server_session_create      esp_mbedtls_server_session_create
 #define _esp_tls_server_session_delete      esp_mbedtls_server_session_delete
+#define _esp_tls_session_ticket_ctx_init    esp_mbedtls_session_ticket_ctx_init
+#define _esp_tls_session_ticket_ctx_free    esp_mbedtls_session_ticket_ctx_free
 #endif  /* CONFIG_ESP_TLS_SERVER */
 #define _esp_tls_get_bytes_avail            esp_mbedtls_get_bytes_avail
 #define _esp_tls_init_global_ca_store       esp_mbedtls_init_global_ca_store
@@ -570,7 +572,8 @@ mbedtls_x509_crt *esp_tls_get_global_ca_store(void)
 #endif /* CONFIG_ESP_TLS_USING_MBEDTLS */
 #ifdef CONFIG_ESP_TLS_SERVER
 
-int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t * cfg) {
+int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg)
+{
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
     if (cfg->ticket_ctx) {
         return ESP_ERR_INVALID_ARG;
@@ -579,7 +582,7 @@ int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t * cfg) {
     if (!cfg->ticket_ctx) {
         return ESP_ERR_NO_MEM;
     }
-    if (esp_tls_session_ticket_ctx_init(cfg->ticket_ctx) != ESP_OK) {
+    if (_esp_tls_session_ticket_ctx_init(cfg->ticket_ctx) != ESP_OK) {
         return ESP_FAIL;
     }
     return ESP_OK;
@@ -588,9 +591,10 @@ int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t * cfg) {
 #endif
 }
 
-void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t * cfg) {
+void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
+{
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
-    esp_tls_session_ticket_ctx_free(cfg->ticket_ctx);
+    _esp_tls_session_ticket_ctx_free(cfg->ticket_ctx);
 #endif
 }
 

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -21,7 +21,7 @@
 #include "mbedtls/error.h"
 #include "mbedtls/certs.h"
 #ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
-    #include "mbedtls/ssl_ticket.h"
+#include "mbedtls/ssl_ticket.h"
 #endif
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
 #include "wolfssl/wolfcrypt/settings.h"

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -20,7 +20,7 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/error.h"
 #include "mbedtls/certs.h"
-#ifdef CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS
+#ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
     #include "mbedtls/ssl_ticket.h"
 #endif
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
@@ -174,7 +174,7 @@ typedef struct esp_tls_cfg {
 } esp_tls_cfg_t;
 
 #ifdef CONFIG_ESP_TLS_SERVER
-#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
 typedef struct esp_tls_session_ticket_ctx {
     mbedtls_entropy_context entropy;                                            /*!< mbedTLS entropy context structure */
 
@@ -238,7 +238,7 @@ typedef struct esp_tls_cfg_server {
     unsigned int serverkey_password_len;        /*!< String length of the password pointed to by
                                                      serverkey_password */
 
-#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS)
+#if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
     esp_tls_session_ticket_ctx_t ticket_ctx;                          /*!< Session ticket generation context */
 #endif
 } esp_tls_cfg_server_t;

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -175,6 +175,9 @@ typedef struct esp_tls_cfg {
 
 #ifdef CONFIG_ESP_TLS_SERVER
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
+/**
+ * @brief Data structures necessary to support TLS session tickets according to RFC5077
+ */
 typedef struct esp_tls_session_ticket_ctx {
     mbedtls_entropy_context entropy;                                            /*!< mbedTLS entropy context structure */
 
@@ -183,8 +186,6 @@ typedef struct esp_tls_session_ticket_ctx {
                                                                                      bit generation based on AES-256 */
     mbedtls_ssl_ticket_context ticket_ctx;                                     /*!< Session ticket generation context */
 } esp_tls_session_ticket_ctx_t;
-int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * cfg);
-void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * cfg);
 #endif
 
 typedef struct esp_tls_cfg_server {
@@ -239,12 +240,36 @@ typedef struct esp_tls_cfg_server {
                                                      serverkey_password */
 
 #if defined(CONFIG_ESP_TLS_USING_MBEDTLS) && defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
-    esp_tls_session_ticket_ctx_t ticket_ctx;                          /*!< Session ticket generation context */
+    esp_tls_session_ticket_ctx_t * ticket_ctx; /*!< Session ticket generation context.
+                                                    You have to call esp_tls_cfg_server_session_tickets_init
+                                                    to use it.
+                                                    Call esp_tls_cfg_server_session_tickets_free
+                                                    to free the data associated with this context. */
 #endif
 } esp_tls_cfg_server_t;
 
-int esp_tls_cfg_server_init(esp_tls_cfg_server_t * cfg);
-void esp_tls_cfg_server_free(esp_tls_cfg_server_t * cfg);
+/**
+ * @brief Initialize the server side TLS session ticket context
+ *
+ * This function initializes the server side tls session ticket context
+ * which holds all necessary data structures to enable tls session tickets
+ * according to RFC5077.
+ * Use esp_tls_cfg_server_session_tickets_free to free the data.
+ *
+ * @param[in]  cfg server configuration as esp_tls_cfg_server_t
+ * @return
+ *             ESP_OK if setup succeeded
+ *             ESP_ERR_INVALID_ARG if context is already initialized
+ *             ESP_ERR_NO_MEM if memory allocation failed
+ *             ESP_ERR_NOT_SUPPORTED if session tickets are not available due to build configuration
+ *             ESP_FAIL if setup failed
+ */
+int esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t * cfg);
+
+/**
+ * @brief Free the server side TLS session ticket context
+ */
+void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t * cfg);
 #endif /* ! CONFIG_ESP_TLS_SERVER */
 
 /**

--- a/components/esp-tls/esp_tls_errors.h
+++ b/components/esp-tls/esp_tls_errors.h
@@ -31,18 +31,19 @@ extern "C" {
 #define ESP_ERR_MBEDTLS_PK_PARSE_KEY_FAILED               (ESP_ERR_ESP_TLS_BASE + 0x0F)  /*!< mbedtls api returned failed  */
 #define ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED              (ESP_ERR_ESP_TLS_BASE + 0x10)  /*!< mbedtls api returned failed  */
 #define ESP_ERR_MBEDTLS_SSL_CONF_PSK_FAILED               (ESP_ERR_ESP_TLS_BASE + 0x11)  /*!< mbedtls api returned failed  */
-#define ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT                (ESP_ERR_ESP_TLS_BASE + 0x12)  /*!< new connection in esp_tls_low_level_conn connection timeouted */
-#define ESP_ERR_WOLFSSL_SSL_SET_HOSTNAME_FAILED           (ESP_ERR_ESP_TLS_BASE + 0x13)  /*!< wolfSSL api returned error */
-#define ESP_ERR_WOLFSSL_SSL_CONF_ALPN_PROTOCOLS_FAILED    (ESP_ERR_ESP_TLS_BASE + 0x14)  /*!< wolfSSL api returned error */
-#define ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED          (ESP_ERR_ESP_TLS_BASE + 0x15)  /*!< wolfSSL api returned error */
-#define ESP_ERR_WOLFSSL_KEY_VERIFY_SETUP_FAILED           (ESP_ERR_ESP_TLS_BASE + 0x16)  /*!< wolfSSL api returned error */
-#define ESP_ERR_WOLFSSL_SSL_HANDSHAKE_FAILED              (ESP_ERR_ESP_TLS_BASE + 0x17)  /*!< wolfSSL api returned failed  */
-#define ESP_ERR_WOLFSSL_CTX_SETUP_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x18)  /*!< wolfSSL api returned failed */
-#define ESP_ERR_WOLFSSL_SSL_SETUP_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x19)  /*!< wolfSSL api returned failed */
-#define ESP_ERR_WOLFSSL_SSL_WRITE_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x1A)  /*!< wolfSSL api returned failed */
+#define ESP_ERR_MBEDTLS_SSL_SESSION_TICKET_SETUP_FAILED   (ESP_ERR_ESP_TLS_BASE + 0x12)  /*!< mbedtls api returned failed  */
+#define ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT                (ESP_ERR_ESP_TLS_BASE + 0x13)  /*!< new connection in esp_tls_low_level_conn connection timeouted */
+#define ESP_ERR_WOLFSSL_SSL_SET_HOSTNAME_FAILED           (ESP_ERR_ESP_TLS_BASE + 0x14)  /*!< wolfSSL api returned error */
+#define ESP_ERR_WOLFSSL_SSL_CONF_ALPN_PROTOCOLS_FAILED    (ESP_ERR_ESP_TLS_BASE + 0x15)  /*!< wolfSSL api returned error */
+#define ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED          (ESP_ERR_ESP_TLS_BASE + 0x16)  /*!< wolfSSL api returned error */
+#define ESP_ERR_WOLFSSL_KEY_VERIFY_SETUP_FAILED           (ESP_ERR_ESP_TLS_BASE + 0x17)  /*!< wolfSSL api returned error */
+#define ESP_ERR_WOLFSSL_SSL_HANDSHAKE_FAILED              (ESP_ERR_ESP_TLS_BASE + 0x18)  /*!< wolfSSL api returned failed  */
+#define ESP_ERR_WOLFSSL_CTX_SETUP_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x19)  /*!< wolfSSL api returned failed */
+#define ESP_ERR_WOLFSSL_SSL_SETUP_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x1A)  /*!< wolfSSL api returned failed */
+#define ESP_ERR_WOLFSSL_SSL_WRITE_FAILED                  (ESP_ERR_ESP_TLS_BASE + 0x1B)  /*!< wolfSSL api returned failed */
 
-#define ESP_ERR_ESP_TLS_SE_FAILED                         (ESP_ERR_ESP_TLS_BASE + 0x1B)  /*< esp-tls use Secure Element returned failed */
-#define ESP_ERR_ESP_TLS_TCP_CLOSED_FIN                    (ESP_ERR_ESP_TLS_BASE + 0x1C)  /*< esp-tls's TPC transport connection has benn closed (in a clean way) */
+#define ESP_ERR_ESP_TLS_SE_FAILED                         (ESP_ERR_ESP_TLS_BASE + 0x1C)  /*< esp-tls use Secure Element returned failed */
+#define ESP_ERR_ESP_TLS_TCP_CLOSED_FIN                    (ESP_ERR_ESP_TLS_BASE + 0x1D)  /*< esp-tls's TPC transport connection has benn closed (in a clean way) */
 
 /**
 * Definition of errors reported from IO API (potentially non-blocking) in case of error:

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -376,7 +376,6 @@ int esp_mbedtls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *
 #ifndef NDEBUG
     if (ret != 0) {
         ESP_LOGE(TAG, "Writing session ticket resulted in error code -0x%04X", -ret);
-        mbedtls_print_error_msg(ret);
     }
 #endif
     return ret;
@@ -388,7 +387,6 @@ int esp_mbedtls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *sessio
 #ifndef NDEBUG
     if (ret != 0) {
         ESP_LOGD(TAG, "Parsing session ticket resulted in error code -0x%04X", -ret);
-        mbedtls_print_error_msg(ret);
     }
 #endif
     return ret;
@@ -403,7 +401,6 @@ int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
     if ((ret = mbedtls_ctr_drbg_seed(&ctx->ctr_drbg,
                                      mbedtls_entropy_func, &ctx->entropy, NULL, 0)) != 0) {
         ESP_LOGE(TAG, "mbedtls_ctr_drbg_seed returned -0x%04X", -ret);
-        mbedtls_print_error_msg(ret);
         return ESP_ERR_MBEDTLS_CTR_DRBG_SEED_FAILED;
     }
 
@@ -413,7 +410,6 @@ int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
                     CONFIG_ESP_TLS_SERVER_SESSION_TICKET_TIMEOUT ) ) != 0 )
         {
             ESP_LOGE(TAG, "mbedtls_ssl_ticket_setup returned -0x%04X", -ret);
-            mbedtls_print_error_msg(ret);
             return ESP_ERR_MBEDTLS_SSL_SESSION_TICKET_SETUP_FAILED;
         }
     return ESP_OK;

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -369,7 +369,7 @@ static esp_err_t set_global_ca_store(esp_tls_t *tls)
 }
 
 #ifdef CONFIG_ESP_TLS_SERVER
-#ifdef CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS
+#ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
 int esp_tls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *session, unsigned char *start, const unsigned char *end, size_t *tlen, uint32_t *lifetime) {
     int ret = mbedtls_ssl_ticket_write(p_ticket, session, start, end, tlen, lifetime);
 #ifndef NDEBUG
@@ -442,7 +442,7 @@ esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
         return ESP_ERR_INVALID_STATE;
     }
 
-#ifdef CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS
+#ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
     ESP_LOGD(TAG, "Enabling server-side tls session ticket support");
 
     mbedtls_ssl_conf_session_tickets_cb( &tls->conf,

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -370,7 +370,8 @@ static esp_err_t set_global_ca_store(esp_tls_t *tls)
 
 #ifdef CONFIG_ESP_TLS_SERVER
 #ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
-int esp_tls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *session, unsigned char *start, const unsigned char *end, size_t *tlen, uint32_t *lifetime) {
+int esp_mbedtls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *session, unsigned char *start, const unsigned char *end, size_t *tlen, uint32_t *lifetime)
+{
     int ret = mbedtls_ssl_ticket_write(p_ticket, session, start, end, tlen, lifetime);
 #ifndef NDEBUG
     if (ret != 0) {
@@ -379,7 +380,9 @@ int esp_tls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *sess
 #endif
     return ret;
 }
-int esp_tls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *session, unsigned char *buf, size_t len) {
+
+int esp_mbedtls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *session, unsigned char *buf, size_t len)
+{
     int ret = mbedtls_ssl_ticket_parse(p_ticket, session, buf, len);
 #ifndef NDEBUG
     if (ret != 0) {
@@ -389,8 +392,8 @@ int esp_tls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *session, u
     return ret;
 }
 
-int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * ctx) {
-
+int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
+{
     mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
     mbedtls_entropy_init(&ctx->entropy);
     mbedtls_ssl_ticket_init(&ctx->ticket_ctx);
@@ -412,7 +415,8 @@ int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * ctx) {
     return ESP_OK;
 }
 
-void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * ctx) {
+void esp_mbedtls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t *ctx)
+{
     mbedtls_ssl_ticket_free(&ctx->ticket_ctx);
     mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
     mbedtls_entropy_free(&ctx->entropy);
@@ -476,8 +480,8 @@ esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
         ESP_LOGD(TAG, "Enabling server-side tls session ticket support");
 
         mbedtls_ssl_conf_session_tickets_cb( &tls->conf,
-                esp_tls_session_ticket_write,
-                esp_tls_session_ticket_parse,
+                esp_mbedtls_session_ticket_write,
+                esp_mbedtls_session_ticket_parse,
                 &cfg->ticket_ctx->ticket_ctx );
     }
 #endif

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -394,6 +394,9 @@ int esp_mbedtls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *sessio
 
 int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
 {
+    if (!ctx) {
+        return ESP_ERR_INVALID_ARG;
+    }
     mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
     mbedtls_entropy_init(&ctx->entropy);
     mbedtls_ssl_ticket_init(&ctx->ticket_ctx);
@@ -417,9 +420,11 @@ int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
 
 void esp_mbedtls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t *ctx)
 {
-    mbedtls_ssl_ticket_free(&ctx->ticket_ctx);
-    mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
-    mbedtls_entropy_free(&ctx->entropy);
+    if (ctx) {
+        mbedtls_ssl_ticket_free(&ctx->ticket_ctx);
+        mbedtls_ctr_drbg_init(&ctx->ctr_drbg);
+        mbedtls_entropy_free(&ctx->entropy);
+    }
 }
 #endif
 

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -374,7 +374,7 @@ int esp_tls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *sess
     int ret = mbedtls_ssl_ticket_write(p_ticket, session, start, end, tlen, lifetime);
 #ifndef NDEBUG
     if (ret != 0) {
-        ESP_LOGD(TAG, "Writing session ticket resulted in error code %d", ret);
+        ESP_LOGE(TAG, "Writing session ticket resulted in error code %d", ret);
     }
 #endif
     return ret;

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -375,7 +375,8 @@ int esp_mbedtls_session_ticket_write(void *p_ticket, const mbedtls_ssl_session *
     int ret = mbedtls_ssl_ticket_write(p_ticket, session, start, end, tlen, lifetime);
 #ifndef NDEBUG
     if (ret != 0) {
-        ESP_LOGE(TAG, "Writing session ticket resulted in error code %d", ret);
+        ESP_LOGE(TAG, "Writing session ticket resulted in error code -0x%04X", -ret);
+        mbedtls_print_error_msg(ret);
     }
 #endif
     return ret;
@@ -386,7 +387,8 @@ int esp_mbedtls_session_ticket_parse(void *p_ticket, mbedtls_ssl_session *sessio
     int ret = mbedtls_ssl_ticket_parse(p_ticket, session, buf, len);
 #ifndef NDEBUG
     if (ret != 0) {
-        ESP_LOGD(TAG, "Parsing session ticket resulted in error code %d", ret);
+        ESP_LOGD(TAG, "Parsing session ticket resulted in error code -0x%04X", -ret);
+        mbedtls_print_error_msg(ret);
     }
 #endif
     return ret;
@@ -400,7 +402,8 @@ int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
     int ret;
     if ((ret = mbedtls_ctr_drbg_seed(&ctx->ctr_drbg,
                                      mbedtls_entropy_func, &ctx->entropy, NULL, 0)) != 0) {
-        ESP_LOGE(TAG, "mbedtls_ctr_drbg_seed returned -0x%x", -ret);
+        ESP_LOGE(TAG, "mbedtls_ctr_drbg_seed returned -0x%04X", -ret);
+        mbedtls_print_error_msg(ret);
         return ESP_ERR_MBEDTLS_CTR_DRBG_SEED_FAILED;
     }
 
@@ -409,7 +412,8 @@ int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t *ctx)
                     MBEDTLS_CIPHER_AES_256_GCM,
                     CONFIG_ESP_TLS_SERVER_SESSION_TICKET_TIMEOUT ) ) != 0 )
         {
-            ESP_LOGE(TAG, "Failed mbedtls_ssl_ticket_setup with error code %d", ret);
+            ESP_LOGE(TAG, "mbedtls_ssl_ticket_setup returned -0x%04X", -ret);
+            mbedtls_print_error_msg(ret);
             return ESP_ERR_MBEDTLS_SSL_SESSION_TICKET_SETUP_FAILED;
         }
     return ESP_OK;

--- a/components/esp-tls/private_include/esp_tls_mbedtls.h
+++ b/components/esp-tls/private_include/esp_tls_mbedtls.h
@@ -83,14 +83,14 @@ void esp_mbedtls_server_session_delete(esp_tls_t *tls);
  *
  * /note :- The function can only be used with mbedtls ssl library
  */
-int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * cfg);
+int esp_mbedtls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * cfg);
 
 /**
  * Internal function to free server side session ticket context
  *
  * /note :- The function can only be used with mbedtls ssl library
  */
-void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * cfg);
+void esp_mbedtls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * cfg);
 #endif
 #endif
 

--- a/components/esp-tls/private_include/esp_tls_mbedtls.h
+++ b/components/esp-tls/private_include/esp_tls_mbedtls.h
@@ -76,6 +76,22 @@ int esp_mbedtls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
  * /note :- The function can only be used with mbedtls ssl library
  */
 void esp_mbedtls_server_session_delete(esp_tls_t *tls);
+
+#ifdef CONFIG_ESP_TLS_SERVER_SESSION_TICKETS
+/**
+ * Internal function to setup server side session ticket context
+ *
+ * /note :- The function can only be used with mbedtls ssl library
+ */
+int esp_tls_session_ticket_ctx_init(esp_tls_session_ticket_ctx_t * cfg);
+
+/**
+ * Internal function to free server side session ticket context
+ *
+ * /note :- The function can only be used with mbedtls ssl library
+ */
+void esp_tls_session_ticket_ctx_free(esp_tls_session_ticket_ctx_t * cfg);
+#endif
 #endif
 
 /**

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -63,6 +63,9 @@ struct httpd_ssl_config {
 
     /** Port used when transport mode is insecure (default 80) */
     uint16_t port_insecure;
+
+    /** Enable tls session tickets */
+    bool session_tickets;
 };
 
 typedef struct httpd_ssl_config httpd_ssl_config_t;
@@ -109,6 +112,7 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     .transport_mode = HTTPD_SSL_TRANSPORT_SECURE, \
     .port_secure = 443,                           \
     .port_insecure = 80,                          \
+    .session_tickets = false,                     \
 }
 
 /**

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -145,6 +145,7 @@ static void free_secure_context(void *ctx)
     if (cfg->serverkey_buf) {
         free((void *)cfg->serverkey_buf);
     }
+    esp_tls_cfg_server_free(cfg);
     free(cfg);
     free(ssl_ctx);
 }
@@ -160,6 +161,13 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
         free(ssl_ctx);
         return NULL;
     }
+
+    if (esp_tls_cfg_server_init(cfg) != ESP_OK) {
+        free(ssl_ctx);
+        free(cfg);
+        return NULL;
+    }
+
     ssl_ctx->tls_cfg = cfg;
 /* cacert = CA which signs client cert, or client cert itself , which is mapped to client_verify_cert_pem */
     if(config->client_verify_cert_pem != NULL) {

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -145,7 +145,7 @@ static void free_secure_context(void *ctx)
     if (cfg->serverkey_buf) {
         free((void *)cfg->serverkey_buf);
     }
-    esp_tls_cfg_server_free(cfg);
+    esp_tls_cfg_server_session_tickets_free(cfg);
     free(cfg);
     free(ssl_ctx);
 }
@@ -162,10 +162,13 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
         return NULL;
     }
 
-    if (esp_tls_cfg_server_init(cfg) != ESP_OK) {
-        free(ssl_ctx);
-        free(cfg);
-        return NULL;
+    if (config->session_tickets) {
+        if ( esp_tls_cfg_server_session_tickets_init(cfg) != ESP_OK ) {
+            ESP_LOGE(TAG, "Failed to init session ticket support");
+            free(ssl_ctx);
+            free(cfg);
+            return NULL;
+        }
     }
 
     ssl_ctx->tls_cfg = cfg;


### PR DESCRIPTION
This PR implements session ticket support in case mbedtls is selected as the ssl library and sever side session ticket support is enabled.

We're still using 4.2 and consider upgrading to 4.3. Is there any chance this change could get into 4.3?