### PR TITLE
example: Synchronize includes in BLE walkthrough (IDFGH-6417)

### DIFF
--- a/examples/bluetooth/bluedroid/ble/gatt_server/tutorial/Gatt_Server_Example_Walkthrough.md
+++ b/examples/bluetooth/bluedroid/ble/gatt_server/tutorial/Gatt_Server_Example_Walkthrough.md
@@ -18,17 +18,17 @@ First, let’s take a look at the includes:
 #include "esp_system.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
-#include "bt.h"
-#include "bta_api.h"
+#include "esp_bt.h"
 #include "esp_gap_ble_api.h"
 #include "esp_gatts_api.h"
 #include "esp_bt_defs.h"
 #include "esp_bt_main.h"
+#include "esp_gatt_common_api.h"
 #include "sdkconfig.h"
 ```
-These includes are required for the FreeRTOS and underlaying system components to run, including the logging functionality and a library to store data in non-volatile flash memory. We are interested in `"bt.h"`, `"esp_bt_main.h"`, `"esp_gap_ble_api.h"` and `"esp_gatts_api.h"`, which expose the BLE APIs required to implement this example.
+These includes are required for the FreeRTOS and underlaying system components to run, including the logging functionality and a library to store data in non-volatile flash memory. We are interested in `"esp_bt.h"`, `"esp_bt_main.h"`, `"esp_gap_ble_api.h"` and `"esp_gatts_api.h"`, which expose the BLE APIs required to implement this example.
 
-* `bt.h`: implements BT controller and VHCI configuration procedures from the host side.
+* `esp_bt.h`: implements BT controller and VHCI configuration procedures from the host side.
 * `esp_bt_main.h`: implements initialization and enabling of the Bluedroid stack.
 * `esp_gap_ble_api.h`: implements GAP configuration, such as advertising and connection parameters.
 * `esp_gatts_api.h`: implements GATT configuration, such as creating services and characteristics.


### PR DESCRIPTION
While following one of the examples for BLE GATT server, I got stuck on an issue with includes where my code could not be compiled. After some struggling I found out that the walkthrough which I was partly taking code from had wrong includes for the BT headers (the source code for the example is correct).

I am completely new to ESP IDF so I am not sure whether the headers used to be correct and perhaps they were renamed later without reflecting the changes into the guide or whether the guide was wrong in the first place. I just found it a bit confusing, since this document is even linked from the  official docs :) The guide should now be the same as the source file in this regard.