### PR TITLE
esp_https_ota: add user_ctx to decrypt_cb (IDFGH-6924)

### DIFF
--- a/components/esp_https_ota/include/esp_https_ota.h
+++ b/components/esp_https_ota/include/esp_https_ota.h
@@ -25,7 +25,7 @@ typedef struct {
     size_t data_out_len;    /*!< Output data length */
 } decrypt_cb_arg_t;
 
-typedef esp_err_t(*decrypt_cb_t)(decrypt_cb_arg_t *args);
+typedef esp_err_t(*decrypt_cb_t)(decrypt_cb_arg_t *args, void *user_ctx);
 #endif // CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
 
 /**
@@ -39,6 +39,7 @@ typedef struct {
     int max_http_request_size;                     /*!< Maximum request size for partial HTTP download */
 #if CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
     decrypt_cb_t decrypt_cb;                       /*!< Callback for external decryption layer */
+    void *decrypt_user_ctx;                        /*!< User context for external decryption layer */
 #endif
 } esp_https_ota_config_t;
 

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -45,6 +45,7 @@ struct esp_https_ota_handle {
     bool partial_http_download;
 #if CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
     decrypt_cb_t decrypt_cb;
+    void *decrypt_user_ctx;
 #endif
 };
 
@@ -153,7 +154,7 @@ static void _http_cleanup(esp_http_client_handle_t client)
 #if CONFIG_ESP_HTTPS_OTA_DECRYPT_CB
 static esp_err_t esp_https_ota_decrypt_cb(esp_https_ota_t *handle, decrypt_cb_arg_t *args)
 {
-    esp_err_t ret = handle->decrypt_cb(args);
+    esp_err_t ret = handle->decrypt_cb(args, handle->decrypt_user_ctx);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Decrypt callback failed %d", ret);
         return ret;
@@ -310,6 +311,7 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
         goto http_cleanup;
     }
     https_ota_handle->decrypt_cb = ota_config->decrypt_cb;
+    https_ota_handle->decrypt_user_ctx = ota_config->decrypt_user_ctx;
 #endif
     https_ota_handle->ota_upgrade_buf_size = alloc_size;
     https_ota_handle->bulk_flash_erase = ota_config->bulk_flash_erase;

--- a/examples/system/ota/pre_encrypted_ota/main/pre_encrypted_ota.c
+++ b/examples/system/ota/pre_encrypted_ota/main/pre_encrypted_ota.c
@@ -41,7 +41,7 @@ extern const uint8_t rsa_private_pem_end[]   asm("_binary_private_pem_end");
 
 static esp_decrypt_handle_t *ctx;
 
-static esp_err_t _decrypt_cb(decrypt_cb_arg_t *args)
+static esp_err_t _decrypt_cb(decrypt_cb_arg_t *args, void *user_ctx)
 {
     esp_err_t err;
     pre_enc_decrypt_arg_t pargs = {};
@@ -106,6 +106,7 @@ void pre_encrypted_ota_task(void *pvParameter)
         .max_http_request_size = CONFIG_EXAMPLE_HTTP_REQUEST_SIZE,
 #endif
         .decrypt_cb = _decrypt_cb,
+        .decrypt_user_ctx = NULL
     };
 
     esp_https_ota_handle_t https_ota_handle = NULL;


### PR DESCRIPTION
This makes the decryption layer easier to use in C++ wrappers, or whenever you want to avoid a global.

Without this you're forced to make a global variable for the `esp_decrypt_handle_t` for pre-encrypted OTA (instead of a member variable in the case of a C++ wrapper).