### PR TITLE
Clarify when the socket is closed if a custom session closing callbac… (IDFGH-6279)

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -206,6 +206,9 @@ typedef struct httpd_config {
      * Called when a session is deleted, before freeing user and transport contexts and before
      * closing the socket. This is a place for custom de-init code common to all sockets.
      *
+     * The server will only close the socket if no custom session closing callback is set.
+     * If a custom callback is used, `close(sockfd)` should be called in here for most cases.
+     *
      * Set the user or transport context to NULL if it was freed here, so the server does not
      * try to free it again.
      *


### PR DESCRIPTION
…k is used

When using a custom session closing callback, the IDF will not close the socket for the user. This might result in the system running out of fds. Without any note on that in the documentation, this is easy to miss.