### PR TITLE
Update echo_example_main.c (IDFGH-7382)

### DIFF
--- a/examples/protocols/icmp_echo/main/echo_example_main.c
+++ b/examples/protocols/icmp_echo/main/echo_example_main.c
@@ -137,10 +137,10 @@ static int do_ping_cmd(int argc, char **argv)
 
     /* set callback functions */
     esp_ping_callbacks_t cbs = {
+        .cb_args = NULL,
         .on_ping_success = cmd_ping_on_ping_success,
         .on_ping_timeout = cmd_ping_on_ping_timeout,
-        .on_ping_end = cmd_ping_on_ping_end,
-        .cb_args = NULL
+        .on_ping_end = cmd_ping_on_ping_end
     };
     esp_ping_handle_t ping;
     esp_ping_new_session(&config, &cbs, &ping);


### PR DESCRIPTION
Fixed compile error in example.  `error: designator order for field 'esp_ping_callbacks_t::cb_args' does not match declaration order in 'esp_ping_callbacks_t'`. Moved `.cb_args` in example to match declaration.