### PR TITLE
Fix random crash with Plex mdns queries on my network (IDFGH-6606)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -1552,6 +1552,8 @@ static bool _mdns_service_match_ptr_question(const mdns_service_t *service, cons
         }
         return false;
     }
+    if (question->host && !service->instance)
+        return false;
     if (question->host) {
         if (strcasecmp(service->instance, question->host) != 0) {
             return false;


### PR DESCRIPTION
While i was watching movies all my esp32 based projects crash at the same time every 30minutes. For now I only have the uploaded coredump stack traces the esp's.

This "fix" seems to avoid the crash, but I do not understand why it fixes it.

According sentry entry

![image](https://user-images.githubusercontent.com/10342708/149804577-6bc01e7c-7047-4e1e-8749-75c2a2dec58c.png)
