### PR TITLE
update clk_flags requirement for i2c docs (IDFGH-5949)

### DIFF
--- a/docs/en/api-reference/peripherals/i2c.rst
+++ b/docs/en/api-reference/peripherals/i2c.rst
@@ -79,7 +79,7 @@ Configuration example (master):
         .scl_io_num = I2C_MASTER_SCL_IO,         // select GPIO specific to your project
         .scl_pullup_en = GPIO_PULLUP_ENABLE,
         .master.clk_speed = I2C_MASTER_FREQ_HZ,  // select frequency specific to your project
-        // .clk_flags = 0,          /*!< Optional, you can use I2C_SCLK_SRC_FLAG_* flags to choose i2c source clock here. */
+        .clk_flags = 0,          /* you can use I2C_SCLK_SRC_FLAG_* flags to choose i2c source clock here. */
     };
 
 Configuration example (slave):
@@ -95,6 +95,7 @@ Configuration example (slave):
         .mode = I2C_MODE_SLAVE,
         .slave.addr_10bit_en = 0,
         .slave.slave_addr = ESP_SLAVE_ADDR,      // address of your project
+        .clk_flags = 0,
     };
 
 At this stage, :cpp:func:`i2c_param_config` also sets a few other I2C configuration parameters to default values that are defined by the I2C specification. For more details on the values and how to modify them, see :ref:`i2c-api-customized-configuration`.


### PR DESCRIPTION
As it seems, the latest version is requiring the clk_flags to have a value for the i2c driver to initialize, not sure if its intended to be like this or not honestly, but the docs are not inclined with code apparently, either the docs or the code needs to be updated, this is the shortest path :)