### PR TITLE
freertos: fix multicore scheduler (IDFGH-5635)

### DIFF
--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3337,7 +3337,7 @@ void vTaskSwitchContext( void )
 						if (pxTCB->xCoreID == tskNO_AFFINITY || pxTCB->xCoreID == xPortGetCoreID()) {
 							pxCurrentTCB[xPortGetCoreID()] = pxTCB;
 							ableToSchedule = pdTRUE;
-							if(skippedTask == pdTRUE) {
+							if(skippedTask == pdTRUE && listCURRENT_LIST_LENGTH(&(pxReadyTasksLists[ uxDynamicTopReady ])) > ( UBaseType_t ) 2 ) {
 								/* Move the task we are about to run to the end of the list
 								and set the skipped task to be next up */
 								ListItem_t * moveItem = pxReadyTasksLists[ uxDynamicTopReady ].pxIndex; 


### PR DESCRIPTION
This is a quick proposal to fix the issues described below.  Please review as I can't claim this is well thought out or fully tested.

> ToDo: This scheduler doesn't correctly implement the round-robin scheduling as done in the single-core
> 		 *  FreeRTOS stack when multiple tasks have the same priority and are all ready; it just keeps grabbing the
> 		 *  first one. ToDo: fix this.
> 		 *  (Is this still true? if any, there's the issue with one core skipping over the processes for the other
> 		 *  core, potentially not giving the skipped-over processes any time.)

