### PR TITLE
Make blufi(nimble) customizable broadcast (IDFGH-7378)

### DIFF
--- a/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
+++ b/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
@@ -232,8 +232,8 @@ int esp_blufi_gatt_svr_init(void)
     return 0;
 }
 
-static int
-esp_blufi_gap_event(struct ble_gap_event *event, void *arg)
+int
+esp_blufi_gap_event(struct ble_gap_event *event, void *adv_start_callback)
 {
     struct ble_gap_conn_desc desc;
     int rc;
@@ -265,7 +265,7 @@ esp_blufi_gap_event(struct ble_gap_event *event, void *arg)
         }
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
-            esp_blufi_adv_start();
+            ((void(*)())adv_start_callback)();
         }
         return 0;
     case BLE_GAP_EVENT_DISCONNECT:
@@ -300,7 +300,7 @@ esp_blufi_gap_event(struct ble_gap_event *event, void *arg)
     case BLE_GAP_EVENT_ADV_COMPLETE:
         ESP_LOGI(TAG, "advertise complete; reason=%d",
                  event->adv_complete.reason);
-        esp_blufi_adv_start();
+        ((void(*)())adv_start_callback)();
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
@@ -395,7 +395,7 @@ void esp_blufi_adv_start(void)
     adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
     rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
-                           &adv_params, esp_blufi_gap_event, NULL);
+                           &adv_params, esp_blufi_gap_event, esp_blufi_adv_start);
     if (rc != 0) {
         ESP_LOGE(TAG, "error enabling advertisement; rc=%d\n", rc);
         return;


### PR DESCRIPTION
BluFi which using the Nimble host cannot customize the BLE GAP broadcast, because the `esp_blufi_gap_event` function called by the `esp_blufi_adv_start` function has a `static` identifier, and the `esp_blufi_gap_event` function uses the specified function to re-broadcast when the connection fails or disconnects. So I tried removing the `static` flag and passing the broadcast function pointer through the `arg` parameter. These changes worked fine in my project.