### PR TITLE
Fix GDB backtraces in optimized builds (IDFGH-6444)

### DIFF
--- a/components/freertos/Kconfig
+++ b/components/freertos/Kconfig
@@ -421,7 +421,7 @@ menu "FreeRTOS"
 
     config FREERTOS_TASK_FUNCTION_WRAPPER
         bool "Enclose all task functions in a wrapper function"
-        depends on COMPILER_OPTIMIZATION_DEFAULT
+        depends on COMPILER_OPTIMIZATION_DEFAULT || ESP_COREDUMP_ENABLE || ESP_GDBSTUB_ENABLED
         default y
         help
             If enabled, all FreeRTOS task functions will be enclosed in a wrapper function.


### PR DESCRIPTION
If `COMPILER_OPTIMIZATION` is not set to default, the `FREERTOS_TASK_FUNCTION_WRAPPER` option is ignored and wrapper functions are not generated. This makes backtraces in coredumps crash GDB, which makes `espcoredump.py` hang (see #8105).