### PR TITLE
Add pin level selectable for factory reset (IDFGH-5337)

### DIFF
--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -131,6 +131,14 @@ menu "Bootloader config"
             To trigger a factory reset, this GPIO must be pulled low on reset.
             Note that GPIO34-39 do not have an internal pullup and an external one must be provided.
 
+    config BOOTLOADER_PIN_LEVEL_FACTORY_RESET
+        int "Level of the GPIO input for factory reset"
+        depends on BOOTLOADER_FACTORY_RESET
+        range 0 1
+        default 0
+        help
+            Pin level for factory reset. 0 for LOW and 1 for HIGH.
+
     config BOOTLOADER_OTA_DATA_ERASE
         bool "Clear OTA data on factory reset (select factory partition)"
         depends on BOOTLOADER_FACTORY_RESET

--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -79,7 +79,7 @@ static int selected_boot_partition(const bootloader_state_t *bs)
     if (bootloader_common_get_reset_reason(0) != DEEPSLEEP_RESET) {
         // Factory firmware.
 #ifdef CONFIG_BOOTLOADER_FACTORY_RESET
-        if (bootloader_common_check_long_hold_gpio(CONFIG_BOOTLOADER_NUM_PIN_FACTORY_RESET, CONFIG_BOOTLOADER_HOLD_TIME_GPIO) == 1) {
+        if (bootloader_common_check_long_hold_gpio(CONFIG_BOOTLOADER_NUM_PIN_FACTORY_RESET, CONFIG_BOOTLOADER_HOLD_TIME_GPIO, CONFIG_BOOTLOADER_PIN_LEVEL_FACTORY_RESET) == 1) {
             ESP_LOGI(TAG, "Detect a condition of the factory reset");
             bool ota_data_erase = false;
 #ifdef CONFIG_BOOTLOADER_OTA_DATA_ERASE

--- a/components/bootloader_support/include/bootloader_common.h
+++ b/components/bootloader_support/include/bootloader_common.h
@@ -76,9 +76,10 @@ bool bootloader_common_ota_select_invalid(const esp_ota_select_entry_t *s);
  *
  * @param[in] num_pin Number of the GPIO input.
  * @param[in] delay_sec Input must be driven low for at least this long, continuously.
+ * @param[in] level Input pin level to trigger lang hold, 0 - LOW, 1 - HIGH
  * @return esp_comm_gpio_hold_t Defines type of hold a GPIO in low state.
  */
-esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec);
+esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec, int level);
 
 /**
  * @brief Erase the partition data that is specified in the transferred list.

--- a/components/bootloader_support/src/bootloader_common.c
+++ b/components/bootloader_support/src/bootloader_common.c
@@ -45,7 +45,7 @@
 
 static const char* TAG = "boot_comm";
 
-esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec)
+esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec, int level)
 {
     esp_rom_gpio_pad_select_gpio(num_pin);
     if (GPIO_PIN_MUX_REG[num_pin]) {
@@ -53,11 +53,11 @@ esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, ui
     }
     esp_rom_gpio_pad_pullup_only(num_pin);
     uint32_t tm_start = esp_log_early_timestamp();
-    if (gpio_ll_get_level(&GPIO, num_pin) == 1) {
+    if (gpio_ll_get_level(&GPIO, num_pin) != level) {
         return GPIO_NOT_HOLD;
     }
     do {
-        if (gpio_ll_get_level(&GPIO, num_pin) != 0) {
+        if (gpio_ll_get_level(&GPIO, num_pin) != level) {
             return GPIO_SHORT_HOLD;
         }
     } while (delay_sec > ((esp_log_early_timestamp() - tm_start) / 1000L));


### PR DESCRIPTION
Allow to select pin level for factory reset with pin. Now it is possible to select in menuconfig if pin is pulled LOW or HIGH to trigger factory reset (default LOW).
#7043