### PR TITLE
uart: expose uart context for custom uart interrupt handlers

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -19,6 +19,7 @@ extern "C" {
 #include "freertos/queue.h"
 #include "freertos/ringbuf.h"
 #include "hal/uart_types.h"
+#include "hal/uart_hal.h"
 
 // Valid UART port number
 #define UART_NUM_0             (0) /*!< UART port 0 */
@@ -75,6 +76,12 @@ typedef struct {
 } uart_event_t;
 
 typedef intr_handle_t uart_isr_handle_t;
+
+typedef struct {
+    uart_hal_context_t hal;        /*!< UART hal context*/
+    portMUX_TYPE spinlock;
+    bool hw_enabled;
+} uart_context_t;
 
 /**
  * @brief Install UART driver and set the UART to the default configuration.

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -14,7 +14,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/ringbuf.h"
-#include "hal/uart_hal.h"
 #include "hal/gpio_hal.h"
 #include "soc/uart_periph.h"
 #include "soc/rtc_cntl_reg.h"
@@ -147,15 +146,9 @@ typedef struct {
 #endif
 } uart_obj_t;
 
-typedef struct {
-    uart_hal_context_t hal;        /*!< UART hal context*/
-    portMUX_TYPE spinlock;
-    bool hw_enabled;
-} uart_context_t;
-
 static uart_obj_t *p_uart_obj[UART_NUM_MAX] = {0};
 
-static uart_context_t uart_context[UART_NUM_MAX] = {
+uart_context_t uart_context[UART_NUM_MAX] = {
     UART_CONTEX_INIT_DEF(UART_NUM_0),
     UART_CONTEX_INIT_DEF(UART_NUM_1),
 #if UART_NUM_MAX > 2


### PR DESCRIPTION
Exposing the UART context is needed to be able to easily access the HAL dev and the context's spinlock in user-defined UART interrupt handlers.