### PR TITLE
Tools: fix idf.py monitor reset with hotkey with --no-reset arg (IDFGH-7375)

### DIFF
--- a/tools/idf_monitor_base/serial_reader.py
+++ b/tools/idf_monitor_base/serial_reader.py
@@ -57,6 +57,8 @@ class SerialReader(Reader):
 
                 # Add a delay to meet the requirements of minimal EN low time (2ms for ESP32-C3)
                 time.sleep(MINIMAL_EN_LOW_DELAY)
+            elif not self.reset:
+                self.serial.setDTR(high)  # IO0=HIGH, default state
             self.gdb_exit = False
             self.serial.rts = high             # Set rts/dtr to the working state
             self.serial.dtr = self.serial.dtr   # usbser.sys workaround


### PR DESCRIPTION
Previous --no-reset PR (https://github.com/espressif/esp-idf/pull/8788) was not merged completely. Without this patch, the hotkey reset in idf.py monitor (ctrl+t ctrl+r) does not work when --no-reset argument is used.