### PR TITLE
Update simple_ota_example.c

### DIFF
--- a/examples/system/ota/simple_ota_example/main/simple_ota_example.c
+++ b/examples/system/ota/simple_ota_example/main/simple_ota_example.c
@@ -125,7 +125,7 @@ void simple_ota_example_task(void *pvParameter)
         .http_config = &config,
     };
     ESP_LOGI(TAG, "Attempting to download update from %s", config.url);
-    esp_err_t ret = esp_https_ota(&ota_config);
+    esp_err_t ret = esp_https_ota(ota_config.http_config);
     if (ret == ESP_OK) {
         esp_restart();
     } else {


### PR DESCRIPTION
The original code passes the argument &ota_config, which is of type esp_https_ota_config_t *. The called function is esp_https_ota(const esp_http_client_config_t *config). The passed argument does not match the expected argument type.
ota_config.http_config is of type esp_http_client_config_t *, which matches the expected type of the called function.