### PR TITLE
Tools: Add missing DTR/RTS set before serial port open on reconnect (IDFGH-7403)

### DIFF
--- a/tools/idf_monitor_base/serial_reader.py
+++ b/tools/idf_monitor_base/serial_reader.py
@@ -76,6 +76,10 @@ class SerialReader(Reader):
                     while self.alive:  # so that exiting monitor works while waiting
                         try:
                             time.sleep(RECONNECT_DELAY)
+                            if not self.reset:
+                                self.serial.dtr = low      # Non reset state
+                                self.serial.rts = high     # IO0=HIGH
+                                self.serial.dtr = self.serial.dtr   # usbser.sys workaround
                             self.serial.open()
                             break  # device connected
                         except serial.serialutil.SerialException:


### PR DESCRIPTION
This makes sure --no-reset works correctly when the monitor reconnects the serial port.