### PR TITLE
esp_wifi: fix clearing default wifi netif procedure (IDFGH-7179)

### DIFF
--- a/components/esp_wifi/src/wifi_default.c
+++ b/components/esp_wifi/src/wifi_default.c
@@ -236,6 +236,8 @@ esp_err_t esp_wifi_clear_default_wifi_driver_and_handlers(void *esp_netif)
         if (s_wifi_netifs[i] == esp_netif) {
             s_wifi_netifs[i] = NULL;
         }
+    }
+    for (i = 0; i< MAX_WIFI_IFS; ++i) {
         // check if all netifs are cleared to delete default handlers
         if (s_wifi_netifs[i] != NULL) {
             break;


### PR DESCRIPTION
Prior to this change "esp_wifi_clear_default_wifi_driver_and_handlers"
will not remove netif pointer from table when both AP and STA interfaces were
created and destroying default wifi interfaces is done in unfortunate
order. As a result there is dangling pointer left and it may cause crash in
later code (i.e. when esp_wifi_stop() is called).