### PR TITLE
print Firmware Upgrade URL to help user debug (IDFGH-6382)

### DIFF
--- a/examples/system/ota/simple_ota_example/main/simple_ota_example.c
+++ b/examples/system/ota/simple_ota_example/main/simple_ota_example.c
@@ -72,7 +72,7 @@ esp_err_t _http_event_handler(esp_http_client_event_t *evt)
 
 void simple_ota_example_task(void *pvParameter)
 {
-    ESP_LOGI(TAG, "Starting OTA example");
+    ESP_LOGI(TAG, "Starting OTA example. Attempting to download update from %s", CONFIG_EXAMPLE_FIRMWARE_UPGRADE_URL);
 #ifdef CONFIG_EXAMPLE_FIRMWARE_UPGRADE_BIND_IF
     esp_netif_t *netif = get_example_netif_from_desc(bind_interface_name);
     if (netif == NULL) {


### PR DESCRIPTION
The log previously didn't print the CONFIG_EXAMPLE_FIRMWARE_UPGRADE_URL.  But I think this URL is a fairly important piece of debug info, cause an incorrect URL will cause the update to fail.  So I think put this URL in the log, to help user diagnose if the error is due to a misspelled or misconfigured URL.