### PR TITLE
fix: missing initializer waring in esp_eth (IDFGH-6293)

### DIFF
--- a/components/esp_eth/include/esp_eth.h
+++ b/components/esp_eth/include/esp_eth.h
@@ -43,12 +43,6 @@ typedef struct {
     uint32_t check_link_period_ms;
 
     /**
-     * @brief Configuration status of PHY autonegotiation feature
-     *
-     */
-    bool auto_nego_en;
-
-    /**
     * @brief Input frame buffer to user's stack
     *
     * @param[in] eth_handle: handle of Ethernet driver


### PR DESCRIPTION
add auto_nego_en initializer to ETH_DEFAULT_CONFIG

fixes the following warning:
```
<source>/esp-idf/components/esp_eth/include/esp_eth.h:144:5: warning: missing initializer for member 'esp_eth_config_t::auto_nego_en' [-Wmissing-field-initializers]
     }
     ^
note: in expansion of macro 'ETH_DEFAULT_CONFIG'
   esp_eth_config_t config = ETH_DEFAULT_CONFIG(pMac, pPhy);
```