### PR TITLE
Expand lcd/i80_controller example to support ILI9341 display (IDFGH-7775)

### DIFF
--- a/examples/peripherals/lcd/i80_controller/README.md
+++ b/examples/peripherals/lcd/i80_controller/README.md
@@ -19,7 +19,7 @@ This example uses the [esp_timer](https://docs.espressif.com/projects/esp-idf/en
 ### Hardware Required
 
 * An ESP development board
-* An Intel 8080 interfaced (so called MCU interface or parallel interface) LCD (this example can use ST7789 or NT35510)
+* An Intel 8080 interfaced (so called MCU interface or parallel interface) LCD (this example can use ST7789, NT35510 or ILI9341)
 * An USB cable for power supply and programming
 
 ### Hardware Connection

--- a/examples/peripherals/lcd/i80_controller/main/Kconfig.projbuild
+++ b/examples/peripherals/lcd/i80_controller/main/Kconfig.projbuild
@@ -19,6 +19,9 @@ menu "Example Configuration"
 
         config EXAMPLE_LCD_I80_CONTROLLER_NT35510
             bool "NT35510"
+
+        config EXAMPLE_LCD_I80_CONTROLLER_ILI9341
+            bool "ILI9341"
     endchoice
 
     if EXAMPLE_LCD_I80_CONTROLLER_NT35510

--- a/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
+++ b/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
@@ -55,20 +55,16 @@ static const char *TAG = "example";
 #define EXAMPLE_PIN_NUM_BK_LIGHT       1
 
 // The pixel number in horizontal and vertical
-// Bit number used to represent command and parameter
-#if CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ST7789
 #define EXAMPLE_LCD_H_RES              240
 #define EXAMPLE_LCD_V_RES              280
+// Bit number used to represent command and parameter
+#if CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ST7789
 #define EXAMPLE_LCD_CMD_BITS           8
 #define EXAMPLE_LCD_PARAM_BITS         8
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_NT35510
-#define EXAMPLE_LCD_H_RES              240
-#define EXAMPLE_LCD_V_RES              280
 #define EXAMPLE_LCD_CMD_BITS           16
 #define EXAMPLE_LCD_PARAM_BITS         16
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ILI9341
-#define EXAMPLE_LCD_H_RES              320
-#define EXAMPLE_LCD_V_RES              240
 #define EXAMPLE_LCD_CMD_BITS           8
 #define EXAMPLE_LCD_PARAM_BITS         8
 #endif

--- a/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
+++ b/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
@@ -210,11 +210,9 @@ void app_main(void)
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_NT35510
     esp_lcd_panel_swap_xy(panel_handle, true);
     esp_lcd_panel_mirror(panel_handle, true, false);
-    esp_lcd_panel_set_gap(panel_handle, 0, 20);
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ILI9341
     esp_lcd_panel_swap_xy(panel_handle, true);
     esp_lcd_panel_invert_color(panel_handle, false);
-    esp_lcd_panel_set_gap(panel_handle, 0, 0);
     // ILI9341 is very similar to ST7789 and shares the same driver.
     // Anything unconventional (such as this custom gamma table) can
     // be issued here in user code and need not modify the driver.

--- a/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
+++ b/examples/peripherals/lcd/i80_controller/main/i80_controller_example_main.c
@@ -55,15 +55,22 @@ static const char *TAG = "example";
 #define EXAMPLE_PIN_NUM_BK_LIGHT       1
 
 // The pixel number in horizontal and vertical
-#define EXAMPLE_LCD_H_RES              240
-#define EXAMPLE_LCD_V_RES              280
 // Bit number used to represent command and parameter
 #if CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ST7789
+#define EXAMPLE_LCD_H_RES              240
+#define EXAMPLE_LCD_V_RES              280
 #define EXAMPLE_LCD_CMD_BITS           8
 #define EXAMPLE_LCD_PARAM_BITS         8
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_NT35510
+#define EXAMPLE_LCD_H_RES              240
+#define EXAMPLE_LCD_V_RES              280
 #define EXAMPLE_LCD_CMD_BITS           16
 #define EXAMPLE_LCD_PARAM_BITS         16
+#elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ILI9341
+#define EXAMPLE_LCD_H_RES              320
+#define EXAMPLE_LCD_V_RES              240
+#define EXAMPLE_LCD_CMD_BITS           8
+#define EXAMPLE_LCD_PARAM_BITS         8
 #endif
 
 #define EXAMPLE_LVGL_TICK_PERIOD_MS    2
@@ -153,6 +160,9 @@ void app_main(void)
             .dc_dummy_level = 0,
             .dc_data_level = 1,
         },
