### PR TITLE
Fix infinite recursion in FLAG_ATTR operator (IDFGH-6073)

### DIFF
--- a/components/esp_common/include/esp_attr.h
+++ b/components/esp_common/include/esp_attr.h
@@ -129,8 +129,8 @@ FORCE_INLINE_ATTR constexpr TYPE operator<< (TYPE a, int b) { return (TYPE)((INT
 FORCE_INLINE_ATTR TYPE& operator|=(TYPE& a, TYPE b) { a = a | b; return a; } \
 FORCE_INLINE_ATTR TYPE& operator&=(TYPE& a, TYPE b) { a = a & b; return a; } \
 FORCE_INLINE_ATTR TYPE& operator^=(TYPE& a, TYPE b) { a = a ^ b; return a; } \
-FORCE_INLINE_ATTR TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
-FORCE_INLINE_ATTR TYPE& operator<<=(TYPE& a, int b) { a <<= b; return a; }
+FORCE_INLINE_ATTR TYPE& operator>>=(TYPE& a, int b) { a = a >> b; return a; } \
+FORCE_INLINE_ATTR TYPE& operator<<=(TYPE& a, int b) { a = a << b; return a; }
 
 #define FLAG_ATTR_U32(TYPE) FLAG_ATTR_IMPL(TYPE, uint32_t)
 #define FLAG_ATTR FLAG_ATTR_U32


### PR DESCRIPTION
[clang-tidy](https://clang.llvm.org/extra/clang-tidy/) detected this while linting [esphome](https://github.com/esphome/esphome/)

```
~/espidf/components/hal/include/hal/touch_sensor_types.h:165:1: error: all paths through this function will call itself [clang-diagnostic-infinite-recursion]
FLAG_ATTR(touch_pad_intr_mask_t)
^
~/espidf/components/riscv/include/esp_attr.h:102:19: note: expanded from macro 'FLAG_ATTR'
#define FLAG_ATTR FLAG_ATTR_U32
                  ^
~/espidf/components/riscv/include/esp_attr.h:101:29: note: expanded from macro 'FLAG_ATTR_U32'
#define FLAG_ATTR_U32(TYPE) FLAG_ATTR_IMPL(TYPE, uint32_t)
                            ^
~/espidf/components/riscv/include/esp_attr.h:98:53: note: expanded from macro 'FLAG_ATTR_IMPL'
FORCE_INLINE_ATTR TYPE& operator>>=(TYPE& a, int b) { a >>= b; return a; } \
```

It seems the intention was to use the `>>` and `<<` operators defined a couple of lines above (like in the |= etc operators). But this version currently just results in infinite recursion.