### PR TITLE
Hide download percent when not interactive (IDFGH-7579)

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -281,10 +281,11 @@ def get_file_size_sha256(filename, block_size=65536):  # type: (str, int) -> Tup
 
 
 def report_progress(count, block_size, total_size):  # type: (int, int, int) -> None
-    percent = int(count * block_size * 100 / total_size)
-    percent = min(100, percent)
-    sys.stdout.write('\r%d%%' % percent)
-    sys.stdout.flush()
+    if sys.stdout.isatty():
+        percent = int(count * block_size * 100 / total_size)
+        percent = min(100, percent)
+        sys.stdout.write('\r%d%%' % percent)
+        sys.stdout.flush()
 
 
 def mkdir_p(path):  # type: (str) -> None


### PR DESCRIPTION
When idf_tools.py is run in a script the percent-update printouts shown while
downloading the toolchain end up as 100s to 1000s of lines in log files.
This happens for example when running https://github.com/espressif/esp32-arduino-lib-builder

When stdout is not a terminal, avoid printing these percentages and
shrink logfiles significantly. Errors/etc. are still reported as normal.

This is a "nice to have" and does not impact functionality.

See PR https://github.com/espressif/arduino-esp32/pull/6852 too