### PR TITLE
add address field to read_rmt_name_param in legacy bluetooth (IDFGH-7459)

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_gap_bt_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gap_bt_api.h
@@ -337,6 +337,7 @@ typedef union {
      * @brief ESP_BT_GAP_READ_REMOTE_NAME_EVT
      */
     struct read_rmt_name_param {
+        esp_bd_addr_t bda;                     /*!< remote bluetooth device address*/
         esp_bt_status_t stat;                  /*!< read Remote Name status */
         uint8_t rmt_name[ESP_BT_GAP_MAX_BDNAME_LEN + 1]; /*!< Remote device name */
     } read_rmt_name;                        /*!< read Remote Name parameter struct */

--- a/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
+++ b/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
@@ -735,6 +735,7 @@ static void btc_gap_bt_read_remote_name_cmpl_callback(void *p_data)
     msg.pid = BTC_PID_GAP_BT;
     msg.act = BTC_GAP_BT_READ_REMOTE_NAME_EVT;
 
+    memcpy(param.read_rmt_name.bda,result->bd_addr,BD_ADDR_LEN);
     param.read_rmt_name.stat = btc_btm_status_to_esp_status(result->status);
     memcpy(param.read_rmt_name.rmt_name,result->remote_bd_name,ESP_BT_GAP_MAX_BDNAME_LEN);
 

--- a/components/bt/host/bluedroid/stack/btm/btm_inq.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_inq.c
@@ -2306,6 +2306,7 @@ void btm_process_remote_name (BD_ADDR bda, BD_NAME bdn, UINT16 evt_len, UINT8 hc
             rem_name.length = 0;
             rem_name.remote_bd_name[0] = 0;
         }
+        memcpy(rem_name.bd_addr, p_inq->remname_bda, BD_ADDR_LEN);
         /* Reset the remote BAD to zero and call callback if possible */
         memset(p_inq->remname_bda, 0, BD_ADDR_LEN);
 


### PR DESCRIPTION
This PR adds the field `bda` to `esp_bt_gap_cb_param_t::read_rmt_name_param` and the code to copy the value into the field. This structure is used for the callback function's argument when the name inquiry is resolved. Knowing who responded is mandatory for the callback function to process the information.