### PR TITLE
esp_event: constify event_data pointer (IDFGH-6760)

### DIFF
--- a/components/esp_event/default_event_loop.c
+++ b/components/esp_event/default_event_loop.c
@@ -1,16 +1,8 @@
-// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "esp_event.h"
 #include "esp_event_internal.h"
@@ -74,7 +66,7 @@ esp_err_t esp_event_handler_instance_unregister(esp_event_base_t event_base,
 }
 
 esp_err_t esp_event_post(esp_event_base_t event_base, int32_t event_id,
-        void* event_data, size_t event_data_size, TickType_t ticks_to_wait)
+        const void* event_data, size_t event_data_size, TickType_t ticks_to_wait)
 {
     if (s_default_loop == NULL) {
         return ESP_ERR_INVALID_STATE;
@@ -87,7 +79,7 @@ esp_err_t esp_event_post(esp_event_base_t event_base, int32_t event_id,
 
 #if CONFIG_ESP_EVENT_POST_FROM_ISR
 esp_err_t esp_event_isr_post(esp_event_base_t event_base, int32_t event_id,
-        void* event_data, size_t event_data_size, BaseType_t* task_unblocked)
+        const void* event_data, size_t event_data_size, BaseType_t* task_unblocked)
 {
     if (s_default_loop == NULL) {
         return ESP_ERR_INVALID_STATE;

--- a/components/esp_event/esp_event.c
+++ b/components/esp_event/esp_event.c
@@ -1,16 +1,8 @@
-// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <stdlib.h>
 #include <string.h>
@@ -823,7 +815,7 @@ esp_err_t esp_event_handler_instance_unregister_with(esp_event_loop_handle_t eve
 }
 
 esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop, esp_event_base_t event_base, int32_t event_id,
-                            void* event_data, size_t event_data_size, TickType_t ticks_to_wait)
+                            const void* event_data, size_t event_data_size, TickType_t ticks_to_wait)
 {
     assert(event_loop);
 
@@ -900,7 +892,7 @@ esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop, esp_event_base_t
 
 #if CONFIG_ESP_EVENT_POST_FROM_ISR
 esp_err_t esp_event_isr_post_to(esp_event_loop_handle_t event_loop, esp_event_base_t event_base, int32_t event_id,
-                            void* event_data, size_t event_data_size, BaseType_t* task_unblocked)
+                            const void* event_data, size_t event_data_size, BaseType_t* task_unblocked)
 {
     assert(event_loop);
 

--- a/components/esp_event/include/esp_event.h
+++ b/components/esp_event/include/esp_event.h
@@ -373,7 +373,7 @@ esp_err_t esp_event_handler_instance_unregister(esp_event_base_t event_base,
  */
 esp_err_t esp_event_post(esp_event_base_t event_base,
                          int32_t event_id,
-                         void *event_data,
+                         const void *event_data,
                          size_t event_data_size,
                          TickType_t ticks_to_wait);
 
@@ -402,7 +402,7 @@ esp_err_t esp_event_post(esp_event_base_t event_base,
 esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop,
                             esp_event_base_t event_base,
                             int32_t event_id,
-                            void *event_data,
+                            const void *event_data,
                             size_t event_data_size,
                             TickType_t ticks_to_wait);
 
@@ -431,7 +431,7 @@ esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop,
  */
 esp_err_t esp_event_isr_post(esp_event_base_t event_base,
                              int32_t event_id,
-                             void *event_data,
+                             const void *event_data,
                              size_t event_data_size,
                              BaseType_t *task_unblocked);
 
@@ -461,7 +461,7 @@ esp_err_t esp_event_isr_post(esp_event_base_t event_base,
 esp_err_t esp_event_isr_post_to(esp_event_loop_handle_t event_loop,
                                 esp_event_base_t event_base,
                                 int32_t event_id,
-                                void *event_data,
+                                const void *event_data,
                                 size_t event_data_size,
                                 BaseType_t *task_unblocked);
 #endif

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -451,8 +451,6 @@ components/esp_eth/src/w5500.h
 components/esp_eth/test/test_emac.c
 components/esp_eth/test_apps/component_ut_test.py
 components/esp_eth/test_apps/main/esp_eth_test.c
-components/esp_event/default_event_loop.c
-components/esp_event/esp_event.c
 components/esp_event/esp_event_private.c
 components/esp_event/event_loop_legacy.c
 components/esp_event/event_send.c


### PR DESCRIPTION
The provided user data is immediately copied and never modified (as it should be), hence it should be marked const.
This change should be source compatible with existing code.

I tested this change by compiling and running both `esp_event/` sample projects.