### PR TITLE
Replace lwIP byte order functions with built-in functions (IDFGH-6512)

### DIFF
--- a/components/lwip/port/esp32/include/arch/cc.h
+++ b/components/lwip/port/esp32/include/arch/cc.h
@@ -50,6 +50,12 @@ extern "C" {
 #define BYTE_ORDER LITTLE_ENDIAN
 #endif // BYTE_ORDER
 
+#define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
+#define htons(x) __builtin_bswap16(x)
+#define ntohs(x) __builtin_bswap16(x)
+#define htonl(x) __builtin_bswap32(x)
+#define ntohl(x) __builtin_bswap32(x)
+    
 #ifndef CONFIG_LWIP_ESP_LWIP_ASSERT
 #define LWIP_NOASSERT 1
 #endif


### PR DESCRIPTION
- This replaces the default software implementation (less efficient) with compiler builtin functions (much efficient and possibly assembler implemented).
- These byte order swap functions are used intensively and are on top of the list of the recommended improvements for performance. Please see [Detailed Description here](http://lwip.nongnu.org/2_1_x/def_8c.html) and [here](https://www.nongnu.org/lwip/2_1_x/optimization.html).
