### PR TITLE
wpa_supplicant: Fix wps_free_pins to remove all pins (IDFGH-5519)

### DIFF
--- a/components/wpa_supplicant/src/wps/wps_registrar.c
+++ b/components/wpa_supplicant/src/wps/wps_registrar.c
@@ -101,8 +101,8 @@ static void wps_remove_pin(struct wps_uuid_pin *pin)
 static void wps_free_pins(struct dl_list *pins)
 {
 	struct wps_uuid_pin *pin, *prev;
-	dl_list_for_each_safe(pin, prev, pins, struct wps_uuid_pin, list);
-	wps_remove_pin(pin);
+	dl_list_for_each_safe(pin, prev, pins, struct wps_uuid_pin, list)
+		wps_remove_pin(pin);
 }
 
 #endif


### PR DESCRIPTION
Current code does not correctly free all pins in wps_free_pins due to the
semicolon at the end of dl_list_for_each_safe(). Fix it.

Signed-off-by: Axel Lin <axel.lin@gmail.com>