### PR TITLE
Fix tinyusb_driver_install (dangling pointer) (IDFGH-7723)

### DIFF
--- a/components/tinyusb/additions/src/tinyusb.c
+++ b/components/tinyusb/additions/src/tinyusb.c
@@ -32,16 +32,16 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
         .controller = USB_PHY_CTRL_OTG,
         .otg_mode = USB_OTG_MODE_DEVICE,
     };
+    usb_phy_gpio_conf_t gpio_conf = {
+    .vp_io_num = USBPHY_VP_NUM,
+    .vm_io_num = USBPHY_VM_NUM,
+    .rcv_io_num = USBPHY_RCV_NUM,
+    .oen_io_num = USBPHY_OEN_NUM,
+    .vpo_io_num = USBPHY_VPO_NUM,
+    .vmo_io_num = USBPHY_VMO_NUM,
+    };
     if (config->external_phy) {
         phy_conf.target = USB_PHY_TARGET_EXT;
-        usb_phy_gpio_conf_t gpio_conf = {
-            .vp_io_num = USBPHY_VP_NUM,
-            .vm_io_num = USBPHY_VM_NUM,
-            .rcv_io_num = USBPHY_RCV_NUM,
-            .oen_io_num = USBPHY_OEN_NUM,
-            .vpo_io_num = USBPHY_VPO_NUM,
-            .vmo_io_num = USBPHY_VMO_NUM,
-        };
         phy_conf.gpio_conf = &gpio_conf;
     } else {
         phy_conf.target = USB_PHY_TARGET_INT;


### PR DESCRIPTION
Pointer to `gpio_conf` variable was used out of its scope. This caused dereference to some trash values in the following call `usb_new_phy()`. I moved the variable definition to include usb_new_phy() call in its scope and now it's working ok.