### PR TITLE
components/lwip: errno.h should not be included if LWIP provides errno. (IDFGH-7377)

### DIFF
--- a/components/lwip/port/esp32/include/arch/cc.h
+++ b/components/lwip/port/esp32/include/arch/cc.h
@@ -35,7 +35,6 @@
 #define __ARCH_CC_H__
 
 #include <stdint.h>
-#include <errno.h>
 #include <assert.h>
 #include <stdio.h>
 

--- a/components/lwip/port/esp32/include/lwipopts.h
+++ b/components/lwip/port/esp32/include/lwipopts.h
@@ -61,6 +61,11 @@
 
 #define LWIP_RAND       esp_random
 
+/**
+ * Include <errno.h> from the standard libraries.
+ */
+#define LWIP_ERRNO_STDINCLUDE   1
+
 /*
    ------------------------------------
    ---------- Memory options ----------


### PR DESCRIPTION
The standard `<errno.h>` should not be included directly in `cc.h`, to allow lwip to provide error numbers (via `LWIP_PROVIDE_ERRNO`) or a custom errno.h (via `LWIP_ERRNO_INCLUDE`).