### PR TITLE
Added missing C++ guard/wrapper (IDFGH-5821)

### DIFF
--- a/components/lwip/include/apps/dhcpserver/dhcpserver.h
+++ b/components/lwip/include/apps/dhcpserver/dhcpserver.h
@@ -17,6 +17,10 @@
 #include "sdkconfig.h"
 #include "lwip/ip_addr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dhcps_state{
         s16_t state;
 } dhcps_state;
@@ -90,5 +94,9 @@ bool dhcp_search_ip_on_mac(u8_t *mac, ip4_addr_t *ip);
 void dhcps_dns_setserver(const ip_addr_t *dnsserver);
 ip4_addr_t dhcps_dns_getserver(void);
 void dhcps_set_new_lease_cb(dhcps_cb_t cb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
When the `dhcpserver.h` is included in a C++ source, it results in a linker error (as C symbols are named differently). To fix this, I added the same C++ guards as found in many other sources.