### PR TITLE
docs: Spelling error fix

### DIFF
--- a/docs/en/api-reference/peripherals/pcnt.rst
+++ b/docs/en/api-reference/peripherals/pcnt.rst
@@ -55,7 +55,7 @@ If desired, the pulse input pin and the control input pin may be changed "on the
 
 .. note::
 
-    For the counter not to miss any pulses, the pulse duration should be longer than one APB_CLK cycle (12.5 ns). The pulses are sampled on the edges of the APB_CLK clock and may be missed, if fall between the edges. This applies to counter operation with or without a :ref:`filer <pcnt-api-filtering-pulses>`.
+    For the counter not to miss any pulses, the pulse duration should be longer than one APB_CLK cycle (12.5 ns). The pulses are sampled on the edges of the APB_CLK clock and may be missed, if fall between the edges. This applies to counter operation with or without a :ref:`filter <pcnt-api-filtering-pulses>`.
 
 
 .. _pcnt-api-filtering-pulses:

--- a/docs/en/api-reference/protocols/esp_tls.rst
+++ b/docs/en/api-reference/protocols/esp_tls.rst
@@ -60,7 +60,7 @@ used, wolfssl SSL/TLS library is available publicly at https://github.com/espres
 also provides few examples which are useful for understanding the API. Please refer the repository README.md for
 information on licensing and other options. Please see below option for using wolfssl in your project.
 
-.. note::   `As the library options are internal to ESP-TLS, switching the libries will not change ESP-TLS specific code for a project.`
+.. note::   `As the library options are internal to ESP-TLS, switching the libraries will not change ESP-TLS specific code for a project.`
 
 How to use wolfssl with ESP-IDF
 -------------------------------

--- a/docs/en/api-reference/protocols/esp_websocket_client.rst
+++ b/docs/en/api-reference/protocols/esp_websocket_client.rst
@@ -63,7 +63,7 @@ Configuration:
         .cert_pem = (const char *)websocket_org_pem_start,
     };
 
-.. note:: If you want to verify the server, then you need to provide a certificate in PEM format, and provide to ``cert_pem`` in :cpp:type:`websocket_client_config_t`. If no certficate is provided then the TLS connection will to default not requiring verification.
+.. note:: If you want to verify the server, then you need to provide a certificate in PEM format, and provide to ``cert_pem`` in :cpp:type:`websocket_client_config_t`. If no certficate is provided then the TLS connection will default to not requiring verification.
 
 PEM certificate for this example could be extracted from an openssl `s_client` command connecting to websocket.org.
 In case a host operating system has `openssl` and `sed` packages installed, one could execute the following command to download and save the root or intermediate root certificate to a file (Note for Windows users: Both Linux like environment or Windows native packages may be used).


### PR DESCRIPTION
- Spelling error fixes in the following docs:
  - PCNT
  - ESP-TLS
  - ESP WebSocket Client