### PR TITLE
Exception when trying cleanup a socket that failed to allocate memory (IDFGH-6001)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -724,7 +724,9 @@ esp_err_t esp_http_client_cleanup(esp_http_client_handle_t client)
         return ESP_FAIL;
     }
     esp_http_client_close(client);
-    esp_transport_list_destroy(client->transport_list);
+    if (client->transport_list) {
+        esp_transport_list_destroy(client->transport_list);
+    }
     if (client->request) {
         http_header_destroy(client->request->headers);
         if (client->request->buffer) {


### PR DESCRIPTION
In esp_http_client_cleanup, if client->transport_list was null, it generated an exception when calling esp_transport_list_destroy.