### PR TITLE
Fix unexpected touch measurement start on RTC peripheral init (IDFGH-6021)

### DIFF
--- a/components/hal/esp32/include/hal/touch_sensor_ll.h
+++ b/components/hal/esp32/include/hal/touch_sensor_ll.h
@@ -280,8 +280,8 @@ static inline void touch_ll_stop_fsm(void)
  */
 static inline void touch_ll_start_sw_meas(void)
 {
-    SENS.sar_touch_ctrl2.touch_start_en = 0;
     SENS.sar_touch_ctrl2.touch_start_en = 1;
+    SENS.sar_touch_ctrl2.touch_start_en = 0;
 }
 
 /**

--- a/components/hal/esp32s2/include/hal/touch_sensor_ll.h
+++ b/components/hal/esp32s2/include/hal/touch_sensor_ll.h
@@ -310,8 +310,8 @@ static inline bool touch_ll_get_fsm_state(void)
  */
 static inline void touch_ll_start_sw_meas(void)
 {
-    RTCCNTL.touch_ctrl2.touch_start_en = 0;
     RTCCNTL.touch_ctrl2.touch_start_en = 1;
+    RTCCNTL.touch_ctrl2.touch_start_en = 0;
 }
 
 /**

--- a/components/hal/esp32s3/include/hal/touch_sensor_ll.h
+++ b/components/hal/esp32s3/include/hal/touch_sensor_ll.h
@@ -310,8 +310,8 @@ static inline bool touch_ll_get_fsm_state(void)
  */
 static inline void touch_ll_start_sw_meas(void)
 {
-    RTCCNTL.touch_ctrl2.touch_start_en = 0;
     RTCCNTL.touch_ctrl2.touch_start_en = 1;
+    RTCCNTL.touch_ctrl2.touch_start_en = 0;
 }
 
 /**


### PR DESCRIPTION
touch_ll_start_sw_meas toggles the touch_start_en bit ->0->1 to initiate a touch measurement.
When the RTC peripherals domain is first powered on (eg. on wakeup, ULP startup), the touch controller immediately unexpectedly starts a new measurement because the touch_start_en bit is still set to 1.

Change touch_ll_start_sw_meas to toggle the bit ->1->0 instead to eliminate this unexpected behaviour.

There is a demo to reproduce this here:
https://gist.github.com/boarchuz/9b7d3273734374c677b44a37dccc6d03