### PR TITLE
Add C++ include guard to if.h (to fix linker errors in asio) (IDFGH-7718)

### DIFF
--- a/components/newlib/platform_include/net/if.h
+++ b/components/newlib/platform_include/net/if.h
@@ -14,6 +14,10 @@
 #ifndef _ESP_PLATFORM_NET_IF_H_
 #define _ESP_PLATFORM_NET_IF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lwip/sockets.h"
 #include "lwip/if_api.h"
 
@@ -36,5 +40,9 @@ typedef u32_t socklen_t;
 unsigned int if_nametoindex(const char *ifname);
 
 char *if_indextoname(unsigned int ifindex, char *ifname);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _ESP_PLATFORM_NET_IF_H_


### PR DESCRIPTION
I experienced a linker with asio and this PR tries to fix it.

asio uses `if_indextoname()` which needs to be defined with `extern "C"`

```
[...]
Signed 53248 bytes of data from <firmware>/build/bootloader/bootloader-unsigned.bin. Signature sector now has 1 signature blocks.
Generated signed binary image <firmware>/build/bootloader/bootloader.bin from <firmware>/build/bootloader/bootloader-unsigned.bin
[733/737 163.9/sec] Generating ld/sections.ld
[734/737 19.1/sec] Linking CXX executable firmware.elf
FAILED: firmware.elf 
: && <home>/.espressif/tools/xtensa-esp32-elf/esp-2022r1-RC1-11.2.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-g++ -mlongcalls -Wno-frame-address  -Wno-volatile  CMakeFiles/firmware.elf.dir/project_elf_src_esp32.c.obj -o firmware.elf  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/app_trace/libapp_trace.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/asio/libasio.a  esp-idf/unity/libunity.a  esp-idf/cmock/libcmock.a  esp-idf/console/libconsole.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_adc_cal/libesp_adc_cal.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/esp_hid/libesp_hid.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/esp_https_server/libesp_https_server.a  esp-idf/esp_lcd/libesp_lcd.a  esp-idf/protobuf-c/libprotobuf-c.a  esp-idf/protocomm/libprotocomm.a  esp-idf/mdns/libmdns.a  esp-idf/esp_local_ctrl/libesp_local_ctrl.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/wear_levelling/libwear_levelling.a  esp-idf/fatfs/libfatfs.a  esp-idf/json/libjson.a  esp-idf/mqtt/libmqtt.a  esp-idf/perfmon/libperfmon.a  esp-idf/spiffs/libspiffs.a  esp-idf/ulp/libulp.a  esp-idf/wifi_provisioning/libwifi_provisioning.a  esp-idf/esp_websocket_client/libesp_websocket_client.a  esp-idf/fmt/libfmt.a  esp-idf/cpputils/libcpputils.a  esp-idf/espchrono/libespchrono.a  esp-idf/espcpputils/libespcpputils.a  esp-idf/arduino-esp32/libarduino-esp32.a  esp-idf/ArduinoJson/libArduinoJson.a  esp-idf/esp-api-lib/libesp-api-lib.a  esp-idf/esphttpdutils/libesphttpdutils.a  esp-idf/espwifistack/libespwifistack.a  esp-idf/espconfiglib/libespconfiglib.a  esp-idf/espasyncota/libespasyncota.a  esp-idf/mobile-charger-logic/libmobile-charger-logic.a  esp-idf/ledmatrix/libledmatrix.a  esp-idf/MFRC522_I2C_Library/libMFRC522_I2C_Library.a  esp-idf/LM75/libLM75.a  esp-idf/espasynchttpreq/libespasynchttpreq.a  esp-idf/espasyncmdns/libespasyncmdns.a  esp-idf/espasyncudplistener/libespasyncudplistener.a  esp-idf/FastLED/libFastLED.a  esp-idf/ArduinoTime/libArduinoTime.a  esp-idf/asio_webserver/libasio_webserver.a  esp-idf/mobile-esp-firmware/libmobile-esp-firmware.a  esp-idf/esp_modem/libesp_modem.a  esp-idf/NeoPixelBus/libNeoPixelBus.a  esp-idf/esp-nimble-cpp/libesp-nimble-cpp.a  esp-idf/nfc-trf7964a/libnfc-trf7964a.a  esp-idf/rts-driver/librts-driver.a  -Wl,--cref  -Wl,--defsym=IDF_TARGET_ESP32=0  -Wl,--Map="<firmware>/build/firmware.map"  -fno-rtti  -fno-lto  -Wl,--gc-sections  -Wl,--warn-common  esp-idf/app_trace/libapp_trace.a  -lgcov  esp-idf/app_trace/libapp_trace.a  -lgcov  esp-idf/unity/libunity.a  esp-idf/wear_levelling/libwear_levelling.a  esp-idf/mobile-esp-firmware/libmobile-esp-firmware.a  esp-idf/esp_https_server/libesp_https_server.a  esp-idf/esp-api-lib/libesp-api-lib.a  esp-idf/espasyncota/libespasyncota.a  esp-idf/mobile-charger-logic/libmobile-charger-logic.a  esp-idf/espconfiglib/libespconfiglib.a  esp-idf/ArduinoJson/libArduinoJson.a  esp-idf/esphttpdutils/libesphttpdutils.a  esp-idf/ledmatrix/libledmatrix.a  esp-idf/MFRC522_I2C_Library/libMFRC522_I2C_Library.a  esp-idf/LM75/libLM75.a  esp-idf/espasynchttpreq/libespasynchttpreq.a  esp-idf/espasyncmdns/libespasyncmdns.a  esp-idf/mdns/libmdns.a  esp-idf/espasyncudplistener/libespasyncudplistener.a  esp-idf/espwifistack/libespwifistack.a  esp-idf/FastLED/libFastLED.a  esp-idf/arduino-esp32/libarduino-esp32.a  esp-idf/esp_adc_cal/libesp_adc_cal.a  esp-idf/wifi_provisioning/libwifi_provisioning.a  esp-idf/protocomm/libprotocomm.a  esp-idf/console/libconsole.a  esp-idf/protobuf-c/libprotobuf-c.a  esp-idf/json/libjson.a  esp-idf/ArduinoTime/libArduinoTime.a  esp-idf/asio_webserver/libasio_webserver.a  esp-idf/asio/libasio.a  esp-idf/espcpputils/libespcpputils.a  esp-idf/esp_websocket_client/libesp_websocket_client.a  esp-idf/espchrono/libespchrono.a  esp-idf/cpputils/libcpputils.a  esp-idf/fmt/libfmt.a  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/ulp/libulp.a  esp-idf/mbedtls/mbedtls/library/libmbedtls.a  esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a  esp-idf/mbedtls/mbedtls/library/libmbedx509.a  ../esp-idf/components/esp_wifi/lib/esp32/libcoexist.a  ../esp-idf/components/esp_wifi/lib/esp32/libcore.a  ../esp-idf/components/esp_wifi/lib/esp32/libespnow.a  ../esp-idf/components/esp_wifi/lib/esp32/libmesh.a  ../esp-idf/components/esp_wifi/lib/esp32/libnet80211.a  ../esp-idf/components/esp_wifi/lib/esp32/libpp.a  ../esp-idf/components/esp_wifi/lib/esp32/libsmartconfig.a  ../esp-idf/components/esp_wifi/lib/esp32/libwapi.a  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/ulp/libulp.a  esp-idf/mbedtls/mbedtls/library/libmbedtls.a  esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a  esp-idf/mbedtls/mbedtls/library/libmbedx509.a  ../esp-idf/components/esp_wifi/lib/esp32/libcoexist.a  ../esp-idf/components/esp_wifi/lib/esp32/libcore.a  ../esp-idf/components/esp_wifi/lib/esp32/libespnow.a  ../esp-idf/components/esp_wifi/lib/esp32/libmesh.a  ../esp-idf/components/esp_wifi/lib/esp32/libnet80211.a  ../esp-idf/components/esp_wifi/lib/esp32/libpp.a  ../esp-idf/components/esp_wifi/lib/esp32/libsmartconfig.a  ../esp-idf/components/esp_wifi/lib/esp32/libwapi.a  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/ulp/libulp.a  esp-idf/mbedtls/mbedtls/library/libmbedtls.a  esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a  esp-idf/mbedtls/mbedtls/library/libmbedx509.a  ../esp-idf/components/esp_wifi/lib/esp32/libcoexist.a  ../esp-idf/components/esp_wifi/lib/esp32/libcore.a  ../esp-idf/components/esp_wifi/lib/esp32/libespnow.a  ../esp-idf/components/esp_wifi/lib/esp32/libmesh.a  ../esp-idf/components/esp_wifi/lib/esp32/libnet80211.a  ../esp-idf/components/esp_wifi/lib/esp32/libpp.a  ../esp-idf/components/esp_wifi/lib/esp32/libsmartconfig.a  ../esp-idf/components/esp_wifi/lib/esp32/libwapi.a  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/ulp/libulp.a  esp-idf/mbedtls/mbedtls/library/libmbedtls.a  esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a  esp-idf/mbedtls/mbedtls/library/libmbedx509.a  ../esp-idf/components/esp_wifi/lib/esp32/libcoexist.a  ../esp-idf/components/esp_wifi/lib/esp32/libcore.a  ../esp-idf/components/esp_wifi/lib/esp32/libespnow.a  ../esp-idf/components/esp_wifi/lib/esp32/libmesh.a  ../esp-idf/components/esp_wifi/lib/esp32/libnet80211.a  ../esp-idf/components/esp_wifi/lib/esp32/libpp.a  ../esp-idf/components/esp_wifi/lib/esp32/libsmartconfig.a  ../esp-idf/components/esp_wifi/lib/esp32/libwapi.a  esp-idf/xtensa/libxtensa.a  esp-idf/esp_ringbuf/libesp_ringbuf.a  esp-idf/efuse/libefuse.a  esp-idf/driver/libdriver.a  esp-idf/esp_pm/libesp_pm.a  esp-idf/mbedtls/libmbedtls.a  esp-idf/app_update/libapp_update.a  esp-idf/bootloader_support/libbootloader_support.a  esp-idf/spi_flash/libspi_flash.a  esp-idf/pthread/libpthread.a  esp-idf/esp_system/libesp_system.a  esp-idf/esp_rom/libesp_rom.a  esp-idf/hal/libhal.a  esp-idf/log/liblog.a  esp-idf/heap/libheap.a  esp-idf/soc/libsoc.a  esp-idf/esp_hw_support/libesp_hw_support.a  esp-idf/freertos/libfreertos.a  esp-idf/newlib/libnewlib.a  esp-idf/cxx/libcxx.a  esp-idf/esp_common/libesp_common.a  esp-idf/esp_timer/libesp_timer.a  esp-idf/vfs/libvfs.a  esp-idf/esp_netif/libesp_netif.a  esp-idf/esp_event/libesp_event.a  esp-idf/nvs_flash/libnvs_flash.a  esp-idf/esp_phy/libesp_phy.a  esp-idf/wpa_supplicant/libwpa_supplicant.a  esp-idf/esp_wifi/libesp_wifi.a  esp-idf/lwip/liblwip.a  esp-idf/http_parser/libhttp_parser.a  esp-idf/esp-tls/libesp-tls.a  esp-idf/esp_gdbstub/libesp_gdbstub.a  esp-idf/tcp_transport/libtcp_transport.a  esp-idf/esp_http_client/libesp_http_client.a  esp-idf/esp_http_server/libesp_http_server.a  esp-idf/esp_https_ota/libesp_https_ota.a  esp-idf/sdmmc/libsdmmc.a  esp-idf/esp_serial_slave_link/libesp_serial_slave_link.a  esp-idf/espcoredump/libespcoredump.a  esp-idf/ulp/libulp.a  esp-idf/mbedtls/mbedtls/library/libmbedtls.a  esp-idf/mbedtls/mbedtls/library/libmbedcrypto.a  esp-idf/mbedtls/mbedtls/library/libmbedx509.a  ../esp-idf/components/esp_wifi/lib/esp32/libcoexist.a  ../esp-idf/components/esp_wifi/lib/esp32/libcore.a  ../esp-idf/components/esp_wifi/lib/esp32/libespnow.a  ../esp-idf/components/esp_wifi/lib/esp32/libmesh.a  ../esp-idf/components/esp_wifi/lib/esp32/libnet80211.a  ../esp-idf/components/esp_wifi/lib/esp32/libpp.a  ../esp-idf/components/esp_wifi/lib/esp32/libsmartconfig.a  ../esp-idf/components/esp_wifi/lib/esp32/libwapi.a  ../esp-idf/components/xtensa/esp32/libxt_hal.a  -Wl,--wrap=mbedtls_ssl_handshake_client_step  -Wl,--wrap=mbedtls_ssl_handshake_server_step  -Wl,--wrap=mbedtls_ssl_read  -Wl,--wrap=mbedtls_ssl_write  -Wl,--wrap=mbedtls_ssl_session_reset  -Wl,--wrap=mbedtls_ssl_free  -Wl,--wrap=mbedtls_ssl_setup  -Wl,--wrap=mbedtls_ssl_send_alert_message  -Wl,--wrap=mbedtls_ssl_close_notify  -u esp_app_desc  -u pthread_include_pthread_impl  -u pthread_include_pthread_cond_impl  -u pthread_include_pthread_local_storage_impl  -u pthread_include_pthread_rwlock_impl  -u ld_include_highint_hdl  -u start_app  -u start_app_other_cores  -L "<firmware>/build/esp-idf/esp_system/ld"  -T memory.ld  -T sections.ld  -u __ubsan_include  -L "<firmware>/esp-idf/components/esp_rom/esp32/ld"  -T esp32.rom.ld  -T esp32.rom.api.ld  -T esp32.rom.libgcc.ld  -T esp32.rom.newlib-data.ld  -T esp32.rom.syscalls.ld  -T esp32.rom.newlib-funcs.ld  -T esp32.rom.eco3.ld  -Wl,--wrap=longjmp  -u __assert_func  -u esp_dport_access_reg_read  -L "<firmware>/esp-idf/components/soc/esp32/ld"  -T esp32.peripherals.ld  -Wl,--undefined=uxTopUsedPriority  -Wl,--undefined=FreeRTOS_openocd_params  -u app_main  -lc  -lm  esp-idf/newlib/libnewlib.a  -u newlib_include_heap_impl  -u newlib_include_syscalls_impl  -u newlib_include_pthread_impl  -u newlib_include_assert_impl  -Wl,--wrap=_Unwind_SetEnableExceptionFdeSorting  -Wl,--wrap=__register_frame_info_bases  -Wl,--wrap=__register_frame_info  -Wl,--wrap=__register_frame  -Wl,--wrap=__register_frame_info_table_bases  -Wl,--wrap=__register_frame_info_table  -Wl,--wrap=__register_frame_table  -Wl,--wrap=__deregister_frame_info_bases  -Wl,--wrap=__deregister_frame_info  -Wl,--wrap=_Unwind_Find_FDE  -Wl,--wrap=_Unwind_GetGR  -Wl,--wrap=_Unwind_GetCFA  -Wl,--wrap=_Unwind_GetIP  -Wl,--wrap=_Unwind_GetIPInfo  -Wl,--wrap=_Unwind_GetRegionStart  -Wl,--wrap=_Unwind_GetDataRelBase  -Wl,--wrap=_Unwind_GetTextRelBase  -Wl,--wrap=_Unwind_SetIP  -Wl,--wrap=_Unwind_SetGR  -Wl,--wrap=_Unwind_GetLanguageSpecificData  -Wl,--wrap=_Unwind_FindEnclosingFunction  -Wl,--wrap=_Unwind_Resume  -Wl,--wrap=_Unwind_RaiseException  -Wl,--wrap=_Unwind_DeleteException  -Wl,--wrap=_Unwind_ForcedUnwind  -Wl,--wrap=_Unwind_Resume_or_Rethrow  -Wl,--wrap=_Unwind_Backtrace  -Wl,--wrap=__cxa_call_unexpected  -Wl,--wrap=__gxx_personality_v0  -u __cxa_guard_dummy  -lstdc++  esp-idf/pthread/libpthread.a  -lgcc  esp-idf/cxx/libcxx.a  -u __cxx_fatal_exception  -u vfs_include_syscalls_impl  -L "<firmware>/esp-idf/components/esp_phy/lib/esp32"  -u include_esp_phy_override  -lphy  -lrtc  esp-idf/esp_phy/libesp_phy.a  -lphy  -lrtc  esp-idf/esp_phy/libesp_phy.a  -lphy  -lrtc  -L "<firmware>/esp-idf/components/esp_wifi/lib/esp32" && :
<home>/.espressif/tools/xtensa-esp32-elf/esp-2022r1-RC1-11.2.0/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/11.2.0/../../../../xtensa-esp32-elf/bin/ld: esp-idf/asio/libasio.a(asio.cpp.obj):(.literal._ZN4asio6detail10socket_ops9inet_ntopEiPKvPcjmRSt10error_code+0x4): undefined reference to `_Z14if_indextonamejPc'
<home>/.espressif/tools/xtensa-esp32-elf/esp-2022r1-RC1-11.2.0/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/11.2.0/../../../../xtensa-esp32-elf/bin/ld: esp-idf/asio/libasio.a(asio.cpp.obj): in function `_ZN4asio6detail10socket_ops9inet_ntopEiPKvPcjmRSt10error_code':
<firmware>/esp-protocols/components/asio/asio/asio/include/asio/detail/impl/socket_ops.ipp:2128: undefined reference to `_Z14if_indextonamejPc'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```