### PR TITLE
Fix the PARALLEL_LINES size of the tjpgd example to ensure that esp32c2 can also be used normally (IDFGH-7559)

### DIFF
--- a/examples/peripherals/lcd/tjpgd/main/lcd_tjpgd_example_main.c
+++ b/examples/peripherals/lcd/tjpgd/main/lcd_tjpgd_example_main.c
@@ -20,7 +20,7 @@
 // To speed up transfers, every SPI transfer sends a bunch of lines. This define specifies how many.
 // More means more memory use, but less overhead for setting up / finishing transfers. Make sure 240
 // is dividable by this.
-#define PARALLEL_LINES 16
+#define PARALLEL_LINES 12
 // The number of frames to show before rotate the graph
 #define ROTATE_FRAME   30
 


### PR DESCRIPTION
https://github.com/espressif/esp-idf/issues/9109

Try changing the default PARALLEL LINES size to be compatible with ESP32C2 running the example