### PR TITLE
Fix typo in `include/hal/uart_ll.h` (IDFGH-5320)

### DIFF
--- a/components/hal/esp32/include/hal/uart_ll.h
+++ b/components/hal/esp32/include/hal/uart_ll.h
@@ -923,7 +923,7 @@ FORCE_INLINE_ATTR void uart_ll_force_xon(uart_port_t uart_num)
 }
 
 /**
- * @brief  Get UART final state machine status.
+ * @brief  Get UART finite-state machine status.
  *
  * @param  uart_num UART port number, the max port number is (UART_NUM_MAX -1).
  *

--- a/components/hal/esp32c3/include/hal/uart_ll.h
+++ b/components/hal/esp32c3/include/hal/uart_ll.h
@@ -921,7 +921,7 @@ static inline void uart_ll_force_xon(uart_port_t uart_num)
 }
 
 /**
- * @brief  Get UART final state machine status.
+ * @brief  Get UART finite-state machine status.
  *
  * @param  uart_num UART port number, the max port number is (UART_NUM_MAX -1).
  *

--- a/components/hal/esp32s2/include/hal/uart_ll.h
+++ b/components/hal/esp32s2/include/hal/uart_ll.h
@@ -855,7 +855,7 @@ FORCE_INLINE_ATTR void uart_ll_force_xon(uart_port_t uart_num)
 }
 
 /**
- * @brief  Get UART final state machine status.
+ * @brief  Get UART finite-state machine status.
  *
  * @param  uart_num UART port number, the max port number is (UART_NUM_MAX -1).
  *

--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -886,7 +886,7 @@ FORCE_INLINE_ATTR void uart_ll_force_xon(uart_port_t uart_num)
 }
 
 /**
- * @brief  Get UART final state machine status.
+ * @brief  Get UART finite-state machine status.
  *
  * @param  uart_num UART port number, the max port number is (UART_NUM_MAX -1).
  *


### PR DESCRIPTION
s/final state machine/finite-state machine/g