### PR TITLE
[4.3 backport] monitor: Print buffer when reading an escape character (IDFGH-6442)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -1282,6 +1282,7 @@ if os.name == 'nt':
                 b = bytes([b])
                 length = len(self.matched)
                 if b == b'\033':  # ESC
+                    self._output_write(self.matched)
                     self.matched = b
                 elif (length == 1 and b == b'[') or (1 < length < 7):
                     self.matched += b


### PR DESCRIPTION
See #8100