### PR TITLE
esp_supplicant: Make esp_rrm_send_neighbor_rep_request return proper … (IDFGH-5503)

### DIFF
--- a/components/wpa_supplicant/src/esp_supplicant/esp_common.c
+++ b/components/wpa_supplicant/src/esp_supplicant/esp_common.c
@@ -265,9 +265,7 @@ int esp_rrm_send_neighbor_rep_request(neighbor_rep_request_cb cb,
 	struct wifi_ssid *ssid = esp_wifi_sta_get_prof_ssid_internal();
 	os_memcpy(wpa_ssid.ssid, ssid->ssid, ssid->len);
 	wpa_ssid.ssid_len = ssid->len;
-	wpas_rrm_send_neighbor_rep_request(wpa_s, &wpa_ssid, 0, 0, cb, cb_ctx);
-
-	return 0;
+	return wpas_rrm_send_neighbor_rep_request(wpa_s, &wpa_ssid, 0, 0, cb, cb_ctx);
 }
 
 int esp_wnm_send_bss_transition_mgmt_query(enum btm_query_reason query_reason,


### PR DESCRIPTION
…error

Current code always return 0 even though wpas_rrm_send_neighbor_rep_request()
fails. Return proper error so the caller can know what's wrong.

Signed-off-by: Axel Lin <axel.lin@gmail.com>