### PR TITLE
Upgrade esp_encrypted_img version in pre-encrypted OTA example (IDFGH-6915)

### DIFF
--- a/examples/system/ota/pre_encrypted_ota/README.md
+++ b/examples/system/ota/pre_encrypted_ota/README.md
@@ -1,11 +1,17 @@
 
 # Encrypted Binary OTA
 
-This example demonstrates OTA updates with pre-encrypted binary using `esp_encrypted_img` component's APIs and tool. Pre encrypted firmware binary must be hosted on OTA update server. This firmware will be fetched and then decrypted on device before being flashed. This allows firmware to remain `confidential` on the OTA update channel irrespective of underlying transport (e.g., non-TLS).
+This example demonstrates OTA updates with pre-encrypted binary using `esp_encrypted_img` component's APIs and tool.
+
+Pre-encrypted firmware binary must be hosted on OTA update server.
+This firmware will be fetched and then decrypted on device before being flashed.
+This allows firmware to remain `confidential` on the OTA update channel irrespective of underlying transport (e.g., non-TLS).
 
 ## ESP Encrypted Image Abstraction Layer
 
-This example uses `esp_encrypted_img` component hosted at https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img through component manager. Please refer to its documentation [here](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/README.md) for more details
+This example uses `esp_encrypted_img` component hosted at [idf-extra-components/esp_encrypted_img](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img) and available though the [IDF component manager](https://components.espressif.com/component/espressif/esp_encrypted_img).
+
+Please refer to its documentation [here](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/README.md) for more details.
 
 
 ## How to use the example

--- a/examples/system/ota/pre_encrypted_ota/main/idf_component.yml
+++ b/examples/system/ota/pre_encrypted_ota/main/idf_component.yml
@@ -1,3 +1,3 @@
 dependencies:
   idf: ">=4.4"
-  espressif/esp_encrypted_img: "^1.0.0"
+  espressif/esp_encrypted_img: "^2.0.1"


### PR DESCRIPTION
This PR updates `esp_encrypted_img` version to `^2.0.1` and updates the example accordingly.

The previous version had some issues that broke C++ compatibility (discussed here https://github.com/espressif/idf-extra-components/pull/17)

I've also added a link to the IDF component manager in the readme.
