### PR TITLE
Add hint about sdkconfig.ci in IDF examples (IDFGH-5657)

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -1019,6 +1019,8 @@ For example projects or other projects where you don't want to specify a full sd
 
 To override the name of this file or to specify multiple files, set the ``SDKCONFIG_DEFAULTS`` environment variable or set ``SDKCONFIG_DEFAULTS`` in top-level CMakeLists.txt. If specifying multiple files, use semicolon as the list separator. File names not specified as full paths are resolved relative to current project.
 
+Some of the IDF examples include a ``sdkconfig.ci`` file. This is part of the continuous integration (CI) test framework and is ignored by the normal build process.
+
 Target-dependent sdkconfig defaults
 -----------------------------------
 


### PR DESCRIPTION
Individual developers may not know about CI and may be confused by the sdkconfig.ci files in the examples.