### PR TITLE
fix glb_clk may be uninitialized build error in ledc driver (IDFGH-7450)

### DIFF
--- a/components/driver/ledc.c
+++ b/components/driver/ledc.c
@@ -162,6 +162,10 @@ static uint32_t ledc_get_glb_clk_freq(ledc_slow_clk_sel_t clk_cfg)
             src_clk_freq = esp_clk_xtal_freq();
             break;
 #endif
+        case LEDC_CLK_NOT_INIT:
+        default:
+            ESP_LOGE(LEDC_TAG, "Clock not initialized");
+            break;
     }
 
     return src_clk_freq;
@@ -494,7 +498,7 @@ static esp_err_t ledc_set_timer_div(ledc_mode_t speed_mode, ledc_timer_t timer_n
     /* Timer-specific mux. Set to timer-specific clock or LEDC_SCLK if a global clock is used. */
     ledc_clk_src_t timer_clk_src;
     /* Global clock mux. Should be set when LEDC_SCLK is used in LOW_SPEED_MODE. Otherwise left uninitialized. */
-    ledc_slow_clk_sel_t glb_clk;
+    ledc_slow_clk_sel_t glb_clk = LEDC_CLK_NOT_INIT;
 
     if (clk_cfg == LEDC_AUTO_CLK) {
         /* User hasn't specified the speed, we should try to guess it. */

--- a/components/hal/include/hal/ledc_types.h
+++ b/components/hal/include/hal/ledc_types.h
@@ -45,6 +45,7 @@ typedef enum {
 #if SOC_LEDC_SUPPORT_XTAL_CLOCK
     LEDC_SLOW_CLK_XTAL,    /*!< LEDC low speed timer clock source XTAL clock*/
 #endif
+    LEDC_CLK_NOT_INIT,
 } ledc_slow_clk_sel_t;
 
 /**


### PR DESCRIPTION
I am not sure if this is a complete solution to the problem, but at least it seems to fix it on esp32.
The issue was introduced in: d64c6f581d4391146c91ccc6c75d5630944c9c26 ledc: cleanup the clock selection code

The offending line is a print: line 570:         ESP_LOGD(LEDC_TAG, "In slow speed mode, global clk set: %d", glb_clk);

Am I missing something else here?

build error:

In file included from components/driver/ledc.c:10:
components/driver/ledc.c: In function 'ledc_set_timer_div':
components/log/include/esp_log.h:419:47: error: 'glb_clk' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_SYSTEM_TIME_FORMAT(D, format), esp_log_system_timestamp(), tag, ##__VA_ARGS__); } \
                                               ^~~~~~~~~~~~~
components/driver/ledc.c:497:25: note: 'glb_clk' was declared here
     ledc_slow_clk_sel_t glb_clk;
                         ^~~~~~~
