### PR TITLE
ESP32S3 USB external PHY pinout

### DIFF
--- a/components/soc/esp32s3/include/soc/usb_pins.h
+++ b/components/soc/esp32s3/include/soc/usb_pins.h
@@ -15,11 +15,11 @@
 #pragma once
 
 /* GPIOs used to connect an external USB PHY */
-#define USBPHY_VP_NUM 33
-#define USBPHY_VM_NUM 34
-#define USBPHY_RCV_NUM 35
-#define USBPHY_OEN_NUM 36
-#define USBPHY_VPO_NUM 37
+#define USBPHY_VP_NUM 42
+#define USBPHY_VM_NUM 41
+#define USBPHY_RCV_NUM 21
+#define USBPHY_OEN_NUM 40
+#define USBPHY_VPO_NUM 39
 #define USBPHY_VMO_NUM 38
 
 /* GPIOs corresponding to the pads of the internal USB PHY */


### PR DESCRIPTION
Change USB pinout for ESP32-S3 as in Reference Manual Figure 29-3.
Now the pinout causes crash and uses pins non existing in ESP32-S3. The connection for external PHY is not well described, pinout seems not to be user configurable and the only place where it is documented is Reference Manual chapter 29.
I use internal PHY for JTAG and external for USB CDC simultaneously, after this pinout change it works ok.