### PR TITLE
Added an Arduino variant of the generic_gpio example

### DIFF
--- a/examples/peripherals/gpio/generic_gpio_arduino_ready_variant/generic_gpio_arduino_ready_variant.ino
+++ b/examples/peripherals/gpio/generic_gpio_arduino_ready_variant/generic_gpio_arduino_ready_variant.ino
@@ -1,0 +1,120 @@
+/* GPIO Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "driver/gpio.h"
+
+/**
+ * Brief:
+ * This test code shows how to configure gpio and how to use gpio interrupt.
+ *
+ * GPIO status:
+ * GPIO18: output
+ * GPIO19: output
+ * GPIO4:  input, pulled up, interrupt from rising edge and falling edge
+ * GPIO5:  input, pulled up, interrupt from rising edge.
+ *
+ * Test:
+ * Connect GPIO18 with GPIO4
+ * Connect GPIO19 with GPIO5
+ * Generate pulses on GPIO18/19, that triggers interrupt on GPIO4/5
+ *
+ */
+
+#define GPIO_OUTPUT_IO_0    18
+#define GPIO_OUTPUT_IO_1    19
+#define GPIO_OUTPUT_PIN_SEL  ((1ULL<<GPIO_OUTPUT_IO_0) | (1ULL<<GPIO_OUTPUT_IO_1))
+#define GPIO_INPUT_IO_0     4
+#define GPIO_INPUT_IO_1     5
+#define GPIO_INPUT_PIN_SEL  ((1ULL<<GPIO_INPUT_IO_0) | (1ULL<<GPIO_INPUT_IO_1))
+#define ESP_INTR_FLAG_DEFAULT 0
+
+static xQueueHandle gpio_evt_queue = NULL;
+
+static void IRAM_ATTR gpio_isr_handler(void* arg)
+{
+    uint32_t gpio_num = (uint32_t) arg;
+    xQueueSendFromISR(gpio_evt_queue, &gpio_num, NULL);
+}
+
+static void gpio_task_example(void* arg)
+{
+    uint32_t io_num;
+    for(;;) {
+        if(xQueueReceive(gpio_evt_queue, &io_num, portMAX_DELAY)) {
+            printf("GPIO[%d] intr, val: %d\n", io_num, gpio_get_level((gpio_num_t)io_num));
+        }
+    }
+}
+
+void setup()
+{
+    //115200 is the default baud rate on an ESP32 WROVER iirc, I have no idea if this is needed at all but I left it just in case
+    //Serial.begin(115200);
+
+    //zero-initialize the config structure.
+    gpio_config_t io_conf = {};
+    //disable interrupt
+    io_conf.intr_type = GPIO_INTR_DISABLE;
+    //set as output mode
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    //bit mask of the pins that you want to set,e.g.GPIO18/19
+    io_conf.pin_bit_mask = GPIO_OUTPUT_PIN_SEL;
+    //disable pull-down mode
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    //disable pull-up mode
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    //configure GPIO with the given settings
+    gpio_config(&io_conf);
+
+    //interrupt of rising edge
+    io_conf.intr_type = GPIO_INTR_POSEDGE;
+    //bit mask of the pins, use GPIO4/5 here
+    io_conf.pin_bit_mask = GPIO_INPUT_PIN_SEL;
+    //set as input mode
+    io_conf.mode = GPIO_MODE_INPUT;
+    //enable pull-up mode
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    gpio_config(&io_conf);
+
+    //change gpio intrrupt type for one pin
+    gpio_set_intr_type((gpio_num_t)GPIO_INPUT_IO_0, GPIO_INTR_ANYEDGE);
+
+    //create a queue to handle gpio event from isr
+    gpio_evt_queue = xQueueCreate(10, sizeof(uint32_t));
+    //start gpio task
+    xTaskCreate(gpio_task_example, "gpio_task_example", 2048, NULL, 10, NULL);
+
+    //install gpio isr service
+    gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT);
+    //hook isr handler for specific gpio pin
+    gpio_isr_handler_add((gpio_num_t)GPIO_INPUT_IO_0, gpio_isr_handler, (void*) GPIO_INPUT_IO_0);
+    //hook isr handler for specific gpio pin
+    gpio_isr_handler_add((gpio_num_t)GPIO_INPUT_IO_1, gpio_isr_handler, (void*) GPIO_INPUT_IO_1);
+
+    //remove isr handler for gpio number.
+    gpio_isr_handler_remove((gpio_num_t)GPIO_INPUT_IO_0);
+    //hook isr handler for specific gpio pin again
+    gpio_isr_handler_add((gpio_num_t)GPIO_INPUT_IO_0, gpio_isr_handler, (void*) GPIO_INPUT_IO_0);
+
+    printf("Minimum free heap size: %d bytes\n", esp_get_minimum_free_heap_size());
+}
+
+
+void loop(){
+  static int cnt = 0;
+  printf("cnt: %d\n", cnt++);
+  vTaskDelay(1000 / portTICK_RATE_MS);
+  gpio_set_level((gpio_num_t)GPIO_OUTPUT_IO_0, cnt % 2);
+  gpio_set_level((gpio_num_t)GPIO_OUTPUT_IO_1, cnt % 2);
+}


### PR DESCRIPTION
Apart from the fact the original code is meant for another development environment.
I found a bunch of implicit castings issues I don't know if it's a compiler issue what but I hacked it by adding the following cast `(gpio_num_t)` to the uint32_t values holding the gpio value.
Tested on my ESP32 WROVER and it works fine.