### PR TITLE
Increased LAN8720 ETH-PHY reset assertion time (IDFGH-6018) (IDFGH-6132)

### DIFF
--- a/components/esp_eth/src/esp_eth_phy_lan87xx.c
+++ b/components/esp_eth/src/esp_eth_phy_lan87xx.c
@@ -337,7 +337,8 @@ static esp_err_t lan87xx_reset_hw(esp_eth_phy_t *phy)
         esp_rom_gpio_pad_select_gpio(lan87xx->reset_gpio_num);
         gpio_set_direction(lan87xx->reset_gpio_num, GPIO_MODE_OUTPUT);
         gpio_set_level(lan87xx->reset_gpio_num, 0);
-        esp_rom_delay_us(100); // insert min input assert time
+        /* assert nRST signal on LAN87xx a little longer than the minimum specified in datasheet */
+        esp_rom_delay_us(150);
         gpio_set_level(lan87xx->reset_gpio_num, 1);
     }
     return ESP_OK;


### PR DESCRIPTION
Increase reset assertion time from 100µs (as specified minimum in the datasheet) to 150µs.
Some specimen of the LAN8720/42 need the reset signal asserted longer than 100µs to initialise properly. Otherwise they are in a zombie state where they are establishing and loosing an Ethernet link once in a seconds interval.

This is the second pull request for #7705 , as I messed up my last commit :-/