### PR TITLE
Added filename, line number and method name to log output (IDFGH-6276)

### DIFF
--- a/components/app_trace/include/esp_app_trace_util.h
+++ b/components/app_trace/include/esp_app_trace_util.h
@@ -174,7 +174,7 @@ void esp_apptrace_log_unlock(void);
 #define ESP_APPTRACE_LOG_LEV( _L_, level, format, ... )   \
     do { \
         if (LOG_LOCAL_LEVEL >= level) { \
-            ESP_APPTRACE_LOG(LOG_FORMAT(_L_, format), esp_log_early_timestamp(), TAG, ##__VA_ARGS__); \
+            ESP_APPTRACE_LOG(LOG_EARLY_FORMAT(_L_, format, TAG), ##__VA_ARGS__); \
         } \
     } while(0)
 

--- a/components/app_trace/test/test_trace.c
+++ b/components/app_trace/test/test_trace.c
@@ -54,7 +54,7 @@ const static char *TAG = "esp_apptrace_test";
 #define ESP_APPTRACE_TEST_LOG_LEVEL( _L_, level, format, ... )   \
     do { \
         if (LOG_LOCAL_LEVEL >= level) { \
-            ESP_APPTRACE_TEST_LOG(LOG_FORMAT(_L_, format), esp_log_early_timestamp(), TAG, ##__VA_ARGS__); \
+            ESP_APPTRACE_TEST_LOG(LOG_EARLY_FORMAT(_L_, format, TAG), ##__VA_ARGS__); \
         } \
     } while(0)
 

--- a/components/bt/common/include/bt_common.h
+++ b/components/bt/common/include/bt_common.h
@@ -101,11 +101,11 @@
 
 #define BT_LOG_LEVEL_CHECK(LAYER, LEVEL) (MAX(LAYER##_INITIAL_TRACE_LEVEL, LOG_LOCAL_LEVEL_MAPPING) >= BT_TRACE_LEVEL_##LEVEL)
 
-#define BT_PRINT_E(tag, format, ...)   {esp_log_write(ESP_LOG_ERROR,   tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BT_PRINT_W(tag, format, ...)   {esp_log_write(ESP_LOG_WARN,    tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BT_PRINT_I(tag, format, ...)   {esp_log_write(ESP_LOG_INFO,    tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BT_PRINT_D(tag, format, ...)   {esp_log_write(ESP_LOG_DEBUG,   tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BT_PRINT_V(tag, format, ...)   {esp_log_write(ESP_LOG_VERBOSE, tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
+#define BT_PRINT_E(tag, format, ...)   {esp_log_write(ESP_LOG_ERROR,   tag, LOG_FORMAT(E, format, tag), ##__VA_ARGS__); }
+#define BT_PRINT_W(tag, format, ...)   {esp_log_write(ESP_LOG_WARN,    tag, LOG_FORMAT(W, format, tag), ##__VA_ARGS__); }
+#define BT_PRINT_I(tag, format, ...)   {esp_log_write(ESP_LOG_INFO,    tag, LOG_FORMAT(I, format, tag), ##__VA_ARGS__); }
+#define BT_PRINT_D(tag, format, ...)   {esp_log_write(ESP_LOG_DEBUG,   tag, LOG_FORMAT(D, format, tag), ##__VA_ARGS__); }
+#define BT_PRINT_V(tag, format, ...)   {esp_log_write(ESP_LOG_VERBOSE, tag, LOG_FORMAT(V, format, tag), ##__VA_ARGS__); }
 
 
 #if !UC_BT_STACK_NO_LOG

--- a/components/bt/esp_ble_mesh/mesh_common/include/mesh_trace.h
+++ b/components/bt/esp_ble_mesh/mesh_common/include/mesh_trace.h
@@ -61,11 +61,11 @@ extern "C" {
 
 #define BLE_MESH_LOG_LEVEL_CHECK(LAYER, LEVEL)  (MAX(LAYER##_LOG_LEVEL, BLE_MESH_LOG_LOCAL_LEVEL_MAPPING) >= BLE_MESH_LOG_LEVEL_##LEVEL)
 
-#define BLE_MESH_PRINT_E(tag, format, ...)  {esp_log_write(ESP_LOG_ERROR,   tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BLE_MESH_PRINT_W(tag, format, ...)  {esp_log_write(ESP_LOG_WARN,    tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BLE_MESH_PRINT_I(tag, format, ...)  {esp_log_write(ESP_LOG_INFO,    tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BLE_MESH_PRINT_D(tag, format, ...)  {esp_log_write(ESP_LOG_DEBUG,   tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
-#define BLE_MESH_PRINT_V(tag, format, ...)  {esp_log_write(ESP_LOG_VERBOSE, tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); }
+#define BLE_MESH_PRINT_E(tag, format, ...)  {esp_log_write(ESP_LOG_ERROR,   tag, LOG_FORMAT(E, format, tag), ##__VA_ARGS__); }
+#define BLE_MESH_PRINT_W(tag, format, ...)  {esp_log_write(ESP_LOG_WARN,    tag, LOG_FORMAT(W, format, tag), ##__VA_ARGS__); }
+#define BLE_MESH_PRINT_I(tag, format, ...)  {esp_log_write(ESP_LOG_INFO,    tag, LOG_FORMAT(I, format, tag), ##__VA_ARGS__); }
+#define BLE_MESH_PRINT_D(tag, format, ...)  {esp_log_write(ESP_LOG_DEBUG,   tag, LOG_FORMAT(D, format, tag), ##__VA_ARGS__); }
+#define BLE_MESH_PRINT_V(tag, format, ...)  {esp_log_write(ESP_LOG_VERBOSE, tag, LOG_FORMAT(V, format, tag), ##__VA_ARGS__); }
 
 #define printk          esp_rom_printf
 

--- a/components/bt/host/bluedroid/common/include/common/bt_trace.h
+++ b/components/bt/host/bluedroid/common/include/common/bt_trace.h
@@ -209,11 +209,11 @@ static inline void trc_dump_buffer(const char *prefix, uint8_t *data, uint16_t l
 // btla-specific --
 
 #if !UC_BT_STACK_NO_LOG
-#define LOG_ERROR(format, ... )             {if (LOG_LOCAL_LEVEL >= ESP_LOG_ERROR)    esp_log_write(ESP_LOG_ERROR,   "BT_LOG", LOG_FORMAT(E, format), esp_log_timestamp(), "BT_LOG", ##__VA_ARGS__); }
-#define LOG_WARN(format, ... )              {if (LOG_LOCAL_LEVEL >= ESP_LOG_WARN)     esp_log_write(ESP_LOG_WARN,    "BT_LOG", LOG_FORMAT(W, format), esp_log_timestamp(), "BT_LOG", ##__VA_ARGS__); }
-#define LOG_INFO(format, ... )              {if (LOG_LOCAL_LEVEL >= ESP_LOG_INFO)     esp_log_write(ESP_LOG_INFO,    "BT_LOG", LOG_FORMAT(I, format), esp_log_timestamp(), "BT_LOG", ##__VA_ARGS__); }
-#define LOG_DEBUG(format, ... )             {if (LOG_LOCAL_LEVEL >= ESP_LOG_DEBUG)    esp_log_write(ESP_LOG_DEBUG,   "BT_LOG", LOG_FORMAT(D, format), esp_log_timestamp(), "BT_LOG", ##__VA_ARGS__); }
-#define LOG_VERBOSE(format, ... )           {if (LOG_LOCAL_LEVEL >= ESP_LOG_VERBOSE)  esp_log_write(ESP_LOG_VERBOSE, "BT_LOG", LOG_FORMAT(V, format), esp_log_timestamp(), "BT_LOG", ##__VA_ARGS__); }
+#define LOG_ERROR(format, ... )             {if (LOG_LOCAL_LEVEL >= ESP_LOG_ERROR)    esp_log_write(ESP_LOG_ERROR,   "BT_LOG", LOG_FORMAT(E, format, "BT_LOG"), ##__VA_ARGS__); }
+#define LOG_WARN(format, ... )              {if (LOG_LOCAL_LEVEL >= ESP_LOG_WARN)     esp_log_write(ESP_LOG_WARN,    "BT_LOG", LOG_FORMAT(W, format, "BT_LOG"), ##__VA_ARGS__); }
+#define LOG_INFO(format, ... )              {if (LOG_LOCAL_LEVEL >= ESP_LOG_INFO)     esp_log_write(ESP_LOG_INFO,    "BT_LOG", LOG_FORMAT(I, format, "BT_LOG"), ##__VA_ARGS__); }
+#define LOG_DEBUG(format, ... )             {if (LOG_LOCAL_LEVEL >= ESP_LOG_DEBUG)    esp_log_write(ESP_LOG_DEBUG,   "BT_LOG", LOG_FORMAT(D, format, "BT_LOG"), ##__VA_ARGS__); }
+#define LOG_VERBOSE(format, ... )           {if (LOG_LOCAL_LEVEL >= ESP_LOG_VERBOSE)  esp_log_write(ESP_LOG_VERBOSE, "BT_LOG", LOG_FORMAT(V, format, "BT_LOG"), ##__VA_ARGS__); }
 
 /* Define tracing for BTM
 */

--- a/components/espcoredump/include_core_dump/esp_core_dump_types.h
+++ b/components/espcoredump/include_core_dump/esp_core_dump_types.h
@@ -27,17 +27,12 @@ extern "C" {
 #include "core_dump_checksum.h"
 
 #define ESP_COREDUMP_TAG "COREDUMP"
-//#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(format, esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
-//#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT_DRAM(E, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-//#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT_DRAM(W, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-//#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT_DRAM(I, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-//#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT_DRAM(D, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-//#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT_DRAM(V, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGE( format, ... ) ESP_LOGE(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGW( format, ... ) ESP_LOGW(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGI( format, ... ) ESP_LOGI(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGD( format, ... ) ESP_LOGD(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGV( format, ... ) ESP_LOGV(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
+#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(format, ##__VA_ARGS__); }
+#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT_DRAM(E, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT_DRAM(W, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT_DRAM(I, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT_DRAM(D, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT_DRAM(V, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
 
 /**
  * @brief Assertion to be verified in a release context. Cannot be muted.

--- a/components/espcoredump/include_core_dump/esp_core_dump_types.h
+++ b/components/espcoredump/include_core_dump/esp_core_dump_types.h
@@ -26,12 +26,13 @@ extern "C" {
 #include "esp_private/panic_internal.h"
 #include "core_dump_checksum.h"
 
-#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(DRAM_STR(format), esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
-#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT(E, format), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT(W, format), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT(I, format), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT(D, format), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT(V, format), ##__VA_ARGS__)
+#define ESP_COREDUMP_TAG "COREDUMP"
+#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(format, esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
+#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT_DRAM(E, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT_DRAM(W, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT_DRAM(I, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT_DRAM(D, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT_DRAM(V, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
 
 /**
  * @brief Assertion to be verified in a release context. Cannot be muted.

--- a/components/espcoredump/include_core_dump/esp_core_dump_types.h
+++ b/components/espcoredump/include_core_dump/esp_core_dump_types.h
@@ -27,12 +27,17 @@ extern "C" {
 #include "core_dump_checksum.h"
 
 #define ESP_COREDUMP_TAG "COREDUMP"
-#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(format, esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
-#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT_DRAM(E, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT_DRAM(W, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT_DRAM(I, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT_DRAM(D, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
-#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT_DRAM(V, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+//#define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(format, esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
+//#define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT_DRAM(E, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+//#define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT_DRAM(W, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+//#define ESP_COREDUMP_LOGI( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_INFO, LOG_FORMAT_DRAM(I, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+//#define ESP_COREDUMP_LOGD( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_DEBUG, LOG_FORMAT_DRAM(D, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+//#define ESP_COREDUMP_LOGV( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_VERBOSE, LOG_FORMAT_DRAM(V, format, ESP_COREDUMP_TAG), ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGE( format, ... ) ESP_LOGE(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGW( format, ... ) ESP_LOGW(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGI( format, ... ) ESP_LOGI(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGD( format, ... ) ESP_LOGD(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
+#define ESP_COREDUMP_LOGV( format, ... ) ESP_LOGV(ESP_COREDUMP_TAG, format, ##__VA_ARGS__)
 
 /**
  * @brief Assertion to be verified in a release context. Cannot be muted.

--- a/components/espcoredump/src/core_dump_common.c
+++ b/components/espcoredump/src/core_dump_common.c
@@ -180,7 +180,7 @@ static void esp_core_dump_switch_task_stack_to_isr(core_dump_task_header_t *task
     }
     task->stack_start = (uint32_t) s_exc_frame;
     task->stack_end = esp_core_dump_get_isr_stack_end();
-    ESP_COREDUMP_LOG_PROCESS("Switched task %x to ISR stack [%x...%x]", task->tcb_addr,
+    ESP_COREDUMP_LOG_PROCESS("Switched task %p to ISR stack [%x...%x]", task->tcb_addr,
                                                                         task->stack_start,
                                                                         task->stack_end);
 }
@@ -215,11 +215,11 @@ bool esp_core_dump_get_task_snapshot(void *handle, core_dump_task_header_t *task
         task->stack_start = (uint32_t) s_exc_frame;
     }
     if (!esp_core_dump_check_task(task)) {
-        ESP_COREDUMP_LOG_PROCESS("Task %x is broken!", handle);
+        ESP_COREDUMP_LOG_PROCESS("Task %p is broken!", handle);
         return false;
     }
     if (handle == esp_core_dump_get_current_task_handle()) {
-        ESP_COREDUMP_LOG_PROCESS("Crashed task %x", handle);
+        ESP_COREDUMP_LOG_PROCESS("Crashed task %p", handle);
         esp_core_dump_port_set_crashed_tcb((uint32_t)handle);
         if (xPortInterruptedFromISRContext()) {
             esp_core_dump_switch_task_stack_to_isr(task, interrupted_stack);

--- a/components/espcoredump/src/core_dump_flash.c
+++ b/components/espcoredump/src/core_dump_flash.c
@@ -91,6 +91,9 @@ void esp_core_dump_flash_init(void)
         ESP_COREDUMP_LOGE("No core dump partition found!");
         return;
     }
+    ESP_COREDUMP_LOGI("Found partition '%s'", "test");
+    ESP_COREDUMP_LOGI("Found partition '%p'", core_part);
+    ESP_COREDUMP_LOGI("Found partition '%p'", core_part->label);
     ESP_COREDUMP_LOGI("Found partition '%s' @ %x %d bytes", core_part->label, core_part->address, core_part->size);
     s_core_flash_config.partition.start      = core_part->address;
     s_core_flash_config.partition.size       = core_part->size;

--- a/components/espcoredump/src/port/xtensa/core_dump_port.c
+++ b/components/espcoredump/src/port/xtensa/core_dump_port.c
@@ -369,20 +369,20 @@ bool esp_core_dump_check_task(core_dump_task_header_t *task)
     bool stack_is_valid = false;
 
     if (!esp_core_dump_tcb_addr_is_sane((uint32_t)task->tcb_addr)) {
-        ESP_COREDUMP_LOG_PROCESS("Bad TCB addr=%x!", task->tcb_addr);
+        ESP_COREDUMP_LOG_PROCESS("Bad TCB addr=%p!", task->tcb_addr);
         return false;
     }
 
     stack_is_valid = esp_core_dump_check_stack(task);
     if (!stack_is_valid) {
         // Skip saving of invalid task if stack corrupted
-        ESP_COREDUMP_LOG_PROCESS("Task (TCB:%x), stack is corrupted (%x, %x)",
+        ESP_COREDUMP_LOG_PROCESS("Task (TCB:%p), stack is corrupted (%x, %x)",
                                     task->tcb_addr,
                                     task->stack_start,
                                     task->stack_end);
         task->stack_start = (uint32_t)esp_core_dump_get_fake_stack(&stk_size);
         task->stack_end = (uint32_t)(task->stack_start + stk_size);
-        ESP_COREDUMP_LOG_PROCESS("Task (TCB:%x), use start, end (%x, %x)",
+        ESP_COREDUMP_LOG_PROCESS("Task (TCB:%p), use start, end (%x, %x)",
                                             task->tcb_addr,
                                             task->stack_start,
                                             task->stack_end);
@@ -391,7 +391,7 @@ bool esp_core_dump_check_task(core_dump_task_header_t *task)
          * would point to a fake address. */
         XtSolFrame *sol_frame = (XtSolFrame *)task->stack_start;
         if (sol_frame->exit == 0) {
-            ESP_COREDUMP_LOG_PROCESS("Task (TCB:%x), EXIT/PC/PS/A0/SP %x %x %x %x %x",
+            ESP_COREDUMP_LOG_PROCESS("Task (TCB:%p), EXIT/PC/PS/A0/SP %lx %lx %lx %lx %lx",
                                         task->tcb_addr,
                                         sol_frame->exit,
                                         sol_frame->pc,
@@ -402,7 +402,7 @@ bool esp_core_dump_check_task(core_dump_task_header_t *task)
     // to avoid warning that 'exc_frame' is unused when ESP_COREDUMP_LOG_PROCESS does nothing
     #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
             XtExcFrame *exc_frame = (XtExcFrame *)task->stack_start;
-            ESP_COREDUMP_LOG_PROCESS("Task (TCB:%x) EXIT/PC/PS/A0/SP %x %x %x %x %x",
+            ESP_COREDUMP_LOG_PROCESS("Task (TCB:%p) EXIT/PC/PS/A0/SP %lx %lx %lx %lx %lx",
                                         task->tcb_addr,
                                         exc_frame->exit,
                                         exc_frame->pc,
@@ -431,7 +431,7 @@ uint32_t esp_core_dump_get_task_regs_dump(core_dump_task_header_t *task, void **
 
     stack_len = esp_core_dump_get_stack(task, &stack_vaddr, &stack_paddr);
 
-    ESP_COREDUMP_LOG_PROCESS("Add regs for task 0x%x", task->tcb_addr);
+    ESP_COREDUMP_LOG_PROCESS("Add regs for task 0x%p", task->tcb_addr);
 
     // initialize program status for the task
     s_reg_dump.pr_status.pr_cursig = 0;

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -291,8 +291,12 @@ void esp_log_writev(esp_log_level_t level, const char* tag, const char* format, 
 #define LOG_RESET_COLOR
 #endif //CONFIG_LOG_COLORS
 
-#define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%u) %s: " format LOG_RESET_COLOR "\n"
-#define LOG_SYSTEM_TIME_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%s) %s: " format LOG_RESET_COLOR "\n"
+#define LOG_FORMAT(letter, format, tag)  LOG_COLOR_ ## letter #letter " (%u) %s %s:%u %s(): " format LOG_RESET_COLOR "\n", esp_log_timestamp(), tag, (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__), __LINE__, __FUNCTION__
+#define LOG_SYSTEM_TIME_FORMAT(letter, format, tag)  LOG_COLOR_ ## letter #letter " (%s) %s %s:%u %s(): " format LOG_RESET_COLOR "\n", esp_log_system_timestamp(), tag, (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__), __LINE__, __FUNCTION__
+// the following format helper is used in espcoredump
+#define LOG_FORMAT_DRAM(letter, format, tag)  DRAM_STR(LOG_COLOR_ ## letter #letter " (%u) %s %s:%u %s(): " format LOG_RESET_COLOR "\n"), esp_log_timestamp(), tag, (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__), __LINE__, __FUNCTION__
+// the following format helper is used in app_trace
+#define LOG_EARLY_FORMAT(letter, format, tag)  LOG_COLOR_ ## letter #letter " (%u) %s %s:%u %s(): " format LOG_RESET_COLOR "\n", esp_log_early_timestamp(), tag, (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__), __LINE__, __FUNCTION__
 
 /** @endcond */
 
@@ -339,7 +343,7 @@ void esp_log_writev(esp_log_level_t level, const char* tag, const char* format, 
 
 #define ESP_LOG_EARLY_IMPL(tag, format, log_level, log_tag_letter, ...) do {                             \
         if (_ESP_LOG_EARLY_ENABLED(log_level)) {                                                         \
-            esp_rom_printf(LOG_FORMAT(log_tag_letter, format), esp_log_timestamp(), tag, ##__VA_ARGS__); \
+            esp_rom_printf(LOG_FORMAT(log_tag_letter, format, tag), ##__VA_ARGS__); \
         }} while(0)
 
 #ifndef BOOTLOADER_BUILD
@@ -402,37 +406,37 @@ void esp_log_writev(esp_log_level_t level, const char* tag, const char* format, 
 #if defined(__cplusplus) && (__cplusplus >  201703L)
 #if CONFIG_LOG_TIMESTAMP_SOURCE_RTOS
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
-        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
     } while(0)
 #elif CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
-        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format), esp_log_system_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format), esp_log_system_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format), esp_log_system_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
-        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format), esp_log_system_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format, tag) __VA_OPT__(,) __VA_ARGS__); } \
     } while(0)
 #endif //CONFIG_LOG_TIMESTAMP_SOURCE_xxx
 #else // !(defined(__cplusplus) && (__cplusplus >  201703L))
 #if CONFIG_LOG_TIMESTAMP_SOURCE_RTOS
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
-        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
-        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format, tag), ##__VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format, tag), ##__VA_ARGS__); } \
     } while(0)
 #elif CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM
 #define ESP_LOG_LEVEL(level, tag, format, ...) do {                     \
-        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
-        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
+        if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_SYSTEM_TIME_FORMAT(E, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_SYSTEM_TIME_FORMAT(W, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format, tag), ##__VA_ARGS__); } \
+        else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_SYSTEM_TIME_FORMAT(V, format, tag), ##__VA_ARGS__); } \
+        else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_SYSTEM_TIME_FORMAT(I, format, tag), ##__VA_ARGS__); } \
     } while(0)
 #endif //CONFIG_LOG_TIMESTAMP_SOURCE_xxx
 #endif // !(defined(__cplusplus) && (__cplusplus >  201703L))


### PR DESCRIPTION
The log output now also shows the source of the log statement, the filename, line number and funciton name.

Example from my firmware:
![image](https://user-images.githubusercontent.com/10342708/142774221-160eb3f4-d349-4150-9275-8bc16ef0e2ff.png)
