### PR TITLE
Kconfig: Support M5Stack W5500 PLC base (IDFGH-5826)

### DIFF
--- a/examples/ethernet/basic/main/Kconfig.projbuild
+++ b/examples/ethernet/basic/main/Kconfig.projbuild
@@ -6,7 +6,7 @@ menu "Example Configuration"
 
     config EXAMPLE_GPIO_RANGE_MAX
         int
-        default 33 if IDF_TARGET_ESP32
+        default 34 if IDF_TARGET_ESP32
         default 46 if IDF_TARGET_ESP32S2
         default 19 if IDF_TARGET_ESP32C3
 


### PR DESCRIPTION
The W5500 pinout for the PLC base is:

MOSI	GPIO23
MISO	GPIO19
CLK	GPIO18
CS	GPIO26
RST	GPIO13
INTn	GPIO34

The Kconfig for the project had a max value of GPIO33
so I have changed this to GPIO34 and tested that with
this set the ethernet example works (picks up an IP
address)

@see: https://docs.m5stack.com/en/base/lan_base

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>