### PR TITLE
Moefied the softap_example_main.c

### DIFF
--- a/examples/wifi/getting_started/softAP/main/softap_example_main.c
+++ b/examples/wifi/getting_started/softAP/main/softap_example_main.c
@@ -67,8 +67,6 @@ void wifi_init_softap(void)
             .password = EXAMPLE_ESP_WIFI_PASS,
             .max_connection = EXAMPLE_MAX_STA_CONN,
             .authmode = WIFI_AUTH_WPA_WPA2_PSK,
-            .pmf_cfg = {
-                    .required = false,
             },
         },
     };


### PR DESCRIPTION
I build the esp-idf\examples\wifi\getting_started\softAP find "../main/softap_example_main.c:71:21: error: field name not in record or union initializer  .required = false,",so i delete the ".required = false,".    
This project build ok ,so i try to pull it.