### PR TITLE
fixed misaligned data transfer for ssd1306 (IDFGH-7661)

### DIFF
--- a/components/esp_lcd/src/esp_lcd_panel_io_i2c.c
+++ b/components/esp_lcd/src/esp_lcd_panel_io_i2c.c
@@ -141,10 +141,15 @@ static esp_err_t panel_io_i2c_tx_buffer(esp_lcd_panel_io_t *io, int lcd_cmd, con
         ESP_GOTO_ON_ERROR(i2c_master_write_byte(cmd_link, is_param ? i2c_panel_io->control_phase_cmd : i2c_panel_io->control_phase_data, true),
                         err, TAG, "write control phase failed"); // control phase
     }
-    uint8_t cmds[4] = {BYTESHIFT(lcd_cmd, 3), BYTESHIFT(lcd_cmd, 2), BYTESHIFT(lcd_cmd, 1), BYTESHIFT(lcd_cmd, 0)};
-    size_t cmds_size = i2c_panel_io->lcd_cmd_bits / 8;
-    if (cmds_size > 0 && cmds_size <= sizeof(cmds)) {
-        ESP_GOTO_ON_ERROR(i2c_master_write(cmd_link, cmds + (sizeof(cmds) - cmds_size), cmds_size, true), err, TAG, "write LCD cmd failed");
+
+    // some displays don't want any additional commands on data transfers
+    if (lcd_cmd != -1)
+    {
+        uint8_t cmds[4] = {BYTESHIFT(lcd_cmd, 3), BYTESHIFT(lcd_cmd, 2), BYTESHIFT(lcd_cmd, 1), BYTESHIFT(lcd_cmd, 0)};
+        size_t cmds_size = i2c_panel_io->lcd_cmd_bits / 8;
+        if (cmds_size > 0 && cmds_size <= sizeof(cmds)) {
+            ESP_GOTO_ON_ERROR(i2c_master_write(cmd_link, cmds + (sizeof(cmds) - cmds_size), cmds_size, true), err, TAG, "write LCD cmd failed");
+        }
     }
 
     if (buffer) {

--- a/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
+++ b/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
@@ -171,7 +171,7 @@ static esp_err_t panel_ssd1306_draw_bitmap(esp_lcd_panel_t *panel, int x_start, 
     }, 2);
     // transfer frame buffer
     size_t len = (y_end - y_start) * (x_end - x_start) * ssd1306->bits_per_pixel / 8;
-    esp_lcd_panel_io_tx_color(io, 0, color_data, len);
+    esp_lcd_panel_io_tx_color(io, -1, color_data, len);
 
     return ESP_OK;
 }


### PR DESCRIPTION
I got hold of a https://heltec.org/project/wifi-kit-32/ board.
Then I went for the example peripherals/lcd/i2c_oled which makes use of the ssd1306 oled on the board.
Sadly the scrolling text has shown artifacts. The problem was the sending of one additional 0x00 byte at the start of the color data transfer.

This PR might not be exactly what you are aiming for. I'm pretty new to the esp-idf. So maybe your team has a better solution for this.

Color data is not translated with an additional command as control_phase_data is already what is needed here. Then the color data has to follow immediately.
