### PR TITLE
Linenoise - RAM optimization (IDFGH-5527)

### DIFF
--- a/components/console/linenoise/linenoise.h
+++ b/components/console/linenoise/linenoise.h
@@ -72,6 +72,7 @@ void linenoiseSetDumbMode(int set);
 bool linenoiseIsDumbMode(void);
 void linenoisePrintKeyCodes(void);
 void linenoiseAllowEmpty(bool);
+int linenoiseSetMaxLineLen(int len);
 
 #ifdef __cplusplus
 }

--- a/docs/en/api-reference/system/console.rst
+++ b/docs/en/api-reference/system/console.rst
@@ -39,6 +39,9 @@ Linenoise library does not need explicit initialization. However, some configura
 :cpp:func:`linenoiseAllowEmpty`
   Set whether linenoise library will return a zero-length string (if ``true``) or ``NULL`` (if ``false``) for empty lines. By default, zero-length strings are returned.
 
+:cpp:func:`linenoiseSetMaxLineLen`
+  Set maximum length of the line for linenoise library. Default length is 4096. If you need optimize RAM memory usage, you can do it by this function by setting a value less than default 4kB.
+
 
 Main loop
 ^^^^^^^^^


### PR DESCRIPTION
Linenoise use default 4kB RAM memory. Maybe small default LINENOISE_MAX_LINE doesn't have to be that big.

It's copy of the PR: Linenoise - RAM optimization (IDFGH-5525) #7253, but with correct base/compare branches and better changes (this change not will not affect existing projects).