+        .flags = {
+            .swap_color_bytes = !LV_COLOR_16_SWAP, // Swap can be done in LvGL (default) or DMA
+        },
         .on_color_trans_done = example_notify_lvgl_flush_ready,
         .user_ctx = &disp_drv,
         .lcd_cmd_bits = EXAMPLE_LCD_CMD_BITS,
@@ -177,19 +187,44 @@ void app_main(void)
         .bits_per_pixel = 16,
     };
     ESP_ERROR_CHECK(esp_lcd_new_panel_nt35510(io_handle, &panel_config, &panel_handle));
+#elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ILI9341
+    // ILI9341 is NOT a distinct driver, but a special case of ST7789
+    // (essential registers are identical). A few lines further down in this code,
+    // it's shown how to issue additional device-specific commands.
+    ESP_LOGI(TAG, "Install LCD driver of ili9341 (st7789 compatible)");
+    esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = EXAMPLE_PIN_NUM_RST,
+        .color_space = ESP_LCD_COLOR_SPACE_BGR,
+        .bits_per_pixel = 16,
+    };
+    ESP_ERROR_CHECK(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
 #endif
 
     esp_lcd_panel_reset(panel_handle);
     esp_lcd_panel_init(panel_handle);
     // Set inversion, x/y coordinate order, x/y mirror according to your LCD module spec
+    // the gap is LCD panel specific, even panels with the same driver IC, can have different gap value
 #if CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ST7789
     esp_lcd_panel_invert_color(panel_handle, true);
+    esp_lcd_panel_set_gap(panel_handle, 0, 20);
 #elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_NT35510
     esp_lcd_panel_swap_xy(panel_handle, true);
     esp_lcd_panel_mirror(panel_handle, true, false);
-#endif
-    // the gap is LCD panel specific, even panels with the same driver IC, can have different gap value
     esp_lcd_panel_set_gap(panel_handle, 0, 20);
+#elif CONFIG_EXAMPLE_LCD_I80_CONTROLLER_ILI9341
+    esp_lcd_panel_swap_xy(panel_handle, true);
+    esp_lcd_panel_invert_color(panel_handle, false);
+    esp_lcd_panel_set_gap(panel_handle, 0, 0);
+    // ILI9341 is very similar to ST7789 and shares the same driver.
+    // Anything unconventional (such as this custom gamma table) can
+    // be issued here in user code and need not modify the driver.
+    esp_lcd_panel_io_tx_param(io_handle, 0xF2, (uint8_t[]) { 0 }, 1); // 3Gamma function disable
+    esp_lcd_panel_io_tx_param(io_handle, 0x26, (uint8_t[]) { 1 }, 1); // Gamma curve 1 selected
+    esp_lcd_panel_io_tx_param(io_handle, 0xE0, (uint8_t[]) {          // Set positive gamma
+        0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, 0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00 }, 15);
+    esp_lcd_panel_io_tx_param(io_handle, 0xE1, (uint8_t[]) {          // Set negative gamma
+        0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, 0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F }, 15);
+#endif
 
     // user can flush pre-defined pattern to the screen before we turn on the screen or backlight
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));


### PR DESCRIPTION
This replaces #9266 (closed yesterday as the wrong approach). i80 LCD example is extended to show ILI9341 usage; nearly but not quite the same as ST7789, requires no driver changes, just user code. If nothing else, the addition of .flags.swap_color_bytes being the reverse of the corresponding LvGL setting might be worth keeping.
Tested on ESP32-S3-DevKitC-1 N8R8 with Adafruit ILI9341 breakout (8-bit parallel interface).