### PR TITLE
lwip: menuconfig option for max number of SNTP servers (IDFGH-5616)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -837,7 +837,7 @@ menu "LWIP"
 
     menu "SNTP"
 
-        config LWIP_DHCP_MAX_NTP_SERVERS
+        config LWIP_SNTP_MAX_SERVERS
             int "Maximum number of NTP servers"
             default 1
             range 1 16
@@ -845,6 +845,14 @@ menu "LWIP"
                 Set maximum number of NTP servers used by LwIP SNTP module.
                 First argument of sntp_setserver/sntp_setservername functions
                 is limited to this value.
+
+        config LWIP_DHCP_MAX_NTP_SERVERS
+            int "Maximum number of NTP servers aquired via DHCP"
+            default 1
+            range 1 16
+            help
+                Set maximum number of NTP servers aquired via DHCP-offer.
+                Must be less or equal to total "Maximum number of NTP servers".
 
         config LWIP_SNTP_UPDATE_DELAY
             int "Request interval to update time (ms)"

--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -846,13 +846,22 @@ menu "LWIP"
                 First argument of sntp_setserver/sntp_setservername functions
                 is limited to this value.
 
+        config LWIP_DHCP_GET_NTP_SRV
+            bool "Request NTP servers from DHCP"
+            default n
+            help
+                If enabled, LWIP will add 'NTP' to Parameter-Request Option sent via DHCP-request.
+                DHCP server might reply with an NTP server address in option 42.
+                SNTP callback for such replies should be set accordingly (see sntp_servermode_dhcp() func.)
+
         config LWIP_DHCP_MAX_NTP_SERVERS
             int "Maximum number of NTP servers aquired via DHCP"
             default 1
             range 1 16
+            depends on LWIP_DHCP_GET_NTP_SRV
             help
                 Set maximum number of NTP servers aquired via DHCP-offer.
-                Must be less or equal to total "Maximum number of NTP servers".
+                Should be less or equal to "Maximum number of NTP servers", any extra servers would be just ignored.
 
         config LWIP_SNTP_UPDATE_DELAY
             int "Request interval to update time (ms)"
@@ -1030,6 +1039,11 @@ menu "LWIP"
 
     config LWIP_TCP_DEBUG
         bool "Enable TCP debug messages"
+        depends on LWIP_DEBUG
+        default n
+
+    config LWIP_SNTP_DEBUG
+        bool "Enable SNTP debug messages"
         depends on LWIP_DEBUG
         default n
 

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -1074,6 +1074,11 @@ LWIP_FORWARD_DECLARE_C_CXX void sntp_sync_time(struct timeval *tv);
 
 LWIP_FORWARD_DECLARE_C_CXX uint32_t sntp_get_sync_interval(void);
 
+// Max number of SNTP servers handled (default equal to LWIP_DHCP_MAX_NTP_SERVERS)
+#if CONFIG_LWIP_SNTP_MAX_SERVERS_DEFINED && !defined SNTP_MAX_SERVERS
+#define SNTP_MAX_SERVERS                CONFIG_LWIP_SNTP_MAX_SERVERS
+#endif // CONFIG_LWIP_SNTP_MAX_SERVERS_DEFINED
+
 /** Set this to 1 to support DNS names (or IP address strings) to set sntp servers
  * One server address/name can be defined as default if SNTP_SERVER_DNS == 1:
  * \#define SNTP_SERVER_ADDRESS "pool.ntp.org"

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -911,6 +911,15 @@
 #endif
 
 /**
+ * SNTP_DEBUG: Enable debugging for SNTP.
+ */
+#ifdef CONFIG_LWIP_SNTP_DEBUG
+#define SNTP_DEBUG                       LWIP_DBG_ON
+#else
+#define SNTP_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/**
  * MEMP_DEBUG: Enable debugging in memp.c.
  */
 #define MEMP_DEBUG                      LWIP_DBG_OFF
@@ -1075,9 +1084,13 @@ LWIP_FORWARD_DECLARE_C_CXX void sntp_sync_time(struct timeval *tv);
 LWIP_FORWARD_DECLARE_C_CXX uint32_t sntp_get_sync_interval(void);
 
 // Max number of SNTP servers handled (default equal to LWIP_DHCP_MAX_NTP_SERVERS)
-#if CONFIG_LWIP_SNTP_MAX_SERVERS_DEFINED && !defined SNTP_MAX_SERVERS
+#if defined CONFIG_LWIP_SNTP_MAX_SERVERS
 #define SNTP_MAX_SERVERS                CONFIG_LWIP_SNTP_MAX_SERVERS
-#endif // CONFIG_LWIP_SNTP_MAX_SERVERS_DEFINED
+#endif // CONFIG_LWIP_SNTP_MAX_SERVERS
+
+#ifdef CONFIG_LWIP_DHCP_GET_NTP_SRV
+#define LWIP_DHCP_GET_NTP_SRV           CONFIG_LWIP_DHCP_GET_NTP_SRV
+#endif // CONFIG_LWIP_DHCP_GET_NTP_SRV
 
 /** Set this to 1 to support DNS names (or IP address strings) to set sntp servers
  * One server address/name can be defined as default if SNTP_SERVER_DNS == 1:

--- a/examples/protocols/sntp/main/sntp_example_main.c
+++ b/examples/protocols/sntp/main/sntp_example_main.c
@@ -122,6 +122,14 @@ static void obtain_time(void)
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK( esp_event_loop_create_default() );
 
+    /**
+     * NTP server address could be aquired via DHCP,
+     * see LWIP_DHCP_GET_NTP_SRV menuconfig option
+     */
+#ifdef LWIP_DHCP_GET_NTP_SRV
+    sntp_servermode_dhcp(1);
+#endif
+
     /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.
      * Read "Establishing Wi-Fi or Ethernet Connection" section in
      * examples/protocols/README.md for more information about this function.


### PR DESCRIPTION
LWIP has two define's for setting max number of sntp servers:
 - total number of handled servers
 - max number of sntp's picked via DHCP

by default both values are equal to 1, but could be set separately.
This is a followup for espressif/arduino-esp32#5343. Having this menuconfig option allows building lwip for arduino-esp32 with multiple sntps's supported