### PR TITLE
ADC Fix compiling when included from C++ (IDFGH-6804)

### DIFF
--- a/components/hal/esp32/include/hal/i2s_ll.h
+++ b/components/hal/esp32/include/hal/i2s_ll.h
@@ -754,7 +754,7 @@ static inline void i2s_ll_rx_set_pdm_dsr(i2s_dev_t *hw, i2s_pdm_dsr_t dsr)
  */
 static inline void i2s_ll_rx_get_pdm_dsr(i2s_dev_t *hw, i2s_pdm_dsr_t *dsr)
 {
-    *dsr = hw->pdm_conf.rx_sinc_dsr_16_en;
+    *dsr = (i2s_pdm_dsr_t)hw->pdm_conf.rx_sinc_dsr_16_en;
 }
 
 /**

--- a/components/hal/include/hal/adc_hal.h
+++ b/components/hal/include/hal/adc_hal.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_err.h"
 #include "soc/soc_caps.h"
 #include "hal/dma_types.h"
@@ -382,3 +386,7 @@ uint32_t adc_hal_self_calibration(adc_ll_num_t adc_n, adc_channel_t channel, adc
  * @prarm adc_n ADC unit.
  */
 #define adc_hal_rtc_output_invert(adc_n, inv_en) adc_ll_rtc_output_invert(adc_n, inv_en)
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
c++ is stricter with enum types and needs a external "C" for correct linkage