### PR TITLE
pthread: avoid heap alloc in pthread_cond_timedwait if possible (IDFGH-7409)

### DIFF
--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -1247,7 +1247,6 @@ components/protocomm/python/session_pb2.py
 components/protocomm/src/common/protocomm.c
 components/protocomm/src/common/protocomm_priv.h
 components/protocomm/src/security/security0.c
-components/pthread/pthread_cond_var.c
 components/pthread/pthread_internal.h
 components/pthread/pthread_local_storage.c
 components/pthread/test/test_cxx_cond_var.cpp


### PR DESCRIPTION
This creates the wait sem with `xSemaphoreCreateCountingStatic` if possible taking around 80 bytes off the stack.
This semaphore is only used for the life of this function, which can be quite heavily called, so this avoids any possible heap/performance issues. 
