### PR TITLE
esp_netif_leave_ip6_multicast_group_api: Fixup inversion error causing error prints (IDFGH-7412)

### DIFF
--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -2000,7 +2000,7 @@ static esp_err_t esp_netif_leave_ip6_multicast_group_api(esp_netif_api_msg_t *ms
 #if LWIP_IPV6_SCOPES
     ip6addr.zone = 0;
 #endif
-    ESP_RETURN_ON_FALSE(mld6_leavegroup_netif(msg->esp_netif->lwip_netif, &ip6addr) != ERR_OK,
+    ESP_RETURN_ON_FALSE(mld6_leavegroup_netif(msg->esp_netif->lwip_netif, &ip6addr) == ERR_OK,
                         ESP_ERR_ESP_NETIF_MLD6_FAILED, TAG, "Failed to leave ip6 multicast group");
     return ESP_OK;
 }


### PR DESCRIPTION
ESP_RETURN_ON_FALSE(a, err_code, ...) macro

Will print and return err_code
if (unlikely(!(a)))

so "a" needs to state what we expect to be TRUE
which in this case means:

mld6_leavegroup_netif(...) == ERR_OK