### PR TITLE
Fix compile issue when TinyUSB task is not enabled. (IDFGH-6521)

### DIFF
--- a/components/tinyusb/additions/src/tusb_tasks.c
+++ b/components/tinyusb/additions/src/tusb_tasks.c
@@ -20,6 +20,8 @@
 #include "tinyusb.h"
 #include "tusb_tasks.h"
 
+#if !CONFIG_TINYUSB_NO_DEFAULT_TASK
+
 const static char *TAG = "tusb_tsk";
 static TaskHandle_t s_tusb_tskh;
 
@@ -52,3 +54,5 @@ esp_err_t tusb_stop_task(void)
     s_tusb_tskh = NULL;
     return ESP_OK;
 }
+
+#endif // !CONFIG_TINYUSB_NO_DEFAULT_TASK


### PR DESCRIPTION
Specifying CONFIG_TINYUSB_NO_DEFAULT_TASK in the project configuration produces errors in this code because
CONFIG_TINYUSB_TASK_STACK_SIZE and CONFIG_TINYUSB_TASK_PRIORITY
are not defined.

Conditionally compile this file only if CONFIG_TINYUSB_NO_DEFAULT_TASK is false.