### PR TITLE
Fix compile modbus without TCP (IDFGH-5376)

### DIFF
--- a/components/freemodbus/CMakeLists.txt
+++ b/components/freemodbus/CMakeLists.txt
@@ -36,14 +36,19 @@ set(srcs
     "modbus/functions/mbutils.c"
     "serial_slave/modbus_controller/mbc_serial_slave.c"
     "serial_master/modbus_controller/mbc_serial_master.c"
-    "tcp_slave/port/port_tcp_slave.c"
-    "tcp_slave/modbus_controller/mbc_tcp_slave.c"
-    "tcp_master/modbus_controller/mbc_tcp_master.c"
-    "tcp_master/port/port_tcp_master.c"
     "common/esp_modbus_master_tcp.c"
     "common/esp_modbus_slave_tcp.c"
     "common/esp_modbus_master_serial.c"
     "common/esp_modbus_slave_serial.c")
+
+if(CONFIG_FMB_COMM_MODE_TCP_EN)
+    list(APPEND srcs    "tcp_slave/port/port_tcp_slave.c"
+                        "tcp_slave/modbus_controller/mbc_tcp_slave.c"
+                        "tcp_master/modbus_controller/mbc_tcp_master.c"
+                        "tcp_master/port/port_tcp_master.c"
+    )
+endif(CONFIG_FMB_COMM_MODE_TCP_EN)
+
 
 set(include_dirs common/include)
 


### PR DESCRIPTION
If `CONFIG_FMB_COMM_MODE_TCP_EN` is false but `CONFIG_FMB_COMM_MODE_RTU_EN` is true get the following errors when compiling


