### PR TITLE
Fix out of range in mcpwm example (IDFGH-7666)

### DIFF
--- a/examples/peripherals/mcpwm/mcpwm_bldc_hall_control/main/mcpwm_bldc_hall_control_example_main.c
+++ b/examples/peripherals/mcpwm/mcpwm_bldc_hall_control/main/mcpwm_bldc_hall_control_example_main.c
@@ -243,7 +243,7 @@ void app_main(void)
     while (1) {
         // The rotation direction is controlled by inverting the hall sensor value
         hall_sensor_value = bldc_get_hall_sensor_value(false);
-        if (hall_sensor_value >= 1 && hall_sensor_value <= sizeof(s_hall_actions) / sizeof(s_hall_actions[0])) {
+        if (hall_sensor_value >= 1 && hall_sensor_value < sizeof(s_hall_actions) / sizeof(s_hall_actions[0])) {
             s_hall_actions[hall_sensor_value]();
         } else {
             ESP_LOGE(TAG, "invalid bldc phase, wrong hall sensor value:%d", hall_sensor_value);


### PR DESCRIPTION
hall_sensor_value 7 must not be allowed (s_hall_actions  array has length 7, index 0 to 6)