### PR TITLE
if wpa peap username or password is not configured, build nak response message and send back to authenticator (IDFGH-6088)

### DIFF
--- a/components/wpa_supplicant/src/eap_peer/eap_peap.c
+++ b/components/wpa_supplicant/src/eap_peer/eap_peap.c
@@ -159,6 +159,12 @@ eap_peap_init(struct eap_sm *sm)
 		return NULL;
 	}
 
+	if (!sm->config.identity || !sm->config.password) {
+		wpa_printf(MSG_ERROR, "EAP-PEAP: failed to init with user name, password");
+		eap_peap_deinit(sm, data);
+		return NULL;
+	}
+
 	data->phase2_type.vendor = EAP_VENDOR_IETF;
 	data->phase2_type.method = EAP_TYPE_NONE;
 


### PR DESCRIPTION
Fixed the issue that unable to use Wpa Tls to connect to windows radius server when the radius serer is configured to check PEAP and then TLS.
If radius server's rule is configured to authenticate PEAP and then TLS and esp-idf is configured as Tls, esp-idf needs to respond a nak message to radius server to trigger to it to retry with Tls.