### PR TITLE
Check for failure in stopping http server (IDFGH-6166)

### DIFF
--- a/components/esp_http_server/src/httpd_main.c
+++ b/components/esp_http_server/src/httpd_main.c
@@ -450,7 +450,9 @@ esp_err_t httpd_stop(httpd_handle_t handle)
     struct httpd_ctrl_data msg;
     memset(&msg, 0, sizeof(msg));
     msg.hc_msg = HTTPD_CTRL_SHUTDOWN;
-    cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg));
+    if (cs_send_to_ctrl_sock(hd->msg_fd, hd->config.ctrl_port, &msg, sizeof(msg)) < 0)
+        return ESP_FAIL;
+    }
 
     ESP_LOGD(TAG, LOG_FMT("sent control msg to stop server"));
     while (hd->hd_td.status != THREAD_STOPPED) {


### PR DESCRIPTION
In some cases, sending the shutdown signal may fail, which causes `httpd_stop` to wait indefinitely. This PR adds a check to prevent this infinite loop.