### PR TITLE
docs: fix spelling errors in bt_spp_initiator (IDFGH-6281)

### DIFF
--- a/examples/bluetooth/bluedroid/classic_bt/bt_spp_initiator/README.md
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_spp_initiator/README.md
@@ -17,7 +17,7 @@ This example is designed to run on commonly available ESP32 development board, e
 idf.py menuconfig
 ```
 
-In `menuconfig` path: `Coponent config --> Bluetooth--> Bluedroid Options -->SPP` and `Coponent config --> Bluetooth--> Bluedroid Options -->Secure Simple Pair`.
+In `menuconfig` path: `Component config --> Bluetooth--> Bluedroid Options -->SPP` and `Component config --> Bluetooth--> Bluedroid Options -->Secure Simple Pair`.
 
 ### Build and Flash
 


### PR DESCRIPTION
when checking the menuconfig, we see that the first option should be 'component config'