### PR TITLE
wpa_supplicant: Fix memory leak in esp_issue_scan error paths (IDFGH-5510)

### DIFF
--- a/components/wpa_supplicant/src/esp_supplicant/esp_scan.c
+++ b/components/wpa_supplicant/src/esp_supplicant/esp_scan.c
@@ -195,7 +195,8 @@ static int esp_issue_scan(struct wpa_supplicant *wpa_s,
 			params->ssid = os_zalloc(scan_params->ssids[0].ssid_len + 1);
 			if (!params->ssid) {
 				wpa_printf(MSG_ERROR, "failed to allocate memory");
-				return -1;
+				ret = -1;
+				goto cleanup;
 			}
 			os_memcpy(params->ssid, scan_params->ssids[0].ssid, scan_params->ssids[0].ssid_len);
 			params->scan_type = WIFI_SCAN_TYPE_ACTIVE;
@@ -206,7 +207,8 @@ static int esp_issue_scan(struct wpa_supplicant *wpa_s,
 			params->bssid = os_zalloc(ETH_ALEN);
 			if (!params->bssid) {
 				wpa_printf(MSG_ERROR, "failed to allocate memory");
-				return -1;
+				ret = -1;
+				goto cleanup;
 			}
 			os_memcpy(params->bssid, scan_params->bssid, ETH_ALEN);
 		}


### PR DESCRIPTION
Fix memory leak when allocate memory for params->ssid / params->bssid fails.

Fixes: 27101f94546b ("wpa_supplicant: Add initial roaming support")
Signed-off-by: Axel Lin <axel.lin@gmail.com>