### PR TITLE
Update rtc_tempsensor.c (IDFGH-6458)

### DIFF
--- a/components/driver/esp32c3/rtc_tempsensor.c
+++ b/components/driver/esp32c3/rtc_tempsensor.c
@@ -111,6 +111,7 @@ esp_err_t temp_sensor_stop(void)
 {
     APB_SARADC.apb_tsens_ctrl.tsens_pu = 0;
     APB_SARADC.apb_tsens_ctrl2.tsens_clk_sel = 0;
+    tsens_hw_state = TSENS_HW_STATE_CONFIGURED
     return ESP_OK;
 }
 


### PR DESCRIPTION
update tsens_hw_state in temp_sensor_stop(), which is forgotten by the careless programmer. Without this, the temp sensor cannot be re-configured by temp_sensor_set_config.