### PR TITLE
Linenoise - RAM optimization (IDFGH-5525)

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -118,7 +118,7 @@
 #include "linenoise.h"
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
-#define LINENOISE_MAX_LINE 4096
+#define LINENOISE_MAX_LINE 512
 
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;


### PR DESCRIPTION
Linenoise use default 4kB RAM memory. Maybe small default LINENOISE_MAX_LINE doesn't have to be that big.