### PR TITLE
Add esp_tls option to skip server verification (IDFGH-7592)

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -151,6 +151,10 @@ typedef struct esp_tls_cfg {
     bool use_global_ca_store;               /*!< Use a global ca_store for all the connections in which
                                                  this bool is set. */
 
+    bool skip_server_verification;          /*!< Don't try to verificate the server's certificate in any
+                                                 way. Should never be used in production and only help to debug
+                                                 a faulty connection. */
+
     const char *common_name;                /*!< If non-NULL, server certificate CN must match this name.
                                                  If NULL, server certificate CN must match hostname. */
 

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -664,6 +664,9 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
         if (esp_ret != ESP_OK) {
             return esp_ret;
         }
+    } else if (cfg->skip_server_verification == true) {
+        mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
+        ESP_LOGE(TAG, "insecure connection without server verification, USE ONLY FOR DEBUGGING!");
     } else if (cfg->cacert_buf != NULL) {
         esp_err_t esp_ret = set_ca_cert(tls, cfg->cacert_buf, cfg->cacert_bytes);
         if (esp_ret != ESP_OK) {

--- a/components/esp-tls/esp_tls_wolfssl.c
+++ b/components/esp-tls/esp_tls_wolfssl.c
@@ -203,6 +203,9 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
             return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
         }
         wolfSSL_CTX_set_verify( (WOLFSSL_CTX *)tls->priv_ctx, WOLFSSL_VERIFY_PEER, NULL);
+    } else if (cfg->use_global_ca_store == true) {
+        wolfSSL_CTX_set_verify( (WOLFSSL_CTX *)tls->priv_ctx, WOLFSSL_VERIFY_NONE, NULL);
+        ESP_LOGE(TAG, "insecure connection without server verification, USE ONLY FOR DEBUGGING!");
     } else if (cfg->cacert_buf != NULL) {
         if ((esp_load_wolfssl_verify_buffer(tls, cfg->cacert_buf, cfg->cacert_bytes, FILE_TYPE_CA_CERT, &ret)) != ESP_OK) {
             int err = wolfSSL_get_error( (WOLFSSL *)tls->priv_ssl, ret);

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -639,6 +639,8 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
 #endif
     } else if (config->use_global_ca_store == true) {
         esp_transport_ssl_enable_global_ca_store(ssl);
+    } else if (config->skip_server_verification == true) {
+        esp_transport_ssl_skip_server_verification(ssl);
     } else if (config->cert_pem) {
         if (!config->cert_len) {
             esp_transport_ssl_set_cert_data(ssl, config->cert_pem, strlen(config->cert_pem));

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -130,6 +130,7 @@ typedef struct {
     bool                        is_async;                 /*!< Set asynchronous mode, only supported with HTTPS for now */
     bool                        use_global_ca_store;      /*!< Use a global ca_store for all the connections in which this bool is set. */
     bool                        skip_cert_common_name_check;    /*!< Skip any validation of server certificate CN field */
+    bool                        skip_server_verification;       /*!< Skip server verification completely. Should only be used for debugging */
     esp_err_t (*crt_bundle_attach)(void *conf);      /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification
                                                           bundle for server verification, must be enabled in menuconfig */
     bool                        keep_alive_enable;   /*!< Enable keep-alive timeout */

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -70,6 +70,14 @@ void esp_transport_ssl_crt_bundle_attach(esp_transport_handle_t t, esp_err_t ((*
 void esp_transport_ssl_enable_global_ca_store(esp_transport_handle_t t);
 
 /**
+ * @brief      Disable server verification. Should never be used in production
+ *             and only help to debug a faulty connection.
+ *
+ * @param      t    ssl transport
+ */
+void esp_transport_ssl_skip_server_verification(esp_transport_handle_t t);
+
+/**
  * @brief      Set SSL client certificate data for mutual authentication (as PEM format).
  *             Note that, this function stores the pointer to data, rather than making a copy.
  *             So this data must remain valid until after the connection is cleaned up

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -347,6 +347,12 @@ void esp_transport_ssl_enable_global_ca_store(esp_transport_handle_t t)
     ssl->cfg.use_global_ca_store = true;
 }
 
+void esp_transport_ssl_skip_server_verification(esp_transport_handle_t t)
+{
+    GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);
+    ssl->cfg.skip_server_verification = true;
+}
+
 #ifdef CONFIG_ESP_TLS_PSK_VERIFICATION
 void esp_transport_ssl_set_psk_key_hint(esp_transport_handle_t t, const psk_hint_key_t* psk_hint_key)
 {


### PR DESCRIPTION
I needed to debug a faulty tls websocket connection and did not want to compromise the whole firmware by setting the compile time flag `CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY`.

Instead I implemented a way to disable server verification for one single connection and I put warnings everywhere before you can turn on this option.

I implemented this new option additionaly in other clients mqtt (separate repo), websocket_client (separate repo), http_client