### PR TITLE
Clear notification value in mdns_hostname_set. (IDFGH-6647)

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -5061,7 +5061,7 @@ esp_err_t mdns_hostname_set(const char * hostname)
         free(action);
         return ESP_ERR_NO_MEM;
     }
-    xTaskNotifyWait(0, 0, NULL, portMAX_DELAY);
+    xTaskNotifyWait(0, 0x01, NULL, portMAX_DELAY);
     return ESP_OK;
 }
 


### PR DESCRIPTION
When calling mdns_hostname_set, xTaskNotifyWait is called without clearing the notification value on exit.
This causes subsequent calls to xTaskNotifyWait or ulTaskNotifyTake to unexpectedly not block.