### PR TITLE
freertos: Apply upstream stack masking fix for xtensa/port.c (IDFGH-5549)

### DIFF
--- a/components/freertos/port/xtensa/port.c
+++ b/components/freertos/port/xtensa/port.c
@@ -204,7 +204,7 @@ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t px
 					SP 																pxTopOfStack
 
 		All parts are aligned to 16 byte boundary. */
-	sp = (StackType_t *) (((UBaseType_t)(pxTopOfStack + 1) - XT_CP_SIZE - thread_local_sz - XT_STK_FRMSZ) & ~0xf);
+	sp = (StackType_t *) (((UBaseType_t)pxTopOfStack - XT_CP_SIZE - thread_local_sz - XT_STK_FRMSZ) & ~0xf);
 
 	/* Clear the entire frame (do not use memset() because we don't depend on C library) */
 	for (tp = sp; tp <= pxTopOfStack; ++tp)
@@ -274,6 +274,7 @@ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t px
          * //p = (uint32_t *) xMPUSettings->coproc_area;
 	 */
 	p = (uint32_t *)(((uint32_t) pxTopOfStack - XT_CP_SIZE) & ~0xf);
+        configASSERT( ( uint32_t ) p >= frame->a1 );
 	p[0] = 0;
 	p[1] = 0;
 	p[2] = (((uint32_t) p) + 12 + XCHAL_TOTAL_SA_ALIGN - 1) & -XCHAL_TOTAL_SA_ALIGN;
@@ -348,7 +349,9 @@ void vPortYieldOtherCore( BaseType_t coreid ) {
 void vPortStoreTaskMPUSettings( xMPU_SETTINGS *xMPUSettings, const struct xMEMORY_REGION * const xRegions, StackType_t *pxBottomOfStack, uint32_t usStackDepth )
 {
 	#if XCHAL_CP_NUM > 0
-	xMPUSettings->coproc_area = (StackType_t*)((((uint32_t)(pxBottomOfStack + usStackDepth - 1)) - XT_CP_SIZE ) & ~0xf);
+	xMPUSettings->coproc_area = ( StackType_t * ) ( ( uint32_t ) ( pxBottomOfStack + usStackDepth - 1 ));
+	xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) xMPUSettings->coproc_area ) & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
+	xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( uint32_t ) xMPUSettings->coproc_area - XT_CP_SIZE ) & ~0xf );
 
 
 	/* NOTE: we cannot initialize the coprocessor save area here because FreeRTOS is going to


### PR DESCRIPTION
Link: https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/6a5784598a40adfcb5908db498fe0324c3b00016#diff-cfa9a8b71a9665b5610f59bd2f56cb81b3ee73beaa6cac3fc965884069588d47
Signed-off-by: Axel Lin <axel.lin@gmail.com>