### PR TITLE
Add support for LAN874xA Ethernet PHYs (IDFGH-5544)

### DIFF
--- a/components/esp_eth/src/esp_eth_phy_lan8720.c
+++ b/components/esp_eth/src/esp_eth_phy_lan8720.c
@@ -63,6 +63,38 @@ typedef union {
 #define ETH_PHY_SMR_REG_ADDR (0x12)
 
 /**
+ * @brief Time Domain Reflectometry Patterns/Delay Control Register
+ * Only available in LAN8740A/LAN8742A
+ */
+typedef union {
+    struct {
+        uint32_t tdr_pattern_low : 6;        /* Data pattern sent in TDR mode for the low cycle */
+        uint32_t tdr_pattern_high : 6;       /* Data pattern sent in TDR mode for the high cycle */
+        uint32_t tdr_line_break_counter : 3; /* Increments of 256ms of break time */
+        uint32_t tdr_delay_in : 1;           /* Line break counter used */
+    };
+    uint32_t val;
+} tdr_pattern_reg_t;
+#define EHT_PHY_TDRPD_REG_ADDR (0x18)
+
+/**
+ * @brief Time Domain Reflectometry Control/Status Register)
+ * Only available in LAN8740A/LAN8742A
+ */
+typedef union {
+    struct {
+        uint32_t tdr_channel_length : 8;     /* TDR channel length */
+        uint32_t tdr_channel_status : 1;     /* TDR channel status */
+        uint32_t tdr_channel_cable_type : 2; /* TDR channel cable type */
+        uint32_t reserved : 3;               /* Reserved */
+        uint32_t tdr_a2d_filter_enable: 1;   /* Analog to Digital Filter Enabled */
+        uint32_t tdr_enable : 1;             /* Enable TDR */
+    };
+    uint32_t val;
+} tdr_control_reg_t;
+#define EHT_PHY_TDRC_REG_ADDR (0x19)
+
+/**
  * @brief SECR(Symbol Error Counter Register)
  *
  */
@@ -94,6 +126,19 @@ typedef union {
 #define ETH_PHY_CSIR_REG_ADDR (0x1B)
 
 /**
+ * @brief Cable Length Register
+ * Only available in LAN8740A/LAN8742A
+ */
+typedef union {
+    struct {
+        uint32_t reserved : 12;              /* Reserved */
+        uint32_t cable_length : 4;           /* Cable length */
+    };
+    uint32_t val;
+} cbln_reg_t;
+#define EHT_PHY_CBLN_REG_ADDR (0x1C)
+
+/**
  * @brief ISR(Interrupt Source Register)
  *
  */
@@ -106,8 +151,9 @@ typedef union {
         uint32_t link_down : 1;                /* Link Down */
         uint32_t remote_fault_detect : 1;      /* Remote Fault Detect */
         uint32_t auto_nego_complete : 1;       /* Auto-Negotiation Complete */
-        uint32_t energy_on_generate : 1;       /* ENERYON generated */
-        uint32_t reserved2 : 8;                /* Reserved */
+        uint32_t energy_on_generate : 1;       /* ENERGY ON generated */
+        uint32_t wake_on_lan : 1;              /* Wake on Lan (WOL) event detected (only LAN8740A/LAN8742A) */
+        uint32_t reserved2 : 7;                /* Reserved */
     };
     uint32_t val;
 } isfr_reg_t;
@@ -127,7 +173,8 @@ typedef union {
         uint32_t remote_fault_detect : 1;      /* Remote Fault Detect */
         uint32_t auto_nego_complete : 1;       /* Auto-Negotiation Complete */
         uint32_t energy_on_generate : 1;       /* ENERGY ON generated */
-        uint32_t reserved2 : 8;                /* Reserved */
+        uint32_t wake_on_lan : 1;              /* Wake on Lan (WOL) event detected (only LAN8740A/LAN8742A) */
+        uint32_t reserved2 : 7;                /* Reserved */
     };
     uint32_t val;
 } imr_reg_t;
@@ -141,9 +188,11 @@ typedef union {
     struct {
         uint32_t reserved1 : 2;        /* Reserved */
         uint32_t speed_indication : 3; /* Speed Indication */
-        uint32_t reserved2 : 7;        /* Reserved */
+        uint32_t reserved2 : 1;        /* Reserved */
+        uint32_t enable_4b5b : 1;      /* Enable 4B5B encoder (only LAN8740A/LAN8741A) */
+        uint32_t reserved3 : 5;        /* Reserved */
         uint32_t auto_nego_done : 1;   /* Auto Negotiation Done */
-        uint32_t reserved3 : 3;        /* Reserved */
+        uint32_t reserved4 : 3;        /* Reserved */
     };
     uint32_t val;
 } pscsr_reg_t;


### PR DESCRIPTION
The **LAN8740A**/**LAN8741A**/**LAN8742A** are enhanced versions of the well known **LAN8710A**/**LAN8720A** Ethernet PHYs. They are hardware and software drop-in-replacements for the existing designs. The additional features are enabled by software or by a different bootstrapping on some I/O pins.
The existing LAN8720 driver in esp-idf can be used as is, except for additional `id2.vendor_model` IDs that have to be accepted.
New features like _Wake on LAN_ (WOL), _Cable Diagnostics_ (CD) or Energy Efficient Ethernet (EEE) are not added by this PR.
New or modified vendor specific registers are added just for completeness.

Please refer to [SMSC/Microchip Application Note 25.3](http://ww1.microchip.com/downloads/en/AppNotes/en562713.pdf) for any questions regarding the migration to LAN874xA.