### PR TITLE
Fetch headers in POST example for native requests (IDFGH-6004)

### DIFF
--- a/examples/protocols/esp_http_client/main/esp_http_client_example.c
+++ b/examples/protocols/esp_http_client/main/esp_http_client_example.c
@@ -624,14 +624,19 @@ static void http_native_request(void)
         if (wlen < 0) {
             ESP_LOGE(TAG, "Write failed");
         }
-        int data_read = esp_http_client_read_response(client, output_buffer, MAX_HTTP_OUTPUT_BUFFER);
-        if (data_read >= 0) {
-            ESP_LOGI(TAG, "HTTP GET Status = %d, content_length = %d",
-            esp_http_client_get_status_code(client),
-            esp_http_client_get_content_length(client));
-            ESP_LOG_BUFFER_HEX(TAG, output_buffer, strlen(output_buffer));
+        content_length = esp_http_client_fetch_headers(client);
+        if (content_length < 0) {
+            ESP_LOGE(TAG, "HTTP client fetch headers failed");
         } else {
-            ESP_LOGE(TAG, "Failed to read response");
+            int data_read = esp_http_client_read_response(client, output_buffer, MAX_HTTP_OUTPUT_BUFFER);
+            if (data_read >= 0) {
+                ESP_LOGI(TAG, "HTTP POST Status = %d, content_length = %d",
+                esp_http_client_get_status_code(client),
+                esp_http_client_get_content_length(client));
+                ESP_LOG_BUFFER_HEX(TAG, output_buffer, strlen(output_buffer));
+            } else {
+                ESP_LOGE(TAG, "Failed to read response");
+            }
         }
     }
     esp_http_client_cleanup(client);


### PR DESCRIPTION
In the POST section of `http_native_request` headers are not fetched. thus, just commenting out the GET request example would result in a `status` and `content_length` of `0` being reported (quite confusing).

(Plus, it should log `HTTP POST Status` here, instead of `HTTP GET Status`.)