### PR TITLE
Support for external 32.768kHz oscillator as Bluetooth clock (IDFGH-7241)

### DIFF
--- a/components/bt/controller/esp32/Kconfig.in
+++ b/components/bt/controller/esp32/Kconfig.in
@@ -257,10 +257,10 @@ menu "MODEM SLEEP Options"
                 the bluetooth low power clock source.
 
         config BTDM_CTRL_LPCLK_SEL_EXT_32K_XTAL
-            bool "External 32kHz crystal"
-            depends on RTC_CLK_SRC_EXT_CRYS
+            bool "External 32kHz crystal/oscillator"
+            depends on RTC_CLK_SRC_EXT_CRYS || RTC_CLK_SRC_EXT_OSC
             help
-                External 32kHz crystal has a nominal frequency of 32.768kHz and provides good frequency
+                External 32kHz crystal/oscillator has a nominal frequency of 32.768kHz and provides good frequency
                 stability. If used as Bluetooth low power clock, External 32kHz can support Bluetooth
                 modem sleep to be used with both DFS and light sleep.
     endchoice

--- a/components/bt/controller/esp32s3/Kconfig.in
+++ b/components/bt/controller/esp32s3/Kconfig.in
@@ -372,10 +372,10 @@ menu "MODEM SLEEP Options"
                 cannot work when light sleep is enabled. Main crystal has a relatively better performance than
                 other bluetooth low power clock sources.
         config BT_CTRL_LPCLK_SEL_EXT_32K_XTAL
-            bool "External 32kHz crystal"
-            depends on RTC_CLK_SRC_EXT_CRYS
+            bool "External 32kHz crystal/oscillator"
+            depends on RTC_CLK_SRC_EXT_CRYS || RTC_CLK_SRC_EXT_OSC
             help
-                External 32kHz crystal has a nominal frequency of 32.768kHz and provides good frequency
+                External 32kHz crystal/oscillator has a nominal frequency of 32.768kHz and provides good frequency
                 stability. If used as Bluetooth low power clock, External 32kHz can support Bluetooth
                 modem sleep to be used with both DFS and light sleep.
 


### PR DESCRIPTION
Currently, only a 32.768kHz crystal can be used as the Bluetooth low-power clock since `BTDM_CTRL_LPCLK_SEL_EXT_32K_XTAL` depends on `RTC_CLK_SRC_EXT_CRYS` (and not also `RTC_CLK_SRC_EXT_OSC`).

This change makes it so that you can set `BTDM_CTRL_LPCLK_SEL_EXT_32K_XTAL` when using the external oscillator.

Tested using a similar change on ESP-IDF v4.4.1.