### PR TITLE
[4.3] Force espcoredump.py to terminate (IDFGH-6446)

### DIFF
--- a/components/espcoredump/espcoredump.py
+++ b/components/espcoredump/espcoredump.py
@@ -290,10 +290,14 @@ if __name__ == '__main__':
         log_level = logging.DEBUG
     logging.basicConfig(format='%(levelname)s: %(message)s', level=log_level)
 
-    print('espcoredump.py v%s' % __version__)
-    if args.operation == 'info_corefile':
-        info_corefile()
-    elif args.operation == 'dbg_corefile':
-        dbg_corefile()
-    else:
-        raise ValueError('Please specify action, should be info_corefile or dbg_corefile')
+    try:
+        print('espcoredump.py v%s' % __version__)
+        if args.operation == 'info_corefile':
+            info_corefile()
+        elif args.operation == 'dbg_corefile':
+            dbg_corefile()
+        else:
+            raise ValueError('Please specify action, should be info_corefile or dbg_corefile')
+    except Exception as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
If the underlying gdb process terminates early for some reason, `espcoredump.py` might never exit. This PR forces the process to terminate if an exception occurs.

This is not the most elegant solution and might leave behind temp files, but that's better than a hanging process.