### PR TITLE
Just a markdown syntax typo in the docs... (IDFGH-7069)

### DIFF
--- a/docs/en/api-reference/peripherals/spi_master.rst
+++ b/docs/en/api-reference/peripherals/spi_master.rst
@@ -419,7 +419,7 @@ To have better control of the calling sequence of functions, send mixed transact
     | QUADHD   | 4    | 21   |
     +----------+------+------+
 
-    * Only the first Device attached to the bus can use the CS0 pin.
+    \* Only the first Device attached to the bus can use the CS0 pin.
 
 
 .. _speed_considerations:


### PR DESCRIPTION
Searched the asterisk for a while... :facepalm: 
Was rendered as a bullet point.