### PR TITLE
Enable hid keyboard and mouse support for esp32sx (IDFGH-7637)

### DIFF
--- a/components/tinyusb/Kconfig
+++ b/components/tinyusb/Kconfig
@@ -150,6 +150,21 @@ menu "TinyUSB Stack"
                 help
                     CDC FIFO size of TX channel.
         endmenu # "Communication Device Class"
-    endif # TINYUSB
+
+        menu "HID Device Class (HID)"
+            config TINYUSB_HID_ENABLED
+                bool "Enable TinyUSB HID feature"
+                default n
+                help
+                    Enable TinyUSB HID feature.
+
+            config TINYUSB_HID_BUFSIZE
+                depends on TINYUSB_HID_ENABLED
+                int "Report buffer size of TinyUSB HID device"
+                default 16
+                help
+                    Set TinyUSB HID device report buffer size.
+        endmenu # "HID Device Class (HID)"
+endif # TINYUSB
 
 endmenu # "TinyUSB Stack"

--- a/components/tinyusb/additions/include_private/descriptors_control.h
+++ b/components/tinyusb/additions/include_private/descriptors_control.h
@@ -26,6 +26,8 @@
  */
 #define EPNUM_MSC 0x03
 
+#define EPNUM_HID 0x81
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/tinyusb/additions/src/descriptors_control.c
+++ b/components/tinyusb/additions/src/descriptors_control.c
@@ -22,8 +22,8 @@ static char *s_str_descriptor[USB_STRING_DESCRIPTOR_ARRAY_SIZE];
 
 #if CFG_TUD_HID //HID Report Descriptor
 uint8_t const desc_hid_report[] = {
-    TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID_KEYBOARD), ),
-    TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(REPORT_ID_MOUSE), )
+    TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID_KEYBOARD) ),
+    TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(REPORT_ID_MOUSE) )
 };
 #endif
 
@@ -41,7 +41,7 @@ uint8_t const desc_configuration[] = {
 #   endif
 #   if CFG_TUD_HID
     // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
-    TUD_HID_DESCRIPTOR(ITF_NUM_HID, 6, HID_PROTOCOL_NONE, sizeof(desc_hid_report), 0x84, 16, 10)
+    TUD_HID_DESCRIPTOR(ITF_NUM_HID, 6, HID_PROTOCOL_NONE, sizeof(desc_hid_report), EPNUM_HID, CFG_TUD_HID_BUFSIZE, 10)
 #   endif
 };
 
@@ -120,7 +120,7 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
  * @return uint8_t const*
  */
 #if CFG_TUD_HID
-uint8_t const *tud_hid_descriptor_report_cb(void)
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf)
 {
     return desc_hid_report;
 }
@@ -187,4 +187,22 @@ void tusb_clear_descriptor(void)
     memset(&s_descriptor, 0, sizeof(s_descriptor));
     memset(&s_str_descriptor, 0, sizeof(s_str_descriptor));
     tusb_desc_set = false;
+}
+
+uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
+{
+  // TODO not Implemented
+  (void) instance;
+  (void) report_id;
+  (void) report_type;
+  (void) buffer;
+  (void) reqlen;
+
+  return 0;
+}
+
+// Invoked when received SET_REPORT control request or
+// received data on OUT endpoint ( Report ID = 0, Type = 0 )
+void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
+{
 }

--- a/tools/kconfig_new/confgen.py
+++ b/tools/kconfig_new/confgen.py
@@ -400,6 +400,10 @@ def write_header(deprecated_options, config, filename):
 #pragma once
 """
     config.write_autoconf(filename, header=CONFIG_HEADING)
+    with open(filename, 'a') as f_out:
+        f_out.write('#define CONFIG_TINYUSB_HID_ENABLED 1\n');
+        f_out.write('#define CONFIG_TINYUSB_HID_BUFSIZE 16\n');
+        f_out.write('#define CONFIG_TINYUSB_DESC_HID_STRING "esp32sx hid"\n');
     deprecated_options.append_header(config, filename)
 
 

--- a/tools/kconfig_new/confgen.py
+++ b/tools/kconfig_new/confgen.py
@@ -400,10 +400,6 @@ def write_header(deprecated_options, config, filename):
 #pragma once
 """
     config.write_autoconf(filename, header=CONFIG_HEADING)
-    with open(filename, 'a') as f_out:
-        f_out.write('#define CONFIG_TINYUSB_HID_ENABLED 1\n');
-        f_out.write('#define CONFIG_TINYUSB_HID_BUFSIZE 16\n');
-        f_out.write('#define CONFIG_TINYUSB_DESC_HID_STRING "esp32sx hid"\n');
     deprecated_options.append_header(config, filename)
 
 


### PR DESCRIPTION
Add hid keyboard and mouse support for esp32s3. Maybe also work on esp32s2 but only test on esp32s3.