### PR TITLE
Don't overwrite errno by a hard coded ENOENT (IDFGH-6378)

### DIFF
--- a/components/vfs/vfs.c
+++ b/components/vfs/vfs.c
@@ -415,7 +415,7 @@ int esp_vfs_open(struct _reent *r, const char * path, int flags, int mode)
         __errno_r(r) = ENOMEM;
         return -1;
     }
-    __errno_r(r) = ENOENT;
+    __errno_r(r) = errno;
     return -1;
 }
 


### PR DESCRIPTION
Calling "open" in CHECK_AND_CALL sets a perfectly correct errno.
There is no need to overwrite that with a value of ENOENT, since doing so hides lower level errors like EIO