### PR TITLE
Minor: typo (IDFGH-6316)

### DIFF
--- a/docs/en/api-guides/unit-tests.rst
+++ b/docs/en/api-guides/unit-tests.rst
@@ -18,7 +18,7 @@ Tests are added in a function in the C file as follows:
 
 .. code-block:: c
 
-    TEST_CASE("test name", "[module name]"
+    TEST_CASE("test name", "[module name]")
     {
             // Add test here
     }


### PR DESCRIPTION
Minor typo: missing parenthesis