### PR TITLE
Reduce error log when calling esp_efuse_mac_get_custom() (IDFGH-6580)

### DIFF
--- a/components/esp_hw_support/mac_addr.c
+++ b/components/esp_hw_support/mac_addr.c
@@ -86,7 +86,12 @@ esp_err_t esp_efuse_mac_get_custom(uint8_t *mac)
     uint8_t version;
     esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM_VER, &version, 8);
     if (version != 1) {
-        ESP_LOGE(TAG, "Base MAC address from BLK3 of EFUSE version error, version = %d", version);
+        // version 0 means has not been setup
+        if (version == 0) {
+            ESP_LOGD(TAG, "No base MAC address in eFuse (version=0)");
+        } else if (version != 1) {
+            ESP_LOGE(TAG, "Base MAC address version error, version = %d", version);
+        }
         return ESP_ERR_INVALID_VERSION;
     }
 


### PR DESCRIPTION
Our firmwares always try to find out, if a custom mac address has been stored in production, and the esp-idf itself logs an error if none is found.

I tried to reduce the log level to DEBUG when version equals to 0. It still logs an error if a newer (or invalid) version is found