### PR TITLE
Update i2c.c: Support to configure the I2C alive_interval 

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -194,6 +194,12 @@ static i2c_obj_t *p_i2c_obj[I2C_NUM_MAX] = {0};
 static void i2c_isr_handler_default(void *arg);
 static void IRAM_ATTR i2c_master_cmd_begin_static(i2c_port_t i2c_num);
 static esp_err_t IRAM_ATTR i2c_hw_fsm_reset(i2c_port_t i2c_num);
+static int i2c_cmd_alive_interval[I2C_NUM_MAX] = { I2C_CMD_ALIVE_INTERVAL_TICK, I2C_CMD_ALIVE_INTERVAL_TICK };
+
+static void i2c_set_alive_interval(i2c_port_t i2c_num, int interval)
+{
+	i2c_cmd_alive_interval[i2c_num] = interval;
+}
 
 static void i2c_hw_disable(i2c_port_t i2c_num)
 {
@@ -1211,11 +1217,11 @@ esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, 
     while (1) {
         TickType_t wait_time = xTaskGetTickCount();
         if (wait_time - ticks_start > ticks_to_wait) { // out of time
-            wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
+            wait_time =  i2c_cmd_alive_interval[i2c_num];
         } else {
             wait_time = ticks_to_wait - (wait_time - ticks_start);
-            if (wait_time < I2C_CMD_ALIVE_INTERVAL_TICK) {
-                wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
+            if (wait_time <  i2c_cmd_alive_interval[i2c_num] ){
+                wait_time =  i2c_cmd_alive_interval[i2c_num];
             }
         }
         // In master mode, since we don't have an interrupt to detective bus error or FSM state, what we do here is to make


### PR DESCRIPTION
Add needed support to configure the I2C alive_interval to overcome a blocking issue with the 1000 ticks default, that equals to 1 second.

The issue is that I2C bus remains blocked by semaphore if one of several devices encounters a an error on reading, what leads to the situation that other devices cannot be reached during that period. A flexible timer will overcome that, and sporadic issues observed with some hardware chips and noisy buses, are mostly gone in the next reread several milliseconds later, so a timer much more less that 1000 ms behaves much more lean and efficient.

The change is 100% backward compatible, 
the default remains as is, but may optionally be overruled by set_i2c_alive_timeout( i2c_num, time );