### PR TITLE
client cert and key need to be configured; otherwise ESP_ERR_INVALID_STATE should be returned (IDFGH-6090)

### DIFF
--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -706,7 +706,7 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
             ESP_LOGE(TAG, "Failed to set client pki context");
             return esp_ret;
         }
-    } else if (cfg->clientcert_buf != NULL || cfg->clientkey_buf != NULL) {
+    } else if (cfg->clientcert_buf == NULL || cfg->clientkey_buf == NULL) {
         ESP_LOGE(TAG, "You have to provide both clientcert_buf and clientkey_buf for mutual authentication");
         return ESP_ERR_INVALID_STATE;
     }


### PR DESCRIPTION
fixed set_client_config(...) to return ESP_ERR_INVALID_STATE if clientcert_buf or clientkey_buf is not set in cfg. 