### PR TITLE
monitor: Print buffer when reading an escape character (IDFGH-6443)

### DIFF
--- a/tools/idf_monitor_base/ansi_color_converter.py
+++ b/tools/idf_monitor_base/ansi_color_converter.py
@@ -95,6 +95,7 @@ class ANSIColorConverter(object):
             b = bytes([b])
             length = len(self.matched)
             if b == b'\033':  # ESC
+                self._output_write(self.matched)
                 self.matched = b
             elif (length == 1 and b == b'[') or (1 < length < 7):
                 self.matched += b


### PR DESCRIPTION
The color converter script currently discards partially processed data when it encounters an escape character. This can result in missing characters when the user prints escape sequences that are not expected by the script. This PR fixes this issue.