### PR TITLE
Fix bootloader hash debug logging (IDFGH-5810)

### DIFF
--- a/components/bootloader_support/src/bootloader_utility.c
+++ b/components/bootloader_support/src/bootloader_utility.c
@@ -858,23 +858,23 @@ esp_err_t bootloader_sha256_hex_to_str(char *out_str, const uint8_t *in_array_he
 
 void bootloader_debug_buffer(const void *buffer, size_t length, const char *label)
 {
-#if LOG_LOCAL_LEVEL >= 4
-    assert(length <= 128); // Avoid unbounded VLA size
-    const uint8_t *bytes = (const uint8_t *)buffer;
-    char hexbuf[length * 2 + 1];
-    hexbuf[length * 2] = 0;
-    for (size_t i = 0; i < length; i++) {
-        for (int shift = 0; shift < 2; shift++) {
-            uint8_t nibble = (bytes[i] >> (shift ? 0 : 4)) & 0x0F;
-            if (nibble < 10) {
-                hexbuf[i * 2 + shift] = '0' + nibble;
-            } else {
-                hexbuf[i * 2 + shift] = 'a' + nibble - 10;
+    if (LOG_LOCAL_LEVEL >= ESP_LOG_DEBUG) {
+        assert(length <= 128); // Avoid unbounded VLA size
+        const uint8_t *bytes = (const uint8_t *)buffer;
+        char hexbuf[length * 2 + 1];
+        hexbuf[length * 2] = 0;
+        for (size_t i = 0; i < length; i++) {
+            for (int shift = 0; shift < 2; shift++) {
+                uint8_t nibble = (bytes[i] >> (shift ? 0 : 4)) & 0x0F;
+                if (nibble < 10) {
+                    hexbuf[i * 2 + shift] = '0' + nibble;
+                } else {
+                    hexbuf[i * 2 + shift] = 'a' + nibble - 10;
+                }
             }
         }
+        ESP_LOGD(TAG, "%s: %s", label, hexbuf);
     }
-    ESP_LOGD(TAG, "%s: %s", label, hexbuf);
-#endif
 }
 
 esp_err_t bootloader_sha256_flash_contents(uint32_t flash_offset, uint32_t len, uint8_t *digest)

--- a/components/bootloader_support/src/bootloader_utility.c
+++ b/components/bootloader_support/src/bootloader_utility.c
@@ -858,7 +858,7 @@ esp_err_t bootloader_sha256_hex_to_str(char *out_str, const uint8_t *in_array_he
 
 void bootloader_debug_buffer(const void *buffer, size_t length, const char *label)
 {
-#if BOOT_LOG_LEVEL >= LOG_LEVEL_DEBUG
+#if LOG_LOCAL_LEVEL >= 4
     assert(length <= 128); // Avoid unbounded VLA size
     const uint8_t *bytes = (const uint8_t *)buffer;
     char hexbuf[length * 2 + 1];

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -792,6 +792,13 @@ err:
     return err;
 }
 
+static void log_debug_hash(const char *label, const uint8_t *buf)
+{
+#if LOG_LOCAL_LEVEL >= 4
+    bootloader_debug_buffer(buf, HASH_LEN, label);
+#endif
+}
+
 static esp_err_t verify_secure_boot_signature(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data, uint8_t *image_digest, uint8_t *verified_digest)
 {
 #if (SECURE_BOOT_CHECK_SIGNATURE == 1)
@@ -822,7 +829,7 @@ static esp_err_t verify_secure_boot_signature(bootloader_sha256_handle_t sha_han
     bootloader_sha256_finish(sha_handle, image_digest);
 
     // Log the hash for debugging
-    bootloader_debug_buffer(image_digest, HASH_LEN, "Calculated secure boot hash");
+    log_debug_hash("Calculated secure boot hash", image_digest);
 
     // Use hash to verify signature block
     esp_err_t err = ESP_ERR_IMAGE_INVALID;
@@ -872,12 +879,12 @@ static esp_err_t verify_simple_hash(bootloader_sha256_handle_t sha_handle, esp_i
     bootloader_sha256_finish(sha_handle, image_hash);
 
     // Log the hash for debugging
-    bootloader_debug_buffer(image_hash, HASH_LEN, "Calculated hash");
+    log_debug_hash("Calculated hash", image_hash);
 
     // Simple hash for verification only
     if (memcmp(data->image_digest, image_hash, HASH_LEN) != 0) {
         ESP_LOGE(TAG, "Image hash failed - image is corrupt");
-        bootloader_debug_buffer(data->image_digest, HASH_LEN, "Expected hash");
+        log_debug_hash("Expected hash", data->image_digest);
 #ifdef CONFIG_IDF_ENV_FPGA
         ESP_LOGW(TAG, "Ignoring invalid SHA-256 as running on FPGA");
         return ESP_OK;

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -794,9 +794,9 @@ err:
 
 static void log_debug_hash(const char *label, const uint8_t *buf)
 {
-#if LOG_LOCAL_LEVEL >= 4
-    bootloader_debug_buffer(buf, HASH_LEN, label);
-#endif
+    if (LOG_LOCAL_LEVEL >= ESP_LOG_DEBUG) {
+        bootloader_debug_buffer(buf, HASH_LEN, label);
+    }
 }
 
 static esp_err_t verify_secure_boot_signature(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data, uint8_t *image_digest, uint8_t *verified_digest)


### PR DESCRIPTION
1. Fix `BOOT_LOG_LEVEL >= LOG_LEVEL_DEBUG` condition in bootloader_debug_buffer. Neither of these are defined.
2. String literals passed to bootloader_debug_buffer are linked even though it ultimately does nothing with them at lower log levels. Currently it's only used in esp_image_format.c, so I've added a static function in there to give the build system a chance to weed them out.