### PR TITLE
Define $IsWindows if not defined. (IDFGH-6181)

### DIFF
--- a/export.ps1
+++ b/export.ps1
@@ -23,6 +23,11 @@ foreach ($line  in $envars_raw) {
     $envars_array += (, ($var_name, $var_val))
 }
 
+if ($IsWindows -eq $null) {
+    # $IsWindows was added in PowerShell Core 6 and PowerShell 7.
+    $IsWindows = $true
+}
+
 foreach ($pair  in $envars_array) {
     # setting the values
     $var_name = $pair[0].Trim() # trim spaces on the ends of the name


### PR DESCRIPTION
The `$IsWindows` PowerShell variable was added in PowerShell Core 6 and
PowerShell 7, and is not present in earlier PowerShell versions. Set to
true if undefined. This fixes https://github.com/espressif/esp-idf/issues/7820.

The first version to run on non-Windows platforms was PowerShell Core
6.0[^1] which means that IsWindows is guaranteed to be defined on all
non-Windows systems. So, if undefined this indicates a Windows platform.

[^1]: https://docs.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.2#release-history