### PR TITLE
wpa_supplicant: Fix checking signal level in compare_scan_neighbor_re… (IDFGH-6477)

### DIFF
--- a/components/wpa_supplicant/src/common/wnm_sta.c
+++ b/components/wpa_supplicant/src/common/wnm_sta.c
@@ -384,7 +384,7 @@ compare_scan_neighbor_results(struct wpa_supplicant *wpa_s, os_time_t age_secs,
 			continue;
 		}
 
-		if (target->level < bss->level && target->level < -80) {
+		if (target->level < bss->level || target->level < -80) {
 			wpa_printf(MSG_DEBUG, "Candidate BSS " MACSTR
 				   " (pref %d) does not have sufficient signal level (%d)",
 				   MAC2STR(nei->bssid),


### PR DESCRIPTION
…sults

Current logic is wrong because it makes the target acceptable
when "target->level < bss->level && target->level >= -80".

Signed-off-by: Axel Lin <axel.lin@gmail.com>