### PR TITLE
Update esp_http_client.c (IDFGH-6083)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1127,6 +1127,11 @@ int esp_http_client_fetch_headers(esp_http_client_handle_t client)
     if (client->state < HTTP_STATE_REQ_COMPLETE_HEADER) {
         return ESP_FAIL;
     }
+    
+    if( client->location ){
+        free( client->location );
+        client->location = NULL;
+    }
 
     client->state = HTTP_STATE_REQ_COMPLETE_DATA;
     esp_http_buffer_t *buffer = client->response->buffer;


### PR DESCRIPTION
When the location field contains data, the "Location:" header from a redirect is simply appended to its end.
This results in concatenated URLs like http://www.blabla.com?anythinghttp://the.redirected.url/and_so_on
That's bad. Is it safe to erase the location field in advance? In my code, this works just fine. 
I'm just not sure of side effects.