### PR TITLE
Fix bootloader size message in build log (IDFGH-5798)

### DIFF
--- a/components/partition_table/check_sizes.py
+++ b/components/partition_table/check_sizes.py
@@ -64,7 +64,7 @@ def check_bootloader(partition_table_offset, bootloader_offset, binary_file):  #
         _fail(msg)
     free_size = max_size - bootloader_size
     print('Bootloader binary size {:#x} bytes. {:#x} bytes ({}%) free.'.format(
-          bootloader_size, free_size, round(free_size * 100 / bootloader_size)))
+          bootloader_size, free_size, round(free_size * 100 / max_size)))
 
 
 def check_partition(ptype, subtype, partition_table_file, bin_file):  # type: (str, str, io.IOBase, IO) -> None


### PR DESCRIPTION
Fixes bootloader size message in the build log by using maximum size (instead of current binary size) to calculate free space percentage.

Before:
`Bootloader binary size 0x5b30 bytes. 0x64d0 bytes (111%) free.`
After:
`Bootloader binary size 0x5b30 bytes. 0x64d0 bytes (53%) free.`