### PR TITLE
Added missing includes in esp_netif_types.h (IDFGH-6002)

### DIFF
--- a/components/esp_netif/include/esp_netif_types.h
+++ b/components/esp_netif/include/esp_netif_types.h
@@ -15,6 +15,9 @@
 #ifndef _ESP_NETIF_TYPES_H_
 #define _ESP_NETIF_TYPES_H_
 
+#include "esp_event_base.h"
+#include "esp_err.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
I had issues when including esp_netif_types.h in my sources as some required macros and types were missing.

Using these added includes all compiles fine again.