### PR TITLE
Don't ignore return value of `httpd_stop` (IDFGH-7222)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -160,8 +160,9 @@ esp_err_t httpd_ssl_start(httpd_handle_t *handle, httpd_ssl_config_t *config);
  * Stop the server. Blocks until the server is shut down.
  *
  * @param[in] handle
+ * @return success
  */
-void httpd_ssl_stop(httpd_handle_t handle);
+esp_err_t httpd_ssl_stop(httpd_handle_t handle);
 
 #ifdef __cplusplus
 }

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -306,7 +306,7 @@ esp_err_t httpd_ssl_start(httpd_handle_t *pHandle, struct httpd_ssl_config *conf
 }
 
 /** Stop the server */
-void httpd_ssl_stop(httpd_handle_t handle)
+esp_err_t httpd_ssl_stop(httpd_handle_t handle)
 {
-    httpd_stop(handle);
+    return httpd_stop(handle);
 }

--- a/components/esp_local_ctrl/src/esp_local_ctrl_transport_httpd.c
+++ b/components/esp_local_ctrl/src/esp_local_ctrl_transport_httpd.c
@@ -1,16 +1,8 @@
-// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2019-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -85,8 +77,8 @@ static void stop_httpd_transport(protocomm_t *pc)
 {
     mdns_service_remove("_esp_local_ctrl", "_tcp");
     protocomm_httpd_stop(pc);
-    httpd_ssl_stop(server_handle);
-    server_handle = NULL;
+    if (httpd_ssl_stop(server_handle) == ESP_OK)
+        server_handle = NULL;
 }
 
 static esp_err_t copy_httpd_config(esp_local_ctrl_transport_config_t *dest_config, const esp_local_ctrl_transport_config_t *src_config)

--- a/components/protocomm/src/transports/protocomm_httpd.c
+++ b/components/protocomm/src/transports/protocomm_httpd.c
@@ -295,7 +295,9 @@ esp_err_t protocomm_httpd_stop(protocomm_t *pc)
     if ((pc != NULL) && (pc == pc_httpd)) {
         if (!pc_ext_httpd_handle_provided) {
             httpd_handle_t *server_handle = (httpd_handle_t *) pc_httpd->priv;
-            httpd_stop(*server_handle);
+            esp_err_t ret = httpd_stop(*server_handle);
+            if (ret != ESP_OK)
+                return ret;
             free(server_handle);
         } else {
             pc_ext_httpd_handle_provided = false;

--- a/examples/protocols/http_server/persistent_sockets/main/main.c
+++ b/examples/protocols/http_server/persistent_sockets/main/main.c
@@ -182,10 +182,10 @@ static httpd_handle_t start_webserver(void)
     return NULL;
 }
 
-static void stop_webserver(httpd_handle_t server)
+static esp_err_t stop_webserver(httpd_handle_t server)
 {
     // Stop the httpd server
-    httpd_stop(server);
+    return httpd_stop(server);
 }
 
 
@@ -195,8 +195,8 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
         ESP_LOGI(TAG, "Stopping webserver");
-        stop_webserver(*server);
-        *server = NULL;
+        if (stop_webserver(*server) == ESP_OK)
+            *server = NULL;
     }
 }
 

--- a/examples/protocols/http_server/simple/main/main.c
+++ b/examples/protocols/http_server/simple/main/main.c
@@ -362,10 +362,10 @@ static httpd_handle_t start_webserver(void)
     return NULL;
 }
 
-static void stop_webserver(httpd_handle_t server)
+static esp_err_t stop_webserver(httpd_handle_t server)
 {
     // Stop the httpd server
-    httpd_stop(server);
+    return httpd_stop(server);
 }
 
 static void disconnect_handler(void* arg, esp_event_base_t event_base,
@@ -374,8 +374,8 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
         ESP_LOGI(TAG, "Stopping webserver");
-        stop_webserver(*server);
-        *server = NULL;
+        if (stop_webserver(*server) == ESP_OK)
+            *server = NULL;
     }
 }
 

--- a/examples/protocols/http_server/ws_echo_server/main/ws_echo_server.c
+++ b/examples/protocols/http_server/ws_echo_server/main/ws_echo_server.c
@@ -140,10 +140,10 @@ static httpd_handle_t start_webserver(void)
     return NULL;
 }
 
-static void stop_webserver(httpd_handle_t server)
+static esp_err_t stop_webserver(httpd_handle_t server)
 {
     // Stop the httpd server
-    httpd_stop(server);
+    return httpd_stop(server);
 }
 
 static void disconnect_handler(void* arg, esp_event_base_t event_base,
@@ -152,8 +152,8 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
         ESP_LOGI(TAG, "Stopping webserver");
-        stop_webserver(*server);
-        *server = NULL;
+        if (stop_webserver(*server) == ESP_OK)
+            *server = NULL;
     }
 }
 

--- a/examples/protocols/https_server/simple/main/main.c
+++ b/examples/protocols/https_server/simple/main/main.c
@@ -139,10 +139,10 @@ static httpd_handle_t start_webserver(void)
     return server;
 }
 
-static void stop_webserver(httpd_handle_t server)
+static esp_err_t stop_webserver(httpd_handle_t server)
 {
     // Stop the httpd server
-    httpd_ssl_stop(server);
+    return httpd_ssl_stop(server);
 }
 
 static void disconnect_handler(void* arg, esp_event_base_t event_base,
@@ -150,8 +150,8 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
-        stop_webserver(*server);
-        *server = NULL;
+        if (stop_webserver(*server) == ESP_OK)
+            *server = NULL;
     }
 }
 

--- a/examples/protocols/https_server/wss_server/main/wss_server_example.c
+++ b/examples/protocols/https_server/wss_server/main/wss_server_example.c
@@ -206,12 +206,12 @@ static httpd_handle_t start_wss_echo_server(void)
     return server;
 }
 
-static void stop_wss_echo_server(httpd_handle_t server)
+static esp_err_t stop_wss_echo_server(httpd_handle_t server)
 {
     // Stop keep alive thread
     wss_keep_alive_stop(httpd_get_global_user_ctx(server));
     // Stop the httpd server
-    httpd_ssl_stop(server);
+    return httpd_ssl_stop(server);
 }
 
 static void disconnect_handler(void* arg, esp_event_base_t event_base,
@@ -219,8 +219,8 @@ static void disconnect_handler(void* arg, esp_event_base_t event_base,
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
-        stop_wss_echo_server(*server);
-        *server = NULL;
+        if (stop_wss_echo_server(*server) == ESP_OK)
+            *server = NULL;
     }
 }
 

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -473,7 +473,6 @@ components/esp_local_ctrl/src/esp_local_ctrl.c
 components/esp_local_ctrl/src/esp_local_ctrl_handler.c
 components/esp_local_ctrl/src/esp_local_ctrl_priv.h
 components/esp_local_ctrl/src/esp_local_ctrl_transport_ble.c
-components/esp_local_ctrl/src/esp_local_ctrl_transport_httpd.c
 components/esp_netif/include/esp_netif_ppp.h
 components/esp_netif/include/esp_netif_slip.h
 components/esp_netif/loopback/esp_netif_loopback.c


### PR DESCRIPTION
In various places the return value of `httpd_stop` is ignored. Most notably this happens in example code, which will lead to users copying this style and in `httpd_ssl_stop`, which means users of the HTTPS server are completely unable to access this return value. This PR fixes that.