### PR TITLE
Change default PoP argument of esp_prov.get_security from None to string (IDFGH-5381)

### DIFF
--- a/tools/esp_prov/esp_prov.py
+++ b/tools/esp_prov/esp_prov.py
@@ -51,7 +51,7 @@ def on_except(err):
         print(err)
 
 
-def get_security(secver, pop=None, verbose=False):
+def get_security(secver, pop='', verbose=False):
     if secver == 1:
         return security.Security1(pop, verbose)
     elif secver == 0:


### PR DESCRIPTION
Closes [IDFGH-5380](https://github.com/espressif/esp-idf/issues/7129)