### PR TITLE
Avoid bootloop if chip is unknown

### DIFF
--- a/components/esp32/spiram_psram.c
+++ b/components/esp32/spiram_psram.c
@@ -810,7 +810,7 @@ esp_err_t IRAM_ATTR psram_enable(psram_cache_mode_t mode, psram_vaddr_mode_t vad
         psram_io.psram_cs_io  = D2WD_PSRAM_CS_IO;
     } else if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4 && esp_efuse_get_chip_ver() >= 3) {
         ESP_EARLY_LOGE(TAG, "This chip is ESP32-PICO-V3. It does not support PSRAM (disable it in Kconfig)");
-        abort();
+        return ESP_FAIL;
     } else if ((pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2) || (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4)) {
         ESP_EARLY_LOGI(TAG, "This chip is ESP32-PICO");
         rtc_vddsdio_config_t cfg = rtc_vddsdio_get_config();
@@ -837,7 +837,7 @@ esp_err_t IRAM_ATTR psram_enable(psram_cache_mode_t mode, psram_vaddr_mode_t vad
         psram_io.psram_cs_io  = D0WD_PSRAM_CS_IO;
     } else {
         ESP_EARLY_LOGE(TAG, "Not a valid or known package id: %d", pkg_ver);
-        abort();
+        return ESP_FAIL;
     }
 
     const uint32_t spiconfig = esp_rom_efuse_get_flash_gpio_info();


### PR DESCRIPTION
In case the PSIRAM chip is unknown, return an error and disable PSRAM
instead of calling abort() and causing a bootloop.

In Tasmota, we provide pre-compiled firmwares and we try to make the generic work on as many chips as possible. We have now enabled PSRAM by default, but when the chip is unknown, it bootloops because of the call to abort().

I don't see any downside in returning an error instead and letting the chip boot without PSRAM, and give control to the software as to how it should handle it.