### PR TITLE
Initialize `$envvars_array` to an empty list. (IDFGH-6140)

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -12,7 +12,7 @@ $OLD_PATH = $env:PATH.split($S) | Select-Object -Unique # array without duplicat
 $envars_raw = python $IDF_PATH/tools/idf_tools.py export --format key-value
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } # if error
 
-$envars_array # will be filled like:
+$envars_array = @() # will be filled like:
 #               [
 #                    [vname1, vval1], [vname2, vval2], ...
 #               ]


### PR DESCRIPTION
With strict debugging, i.e. `Set-PSDebug -strict`, execution of export.ps1 will
report the following error:

```
The variable '$envars_array' cannot be retrieved because it has not been set.
At C:\path\to\export.ps1:15 char:1
+ $envars_array # will be filled like:
+ ~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (envars_array:String) [], RuntimeException
    + FullyQualifiedErrorId : VariableIsUndefined
```