### PR TITLE
esp_modem_dce_service: Make esp_modem_dce_handle_* functions static (IDFGH-5542)

### DIFF
--- a/examples/protocols/pppos_client/components/modem/include/esp_modem_dce_service.h
+++ b/examples/protocols/pppos_client/components/modem/include/esp_modem_dce_service.h
@@ -62,28 +62,6 @@ static inline void strip_cr_lf_tail(char *str, uint32_t len)
 esp_err_t esp_modem_dce_handle_response_default(modem_dce_t *dce, const char *line);
 
 /**
- * @brief Handle response from AT+CSQ (Get signal quality)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_csq(modem_dce_t *dce, const char *line);
-
-/**
- * @brief Handle response from AT+CBC (Get battery status)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_cbc(modem_dce_t *dce, const char *line);
-
-/**
  * @brief Handle response from +++ (Set Working Mode)
  *
  * @param dce Modem DCE object
@@ -104,50 +82,6 @@ esp_err_t esp_modem_dce_handle_exit_data_mode(modem_dce_t *dce, const char *line
  *      - ESP_FAIL on error
  */
 esp_err_t esp_modem_dce_handle_atd_ppp(modem_dce_t *dce, const char *line);
-
-/**
- * @brief Handle response from AT+CGMM (Get DCE module name)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_cgmm(modem_dce_t *dce, const char *line);
-
-/**
- * @brief Handle response from AT+CGSN (Get DCE module IMEI number)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_cgsn(modem_dce_t *dce, const char *line);
-
-/**
- * @brief Handle response from AT+CIMI (Get DCE module IMSI number)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_cimi(modem_dce_t *dce, const char *line);
-
-/**
- * @brief Handle response from AT+COPS? (Get Operator's name)
- *
- * @param dce Modem DCE object
- * @param line line string
- * @return esp_err_t
- *      - ESP_OK on success
- *      - ESP_FAIL on error
- */
-esp_err_t esp_modem_dce_handle_cops(modem_dce_t *dce, const char *line);
 
 /**
  * @brief Syncronization

--- a/examples/protocols/pppos_client/components/modem/src/esp_modem_dce_service.c
+++ b/examples/protocols/pppos_client/components/modem/src/esp_modem_dce_service.c
@@ -42,7 +42,11 @@ esp_err_t esp_modem_dce_handle_response_default(modem_dce_t *dce, const char *li
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_csq(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+CSQ (Get signal quality)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_csq(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     esp_modem_dce_t *esp_dce = __containerof(dce, esp_modem_dce_t, parent);
@@ -60,7 +64,11 @@ esp_err_t esp_modem_dce_handle_csq(modem_dce_t *dce, const char *line)
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_cbc(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+CBC (Get battery status)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_cbc(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     esp_modem_dce_t *esp_dce = __containerof(dce, esp_modem_dce_t, parent);
@@ -102,7 +110,11 @@ esp_err_t esp_modem_dce_handle_atd_ppp(modem_dce_t *dce, const char *line)
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_cgmm(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+CGMM (Get DCE module name)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_cgmm(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     if (strstr(line, MODEM_RESULT_CODE_SUCCESS)) {
@@ -120,7 +132,11 @@ esp_err_t esp_modem_dce_handle_cgmm(modem_dce_t *dce, const char *line)
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_cgsn(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+CGSN (Get DCE module IMEI number)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_cgsn(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     if (strstr(line, MODEM_RESULT_CODE_SUCCESS)) {
@@ -138,7 +154,11 @@ esp_err_t esp_modem_dce_handle_cgsn(modem_dce_t *dce, const char *line)
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_cimi(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+CIMI (Get DCE module IMSI number)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_cimi(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     if (strstr(line, MODEM_RESULT_CODE_SUCCESS)) {
@@ -156,7 +176,11 @@ esp_err_t esp_modem_dce_handle_cimi(modem_dce_t *dce, const char *line)
     return err;
 }
 
-esp_err_t esp_modem_dce_handle_cops(modem_dce_t *dce, const char *line)
+/**
+ * @brief Handle response from AT+COPS? (Get Operator's name)
+ *
+ */
+static esp_err_t esp_modem_dce_handle_cops(modem_dce_t *dce, const char *line)
 {
     esp_err_t err = ESP_FAIL;
     if (strstr(line, MODEM_RESULT_CODE_SUCCESS)) {


### PR DESCRIPTION
These functions are unlikely to be reused, make them static.
Take esp_modem_dce_handle_cbc as an example, it's internal implementation
of esp_modem_dce_get_battery_status, expose esp_modem_dce_get_battery_status
function is enough.

Signed-off-by: Axel Lin <axel.lin@gmail.com>