### PR TITLE
Fixed the commented out coap_new_optlist() in the coap_client example. (IDFGH-7262)

### DIFF
--- a/examples/protocols/coap_client/main/coap_client_example_main.c
+++ b/examples/protocols/coap_client/main/coap_client_example_main.c
@@ -436,7 +436,8 @@ static void coap_example_client(void *p)
          *   coap_insert_optlist(&optlist,
          *                       coap_new_optlist(COAP_OPTION_CONTENT_FORMAT,
          *                                        coap_encode_var_safe (buf, sizeof (buf),
-         *                                                              COAP_MEDIATYPE_APPLICATION_JSON));
+         *                                                              COAP_MEDIATYPE_APPLICATION_JSON),
+         *                                        buf));
          * Add in here the POST data of length length. E.G.
          *   coap_add_data_large_request(session, request length, data, NULL, NULL);
          */


### PR DESCRIPTION
coap_new_optlist() requires 3 arguments but the example had 2 arguments.