### PR TITLE
bump mypy version (IDFGH-7240)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,7 +94,7 @@ repos:
         name: Check type annotations in python files
         entry: tools/ci/check_type_comments.py
         additional_dependencies:
-          - 'mypy==0.800'
+          - 'mypy==0.940'
           - 'mypy-extensions==0.4.3'
         language: python
         types: [python]


### PR DESCRIPTION
mypy version 0.800 does not work with MacBook M1 / Python 3.9.12 (installed with brew).

The error seems to come from `typed-ast` version 1.4.3:

```
ERROR: Failed building wheel for typed-ast
error: subprocess-exited-with-error
      
× Running setup.py install for typed-ast did not run successfully.
│ exit code: 1
╰─> [69 lines of output
```

The version 0.940 seems to work fine.