### PR TITLE
Add timstamps to i2s DMA events via sdkconfig (IDFGH-5633)

### DIFF
--- a/components/driver/Kconfig
+++ b/components/driver/Kconfig
@@ -170,4 +170,17 @@ menu "Driver configurations"
 
     endmenu # GPIO Configuration
 
+    menu "I2S Configuration"
+        visible if IDF_TARGET_ESP32
+
+        config I2S_ESP32_DMA_QUEUE_TIMESTAMPS
+            bool "Add timestamps in DMA queue events"
+            depends on IDF_TARGET_ESP32
+            default n
+            help
+                This option adds  esp_timer_get_time() timestamp to the DMA queue events so the buffers
+                can be related to other events in the system
+
+    endmenu # GPIO Configuration
+
 endmenu  # Driver configurations

--- a/components/hal/include/hal/i2s_types.h
+++ b/components/hal/include/hal/i2s_types.h
@@ -17,6 +17,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stddef.h>
+
+#include "sdkconfig.h"
+
 #include "soc/soc_caps.h"
 
 #ifdef __cplusplus
@@ -165,6 +168,9 @@ typedef enum {
  */
 typedef struct {
     i2s_event_type_t    type;   /*!< I2S event type */
+#ifdef CONFIG_I2S_ESP32_DMA_QUEUE_TIMESTAMPS
+    int64_t timestamp;  /*!< I2S event timestamp from esp_timer_get_time() */
+#endif
     size_t              size;   /*!< I2S data size for I2S_DATA event*/
 } i2s_event_t;
 


### PR DESCRIPTION
As per https://github.com/espressif/esp-idf/issues/7339:

I'm in a project where ADC via I2S DMA is used to track an analog signal. The signal must be correlated to other events. As you an imagine the timing is important and with tight limits. Using the I2S driver's capability to send events via queue is almost perfect with the only downside is that the events might get variable time to get delivered. This can be easily solved by punting a timestamp from a call to esp_timer_get_time() in the queue event. The only problem I see is keeping the code compatible with older users of the event queue. To keep it clean this is  made selectable from the configuration system with default to non-timestamped events.
Any suggestions/guides are welcome :)