### PR TITLE
initialize all elements of esp_bt_controller_config_t (IDFGH-7506)

### DIFF
--- a/components/bt/include/esp32s3/include/esp_bt.h
+++ b/components/bt/include/esp32s3/include/esp_bt.h
@@ -162,7 +162,9 @@ typedef void (* esp_bt_hci_tl_callback_t) (void *arg, uint8_t status);
     .ble_st_acl_tx_buf_nb = CONFIG_BT_CTRL_BLE_STATIC_ACL_TX_BUF_NB,       \
     .ble_hw_cca_check = CONFIG_BT_CTRL_HW_CCA_EFF,                         \
     .ble_adv_dup_filt_max = CONFIG_BT_CTRL_ADV_DUP_FILT_MAX,               \
+    .coex_param_en = false,                                                \
     .ce_len_type = CONFIG_BT_CTRL_CE_LENGTH_TYPE_EFF,                      \
+    .coex_use_hooks = false,                                               \
     .hci_tl_type = CONFIG_BT_CTRL_HCI_TL_EFF,                              \
     .hci_tl_funcs = NULL,                                                  \
     .txant_dft = CONFIG_BT_CTRL_TX_ANTENNA_INDEX_EFF,                      \


### PR DESCRIPTION
Fixes warnings when using bt in C++ on ESP32-S3 by explicitly initializing all elements of the esp_bt_controller_config_t struct (even those that are deprecated).