### PR TITLE
esp_websocket_client: error handling improved and new 'before connect… (IDFGH-7805)

### DIFF
--- a/components/tcp_transport/include/esp_transport_ws.h
+++ b/components/tcp_transport/include/esp_transport_ws.h
@@ -127,6 +127,16 @@ esp_err_t esp_transport_ws_set_config(esp_transport_handle_t t, const esp_transp
 int esp_transport_ws_send_raw(esp_transport_handle_t t, ws_transport_opcodes_t opcode, const char *b, int len, int timeout_ms);
 
 /**
+ * @brief               Returns the HTTP status code of the websocket handshake
+ *
+ * @param t             websocket transport handle
+ *
+ * @return
+ *      - HTTP status code
+ */
+int esp_transport_ws_get_http_status_code(esp_transport_handle_t t);
+
+/**
  * @brief               Returns websocket op-code for last received data
  *
  * @param t             websocket transport handle

--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -61,6 +61,7 @@ typedef struct {
     char *sub_protocol;
     char *user_agent;
     char *headers;
+    int http_status_code;
     bool propagate_control_frames;
     ws_transport_frame_state_t frame_state;
     esp_transport_handle_t parent;
@@ -123,6 +124,29 @@ static char *trimwhitespace(const char *str)
     *(end + 1) = 0;
 
     return (char *)str;
+}
+
+static int get_http_status_code(const char *buffer)
+{
+    const char *found = strcasestr(buffer, "HTTP/");
+    if (found) {
+        found += 5;
+        found = strstr(found, " ");
+        if (found) {
+            found++;
+            const char *found_end = strstr(found, " ");
+            if (found_end && (found_end - found == 3)) {
+                // copy status code to keep buffer unchanged
+                char code[4];
+                memcpy(code, found, found_end - found);
+                code[3] = 0;
+
+                return atoi(code);
+            }
+        }
+    }
+
+    return -1;
 }
 
 static char *get_http_header(const char *buffer, const char *key)
@@ -215,6 +239,13 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
         ws->buffer[header_len] = '\0';
         ESP_LOGD(TAG, "Read header chunk %d, current header size: %d", len, header_len);
     } while (NULL == strstr(ws->buffer, "\r\n\r\n") && header_len < WS_BUFFER_SIZE);
+
+    int status = get_http_status_code(ws->buffer);
+    if (status != WS_RESPONSE_OK) {
+        ws->http_status_code = status;
+        ESP_LOGE(TAG, "HTTP upgrade failed");
+        return -1;
+    }
 
     char *server_key = get_http_header(ws->buffer, "Sec-WebSocket-Accept:");
     if (server_key == NULL) {
@@ -710,6 +741,12 @@ esp_err_t esp_transport_ws_set_config(esp_transport_handle_t t, const esp_transp
     ws->propagate_control_frames = config->propagate_control_frames;
 
     return err;
+}
+
+int esp_transport_ws_get_http_status_code(esp_transport_handle_t t)
+{
+    transport_ws_t *ws = esp_transport_get_context_data(t);
+    return ws->http_status_code;
 }
 
 ws_transport_opcodes_t esp_transport_ws_get_read_opcode(esp_transport_handle_t t)


### PR DESCRIPTION
…' event added to improve handling OAuth flows

* error handling is now similar to mqtt client, allowing handling of socket and TLS errors
* handling of http status codes during upgrade handshake is now possible
* new headers setter function added
* added before-connect event to modify URL or headers before websocket re-/connect (similar to mqtt client)

now it is easy to implement OAuth flows and token renewal mechanism in a simple way.