### PR TITLE
Missing dependency for idf.py 'encrypted-flash' target (IDFGH-5766)

### DIFF
--- a/components/app_update/CMakeLists.txt
+++ b/components/app_update/CMakeLists.txt
@@ -46,6 +46,7 @@ if(NOT BOOTLOADER_BUILD)
 
         add_custom_target(blank_ota_data ALL DEPENDS ${blank_otadata_file})
         add_dependencies(flash blank_ota_data)
+        add_dependencies(encrypted-flash blank_ota_data)
 
         set(otatool_py ${python} ${COMPONENT_DIR}/otatool.py)
 


### PR DESCRIPTION
To reproduce the issue:
- set-up a project with both encrypted flash && OTA
- `rm -rf build`
- `idf.py encrypted-flash`
- => error because flashing 'ota_data_initial.bin' is done before it gets generated 