### PR TITLE
Adding documentation --Displaying the board's port on Linux is more intuitive (IDFGH-5461)

### DIFF
--- a/docs/en/get-started/establish-serial-connection.rst
+++ b/docs/en/get-started/establish-serial-connection.rst
@@ -62,7 +62,7 @@ Display the port of your board / dongle ::
 And then finally remove the two files ::
 
     rm ~/before_plugging.txt ~/after_plugging.txt
-    
+
 macOS ::
 
     ls /dev/cu.*

--- a/docs/en/get-started/establish-serial-connection.rst
+++ b/docs/en/get-started/establish-serial-connection.rst
@@ -45,12 +45,24 @@ Figures below show serial port for ESP32 DevKitC and ESP32 WROVER KIT
 Check port on Linux and macOS
 -----------------------------
 
-To check the device name for the serial port of your {IDF_TARGET_NAME} board (or external converter dongle), run this command two times, first with the board / dongle unplugged, then with plugged in. The port which appears the second time is the one you need:
+To check the device name for the serial port of your {IDF_TARGET_NAME} board (or external converter dongle), run this command with the board / dongle unplugged:
 
 Linux ::
 
-    ls /dev/tty*
+    ls /dev/tty* >> ~/before_plugging.txt
 
+Plug the board / dongle, then type the following command ::
+
+    ls /dev/tty* >> ~/after_plugging.txt
+
+Display the port of your board / dongle ::
+
+    diff ~/before_plugging.txt ~/after_plugging.txt
+
+And then finally remove the two files ::
+
+    rm ~/before_plugging.txt ~/after_plugging.txt
+    
 macOS ::
 
     ls /dev/cu.*

--- a/docs/en/get-started/establish-serial-connection.rst
+++ b/docs/en/get-started/establish-serial-connection.rst
@@ -49,11 +49,11 @@ To check the device name for the serial port of your {IDF_TARGET_NAME} board (or
 
 Linux ::
 
-    ls /dev/tty* >> ~/before_plugging.txt
+    ls /dev/tty* > ~/before_plugging.txt
 
 Plug the board / dongle, then type the following command ::
 
-    ls /dev/tty* >> ~/after_plugging.txt
+    ls /dev/tty* > ~/after_plugging.txt
 
 Display the port of your board / dongle ::
 


### PR DESCRIPTION
I added explanation to the available command, added more steps to it so it should be clear right now. All the commands used are POSIX and therefore work on most Linux flavours.