### PR TITLE
Return EAGAIN in http client perform (IDFGH-6997)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1086,7 +1086,7 @@ int esp_http_client_read(esp_http_client_handle_t client, char *buffer, int len)
 esp_err_t esp_http_client_perform(esp_http_client_handle_t client)
 {
     esp_err_t err;
-    do {
+    //do {
         if (client->process_again) {
             esp_http_client_prepare(client);
         }
@@ -1186,8 +1186,9 @@ esp_err_t esp_http_client_perform(esp_http_client_handle_t client)
                 default:
                 break;
         }
-    } while (client->process_again);
-    return ESP_OK;
+    //} while (client->process_again);
+    //return ESP_OK;
+    return client->process_again ? EAGAIN : ESP_OK;
 }
 
 int64_t esp_http_client_fetch_headers(esp_http_client_handle_t client)

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1086,7 +1086,7 @@ int esp_http_client_read(esp_http_client_handle_t client, char *buffer, int len)
 esp_err_t esp_http_client_perform(esp_http_client_handle_t client)
 {
     esp_err_t err;
-    //do {
+
         if (client->process_again) {
             esp_http_client_prepare(client);
         }
@@ -1186,8 +1186,7 @@ esp_err_t esp_http_client_perform(esp_http_client_handle_t client)
                 default:
                 break;
         }
-    //} while (client->process_again);
-    //return ESP_OK;
+
     return client->process_again ? EAGAIN : ESP_OK;
 }
 


### PR DESCRIPTION
I needed to get the two separate response bodies on a web resource with basic authentication.

First request always fails with [401 Unauthorized](https://developer.mozilla.org/de/docs/Web/HTTP/Status/401) and contains some response body.

Second request succeeds as the needed Authentication header is sent with.

I need both request bodies and by returning EAGAIN i can read both bodies separately. Does this have anything to do with is_async config?