### PR TITLE
tcp_transport: Fix NULL pointer dereference in esp_transport_esp_tls_… (IDFGH-5834)

### DIFF
--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -446,6 +446,9 @@ esp_transport_handle_t esp_transport_ssl_init(void)
 struct transport_esp_tls* esp_transport_esp_tls_create(void)
 {
     transport_esp_tls_t *transport_esp_tls = calloc(1, sizeof(transport_esp_tls_t));
+    if (transport_esp_tls == NULL) {
+        return NULL;
+    }
     transport_esp_tls->sockfd = INVALID_SOCKET;
     return transport_esp_tls;
 }


### PR DESCRIPTION
…create

Add missing NULL checking to prevent NULL pointer dereference if calloc failed.

Signed-off-by: Axel Lin <axel.lin@gmail.com>