### PR TITLE
Add missing REG_SPI_BASE(x) macro

### DIFF
--- a/components/soc/esp32c3/include/soc/spi_reg.h
+++ b/components/soc/esp32c3/include/soc/spi_reg.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 #include "soc.h"
+#define REG_SPI_BASE(i)     (DR_REG_SPI1_BASE + (((i)>1) ? (((i)* 0x1000) + 0x20000) : (((~(i)) & 1)* 0x1000 )))
 
 #define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
 /* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */


### PR DESCRIPTION
The `REG_SPI_BASE(x)` macro is missing for Esp32c3. Considering the address scheme, we can safely use the same formula as Esp32.

I can be further simplified since i can have only values 0/1/2, but for the sake of simplicity, re-using ESP32 formula also works.