### PR TITLE
Add sdmmc_erase_sectors() to erase sectors. (IDFGH-5947)

### DIFF
--- a/components/driver/include/driver/sdmmc_defs.h
+++ b/components/driver/include/driver/sdmmc_defs.h
@@ -47,6 +47,9 @@
 #define MMC_SET_BLOCK_COUNT             23      /* R1 */
 #define MMC_WRITE_BLOCK_SINGLE          24      /* R1 */
 #define MMC_WRITE_BLOCK_MULTIPLE        25      /* R1 */
+#define MMC_ERASE_GROUP_START           35      /* R1 */
+#define MMC_ERASE_GROUP_END             36      /* R1 */
+#define MMC_ERASE                       38      /* R1B */
 #define MMC_APP_CMD                     55      /* R1 */
 
 /* SD commands */                               /* response type */
@@ -154,6 +157,9 @@
 #define EXT_CSD_POWER_CLASS             187     /* R/W */
 #define EXT_CSD_CMD_SET                 191     /* R/W */
 #define EXT_CSD_S_CMD_SET               504     /* RO */
+#define EXT_CSD_ERASED_MEM_CONT         181     /* RO */
+#define EXT_CSD_SEC_FEATURE_SUPPORT     231     /* RO */
+#define EXT_CSD_SANITIZE_START          165     /* WO */
 
 /* EXT_CSD field definitions */
 #define EXT_CSD_CMD_SET_NORMAL          (1U << 0)
@@ -185,6 +191,12 @@
 #define EXT_CSD_CARD_TYPE_52M_V18       0x07
 #define EXT_CSD_CARD_TYPE_52M_V12       0x0b
 #define EXT_CSD_CARD_TYPE_52M_V12_18    0x0f
+
+/* EXT_CSD_SEC_FEATURE_SUPPORT */
+#define EXT_CSD_SECURE_ER_EN            (1 << 0)
+#define EXT_CSD_SEC_BD_BLK_EN           (1 << 2)
+#define EXT_CSD_SEC_GB_CL_EN            (1 << 4)
+#define EXT_CSD_SEC_SANITIZE            (1 << 6)
 
 /* EXT_CSD MMC */
 #define EXT_CSD_MMC_SIZE 512

--- a/components/driver/include/driver/sdmmc_types.h
+++ b/components/driver/include/driver/sdmmc_types.h
@@ -66,7 +66,10 @@ typedef struct {
  * Decoded values of Extended Card Specific Data
  */
 typedef struct {
-    uint8_t power_class;    /*!< Power class used by the card */
+    uint8_t power_class;            /*!< Power class used by the card */
+    uint8_t erased_mem_cont;        /*!< Erased memory contents */
+    uint8_t sec_supports_sanitize;  /*!< Card supports SANITIZE */
+    uint8_t sec_supports_trim;      /*!< Card supports TRIM */
 } sdmmc_ext_csd_t;
 
 /**

--- a/components/sdmmc/include/sdmmc_cmd.h
+++ b/components/sdmmc/include/sdmmc_cmd.h
@@ -1,16 +1,8 @@
-// Copyright 2015-2018 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 
@@ -76,6 +68,23 @@ esp_err_t sdmmc_write_sectors(sdmmc_card_t* card, const void* src,
  */
 esp_err_t sdmmc_read_sectors(sdmmc_card_t* card, void* dst,
         size_t start_sector, size_t sector_count);
+
+/**
+ * Erase given sector range in SD/MMC card
+ *
+ * @param card  pointer to card information structure previously initialized
+ *              using sdmmc_card_init
+ * @param start_address  address where to mark start of erasing
+ * @param end_address    address where to mark end of erasing
+ * @param sanitize  flag to indicate that sectors should be erased
+ *                  immediately instead of the default background
+ *                  erase.
+ * @return
+ *      - ESP_OK on success
+ *      - One of the error codes from SDMMC host controller
+ */
+esp_err_t sdmmc_erase_sectors(sdmmc_card_t* card, size_t start_address,
+        size_t end_address, int sanitize);
 
 /**
  * Read one byte from an SDIO card using IO_RW_DIRECT (CMD52)

--- a/components/sdmmc/sdmmc_mmc.c
+++ b/components/sdmmc/sdmmc_mmc.c
@@ -91,6 +91,15 @@ esp_err_t sdmmc_init_mmc_read_ext_csd(sdmmc_card_t* card)
         card->csd.capacity = sectors;
     }
 
+    if(ext_csd[EXT_CSD_ERASED_MEM_CONT]) {
+        card->ext_csd.erased_mem_cont = 0xFF;
+    } else {
+        card->ext_csd.erased_mem_cont = 0x00;
+    }
+
+    card->ext_csd.sec_supports_sanitize = (ext_csd[EXT_CSD_SEC_FEATURE_SUPPORT] & EXT_CSD_SEC_SANITIZE) != 0;
+    card->ext_csd.sec_supports_trim     = (ext_csd[EXT_CSD_SEC_FEATURE_SUPPORT] & EXT_CSD_SEC_GB_CL_EN) != 0;
+
 out:
     free(ext_csd);
     return err;

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -2213,7 +2213,6 @@ components/riscv/include/riscv/riscv_interrupts.h
 components/riscv/include/riscv/rvruntime-frames.h
 components/riscv/instruction_decode.c
 components/riscv/interrupt.c
-components/sdmmc/include/sdmmc_cmd.h
 components/sdmmc/sdmmc_cmd.c
 components/sdmmc/sdmmc_common.c
 components/sdmmc/sdmmc_common.h
@@ -2221,7 +2220,6 @@ components/sdmmc/sdmmc_init.c
 components/sdmmc/sdmmc_io.c
 components/sdmmc/sdmmc_mmc.c
 components/sdmmc/sdmmc_sd.c
-components/sdmmc/test/test_sd.c
 components/sdmmc/test/test_sdio.c
 components/soc/esp32/adc_periph.c
 components/soc/esp32/dac_periph.c


### PR DESCRIPTION
Adds support for marking blocks for deletion by the
SD/eMMC controller.  Optionally the sanitize flag may
be set to instruct the controller to erase the blocks
immediately.