### PR TITLE
print correct chip model (IDFGH-6031)

### DIFF
--- a/examples/system/console/advanced/components/cmd_system/cmd_system.c
+++ b/examples/system/console/advanced/components/cmd_system/cmd_system.c
@@ -66,11 +66,34 @@ void register_system(void)
 /* 'version' command */
 static int get_version(int argc, char **argv)
 {
+    char *model;
     esp_chip_info_t info;
     esp_chip_info(&info);
+
+    switch(info.model) {
+    case CHIP_ESP32:
+	model = "ESP32";
+	break;
+    case CHIP_ESP32S2:
+        model = "ESP32S2";
+        break;
+    case CHIP_ESP32S3:
+        model = "ESP32S3";
+        break;
+    case CHIP_ESP32C3:
+        model = "ESP32C3";
+        break;
+    case CHIP_ESP32H2:
+        model = "ESP32H2";
+        break;
+    default:
+        model = "Unknown";
+        break;
+    }
+
     printf("IDF Version:%s\r\n", esp_get_idf_version());
     printf("Chip info:\r\n");
-    printf("\tmodel:%s\r\n", info.model == CHIP_ESP32 ? "ESP32" : "Unknown");
+    printf("\tmodel:%s\r\n", model);
     printf("\tcores:%d\r\n", info.cores);
     printf("\tfeature:%s%s%s%s%d%s\r\n",
            info.features & CHIP_FEATURE_WIFI_BGN ? "/802.11bgn" : "",


### PR DESCRIPTION
This example does not accommodate the various ESP32 chip models (it's either ESP32 or Unknown).   

This change prints the correct ESP32 variant.
