### PR TITLE
utils.py: fix assert range with hour (IDFGH-7300)

### DIFF
--- a/components/fatfs/fatfsgen_utils/utils.py
+++ b/components/fatfs/fatfsgen_utils/utils.py
@@ -226,7 +226,7 @@ def build_time_entry(hour: int, minute: int, sec: int) -> int:
 
     :returns: 16 bit integer number (5 bits for hour, 6 bits for minute and 5 bits for second)
     """
-    assert hour in range(0, 23)
+    assert hour in range(0, 24)
     assert minute in range(0, 60)
     assert sec in range(0, 60)
     return int.from_bytes(TIME_ENTRY.build(dict(hour=hour, minute=minute, second=sec // 2)), 'big')


### PR DESCRIPTION
`hour=23` (23 P.M.) will out of the `range(0, 23)`, which should be `range(0, 24)`.

The ErrorLog:
```
Traceback (most recent call last):
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/wl_fatfsgen.py", line 202, in <module>
    wl_fatfs.wl_generate(args.input_directory)
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/wl_fatfsgen.py", line 178, in wl_generate
    self.plain_fatfs.generate(input_directory=input_directory)
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen.py", line 185, in generate
    self._generate_partition_from_folder(folder_name, folder_path=path_to_folder, is_dir=True)
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen.py", line 178, in _generate_partition_from_folder
    self._generate_partition_from_folder(os.path.join(smaller_path, path), folder_path=folder_path)
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen.py", line 164, in _generate_partition_from_folder
    self.create_file(name=file_name,
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen.py", line 85, in create_file
    self.root_directory.new_file(name=name,
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen_utils/fs_object.py", line 261, in new_file
    free_cluster, free_entry, target_dir = self.allocate_object(name=name,
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen_utils/fs_object.py", line 240, in allocate_object
    free_entry.allocate_entry(first_cluster_id=free_cluster.id,
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen_utils/entry.py", line 179, in allocate_entry
    time_entry: int = build_time_entry(*time)
  File "/DIR/HappyWater/App/repro-fs/.embuild/espressif/esp-idf/master/components/fatfs/fatfsgen_utils/utils.py", line 230, in build_time_entry
    assert hour in range(0, 23)
AssertionError
```