### PR TITLE
Fixing a file name typo (plug.c) (IDFGH-7165)

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -527,8 +527,8 @@ Imagine there is a ``car`` component, which uses the ``engine`` component, which
                                          - engine.c
                                          - include/ - engine.h
                                - spark_plug/  - CMakeLists.txt
-                                              - plug.c
-                                              - plug.h
+                                              - spark_plug.c
+                                              - spark_plug.h
 
 Car component
 ^^^^^^^^^^^^^


### PR DESCRIPTION
In [Example of component requirements] it shows "plug.c" while in the rest of the explanation it refer to "spark_plug.c", same thing with "plug.h".