### PR TITLE
wpa_supplicant: Fix clear WLAN_FC_STYPE_ACTION bit in esp_register_ac… (IDFGH-5524)

### DIFF
--- a/components/wpa_supplicant/src/esp_supplicant/esp_common.c
+++ b/components/wpa_supplicant/src/esp_supplicant/esp_common.c
@@ -177,7 +177,7 @@ static void esp_clear_bssid_flag(struct wpa_supplicant *wpa_s)
 
 static void esp_register_action_frame(struct wpa_supplicant *wpa_s)
 {
-	wpa_s->type &= ~WLAN_FC_STYPE_ACTION;
+	wpa_s->type &= ~(1 << WLAN_FC_STYPE_ACTION);
 	/* subtype is defined only for action frame */
 	wpa_s->subtype = 0;
 


### PR DESCRIPTION
…tion_frame

It should clear WLAN_FC_STYPE_ACTION bit intead of WLAN_FC_STYPE_ACTION.

Signed-off-by: Axel Lin <axel.lin@gmail.com>