### PR TITLE
Added typing to serial_write() (IDFGH-6792)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -178,7 +178,7 @@ class Monitor:
                 pass
             normal_print('\n')
 
-    def serial_write(self, *args, **kwargs):  # type: ignore
+    def serial_write(self, *args: str, **kwargs: str) -> None:
         raise NotImplementedError
 
     def check_gdb_stub_and_run(self, line: bytes) -> None:
@@ -237,7 +237,7 @@ class SerialMonitor(Monitor):
             self.gdb_helper.gdb_exit = False
         self.serial_handler.start_cmd_sent = False
 
-    def serial_write(self, *args, **kwargs):  # type: ignore
+    def serial_write(self, *args: str, **kwargs: str) -> None:
         self.serial: serial.Serial
         try:
             self.serial.write(*args, **kwargs)
@@ -268,7 +268,7 @@ class LinuxMonitor(Monitor):
         self.console_reader.start()
         self.serial_reader.start()
 
-    def serial_write(self, *args, **kwargs):  # type: ignore
+    def serial_write(self, *args: str, **kwargs: str) -> None:
         self.serial.stdin.write(*args, **kwargs)
 
     def check_gdb_stub_and_run(self, line: bytes) -> None:


### PR DESCRIPTION
Added type annotation for serial_write() parameters and return types.
Used [pre-commit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/contribute/install-pre-commit-hook.html) as proposed by @dobairoland in pr [#8418](https://github.com/espressif/esp-idf/pull/8418) 