### PR TITLE
bugfix: Conflicting declaration error when include<rom/secure_boot.h> (IDFGH-6308)

### DIFF
--- a/components/esp_rom/include/esp32/rom/secure_boot.h
+++ b/components/esp_rom/include/esp32/rom/secure_boot.h
@@ -14,8 +14,7 @@
 
 #include "sdkconfig.h"
 
-#ifndef _ROM_SECURE_BOOT_H_
-#define _ROM_SECURE_BOOT_H_
+#pragma once
 
 #include <stdint.h>
 #include "ets_sys.h"
@@ -128,5 +127,3 @@ bool ets_use_secure_boot_v2(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* _ROM_SECURE_BOOT_H_ */

--- a/components/esp_rom/include/esp32c3/rom/secure_boot.h
+++ b/components/esp_rom/include/esp32c3/rom/secure_boot.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _ROM_SECURE_BOOT_H_
-#define _ROM_SECURE_BOOT_H_
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -23,9 +22,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
@@ -127,5 +123,3 @@ struct ets_secure_boot_key_digests {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* _ROM_SECURE_BOOT_H_ */

--- a/components/esp_rom/include/esp32h2/rom/secure_boot.h
+++ b/components/esp_rom/include/esp32h2/rom/secure_boot.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _ROM_SECURE_BOOT_H_
-#define _ROM_SECURE_BOOT_H_
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -23,9 +22,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
@@ -127,5 +123,3 @@ struct ets_secure_boot_key_digests {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* _ROM_SECURE_BOOT_H_ */

--- a/components/esp_rom/include/esp32s2/rom/secure_boot.h
+++ b/components/esp_rom/include/esp32s2/rom/secure_boot.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _ROM_SECURE_BOOT_H_
-#define _ROM_SECURE_BOOT_H_
+#pragma once
 
 #include <stdint.h>
 #include "ets_sys.h"
@@ -22,9 +21,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
@@ -126,5 +122,3 @@ struct ets_secure_boot_key_digests {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* _ROM_SECURE_BOOT_H_ */

--- a/components/esp_rom/include/esp32s3/rom/secure_boot.h
+++ b/components/esp_rom/include/esp32s3/rom/secure_boot.h
@@ -23,9 +23,6 @@
 extern "C" {
 #endif
 
-struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
-
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
 typedef struct ets_secure_boot_key_digests ets_secure_boot_key_digests_t;

--- a/components/esp_rom/include/esp8684/rom/secure_boot.h
+++ b/components/esp_rom/include/esp8684/rom/secure_boot.h
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _ROM_SECURE_BOOT_H_
-#define _ROM_SECURE_BOOT_H_
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -15,9 +14,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
@@ -119,5 +115,3 @@ struct ets_secure_boot_key_digests {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* _ROM_SECURE_BOOT_H_ */


### PR DESCRIPTION
Conflicting declaration error occurs between lines 28 and 31 of file rom/secure_boot.h.
This error can be reproduced by writing # include <esp_efuse.h> and building ESP32S2 or ESP32C3 as the target.
```
C:/esp-idf/components/esp_rom/include/esp32c3/rom/secure_boot.h:31:42: error: conflicting declaration 'typedef struct ets_secure_boot_signature ets_secure_boot_signature_t'
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/esp-idf/components/esp_rom/include/esp32c3/rom/secure_boot.h:28:8: note: previous declaration as 'struct ets_secure_boot_signature_t'
 struct ets_secure_boot_signature_t;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This problem is caused by the extra "_t" at the end of the name, as shown below.
```
struct foo_t;
typedef struct foo foo_t;
```
This pull request removes the trailing _t from " struct ets_secure_boot_signature_t; " on line 28.