### PR TITLE
Don't return a hard coded errno in vfs_fat_access (IDFGH-6377)

### DIFF
--- a/components/fatfs/vfs/vfs_fat.c
+++ b/components/fatfs/vfs/vfs_fat.c
@@ -865,7 +865,7 @@ static int vfs_fat_access(void* ctx, const char *path, int amode)
         // it exists then it is readable and executable
     } else {
         ret = -1;
-        errno = ENOENT;
+        errno = fresult_to_errno(res);
     }
 
     return ret;


### PR DESCRIPTION
Why should the return value of vfs_fat_access be hard coded as ENOENT?
This hides errors like FR_DISK_ERR of the lower layers.