### PR TITLE
FIX: reset ethernet TX DMA descriptors sets owner to CPU (IDFGH-6071)

### DIFF
--- a/components/hal/emac_hal.c
+++ b/components/hal/emac_hal.c
@@ -184,6 +184,7 @@ void emac_hal_reset_desc_chain(emac_hal_context_t *hal)
     for (int i = 0; i < CONFIG_ETH_DMA_TX_BUFFER_NUM; i++) {
         /* Set Own bit of the Tx descriptor Status: CPU */
         hal->tx_desc[i].TDES0.Own = EMAC_LL_DMADESC_OWNER_CPU;
+        hal->tx_desc[i].TDES0.SecondAddressChained = 1;
         hal->tx_desc[i].TDES1.TransmitBuffer1Size = CONFIG_ETH_DMA_BUFFER_SIZE;
         /* Enable Ethernet DMA Tx Descriptor interrupt */
         hal->tx_desc[1].TDES0.InterruptOnComplete = 1;

--- a/components/hal/emac_hal.c
+++ b/components/hal/emac_hal.c
@@ -166,7 +166,7 @@ void emac_hal_reset_desc_chain(emac_hal_context_t *hal)
     /* init rx chain */
     for (int i = 0; i < CONFIG_ETH_DMA_RX_BUFFER_NUM; i++) {
         /* Set Own bit of the Rx descriptor Status: DMA */
-        hal->rx_desc[i].RDES0.Own = 1;
+        hal->rx_desc[i].RDES0.Own = EMAC_LL_DMADESC_OWNER_DMA;
         /* Set Buffer1 size and Second Address Chained bit */
         hal->rx_desc[i].RDES1.SecondAddressChained = 1;
         hal->rx_desc[i].RDES1.ReceiveBuffer1Size = CONFIG_ETH_DMA_BUFFER_SIZE;
@@ -182,8 +182,8 @@ void emac_hal_reset_desc_chain(emac_hal_context_t *hal)
 
     /* init tx chain */
     for (int i = 0; i < CONFIG_ETH_DMA_TX_BUFFER_NUM; i++) {
-        /* Set Second Address Chained bit */
-        hal->tx_desc[i].TDES0.SecondAddressChained = 1;
+        /* Set Own bit of the Tx descriptor Status: CPU */
+        hal->tx_desc[i].TDES0.Own = EMAC_LL_DMADESC_OWNER_CPU;
         hal->tx_desc[i].TDES1.TransmitBuffer1Size = CONFIG_ETH_DMA_BUFFER_SIZE;
         /* Enable Ethernet DMA Tx Descriptor interrupt */
         hal->tx_desc[1].TDES0.InterruptOnComplete = 1;


### PR DESCRIPTION
FIX: reset ethernet TX DMA descriptors sets owner to CPU, so re-installing the ethernet driver will now not result in packet loss.

After uninstalling the Ethernet driver, the owner of one or more TX DMA descriptors can still belong to the DMA controller. Since this ownership was not reset in the init function, not all data could be sent and the following error was issued:

Error: emac_esp32: emac_esp32_transmit(257): insufficient TX buffer size