### PR TITLE
Add support for KSZ8061 ethernet PHY (IDF-4.4) (IDFGH-6191)

### DIFF
--- a/components/esp_eth/include/esp_eth_phy.h
+++ b/components/esp_eth/include/esp_eth_phy.h
@@ -294,6 +294,17 @@ esp_eth_phy_t *esp_eth_phy_new_dp83848(const eth_phy_config_t *config);
 esp_eth_phy_t *esp_eth_phy_new_ksz8041(const eth_phy_config_t *config);
 
 /**
+* @brief Create a PHY instance of KSZ8061
+*
+* @param[in] config: configuration of PHY
+*
+* @return
+*      - instance: create PHY instance successfully
+*      - NULL: create PHY instance failed because some error occurred
+*/
+esp_eth_phy_t *esp_eth_phy_new_ksz8061(const eth_phy_config_t *config);
+
+/**
 * @brief Create a PHY instance of KSZ8081
 *
 * @param[in] config: configuration of PHY


### PR DESCRIPTION
* [Product site](https://www.microchip.com/en-us/product/KSZ8061)
* Datasheet: [KSZ8061RNB/RND](https://ww1.microchip.com/downloads/en/DeviceDoc/KSZ8061RNB-RND-10BASE-T-100BASE-TX-PHY-00002197F.pdf), [KSZ8061MNX/MNG](https://ww1.microchip.com/downloads/en/DeviceDoc/KSZ8061MNX-MNG-10BASET-100BASETX-PHY-00002038D.pdf)

Product variants
| Product | Interface | Clock | Package |
| :-- | :-: | :-: | :-: |
| KSZ8061MNX |  MMI | | 32-lead QFN |
| KSZ8061MNG | MMI | | 48-lead QFN or WQFN |
| KSZ8061RNB | RMMI | integrated | 32-pin QFN or WQFN |
| KSZ8061RND | RMMI | external | 32-pin QFN or WQFN |

The modified code is working on a custom hardware with esp32 (EMAC) and KSZ8061RND (PHY).

Pull-Request for IDF-v5.0: #7878