### PR TITLE
Fix bootloader output with silent assertions (IDFGH-5811)

### DIFF
--- a/components/newlib/platform_include/assert.h
+++ b/components/newlib/platform_include/assert.h
@@ -43,7 +43,11 @@
 
 #elif CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT
 
+#ifdef BOOTLOADER_BUILD
+#define assert(__e) (__builtin_expect(!!(__e), 1) ? (void)0 : abort())
+#else
 #define assert(__e) (__builtin_expect(!!(__e), 1) ? (void)0 : __assert_func(NULL, 0, NULL, NULL))
+#endif
 
 #else // !CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT
 


### PR DESCRIPTION
The bootloader assert function (__assert_func in bootloader_panic.c) is still linked despite CONFIG_OPTIMIZATION_ASSERTIONS_SILENT set. If invoked, the following output is printed:
`Assert failed in <null>, <null>:0 (<null>)`

I have changed this to `abort` for the bootloader, and confirmed that the function and string are no longer in the bootloader binary. 

The bootloader assert function would otherwise loop (until WDT reset) here:
https://github.com/espressif/esp-idf/blob/d5f58ab13551cd883e8d8478ba367b6e4543ffec/components/bootloader_support/src/bootloader_panic.c#L13-L18
Is abort ok or should that behaviour be preserved by simply omitting the esp_rom_printf?