### PR TITLE
ldgen: override LC_ALL to C before running objdump (IDFGH-6231)

### DIFF
--- a/tools/ldgen/ldgen.py
+++ b/tools/ldgen/ldgen.py
@@ -131,7 +131,9 @@ def main():
         for library in libraries_file:
             library = library.strip()
             if library:
-                dump = StringIO(subprocess.check_output([objdump, '-h', library]).decode())
+                new_env = os.environ.copy()
+                new_env['LC_ALL']='C'
+                dump = StringIO(subprocess.check_output([objdump, '-h', library], env=new_env).decode())
                 dump.name = library
                 sections_infos.add_sections_info(dump)
 


### PR DESCRIPTION
When using a Linux system configured with `zh_CN.UTF-8` as `$LANG`, and running raw cmake command to build the project (rather than using `idf.py build`), output of objdump will be Chinese (like `在归档文件 libesp_pm.a 中`), resulting in parsing error `pyparsing.ParseException: Expected "In archive" (at char 0), (line:1, col:1)` at entity.py line 129.

This commit forces objdump to use raw locale setting (`C`), to ensure it always make English output that's able to be parsed.