### PR TITLE
adds twai_get_bitrate_timings function (IDFGH-6027)

### DIFF
--- a/components/driver/twai.c
+++ b/components/driver/twai.c
@@ -712,12 +712,17 @@ esp_err_t twai_clear_receive_queue(void)
 }
 
 
-
-
 // Internal function used in twai_get_bitrate_timings
 float _fround(float val) {
     return (float) ((uint16_t) (val * 10000.0 + 0.5)) / 100.0;
 }
+
+
+#if (TWAI_BRP_MAX == 256)
+#define TWAI_BRP_IS_VALID(brp) (((brp) >= 2 && (brp) <= 128 && ((brp) & 0x1) == 0) || ((brp) >= 132 && (brp) <= 256 && ((brp) & 0x3) == 0))
+#else
+#define TWAI_BRP_IS_VALID(brp) ((brp) >= 2 && (brp) <= TWAI_BRP_MAX && ((brp) & 0x1) == 0)
+#endif
 
 
 // This function needs to be called 2 times, the first time passing NULL to matches and 0 to num_matches.
@@ -743,7 +748,7 @@ int16_t twai_get_bitrate_timings(
         } else if (nominal_bitrate > 500000) {
             nominal_sample_point = 80.0F;
         } else {
-            nominal_bitrate = 87.5F;
+            nominal_sample_point = 87.5F;
         }
     }
 

--- a/components/hal/include/hal/twai_types.h
+++ b/components/hal/include/hal/twai_types.h
@@ -49,16 +49,13 @@ extern "C" {
 
 #define TWAI_BRP_MAX    SOC_TWAI_BRP_MAX    /**< Maximum configurable BRP value */
 #define TWAI_BRP_MIN    SOC_TWAI_BRP_MIN    /**< Minimum configurable BRP value */
+#define TWAI_BRP_INC  (2)
 
 #define TWAI_TSEG1_MIN  (2)
 #define TWAI_TSEG1_MAX  (16)
 
 #define TWAI_TSEG2_MIN  (1)
 #define TWAI_TSEG2_MAX  (8)
-
-#define TWAI_BRP_MIN  (2)
-#define BRP_MAX  TWAI_BRP_MAX
-#define TWAI_BRP_INC  (2)
 
 #define TWAI_SJW_MAX  (4)
 #define TWAI_FSYS  (APB_CLK_FREQ)

--- a/components/hal/include/hal/twai_types.h
+++ b/components/hal/include/hal/twai_types.h
@@ -50,6 +50,18 @@ extern "C" {
 #define TWAI_BRP_MAX    SOC_TWAI_BRP_MAX    /**< Maximum configurable BRP value */
 #define TWAI_BRP_MIN    SOC_TWAI_BRP_MIN    /**< Minimum configurable BRP value */
 
+#define TWAI_TSEG1_MIN  (2)
+#define TWAI_TSEG1_MAX  (16)
+
+#define TWAI_TSEG2_MIN  (1)
+#define TWAI_TSEG2_MAX  (8)
+
+#define TWAI_BRP_MIN  (2)
+#define BRP_MAX  TWAI_BRP_MAX
+#define TWAI_BRP_INC  (2)
+
+#define TWAI_SJW_MAX  (4)
+#define TWAI_FSYS  (APB_CLK_FREQ)
 
 /**
  * @brief Initializer macros for timing configuration structure


### PR DESCRIPTION
This function will calculate the brp, tseg1, tseg2 and sjw values that are needed to create the twai interface.

see notes for further information

This is my first PR with esp-idf  and as such I am sure there will be things that are not correct with it. I check out the contributing information but all of the links in it are not functional so I couldn't review past the single document. So that is going to need to be fixed.

All feedback is welcome good or bad and if I need to change something  please give an example and explain what the benefit of the change is. I know enough C to just about get my toes a little wet. I have a decent understanding of C so not a complete noob. LOL.

I am a firm believer of the easier it is to use the more people will use it. It took me 6 months to fully wrap my brain around the whole CAN packet specification and of that information can be transparent to the user then it should be. The user needs to be able to provide the things that they will know like the target bitrate, length of the BUS and the processing delay of the transceiver  which is gotten  from the documentation for the transceiver. If an exact match cannot be found for their target bitrate then then next closest bitrate  the interface is capable of  should be returned. That is what this code does. It makes using a CAN interface as easy as using a serial interface.

Thank you for taking the time to review this