### PR TITLE
i2c: fix typo in SOC_I2C_SUPPORT_SALVE (IDFGH-6893)

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -390,7 +390,7 @@ err:
         if (p_i2c_obj[i2c_num]->cmd_mux) {
             vSemaphoreDelete(p_i2c_obj[i2c_num]->cmd_mux);
         }
-#if SOC_I2C_SUPPORT_SALVE
+#if SOC_I2C_SUPPORT_SLAVE
         if (p_i2c_obj[i2c_num]->slv_rx_mux) {
             vSemaphoreDelete(p_i2c_obj[i2c_num]->slv_rx_mux);
         }


### PR DESCRIPTION
I was browsing the code for the I2C driver and found this typo.
I open a pull request to fix it.