### PR TITLE
fix fatfs_create_spiflash_image() feature (IDFGH-6383) (IDFGH-6518)

### DIFF
--- a/components/fatfs/fatfsgen.py
+++ b/components/fatfs/fatfsgen.py
@@ -167,7 +167,7 @@ class FATFS:
         normal_path = os.path.normpath(folder_relative_path)
         split_path = normal_path.split(os.sep)
         if os.path.isfile(real_path):
-            with open(real_path) as file:
+            with open(real_path, "rb") as file:
                 content = file.read()
             file_name, extension = os.path.splitext(split_path[-1])
             extension = extension[1:]  # remove the dot from the extension

--- a/components/fatfs/fatfsgen_utils/fs_object.py
+++ b/components/fatfs/fatfsgen_utils/fs_object.py
@@ -47,7 +47,7 @@ class File:
         # we assume that the correct amount of clusters is allocated
         current_cluster = self._first_cluster
         for content_part in split_content_into_sectors(content, self.fatfs_state.sector_size):
-            content_as_list = content_part.encode()
+            content_as_list = content_part
             if current_cluster is None:
                 raise FatalError('No free space left!')
 


### PR DESCRIPTION
Open the files in binary mode, and remove the redundant encode.

Fixes #8042 