### PR TITLE
QA: Check driver installation status (IDFGH-6196)

### DIFF
--- a/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
+++ b/examples/peripherals/uart/uart_select/main/uart_select_example_main.c
@@ -22,6 +22,11 @@ static const char* TAG = "uart_select_example";
 
 static void uart_select_task(void *arg)
 {
+    if (uart_driver_install(UART_NUM_0, 2*1024, 0, 0, NULL, 0) != ESP_OK) {
+        ESP_LOGE(TAG, "Driver installation failed");
+        vTaskDelete(NULL);
+    }
+
     uart_config_t uart_config = {
         .baud_rate = 115200,
         .data_bits = UART_DATA_8_BITS,
@@ -30,7 +35,7 @@ static void uart_select_task(void *arg)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .source_clk = UART_SCLK_APB,
     };
-    uart_driver_install(UART_NUM_0, 2*1024, 0, 0, NULL, 0);
+
     uart_param_config(UART_NUM_0, &uart_config);
 
     while (1) {


### PR DESCRIPTION
When you have a large project, `uart_driver_install()` may fail. For QA we should always check the status of the driver first.