### PR TITLE
driver(spi): fix flag check in bus initialization

### DIFF
--- a/components/driver/spi_common.c
+++ b/components/driver/spi_common.c
@@ -654,7 +654,7 @@ esp_err_t spicommon_bus_initialize_io(spi_host_device_t host, const spi_bus_conf
             gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[bus_config->sclk_io_num], FUNC_GPIO);
         }
 #if SOC_SPI_SUPPORT_OCT
-        if (flags & SPICOMMON_BUSFLAG_OCTAL) {
+        if ((flags & SPICOMMON_BUSFLAG_OCTAL) == SPICOMMON_BUSFLAG_OCTAL) {
             int io_nums[] = {bus_config->data4_io_num, bus_config->data5_io_num, bus_config->data6_io_num, bus_config->data7_io_num};
             uint8_t io_signals[4][2] = {{spi_periph_signal[host].spid4_out, spi_periph_signal[host].spid4_in},
                                         {spi_periph_signal[host].spid5_out, spi_periph_signal[host].spid5_in},


### PR DESCRIPTION
The current flag check in the SPI bus initialization is wrong and causes exceptions when using certain SPI hosts in quad transfert mode. 

If the SPI host only supports quad mode and not octal mode (which is the case on the SPI3 host of the ESP32-S3) then we unnecessarily initialize the data4-7 pins which causes an exception.

