### PR TITLE
Fix assertion xQueueGenericSend queue.c:818 (IDFGH-6036)

### DIFF
--- a/components/esp_ringbuf/ringbuf.c
+++ b/components/esp_ringbuf/ringbuf.c
@@ -1041,12 +1041,12 @@ BaseType_t xRingbufferSend(RingbufHandle_t xRingbuffer,
          */
     }
 
+    if (xReturnSemaphore == pdTRUE) {
+        xSemaphoreGive(rbGET_TX_SEM_HANDLE(pxRingbuffer));  //Give back semaphore so other tasks can send
+    }
     if (xReturn == pdTRUE) {
         //Indicate item was successfully sent
         xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
-    }
-    if (xReturnSemaphore == pdTRUE) {
-        xSemaphoreGive(rbGET_TX_SEM_HANDLE(pxRingbuffer));  //Give back semaphore so other tasks can send
     }
     return xReturn;
 }
@@ -1083,12 +1083,12 @@ BaseType_t xRingbufferSendFromISR(RingbufHandle_t xRingbuffer,
     }
     portEXIT_CRITICAL_ISR(&pxRingbuffer->mux);
 
+    if (xReturnSemaphore == pdTRUE) {
+        xSemaphoreGiveFromISR(rbGET_TX_SEM_HANDLE(pxRingbuffer), pxHigherPriorityTaskWoken);  //Give back semaphore so other tasks can send
+    }
     if (xReturn == pdTRUE) {
         //Indicate item was successfully sent
         xSemaphoreGiveFromISR(rbGET_RX_SEM_HANDLE(pxRingbuffer), pxHigherPriorityTaskWoken);
-    }
-    if (xReturnSemaphore == pdTRUE) {
-        xSemaphoreGiveFromISR(rbGET_TX_SEM_HANDLE(pxRingbuffer), pxHigherPriorityTaskWoken);  //Give back semaphore so other tasks can send
     }
     return xReturn;
 }


### PR DESCRIPTION
The release of the semaphore indicating the item was successfully sent must be the last semaphore released.  The receiver may be in another task and may delete the Ringbuffer (such as with a return code across tasks design pattern) if they are through with the Ringbuffer.

The function xRingbufferSendAcquire followed by xRingbufferSendComplete had the semaphores released in the proper order and that same pattern should have been used in xRingbufferSend and xRingbufferSendFromISR.  This commit fixes this order.

Issue (IDFGH-6030) #7716 describes the problem in more detail.