### PR TITLE
mck pin not defined in i2s examples (IDFGH-5973) (IDFGH-5974)

### DIFF
--- a/examples/peripherals/i2s/i2s_audio_recorder_sdcard/main/i2s_recorder_main.c
+++ b/examples/peripherals/i2s/i2s_audio_recorder_sdcard/main/i2s_recorder_main.c
@@ -186,6 +186,7 @@ void init_microphone(void)
     };
 
     i2s_pin_config_t pin_config;
+    pin_config.mck_io_num = I2S_PIN_NO_CHANGE;
     pin_config.bck_io_num = I2S_PIN_NO_CHANGE;
     pin_config.ws_io_num = CONFIG_EXAMPLE_I2S_CLK_GPIO;
     pin_config.data_out_num = I2S_PIN_NO_CHANGE;

--- a/examples/peripherals/i2s/i2s_basic/main/i2s_example_main.c
+++ b/examples/peripherals/i2s/i2s_basic/main/i2s_example_main.c
@@ -102,6 +102,7 @@ void app_main(void)
         .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1                                //Interrupt level 1
     };
     i2s_pin_config_t pin_config = {
+        .mck_io_num = I2S_PIN_NO_CHANGE,
         .bck_io_num = I2S_BCK_IO,
         .ws_io_num = I2S_WS_IO,
         .data_out_num = I2S_DO_IO,


### PR DESCRIPTION
The mck pin must either be set to GPIO 0,1,3 or to I2S_PIN_NO_CHANGE (-1), otherwise the pin configuration will fail.