### PR TITLE
Add idf.py monitor argument --no-reset (-R) (IDFGH-7189)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -75,6 +75,7 @@ class Monitor:
         print_filter,  # type: str
         make='make',  # type: str
         encrypted=False,  # type: bool
+        reset=True,  # type: bool
         toolchain_prefix=DEFAULT_TOOLCHAIN_PREFIX,  # type: str
         eol='CRLF',  # type: str
         decode_coredumps=COREDUMP_DECODE_INFO,  # type: str
@@ -109,7 +110,7 @@ class Monitor:
         if isinstance(self, SerialMonitor):
             socket_mode = serial_instance.port.startswith('socket://')
             self.serial = serial_instance
-            self.serial_reader = SerialReader(self.serial, self.event_queue)
+            self.serial_reader = SerialReader(self.serial, self.event_queue, reset)
 
             self.gdb_helper = GDBHelper(toolchain_prefix, websocket_client, self.elf_file, self.serial.port,
                                         self.serial.baudrate) if self.elf_exists else None
@@ -124,7 +125,7 @@ class Monitor:
 
         cls = SerialHandler if self.elf_exists else SerialHandlerNoElf
         self.serial_handler = cls(b'', socket_mode, self.logger, decode_panic, PANIC_IDLE, b'', target,
-                                  False, False, self.serial, encrypted, self.elf_file)
+                                  False, False, self.serial, encrypted, reset, self.elf_file)
 
         self.console_parser = ConsoleParser(eol)
         self.console_reader = ConsoleReader(self.console, self.event_queue, self.cmd_queue, self.console_parser,
@@ -343,6 +344,7 @@ def main() -> None:
                       args.print_filter,
                       args.make,
                       args.encrypted,
+                      not args.no_reset,
                       args.toolchain_prefix,
                       args.eol,
                       args.decode_coredumps,

--- a/tools/idf_monitor_base/argument_parser.py
+++ b/tools/idf_monitor_base/argument_parser.py
@@ -18,6 +18,13 @@ def get_parser():  # type: () -> argparse.ArgumentParser
     )
 
     parser.add_argument(
+        '--no-reset', '-R',
+        help='Do not reset the chip on monitor startup',
+        default=False,
+        action='store_true'
+    )
+
+    parser.add_argument(
         '--disable-address-decoding', '-d',
         help="Don't print lines about decoded addresses from the application ELF file",
         action='store_true',

--- a/tools/idf_monitor_base/serial_handler.py
+++ b/tools/idf_monitor_base/serial_handler.py
@@ -58,8 +58,8 @@ class SerialHandler:
     The class is responsible for buffering serial input and performing corresponding commands.
     """
     def __init__(self, last_line_part, serial_check_exit, logger, decode_panic, reading_panic, panic_buffer, target,
-                 force_line_print, start_cmd_sent, serial_instance, encrypted, elf_file):
-        # type: (bytes, bool, Logger, str, int, bytes,str, bool, bool, serial.Serial, bool, str) -> None
+                 force_line_print, start_cmd_sent, serial_instance, encrypted, reset, elf_file):
+        # type: (bytes, bool, Logger, str, int, bytes,str, bool, bool, serial.Serial, bool, bool, str) -> None
         self._last_line_part = last_line_part
         self._serial_check_exit = serial_check_exit
         self.logger = logger
@@ -71,6 +71,7 @@ class SerialHandler:
         self.start_cmd_sent = start_cmd_sent
         self.serial_instance = serial_instance
         self.encrypted = encrypted
+        self.reset = reset
         self.elf_file = elf_file
 
     def handle_serial_input(self, data, console_parser, coredump, gdb_helper, line_matcher,
@@ -192,10 +193,11 @@ class SerialHandler:
             console_reader.stop()
             serial_reader.stop()
         elif cmd == CMD_RESET:
-            self.serial_instance.setRTS(low)
+            self.serial_instance.setDTR(high)  # IO0=HIGH, default state
+            self.serial_instance.setRTS(low)  # EN=LOW, chip in reset
             self.serial_instance.setDTR(self.serial_instance.dtr)  # usbser.sys workaround
             time.sleep(reset_delay)
-            self.serial_instance.setRTS(high)
+            self.serial_instance.setRTS(high)  # EN=HIGH, chip out of reset
             self.serial_instance.setDTR(self.serial_instance.dtr)  # usbser.sys workaround
             self.logger.output_enabled = True
         elif cmd == CMD_MAKE:

--- a/tools/idf_monitor_base/serial_reader.py
+++ b/tools/idf_monitor_base/serial_reader.py
@@ -22,13 +22,14 @@ class SerialReader(Reader):
     event queue, until stopped.
     """
 
-    def __init__(self, serial_instance, event_queue):
-        #  type: (serial.Serial, queue.Queue) -> None
+    def __init__(self, serial_instance, event_queue, reset):
+        #  type: (serial.Serial, queue.Queue, bool) -> None
         super(SerialReader, self).__init__()
         self.baud = serial_instance.baudrate
         self.serial = serial_instance
         self.event_queue = event_queue
         self.gdb_exit = False
+        self.reset = reset
         if not hasattr(self.serial, 'cancel_read'):
             # enable timeout for checking alive flag,
             # if cancel_read not available
@@ -49,7 +50,7 @@ class SerialReader(Reader):
             self.serial.dtr = self.serial.dtr   # usbser.sys workaround
             # Current state not reset the target!
             self.serial.open()
-            if not self.gdb_exit:
+            if not self.gdb_exit and self.reset:
                 self.serial.dtr = high     # Set dtr to reset state (affected by rts)
                 self.serial.rts = low      # Set rts/dtr to the reset state
                 self.serial.dtr = self.serial.dtr   # usbser.sys workaround

--- a/tools/idf_py_actions/serial_ext.py
+++ b/tools/idf_py_actions/serial_ext.py
@@ -83,7 +83,7 @@ def action_extensions(base_actions, project_path):
 
         return result
 
-    def monitor(action, ctx, args, print_filter, monitor_baud, encrypted, timestamps, timestamp_format):
+    def monitor(action, ctx, args, print_filter, monitor_baud, encrypted, no_reset, timestamps, timestamp_format):
         """
         Run idf_monitor.py to watch build output
         """
@@ -94,6 +94,10 @@ def action_extensions(base_actions, project_path):
         monitor_args = [PYTHON, idf_monitor]
 
         if project_desc['target'] != 'linux':
+            if no_reset and args.port is None:
+                sys.stderr.write('WARNING: --no-reset is ignored. Please specify the port with the --port argument in order to use this option.\n')
+                no_reset = False
+
             esp_port = args.port or _get_default_serial_port(args)
             monitor_args += ['-p', esp_port]
 
@@ -133,6 +137,9 @@ def action_extensions(base_actions, project_path):
 
         if encrypted:
             monitor_args += ['--encrypted']
+
+        if no_reset:
+            monitor_args += ['--no-reset']
 
         if timestamps:
             monitor_args += ['--timestamps']
@@ -261,6 +268,12 @@ def action_extensions(base_actions, project_path):
                                  'IDF Monitor will invoke encrypted-flash and encrypted-app-flash targets '
                                  'if this option is set. This option is set by default if IDF Monitor was invoked '
                                  'together with encrypted-flash or encrypted-app-flash target.'),
+                    }, {
+                        'names': ['--no-reset', '-R'],
+                        'is_flag': True,
+                        'help': ('Disable reset on monitor startup. '
+                                 'IDF Monitor will not reset the MCU target by toggling DTR/RTS lines on startup '
+                                 'if this option is set.'),
                     }, {
                         'names': ['--timestamps'],
                         'is_flag': True,


### PR DESCRIPTION
Add idf.py monitor argument --no-reset (-R) to be able to optionally prevent resetting the CPU on monitor startup.