### PR TITLE
SPI Slave won't handle CS Interrupt if routed through GPIO Matrix whereas the data lines are on the IO MUX (IDFGH-6768)

### DIFF
--- a/components/driver/spi_slave.c
+++ b/components/driver/spi_slave.c
@@ -97,7 +97,7 @@ static void freeze_cs(spi_slave_t *host)
 // This is used in test by internal gpio matrix connections
 static inline void restore_cs(spi_slave_t *host)
 {
-    if (bus_is_iomux(host)) {
+    if (host->cfg.spics_io_num == spi_periph_signal[host->id].spics0_iomux_pin) {
         gpio_iomux_in(host->cfg.spics_io_num, spi_periph_signal[host->id].spics_in);
     } else {
         esp_rom_gpio_connect_in_signal(host->cfg.spics_io_num, spi_periph_signal[host->id].spics_in, false);


### PR DESCRIPTION
There is a bug in the SPI Slave driver, which only occurs if the SPI Slave uses a GPIO port for the CS line which needs to use the GPIO matrix (that means CS GPIO != 15 for ESP32) whereas the other lines (MISO/MOSI/SCLK) use the default lines and do not need the GPIO matrix.

In this case host->flags&SPICOMMON_BUSFLAG_IOMUX_PINS does not get set, as bus_uses_iomux_pins in spi_common.c only returns false if either the SCLK, QUADWP, QUADHP, MOSI or MISO line uses the GPIO matrix.
I would highly suggest not to add the CS line to this check (which would be one solution) as the CS line is not a high-speed / data line and using using the GPIO matrix for all data lines just because the CS is using the GPIO matrix would reduce the maximum performance to the half.

The initial handling of the CS signal in spi_common.c (spicommon_cs_initialize()) works as the check here is performed not against the flag SPICOMMON_BUSFLAG_IOMUX_PINS but instead it is checked if the CS GPIO is the default or needs routing through the GPIO matrix.

So my suggestion (and this push-request) is not to use the function bus_is_iomux() in restore_cs() (as this returns false even though the CS signal needs the GPIO matrix) but instead does the same as is done in spicommon_cs_initialize and check the routing of the CS signal separately in restore_cs() in spi_slave.c (which doesn’t take longer and thus does not increase the execution time of the interrupt handler).