### PR TITLE
examples/ble_mesh: Replace printf in button.c with ESP_LOGD

### DIFF
--- a/examples/bluetooth/esp_ble_mesh/common_components/button/button.c
+++ b/examples/bluetooth/esp_ble_mesh/common_components/button/button.c
@@ -269,7 +269,7 @@ esp_err_t iot_button_delete(button_handle_t btn_handle)
 button_handle_t iot_button_create(gpio_num_t gpio_num, button_active_t active_level)
 {
     #if USE_ESP_TIMER
-    esp_rom_printf("use esp timer !!!\n");
+    ESP_LOGD(TAG, "Using ESP timer");
     esp_timer_init();
     #endif
 


### PR DESCRIPTION
This seems to have been left in by mistake, and sticks out in logs using this component. 