### PR TITLE
Fix creation of Python2 virtualenv (IDFGH-5332)

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1386,7 +1386,7 @@ def action_install_python_env(args):  # type: ignore
             subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'virtualenv'],
                                   stdout=sys.stdout, stderr=sys.stderr)
 
-        subprocess.check_call([sys.executable, '-m', 'virtualenv', idf_python_env_path],
+        subprocess.check_call([sys.executable, '-m', 'virtualenv', '-p', 'python3', idf_python_env_path],
                               stdout=sys.stdout, stderr=sys.stderr)
     run_args = [virtualenv_python, '-m', 'pip', 'install', '--no-warn-script-location']
     requirements_txt = os.path.join(global_idf_path, 'requirements.txt')


### PR DESCRIPTION
`sys.executable` could be `python3` but the user has the default `virtualenv` interpreter set to `python2` which would result in creating python2 environment and failing with the message `ERROR: Package 'setuptools' requires a different Python: 2.7.12 not in '>=3.5'`.
Thus it's recommended to explicitly specify usage of `python3` as an argument to `virtualenv`.