```
[811/990] Building C object esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/modbus_controller/mbc_tcp_master.c.obj
FAILED: esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/modbus_controller/mbc_tcp_master.c.obj 
~/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc  -Iconfig -I../../../../components/freemodbus/common/include -I../../../../components/freemodbus/common -I../../../../components/freemodbus/port -I../../../../components/freemodbus/modbus -I../../../../components/freemodbus/modbus/ascii -I../../../../components/freemodbus/modbus/functions -I../../../../components/freemodbus/modbus/rtu -I../../../../components/freemodbus/modbus/tcp -I../../../../components/freemodbus/modbus/include -I../../../../components/freemodbus/serial_slave/port -I../../../../components/freemodbus/serial_slave/modbus_controller -I../../../../components/freemodbus/serial_master/port -I../../../../components/freemodbus/serial_master/modbus_controller -I../../../../components/freemodbus/tcp_slave/port -I../../../../components/freemodbus/tcp_slave/modbus_controller -I../../../../components/freemodbus/tcp_master/port -I../../../../components/freemodbus/tcp_master/modbus_controller -I../../../../components/newlib/platform_include -I../../../../components/freertos/include -I../../../../components/freertos/port/xtensa/include -I../../../../components/esp_hw_support/include -I../../../../components/esp_hw_support/port/esp32/. -I../../../../components/heap/include -I../../../../components/log/include -I../../../../components/lwip/include/apps -I../../../../components/lwip/include/apps/sntp -I../../../../components/lwip/lwip/src/include -I../../../../components/lwip/port/esp32/include -I../../../../components/lwip/port/esp32/include/arch -I../../../../components/soc/include -I../../../../components/soc/esp32/. -I../../../../components/soc/esp32/include -I../../../../components/hal/esp32/include -I../../../../components/hal/include -I../../../../components/esp_rom/include -I../../../../components/esp_rom/esp32 -I../../../../components/esp_common/include -I../../../../components/esp_system/include -I../../../../components/esp32/include -I../../../../components/driver/include -I../../../../components/driver/esp32/include -I../../../../components/esp_ringbuf/include -I../../../../components/efuse/include -I../../../../components/efuse/esp32/include -I../../../../components/xtensa/include -I../../../../components/xtensa/esp32/include -I../../../../components/espcoredump/include -I../../../../components/esp_timer/include -I../../../../components/esp_ipc/include -I../../../../components/esp_pm/include -I../../../../components/vfs/include -I../../../../components/esp_wifi/include -I../../../../components/esp_wifi/esp32/include -I../../../../components/esp_event/include -I../../../../components/esp_netif/include -I../../../../components/esp_eth/include -I../../../../components/tcpip_adapter/include -I../../../../components/app_trace/include -mlongcalls -Wno-frame-address   -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Og -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v4.3-rc-dirty\" -DESP_PLATFORM -MD -MT esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/modbus_controller/mbc_tcp_master.c.obj -MF esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/modbus_controller/mbc_tcp_master.c.obj.d -o esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/modbus_controller/mbc_tcp_master.c.obj   -c esp-idf/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
In file included from ../../../../components/freemodbus/modbus/include/mb_m.h:35,
                 from esp-idf/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c:26:
esp-idf/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c: In function 'mbc_tcp_master_create':
../../../../components/freemodbus/port/port.h:49:42: error: 'CONFIG_FMB_TCP_PORT_DEFAULT' undeclared (first use in this function); did you mean 'CONFIG_LWIP_TCP_WND_DEFAULT'?
 #define MB_TCP_DEFAULT_PORT             (CONFIG_FMB_TCP_PORT_DEFAULT)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c:675:34: note: in expansion of macro 'MB_TCP_DEFAULT_PORT'
     mbm_opts->mbm_comm.ip_port = MB_TCP_DEFAULT_PORT;
                                  ^~~~~~~~~~~~~~~~~~~
../../../../components/freemodbus/port/port.h:49:42: note: each undeclared identifier is reported only once for each function it appears in
 #define MB_TCP_DEFAULT_PORT             (CONFIG_FMB_TCP_PORT_DEFAULT)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c:675:34: note: in expansion of macro 'MB_TCP_DEFAULT_PORT'
     mbm_opts->mbm_comm.ip_port = MB_TCP_DEFAULT_PORT;
                                  ^~~~~~~~~~~~~~~~~~~
[817/990] Building C object esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/modbus_controller/mbc_tcp_slave.c.obj
FAILED: esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/modbus_controller/mbc_tcp_slave.c.obj 
~/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc  -Iconfig -I../../../../components/freemodbus/common/include -I../../../../components/freemodbus/common -I../../../../components/freemodbus/port -I../../../../components/freemodbus/modbus -I../../../../components/freemodbus/modbus/ascii -I../../../../components/freemodbus/modbus/functions -I../../../../components/freemodbus/modbus/rtu -I../../../../components/freemodbus/modbus/tcp -I../../../../components/freemodbus/modbus/include -I../../../../components/freemodbus/serial_slave/port -I../../../../components/freemodbus/serial_slave/modbus_controller -I../../../../components/freemodbus/serial_master/port -I../../../../components/freemodbus/serial_master/modbus_controller -I../../../../components/freemodbus/tcp_slave/port -I../../../../components/freemodbus/tcp_slave/modbus_controller -I../../../../components/freemodbus/tcp_master/port -I../../../../components/freemodbus/tcp_master/modbus_controller -I../../../../components/newlib/platform_include -I../../../../components/freertos/include -I../../../../components/freertos/port/xtensa/include -I../../../../components/esp_hw_support/include -I../../../../components/esp_hw_support/port/esp32/. -I../../../../components/heap/include -I../../../../components/log/include -I../../../../components/lwip/include/apps -I../../../../components/lwip/include/apps/sntp -I../../../../components/lwip/lwip/src/include -I../../../../components/lwip/port/esp32/include -I../../../../components/lwip/port/esp32/include/arch -I../../../../components/soc/include -I../../../../components/soc/esp32/. -I../../../../components/soc/esp32/include -I../../../../components/hal/esp32/include -I../../../../components/hal/include -I../../../../components/esp_rom/include -I../../../../components/esp_rom/esp32 -I../../../../components/esp_common/include -I../../../../components/esp_system/include -I../../../../components/esp32/include -I../../../../components/driver/include -I../../../../components/driver/esp32/include -I../../../../components/esp_ringbuf/include -I../../../../components/efuse/include -I../../../../components/efuse/esp32/include -I../../../../components/xtensa/include -I../../../../components/xtensa/esp32/include -I../../../../components/espcoredump/include -I../../../../components/esp_timer/include -I../../../../components/esp_ipc/include -I../../../../components/esp_pm/include -I../../../../components/vfs/include -I../../../../components/esp_wifi/include -I../../../../components/esp_wifi/esp32/include -I../../../../components/esp_event/include -I../../../../components/esp_netif/include -I../../../../components/esp_eth/include -I../../../../components/tcpip_adapter/include -I../../../../components/app_trace/include -mlongcalls -Wno-frame-address   -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Og -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v4.3-rc-dirty\" -DESP_PLATFORM -MD -MT esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/modbus_controller/mbc_tcp_slave.c.obj -MF esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/modbus_controller/mbc_tcp_slave.c.obj.d -o esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/modbus_controller/mbc_tcp_slave.c.obj   -c esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c
esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c: In function 'mbc_tcp_slave_destroy':
esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c:118:11: error: implicit declaration of function 'vMBTCPPortClose'; did you mean 'vMBPortClose'? [-Werror=implicit-function-declaration]
     (void)vMBTCPPortClose();
           ^~~~~~~~~~~~~~~
           vMBPortClose
In file included from ../../../../components/freemodbus/modbus/include/mb.h:34,
                 from esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c:21:
esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c: In function 'mbc_tcp_slave_create':
../../../../components/freemodbus/port/port.h:49:42: error: 'CONFIG_FMB_TCP_PORT_DEFAULT' undeclared (first use in this function); did you mean 'CONFIG_LWIP_TCP_WND_DEFAULT'?
 #define MB_TCP_DEFAULT_PORT             (CONFIG_FMB_TCP_PORT_DEFAULT)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c:172:34: note: in expansion of macro 'MB_TCP_DEFAULT_PORT'
     mbs_opts->mbs_comm.ip_port = MB_TCP_DEFAULT_PORT;
                                  ^~~~~~~~~~~~~~~~~~~
../../../../components/freemodbus/port/port.h:49:42: note: each undeclared identifier is reported only once for each function it appears in
 #define MB_TCP_DEFAULT_PORT             (CONFIG_FMB_TCP_PORT_DEFAULT)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/modbus_controller/mbc_tcp_slave.c:172:34: note: in expansion of macro 'MB_TCP_DEFAULT_PORT'
     mbs_opts->mbs_comm.ip_port = MB_TCP_DEFAULT_PORT;
                                  ^~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
[819/990] Building C object esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/port/port_tcp_slave.c.obj
FAILED: esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/port/port_tcp_slave.c.obj 
~/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc  -Iconfig -I../../../../components/freemodbus/common/include -I../../../../components/freemodbus/common -I../../../../components/freemodbus/port -I../../../../components/freemodbus/modbus -I../../../../components/freemodbus/modbus/ascii -I../../../../components/freemodbus/modbus/functions -I../../../../components/freemodbus/modbus/rtu -I../../../../components/freemodbus/modbus/tcp -I../../../../components/freemodbus/modbus/include -I../../../../components/freemodbus/serial_slave/port -I../../../../components/freemodbus/serial_slave/modbus_controller -I../../../../components/freemodbus/serial_master/port -I../../../../components/freemodbus/serial_master/modbus_controller -I../../../../components/freemodbus/tcp_slave/port -I../../../../components/freemodbus/tcp_slave/modbus_controller -I../../../../components/freemodbus/tcp_master/port -I../../../../components/freemodbus/tcp_master/modbus_controller -I../../../../components/newlib/platform_include -I../../../../components/freertos/include -I../../../../components/freertos/port/xtensa/include -I../../../../components/esp_hw_support/include -I../../../../components/esp_hw_support/port/esp32/. -I../../../../components/heap/include -I../../../../components/log/include -I../../../../components/lwip/include/apps -I../../../../components/lwip/include/apps/sntp -I../../../../components/lwip/lwip/src/include -I../../../../components/lwip/port/esp32/include -I../../../../components/lwip/port/esp32/include/arch -I../../../../components/soc/include -I../../../../components/soc/esp32/. -I../../../../components/soc/esp32/include -I../../../../components/hal/esp32/include -I../../../../components/hal/include -I../../../../components/esp_rom/include -I../../../../components/esp_rom/esp32 -I../../../../components/esp_common/include -I../../../../components/esp_system/include -I../../../../components/esp32/include -I../../../../components/driver/include -I../../../../components/driver/esp32/include -I../../../../components/esp_ringbuf/include -I../../../../components/efuse/include -I../../../../components/efuse/esp32/include -I../../../../components/xtensa/include -I../../../../components/xtensa/esp32/include -I../../../../components/espcoredump/include -I../../../../components/esp_timer/include -I../../../../components/esp_ipc/include -I../../../../components/esp_pm/include -I../../../../components/vfs/include -I../../../../components/esp_wifi/include -I../../../../components/esp_wifi/esp32/include -I../../../../components/esp_event/include -I../../../../components/esp_netif/include -I../../../../components/esp_eth/include -I../../../../components/tcpip_adapter/include -I../../../../components/app_trace/include -mlongcalls -Wno-frame-address   -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Og -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v4.3-rc-dirty\" -DESP_PLATFORM -MD -MT esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/port/port_tcp_slave.c.obj -MF esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/port/port_tcp_slave.c.obj.d -o esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_slave/port/port_tcp_slave.c.obj   -c esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c
In file included from ../../../../components/freemodbus/modbus/include/mb.h:34,
                 from esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:51:
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c: In function 'xMBTCPPortInit':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:127:37: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     xConfig.pxMbClientInfo = calloc(MB_TCP_PORT_MAX_CONN + 1, sizeof(MbClientInfo_t*));
                                     ^~~~~~~~~~~~~~~~~~~~
../../../../components/freemodbus/port/port.h:57:42: note: each undeclared identifier is reported only once for each function it appears in
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:127:37: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     xConfig.pxMbClientInfo = calloc(MB_TCP_PORT_MAX_CONN + 1, sizeof(MbClientInfo_t*));
                                     ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c: In function 'vMBTCPPortServerTask':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:454:29: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
             for (i = 0; i < MB_TCP_PORT_MAX_CONN; i++) {
                             ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:59:43: error: 'CONFIG_FMB_TCP_CONNECTION_TOUT_SEC' undeclared (first use in this function); did you mean 'CONFIG_FMB_COMM_MODE_RTU_EN'?
 #define MB_TCP_DISCONNECT_TIMEOUT       ( CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000000 ) // disconnect timeout in uS
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:59:43: note: in definition of macro 'MB_TCP_DISCONNECT_TIMEOUT'
 #define MB_TCP_DISCONNECT_TIMEOUT       ( CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000000 ) // disconnect timeout in uS
                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../../../../components/freemodbus/modbus/include/mb.h:34,
                 from esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:51:
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c: In function 'vMBTCPPortDisable':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_slave/port/port_tcp_slave.c:639:25: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     for (int i = 0; i < MB_TCP_PORT_MAX_CONN; i++) {
                         ^~~~~~~~~~~~~~~~~~~~
[822/990] Building C object esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/port/port_tcp_master.c.obj
FAILED: esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/port/port_tcp_master.c.obj 
~/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc  -Iconfig -I../../../../components/freemodbus/common/include -I../../../../components/freemodbus/common -I../../../../components/freemodbus/port -I../../../../components/freemodbus/modbus -I../../../../components/freemodbus/modbus/ascii -I../../../../components/freemodbus/modbus/functions -I../../../../components/freemodbus/modbus/rtu -I../../../../components/freemodbus/modbus/tcp -I../../../../components/freemodbus/modbus/include -I../../../../components/freemodbus/serial_slave/port -I../../../../components/freemodbus/serial_slave/modbus_controller -I../../../../components/freemodbus/serial_master/port -I../../../../components/freemodbus/serial_master/modbus_controller -I../../../../components/freemodbus/tcp_slave/port -I../../../../components/freemodbus/tcp_slave/modbus_controller -I../../../../components/freemodbus/tcp_master/port -I../../../../components/freemodbus/tcp_master/modbus_controller -I../../../../components/newlib/platform_include -I../../../../components/freertos/include -I../../../../components/freertos/port/xtensa/include -I../../../../components/esp_hw_support/include -I../../../../components/esp_hw_support/port/esp32/. -I../../../../components/heap/include -I../../../../components/log/include -I../../../../components/lwip/include/apps -I../../../../components/lwip/include/apps/sntp -I../../../../components/lwip/lwip/src/include -I../../../../components/lwip/port/esp32/include -I../../../../components/lwip/port/esp32/include/arch -I../../../../components/soc/include -I../../../../components/soc/esp32/. -I../../../../components/soc/esp32/include -I../../../../components/hal/esp32/include -I../../../../components/hal/include -I../../../../components/esp_rom/include -I../../../../components/esp_rom/esp32 -I../../../../components/esp_common/include -I../../../../components/esp_system/include -I../../../../components/esp32/include -I../../../../components/driver/include -I../../../../components/driver/esp32/include -I../../../../components/esp_ringbuf/include -I../../../../components/efuse/include -I../../../../components/efuse/esp32/include -I../../../../components/xtensa/include -I../../../../components/xtensa/esp32/include -I../../../../components/espcoredump/include -I../../../../components/esp_timer/include -I../../../../components/esp_ipc/include -I../../../../components/esp_pm/include -I../../../../components/vfs/include -I../../../../components/esp_wifi/include -I../../../../components/esp_wifi/esp32/include -I../../../../components/esp_event/include -I../../../../components/esp_netif/include -I../../../../components/esp_eth/include -I../../../../components/tcpip_adapter/include -I../../../../components/app_trace/include -mlongcalls -Wno-frame-address   -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Og -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v4.3-rc-dirty\" -DESP_PLATFORM -MD -MT esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/port/port_tcp_master.c.obj -MF esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/port/port_tcp_master.c.obj.d -o esp-idf/freemodbus/CMakeFiles/__idf_freemodbus.dir/tcp_master/port/port_tcp_master.c.obj   -c esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c
In file included from ../../../../components/freemodbus/modbus/include/mb_m.h:35,
                 from esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:49:
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'xMBMasterTCPPortInit':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:104:42: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     xMbPortConfig.pxMbSlaveInfo = calloc(MB_TCP_PORT_MAX_CONN, sizeof(MbSlaveInfo_t*));
                                          ^~~~~~~~~~~~~~~~~~~~
../../../../components/freemodbus/port/port.h:57:42: note: each undeclared identifier is reported only once for each function it appears in
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:104:42: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     xMbPortConfig.pxMbSlaveInfo = calloc(MB_TCP_PORT_MAX_CONN, sizeof(MbSlaveInfo_t*));
                                          ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'xMBTCPPortMasterGetSlaveReady':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:565:36: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     for (int xIndex = 0; (xIndex < MB_TCP_PORT_MAX_CONN); xIndex++) {
                                    ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'xMBTCPPortMasterCheckConnState':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:601:34: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     } while (pxInfo && (xCount < MB_TCP_PORT_MAX_CONN));
                                  ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'vMBTCPPortMasterTask':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:633:52: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
             if (xMbPortConfig.usMbSlaveInfoCount > MB_TCP_PORT_MAX_CONN) {
                                                    ^~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'vMBMasterTCPPortClose':
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:833:11: error: implicit declaration of function 'vMBMasterTCPPortDisable'; did you mean 'vMBMasterTCPPortClose'? [-Werror=implicit-function-declaration]
     (void)vMBMasterTCPPortDisable();
           ^~~~~~~~~~~~~~~~~~~~~~~
           vMBMasterTCPPortClose
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: At top level:
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:842:1: warning: conflicting types for 'vMBMasterTCPPortDisable'
 vMBMasterTCPPortDisable(void)
 ^~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:833:11: note: previous implicit declaration of 'vMBMasterTCPPortDisable' was here
     (void)vMBMasterTCPPortDisable();
           ^~~~~~~~~~~~~~~~~~~~~~~
In file included from ../../../../components/freemodbus/modbus/include/mb_m.h:35,
                 from esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:49:
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c: In function 'vMBMasterTCPPortDisable':
../../../../components/freemodbus/port/port.h:57:42: error: 'CONFIG_FMB_TCP_PORT_MAX_CONN' undeclared (first use in this function); did you mean 'MB_TCP_PORT_MAX_CONN'?
 #define MB_TCP_PORT_MAX_CONN            (CONFIG_FMB_TCP_PORT_MAX_CONN)
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
esp-idf/components/freemodbus/tcp_master/port/port_tcp_master.c:844:36: note: in expansion of macro 'MB_TCP_PORT_MAX_CONN'
     for (USHORT ucCnt = 0; ucCnt < MB_TCP_PORT_MAX_CONN; ucCnt++) {
                                    ^~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
[828/990] Building CXX object esp-idf/asio/CMakeFiles/__idf_asio.dir/asio/asio/src/asio.cpp.obj
ninja: build stopped: subcommand failed.
ninja failed with exit code 1
```