### PR TITLE
add option to route LWIP logs through ESP_LOG interface (IDFGH-7186)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -998,6 +998,13 @@ menu "LWIP"
 
             All lwIP debug features increase the size of the final binary.
 
+    config LWIP_DEBUG_ESP_LOG
+        bool "Route LWIP debugs through ESP_LOG interface"
+        depends on LWIP_DEBUG
+        default n
+        help
+            Enabling this option routes all enabled LWIP debugs through ESP_LOGD.
+
     config LWIP_NETIF_DEBUG
         bool "Enable netif debug messages"
         depends on LWIP_DEBUG

--- a/components/lwip/port/esp32/include/arch/cc.h
+++ b/components/lwip/port/esp32/include/arch/cc.h
@@ -85,7 +85,15 @@ typedef int sys_prot_t;
 
 #include <stdio.h>
 
+#ifdef CONFIG_LWIP_DEBUG_ESP_LOG
+// lwip debugs routed to ESP_LOGD
+#include "esp_log.h"
+#define LWIP_ESP_LOG_FUNC(format, ...) ESP_LOG_LEVEL(ESP_LOG_DEBUG, "lwip", format, ##__VA_ARGS__)
+#define LWIP_PLATFORM_DIAG(x) LWIP_ESP_LOG_FUNC x
+#else
+// lwip debugs routed to printf
 #define LWIP_PLATFORM_DIAG(x)   do {printf x;} while(0)
+#endif
 
 #ifdef NDEBUG
 


### PR DESCRIPTION
Add an option to route LWIP debugs through ESP_LOGD instead of `printf`. See discussion here: https://github.com/espressif/esp-idf/issues/8361

Only downside with this approach is each LWIP debug has its own newline and ESP_LOG adds its own. In the future a new macro could be added that doesnt append a newline specifically for these logs or other 3rd party components where modifying source is not desired.