### PR TITLE
Encoding base64 with wolfSSL should not encode /w new line (IDFGH-5990)

### DIFF
--- a/components/esp-tls/esp-tls-crypto/esp_tls_crypto.c
+++ b/components/esp-tls/esp-tls-crypto/esp_tls_crypto.c
@@ -56,7 +56,7 @@ static int esp_crypto_base64_encode_woflSSL(unsigned char *dst, size_t dlen, siz
         const unsigned char *src, size_t slen)
 {
     *olen = dlen;
-    return Base64_Encode((const byte *) src, (word32) slen, (byte *) dst, (word32 *) olen);
+    return Base64_Encode_NoNl((const byte *) src, (word32) slen, (byte *) dst, (word32 *) olen);
 }
 
 #else


### PR DESCRIPTION
When using esp_crypto_base64_encode with mbedTLS the result does not include newlines in PEM format, however, when using it with wolfSSL it is encoded in PEM format and includes nelines.

This PR changes the wolfSSL functionality to match that of the default mbedTLS so that both produce the same results.