### PR TITLE
ftm example: clear FTM_FAILURE_BIT too (IDFGH-6094)

### DIFF
--- a/examples/wifi/ftm/main/ftm_main.c
+++ b/examples/wifi/ftm/main/ftm_main.c
@@ -476,7 +476,7 @@ static int wifi_cmd_ftm(int argc, char **argv)
     }
 
     bits = xEventGroupWaitBits(ftm_event_group, FTM_REPORT_BIT | FTM_FAILURE_BIT,
-                                           pdFALSE, pdFALSE, portMAX_DELAY);
+                                           pdTRUE, pdFALSE, portMAX_DELAY);
     /* Processing data from FTM session */
     if (bits & FTM_REPORT_BIT) {
         ftm_process_report();
@@ -485,7 +485,6 @@ static int wifi_cmd_ftm(int argc, char **argv)
         g_ftm_report_num_entries = 0;
         ESP_LOGI(TAG_STA, "Estimated RTT - %d nSec, Estimated Distance - %d.%02d meters",
                           g_rtt_est, g_dist_est / 100, g_dist_est % 100);
-        xEventGroupClearBits(ftm_event_group, FTM_REPORT_BIT);
     } else {
         /* Failure case */
     }


### PR DESCRIPTION
Once some failure with FTM occurred, the FTM_FAILURE_BIT was set forever and caused `xEventGroupWaitBits` to "fall through" right away, dumping the previous session's report (if the success bit was set by the previous session), before the current session could even finish.

All bits need to be cleared (and "handled") if they were set. Instead of explicitly clearing the respective flag after the test, I chose having `xEventGroupWaitBits` clear the flags itself (`xClearOnExit`) atomically.