### PR TITLE
Fix SMP race in xEventGroupSetBits() -> xEventGroupWaitBits() timeout  (IDFGH-7731)

### DIFF
--- a/components/freertos/include/freertos/task.h
+++ b/components/freertos/include/freertos/task.h
@@ -3389,7 +3389,7 @@ void vTaskPlaceOnEventListRestricted( List_t * const pxEventList,
  * making the call, otherwise pdFALSE.
  */
 BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
-void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
+BaseType_t xTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue ) PRIVILEGED_FUNCTION;
 
 /*

--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3741,6 +3741,12 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
 
     taskENTER_CRITICAL();
 
+    if ( listLIST_ITEM_CONTAINER( pxEventListItem ) == NULL ) {
+      // XXX: https://github.com/espressif/esp-idf/issues/8336
+      taskEXIT_CRITICAL();
+      return;
+    }
+
     /* Store the new item value in the event list. */
     listSET_LIST_ITEM_VALUE( pxEventListItem, xItemValue | taskEVENT_LIST_ITEM_VALUE_IN_USE );
 

--- a/components/freertos/tasks.c
+++ b/components/freertos/tasks.c
@@ -3734,7 +3734,7 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 }
 /*-----------------------------------------------------------*/
 
-void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
+BaseType_t xTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue )
 {
     TCB_t * pxUnblockedTCB;
@@ -3744,7 +3744,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     if ( listLIST_ITEM_CONTAINER( pxEventListItem ) == NULL ) {
       // XXX: https://github.com/espressif/esp-idf/issues/8336
       taskEXIT_CRITICAL();
-      return;
+      return pdFALSE;
     }
 
     /* Store the new item value in the event list. */
@@ -3774,6 +3774,8 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     }
 
     taskEXIT_CRITICAL();
+
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-idf/issues/8336

This is a draft PR for my best attempt to fix the SMP race condition described in https://github.com/espressif/esp-idf/issues/8336, where a task calling `xEventGroupSetBits()` on one core can race with `xTaskIncrementTick()` handling a `xEventGroupWaitBits()` timeout on a different core, leading to a crash in `vTaskRemoveFromUnorderedEventList()` -> `uxListRemove()` or lockup.

Tested against the `release/v4.4` branch using the repro case in https://gist.github.com/SpComb/909d20847645aa22361cf4d3e8bc3700 to verify that this fixes the crash/lockup and does not lead to lost event bits.

I'll be happy to clean this up and rebase against master based on feedback if this approach is acceptable - but I'm skeptical about the modifications to the FreeRTOS interfaces, and it looks like the FreeRTOS SMP implementation in the master branch might be changing for 5.0?