### PR TITLE
Fix issue on esp_http_client_example (IDFGH-6717) #8346 (IDFGH-6740)

### DIFF
--- a/examples/protocols/esp_http_client/main/esp_http_client_example.c
+++ b/examples/protocols/esp_http_client/main/esp_http_client_example.c
@@ -100,14 +100,14 @@ esp_err_t _http_event_handler(esp_http_client_event_t *evt)
             int mbedtls_err = 0;
             esp_err_t err = esp_tls_get_and_clear_last_error(evt->data, &mbedtls_err, NULL);
             if (err != 0) {
-                if (output_buffer != NULL) {
-                    free(output_buffer);
-                    output_buffer = NULL;
-                }
-                output_len = 0;
                 ESP_LOGI(TAG, "Last esp error code: 0x%x", err);
                 ESP_LOGI(TAG, "Last mbedtls failure: 0x%x", mbedtls_err);
             }
+            if (output_buffer != NULL) {
+                free(output_buffer);
+                output_buffer = NULL;
+            }
+            output_len = 0;
             break;
         case HTTP_EVENT_REDIRECT:
             ESP_LOGD(TAG, "HTTP_EVENT_REDIRECT");


### PR DESCRIPTION
As stated in (IDFGH-6717) #8346, this commit change the file esp_http_client_example.c to always free output_buffer on HTTP_EVENT_DISCONNECTED, 