### PR TITLE
secure_boot.c add missing '#include "esp_flash_encrypt.h"' (IDFGH-6774)

### DIFF
--- a/components/bootloader_support/src/esp32s2/secure_boot.c
+++ b/components/bootloader_support/src/esp32s2/secure_boot.c
@@ -28,6 +28,8 @@
 #include "esp32s2/rom/efuse.h"
 #include "esp32s2/rom/secure_boot.h"
 
+#include "esp_flash_encrypt.h"
+
 static const char *TAG = "secure_boot_v2";
 #define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
 


### PR DESCRIPTION
with:  
- `CONFIG_SECURE_BOOT_V2_ALLOW_EFUSE_RD_DIS`  not set
and
- `CONFIG_SECURE_FLASH_ENC_ENABLED`  set

function `esp_flash_encryption_enabled` declared in `esp_flash_encrypt.h` gets called