### PR TITLE
cmake: enable coloured compiler output (IDFGH-7449)

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -105,7 +105,10 @@ function(__build_set_default_build_specifications)
                                     "-Wno-sign-compare"
                                     # always generate debug symbols (even in release mode, these don't
                                     # go into the final binary so have no impact on size
-                                    "-ggdb")
+                                    "-ggdb"
+                                    # without this GCC may not enable ANSI colouring, making errors
+                                    # harder to decipher
+                                    "-fdiagnostics-color=always")
 
     list(APPEND c_compile_options   "-std=gnu99")
 


### PR DESCRIPTION
This adds -fdiagnostics-color=always to the default compile_options,
without this GCC won't enabled colored output when called from
ninja (via idf.py), making errors much harder to decipher.