### PR TITLE
Add twai queue size observers (IDFGH-6537)

### DIFF
--- a/components/driver/include/driver/twai.h
+++ b/components/driver/include/driver/twai.h
@@ -223,6 +223,30 @@ esp_err_t twai_stop(void);
 esp_err_t twai_transmit(const twai_message_t *message, TickType_t ticks_to_wait);
 
 /**
+ * @brief   Get the number of pending messages in TX queue
+ *
+ * @param[out]   pending_tx         Number of messages
+ *
+ * @return
+ *      - ESP_OK: Transmission successfully queued/initiated
+ *      - ESP_ERR_INVALID_ARG: Arguments are invalid
+ *      - ESP_ERR_INVALID_STATE: TWAI driver is not in running state, or is not installed
+ */
+esp_err_t twai_get_pending_tx(unsigned *pending_tx);
+
+/**
+ * @brief   Get the number of pending messages in RX queue
+ *
+ * @param[out]   pending_rx         Number of messages
+ *
+ * @return
+ *      - ESP_OK: Transmission successfully queued/initiated
+ *      - ESP_ERR_INVALID_ARG: Arguments are invalid
+ *      - ESP_ERR_INVALID_STATE: TWAI driver is not in running state, or is not installed
+ */
+esp_err_t twai_get_pending_rx(unsigned *pending_rx);
+
+/**
  * @brief   Receive a TWAI message
  *
  * This function receives a message from the RX queue. The flags field of the

--- a/components/driver/twai.c
+++ b/components/driver/twai.c
@@ -584,6 +584,30 @@ esp_err_t twai_transmit(const twai_message_t *message, TickType_t ticks_to_wait)
     return ret;
 }
 
+esp_err_t twai_get_pending_tx(unsigned *pending_tx)
+{
+    //Check arguments
+    TWAI_CHECK(p_twai_obj != NULL, ESP_ERR_INVALID_STATE);
+    if (!pending_tx)
+        return ESP_ERR_INVALID_ARG;
+
+    *pending_tx = uxQueueMessagesWaiting(p_twai_obj->tx_queue);
+
+    return ESP_OK;
+}
+
+esp_err_t twai_get_pending_rx(unsigned *pending_rx)
+{
+    //Check arguments
+    TWAI_CHECK(p_twai_obj != NULL, ESP_ERR_INVALID_STATE);
+    if (!pending_rx)
+        return ESP_ERR_INVALID_ARG;
+
+    *pending_rx = uxQueueMessagesWaiting(p_twai_obj->rx_queue);
+
+    return ESP_OK;
+}
+
 esp_err_t twai_receive(twai_message_t *message, TickType_t ticks_to_wait)
 {
     //Check arguments and state


### PR DESCRIPTION
I need to debug strange TWAI freezes on the esp32 and therefore I wanted to log the queue sizes of rx and tx queues,

I could observe that seconds before the esp32 is stuck the TX queue goes up to 5 or 6.