### PR TITLE
Add a helpful comment to sdkconfig.defaults files in examples (IDFGH-7820)

### DIFF
--- a/components/cxx/test_apps/exception/sdkconfig.defaults
+++ b/components/cxx/test_apps/exception/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y

--- a/components/cxx/test_apps/exception_no_except/sdkconfig.defaults
+++ b/components/cxx/test_apps/exception_no_except/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_CXX_EXCEPTIONS=n
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=0
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y

--- a/components/cxx/test_apps/general/sdkconfig.defaults
+++ b/components/cxx/test_apps/general/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y

--- a/components/cxx/test_apps/rtti/sdkconfig.defaults
+++ b/components/cxx/test_apps/rtti/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024
 CONFIG_COMPILER_CXX_RTTI=y

--- a/components/driver/test_apps/gpio/sdkconfig.defaults
+++ b/components/driver/test_apps/gpio/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n
 CONFIG_SDM_SUPPRESS_DEPRECATE_WARN=y

--- a/components/driver/test_apps/gptimer/sdkconfig.defaults
+++ b/components/driver/test_apps/gptimer/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/driver/test_apps/i2s_test_apps/i2s/sdkconfig.defaults
+++ b/components/driver/test_apps/i2s_test_apps/i2s/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_I2S_ENABLE_DEBUG_LOG=y
 CONFIG_ESP_TASK_WDT=n

--- a/components/driver/test_apps/i2s_test_apps/legacy_i2s_adc_dac/sdkconfig.defaults
+++ b/components/driver/test_apps/i2s_test_apps/legacy_i2s_adc_dac/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_I2S_SUPPRESS_DEPRECATE_WARN=y
 CONFIG_ADC_SUPPRESS_DEPRECATE_WARN=y
 CONFIG_I2S_ENABLE_DEBUG_LOG=y

--- a/components/driver/test_apps/i2s_test_apps/legacy_i2s_driver/sdkconfig.defaults
+++ b/components/driver/test_apps/i2s_test_apps/legacy_i2s_driver/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_I2S_SUPPRESS_DEPRECATE_WARN=y
 CONFIG_ADC_SUPPRESS_DEPRECATE_WARN=y
 CONFIG_I2S_ENABLE_DEBUG_LOG=y

--- a/components/driver/test_apps/legacy_pcnt_driver/sdkconfig.defaults
+++ b/components/driver/test_apps/legacy_pcnt_driver/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n
 CONFIG_PCNT_SUPPRESS_DEPRECATE_WARN=y

--- a/components/driver/test_apps/legacy_rmt_driver/sdkconfig.defaults
+++ b/components/driver/test_apps/legacy_rmt_driver/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n
 CONFIG_RMT_SUPPRESS_DEPRECATE_WARN=y

--- a/components/driver/test_apps/legacy_rtc_temp_driver/sdkconfig.defaults
+++ b/components/driver/test_apps/legacy_rtc_temp_driver/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_TASK_WDT=n
 CONFIG_TEMP_SENSOR_SUPPRESS_DEPRECATE_WARN=y

--- a/components/driver/test_apps/legacy_timer_driver/sdkconfig.defaults
+++ b/components/driver/test_apps/legacy_timer_driver/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n
 CONFIG_GPTIMER_SUPPRESS_DEPRECATE_WARN=y

--- a/components/driver/test_apps/pulse_cnt/sdkconfig.defaults
+++ b/components/driver/test_apps/pulse_cnt/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/driver/test_apps/rmt/sdkconfig.defaults
+++ b/components/driver/test_apps/rmt/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/driver/test_apps/temperature_sensor/sdkconfig.defaults
+++ b/components/driver/test_apps/temperature_sensor/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_event/host_test/esp_event_unit_test/sdkconfig.defaults
+++ b/components/esp_event/host_test/esp_event_unit_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/components/esp_lcd/test_apps/i2c_lcd/sdkconfig.defaults
+++ b/components/esp_lcd/test_apps/i2c_lcd/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_lcd/test_apps/i80_lcd/sdkconfig.defaults
+++ b/components/esp_lcd/test_apps/i80_lcd/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_lcd/test_apps/rgb_lcd/sdkconfig.defaults
+++ b/components/esp_lcd/test_apps/rgb_lcd/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_lcd/test_apps/spi_lcd/sdkconfig.defaults
+++ b/components/esp_lcd/test_apps/spi_lcd/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_netif/test_apps/sdkconfig.defaults
+++ b/components/esp_netif/test_apps/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_FIXTURE=y
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n

--- a/components/esp_psram/test_apps/psram/sdkconfig.defaults
+++ b/components/esp_psram/test_apps/psram/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/esp_rom/host_test/rom_test/sdkconfig.defaults
+++ b/components/esp_rom/host_test/rom_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="linux"
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n

--- a/components/esp_system/test_apps/rtc_8md256/sdkconfig.defaults
+++ b/components/esp_system/test_apps/rtc_8md256/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n
 CONFIG_RTC_CLK_SRC_INT_8MD256=y

--- a/components/esp_system/test_apps/rtc_power_modes/sdkconfig.defaults
+++ b/components/esp_system/test_apps/rtc_power_modes/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_TASK_WDT=n

--- a/components/espcoredump/test_apps/sdkconfig.defaults
+++ b/components/espcoredump/test_apps/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_COREDUMP_ENABLE_TO_UART=y
 CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
 CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y

--- a/components/log/host_test/log_test/sdkconfig.defaults
+++ b/components/log/host_test/log_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="linux"
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_LOG_TIMESTAMP_SOURCE_RTOS=y

--- a/components/lwip/test_afl_host/sdkconfig.defaults
+++ b/components/lwip/test_afl_host/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES=n
 CONFIG_FREERTOS_SMP=n

--- a/components/mqtt/host_test/sdkconfig.defaults
+++ b/components/mqtt/host_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="linux"
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_RTTI=y

--- a/components/newlib/test_apps/sdkconfig.defaults
+++ b/components/newlib/test_apps/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_FIXTURE=y
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_UNITY_ENABLE_64BIT=y

--- a/components/nvs_flash/host_test/nvs_page_test/sdkconfig.defaults
+++ b/components/nvs_flash/host_test/nvs_page_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_COMPILER_HIDE_PATHS_MACROS=n
 CONFIG_IDF_TARGET="linux"

--- a/components/spi_flash/host_test/partition_api_test/sdkconfig.defaults
+++ b/components/spi_flash/host_test/partition_api_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="linux"
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n

--- a/components/wear_levelling/test_apps/sdkconfig.defaults
+++ b/components/wear_levelling/test_apps/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # General options for additional checks
 CONFIG_HEAP_POISONING_COMPREHENSIVE=y
 CONFIG_COMPILER_WARN_WRITE_STRINGS=y

--- a/examples/bluetooth/bluedroid/ble/ble_ancs/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_ancs/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_compatibility_test/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_compatibility_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/bluedroid/ble/ble_eddystone/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_eddystone/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_hid_device_demo/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_ibeacon/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_ibeacon/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_spp_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_spp_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_spp_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_spp_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/bluedroid/ble/ble_throughput/throughput_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_throughput/throughput_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/ble_throughput/throughput_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/ble_throughput/throughput_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/gatt_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gatt_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/gatt_security_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gatt_security_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/gatt_security_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gatt_security_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/gatt_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gatt_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble/gatt_server_service_table/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gatt_server_service_table/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/bluedroid/ble/gattc_multi_connect/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble/gattc_multi_connect/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/ble_50/ble50_security_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble_50/ble50_security_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/bluedroid/ble_50/ble50_security_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble_50/ble50_security_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/bluedroid/ble_50/multi-adv/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble_50/multi-adv/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/bluedroid/ble_50/peroidic_adv/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble_50/peroidic_adv/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/bluedroid/ble_50/peroidic_sync/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/ble_50/peroidic_sync/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_sink/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled and BT_DRAM_RELEASE is disabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/a2dp_source/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/a2dp_source/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_discovery/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_discovery/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable Classic BT and disable BLE
 CONFIG_BT_ENABLED=y
 CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_hid_mouse_device/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_hid_mouse_device/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_BT_ENABLED=y
 CONFIG_BTDM_CTRL_MODE_BLE_ONLY=n
 CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_l2cap_client/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_l2cap_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_l2cap_server/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_l2cap_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_spp_acceptor/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_spp_acceptor/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_spp_initiator/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_spp_initiator/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_spp_vfs_acceptor/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_spp_vfs_acceptor/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/bt_spp_vfs_initiator/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/bt_spp_vfs_initiator/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # and WiFi disabled by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/hfp_ag/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/hfp_ag/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled and BT_DRAM_RELEASE is disabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/classic_bt/hfp_hf/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/classic_bt/hfp_hf/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled and BT_DRAM_RELEASE is disabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/coex/a2dp_gatts_coex/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/coex/a2dp_gatts_coex/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 # Classic BT is enabled and BT_DRAM_RELEASE is disabled
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/bluedroid/coex/gattc_gatts_coex/sdkconfig.defaults
+++ b/examples/bluetooth/bluedroid/coex/gattc_gatts_coex/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/blufi/sdkconfig.defaults
+++ b/examples/bluetooth/blufi/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/esp_ble_mesh/aligenie_demo/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/aligenie_demo/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Partition Table
 #

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_coex_test/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_coex_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file; DO NOT EDIT.
 # Espressif IoT Development Framework Configuration

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_console/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_console/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_fast_provision/fast_prov_client/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_fast_provision/fast_prov_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_fast_provision/fast_prov_server/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_fast_provision/fast_prov_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_node/onoff_client/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_node/onoff_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_node/onoff_server/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_node/onoff_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_provisioner/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_provisioner/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_sensor_model/sensor_client/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_sensor_model/sensor_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_sensor_model/sensor_server/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_sensor_model/sensor_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_vendor_model/vendor_client/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_vendor_model/vendor_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_vendor_model/vendor_server/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_vendor_model/vendor_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/sdkconfig.defaults
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # by default in this example
 CONFIG_BT_ENABLED=y

--- a/examples/bluetooth/esp_hid_device/sdkconfig.defaults
+++ b/examples/bluetooth/esp_hid_device/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_BT_ENABLED=y
 CONFIG_BTDM_CTRL_MODE_BTDM=y
 CONFIG_BTDM_CTRL_HCI_MODE_VHCI=y

--- a/examples/bluetooth/esp_hid_host/sdkconfig.defaults
+++ b/examples/bluetooth/esp_hid_host/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_BT_ENABLED=y
 CONFIG_BTDM_CTRL_MODE_BTDM=y
 CONFIG_BTDM_CTRL_HCI_MODE_VHCI=y

--- a/examples/bluetooth/hci/ble_adv_scan_combined/sdkconfig.defaults
+++ b/examples/bluetooth/hci/ble_adv_scan_combined/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/hci/controller_hci_uart_esp32/sdkconfig.defaults
+++ b/examples/bluetooth/hci/controller_hci_uart_esp32/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/hci/controller_hci_uart_esp32c3_and_esp32s3/sdkconfig.defaults
+++ b/examples/bluetooth/hci/controller_hci_uart_esp32c3_and_esp32s3/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) Project Configuration

--- a/examples/bluetooth/hci/controller_vhci_ble_adv/sdkconfig.defaults
+++ b/examples/bluetooth/hci/controller_vhci_ble_adv/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/ble_spp/spp_client/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/ble_spp/spp_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/ble_spp/spp_server/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/ble_spp/spp_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/blecent/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/blecent/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/blehr/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/blehr/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/blemesh/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/blemesh/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/bleprph/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/bleprph/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/bleprph_wifi_coex/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/bleprph_wifi_coex/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example
 

--- a/examples/bluetooth/nimble/hci/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/hci/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #

--- a/examples/bluetooth/nimble/throughput_app/blecent_throughput/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/throughput_app/blecent_throughput/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example and some misc buffer sizes are increased
 

--- a/examples/bluetooth/nimble/throughput_app/bleprph_throughput/sdkconfig.defaults
+++ b/examples/bluetooth/nimble/throughput_app/bleprph_throughput/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled
 # in this example and some example specific misc sizes are increased.
 

--- a/examples/build_system/cmake/import_lib/sdkconfig.defaults
+++ b/examples/build_system/cmake/import_lib/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/build_system/cmake/linux_host_app/sdkconfig.defaults
+++ b/examples/build_system/cmake/linux_host_app/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_COMPILER_CXX_EXCEPTIONS=y

--- a/examples/build_system/cmake/multi_config/sdkconfig.defaults
+++ b/examples/build_system/cmake/multi_config/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # In this example, the default build (obtained with 'idf.py build')
 # targets a hypothetical development platform.
 CONFIG_EXAMPLE_PRODUCT_NAME="Blinky Development Board"

--- a/examples/cxx/exceptions/sdkconfig.defaults
+++ b/examples/cxx/exceptions/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/blink_cxx/sdkconfig.defaults
+++ b/examples/cxx/experimental/blink_cxx/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/esp_event_async_cxx/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_event_async_cxx/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/esp_event_cxx/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_event_cxx/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/esp_modem_cxx/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_modem_cxx/sdkconfig.defaults
@@ -4,4 +4,11 @@
 # NOTE - if this file changes, to get new defaults, you must erase any existing
 # "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
 
-CONFIG_ESP_WIFI_FTM_ENABLE=y
+# Override some defaults to enable PPP
+CONFIG_LWIP_PPP_SUPPORT=y
+CONFIG_LWIP_PPP_NOTIFY_PHASE_SUPPORT=y
+CONFIG_LWIP_PPP_PAP_SUPPORT=y
+CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=4096
+# Do not enable IPV6 in dte<->dce link local
+CONFIG_LWIP_PPP_ENABLE_IPV6=n
+CONFIG_COMPILER_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/esp_mqtt_cxx/ssl/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_mqtt_cxx/ssl/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/esp_mqtt_cxx/tcp/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_mqtt_cxx/tcp/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/esp_timer_cxx/sdkconfig.defaults
+++ b/examples/cxx/experimental/esp_timer_cxx/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/experimental_cpp_component/host_test/esp_timer/sdkconfig.defaults
+++ b/examples/cxx/experimental/experimental_cpp_component/host_test/esp_timer/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/experimental_cpp_component/host_test/gpio/sdkconfig.defaults
+++ b/examples/cxx/experimental/experimental_cpp_component/host_test/gpio/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/experimental_cpp_component/host_test/i2c/sdkconfig.defaults
+++ b/examples/cxx/experimental/experimental_cpp_component/host_test/i2c/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/experimental_cpp_component/host_test/spi/sdkconfig.defaults
+++ b/examples/cxx/experimental/experimental_cpp_component/host_test/spi/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/experimental_cpp_component/host_test/system/sdkconfig.defaults
+++ b/examples/cxx/experimental/experimental_cpp_component/host_test/system/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_UNITY_ENABLE_IDF_TEST_RUNNER=n
 CONFIG_IDF_TARGET="linux"
 CONFIG_CXX_EXCEPTIONS=y

--- a/examples/cxx/experimental/simple_i2c_rw_example/sdkconfig.defaults
+++ b/examples/cxx/experimental/simple_i2c_rw_example/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/experimental/simple_spi_rw_example/sdkconfig.defaults
+++ b/examples/cxx/experimental/simple_spi_rw_example/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable C++ exceptions and set emergency pool size for exception objects
 CONFIG_COMPILER_CXX_EXCEPTIONS=y
 CONFIG_COMPILER_CXX_EXCEPTIONS_EMG_POOL_SIZE=1024

--- a/examples/cxx/rtti/sdkconfig.defaults
+++ b/examples/cxx/rtti/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_CXX_RTTI=y

--- a/examples/ethernet/iperf/sdkconfig.defaults
+++ b/examples/ethernet/iperf/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Increase main task stack size
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7168
 

--- a/examples/mesh/ip_internal_network/sdkconfig.defaults
+++ b/examples/mesh/ip_internal_network/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 
 CONFIG_LWIP_L2_TO_L3_COPY=y
 CONFIG_LWIP_IP_FORWARD=y

--- a/examples/network/bridge/sdkconfig.defaults
+++ b/examples/network/bridge/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_NETIF_TCPIP_LWIP=y
 CONFIG_ESP_NETIF_BRIDGE_EN=y
 

--- a/examples/network/simple_sniffer/sdkconfig.defaults
+++ b/examples/network/simple_sniffer/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Reduce bootloader log verbosity
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_BOOTLOADER_LOG_LEVEL=2

--- a/examples/openthread/ot_br/sdkconfig.defaults
+++ b/examples/openthread/ot_br/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # libsodium
 #

--- a/examples/openthread/ot_cli/sdkconfig.defaults
+++ b/examples/openthread/ot_cli/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="esp32h2"
 #
 # libsodium

--- a/examples/openthread/ot_rcp/sdkconfig.defaults
+++ b/examples/openthread/ot_rcp/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="esp32h2"
 #
 # libsodium

--- a/examples/peripherals/i2c/i2c_tools/sdkconfig.defaults
+++ b/examples/peripherals/i2c/i2c_tools/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Reduce bootloader log verbosity
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_BOOTLOADER_LOG_LEVEL=2

--- a/examples/peripherals/i2s/i2s_adc_dac/sdkconfig.defaults
+++ b/examples/peripherals/i2s/i2s_adc_dac/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_adc_dac_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_adc_dac_example.csv"

--- a/examples/peripherals/lcd/i2c_oled/sdkconfig.defaults
+++ b/examples/peripherals/lcd/i2c_oled/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #

--- a/examples/peripherals/lcd/i80_controller/sdkconfig.defaults
+++ b/examples/peripherals/lcd/i80_controller/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_LV_MEM_CUSTOM=y
 CONFIG_LV_MEMCPY_MEMSET_STD=y
 CONFIG_LV_USE_PERF_MONITOR=y

--- a/examples/peripherals/lcd/rgb_panel/sdkconfig.defaults
+++ b/examples/peripherals/lcd/rgb_panel/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_LV_MEM_CUSTOM=y
 CONFIG_LV_MEMCPY_MEMSET_STD=y
 CONFIG_LV_USE_USER_DATA=y

--- a/examples/peripherals/lcd/spi_lcd_touch/sdkconfig.defaults
+++ b/examples/peripherals/lcd/spi_lcd_touch/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_LV_USE_USER_DATA=y
 CONFIG_LV_COLOR_16_SWAP=y
 CONFIG_LV_COLOR_DEPTH_16=y

--- a/examples/peripherals/sdio/host/sdkconfig.defaults
+++ b/examples/peripherals/sdio/host/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_EXAMPLE_SLAVE_B1=y

--- a/examples/peripherals/secure_element/atecc608_ecdsa/sdkconfig.defaults
+++ b/examples/peripherals/secure_element/atecc608_ecdsa/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ATCA_MBEDTLS_ECDSA=y
 CONFIG_ATCA_MBEDTLS_ECDSA_SIGN=y
 CONFIG_ATCA_MBEDTLS_ECDSA_VERIFY=y

--- a/examples/peripherals/timer_group/gptimer/sdkconfig.defaults
+++ b/examples/peripherals/timer_group/gptimer/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #

--- a/examples/peripherals/timer_group/legacy_driver/sdkconfig.defaults
+++ b/examples/peripherals/timer_group/legacy_driver/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #

--- a/examples/peripherals/usb/device/tusb_console/sdkconfig.defaults
+++ b/examples/peripherals/usb/device/tusb_console/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_TINYUSB=y
 CONFIG_TINYUSB_CDC_ENABLED=y

--- a/examples/peripherals/usb/device/tusb_midi/sdkconfig.defaults
+++ b/examples/peripherals/usb/device/tusb_midi/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_TINYUSB=y
 CONFIG_TINYUSB_MIDI_ENABLED=y

--- a/examples/peripherals/usb/device/tusb_sample_descriptor/sdkconfig.defaults
+++ b/examples/peripherals/usb/device/tusb_sample_descriptor/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_TINYUSB=y
 CONFIG_TINYUSB_DESC_USE_ESPRESSIF_VID=n
 CONFIG_TINYUSB_DESC_CUSTOM_VID=0x303A

--- a/examples/peripherals/usb/device/tusb_serial_device/sdkconfig.defaults
+++ b/examples/peripherals/usb/device/tusb_serial_device/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_TINYUSB=y
 CONFIG_TINYUSB_CDC_ENABLED=y

--- a/examples/peripherals/usb/host/cdc/cdc_acm_vcp/sdkconfig.defaults
+++ b/examples/peripherals/usb/host/cdc/cdc_acm_vcp/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) Project Minimal Configuration
 #

--- a/examples/protocols/coap_client/sdkconfig.defaults
+++ b/examples/protocols/coap_client/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
 CONFIG_MBEDTLS_PSK_MODES=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y

--- a/examples/protocols/coap_server/sdkconfig.defaults
+++ b/examples/protocols/coap_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
 CONFIG_MBEDTLS_PSK_MODES=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y

--- a/examples/protocols/esp_local_ctrl/sdkconfig.defaults
+++ b/examples/protocols/esp_local_ctrl/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y

--- a/examples/protocols/http2_request/sdkconfig.defaults
+++ b/examples/protocols/http2_request/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y

--- a/examples/protocols/http_server/captive_portal/sdkconfig.defaults
+++ b/examples/protocols/http_server/captive_portal/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_HTTPD_MAX_REQ_HDR_LEN=1024
 CONFIG_LWIP_MAX_SOCKETS=16

--- a/examples/protocols/http_server/file_serving/sdkconfig.defaults
+++ b/examples/protocols/http_server/file_serving/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/protocols/http_server/restful_server/sdkconfig.defaults
+++ b/examples/protocols/http_server/restful_server/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_HTTPD_MAX_REQ_HDR_LEN=1024
 CONFIG_SPIFFS_OBJ_NAME_LEN=64
 CONFIG_FATFS_LONG_FILENAME=y

--- a/examples/protocols/http_server/ws_echo_server/sdkconfig.defaults
+++ b/examples/protocols/http_server/ws_echo_server/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_HTTPD_WS_SUPPORT=y

--- a/examples/protocols/https_request/sdkconfig.defaults
+++ b/examples/protocols/https_request/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_MBEDTLS_HAVE_TIME_DATE=y

--- a/examples/protocols/https_server/simple/sdkconfig.defaults
+++ b/examples/protocols/https_server/simple/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y

--- a/examples/protocols/https_server/wss_server/sdkconfig.defaults
+++ b/examples/protocols/https_server/wss_server/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y
 CONFIG_HTTPD_WS_SUPPORT=y

--- a/examples/protocols/https_x509_bundle/sdkconfig.defaults
+++ b/examples/protocols/https_x509_bundle/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL is not set
 # CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN is not set
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_NONE=y

--- a/examples/protocols/l2tap/sdkconfig.defaults
+++ b/examples/protocols/l2tap/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # L2 TAP currently supports Ethernet only
 CONFIG_EXAMPLE_CONNECT_ETHERNET=y
 CONFIG_EXAMPLE_CONNECT_WIFI=n

--- a/examples/protocols/modbus/serial/mb_master/sdkconfig.defaults
+++ b/examples/protocols/modbus/serial/mb_master/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Modbus configuration
 #

--- a/examples/protocols/modbus/serial/mb_slave/sdkconfig.defaults
+++ b/examples/protocols/modbus/serial/mb_slave/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Modbus configuration
 #

--- a/examples/protocols/modbus/tcp/mb_tcp_master/sdkconfig.defaults
+++ b/examples/protocols/modbus/tcp/mb_tcp_master/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Modbus configuration
 #

--- a/examples/protocols/modbus/tcp/mb_tcp_slave/sdkconfig.defaults
+++ b/examples/protocols/modbus/tcp/mb_tcp_slave/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Modbus configuration
 #

--- a/examples/protocols/mqtt/ssl_ds/sdkconfig.defaults
+++ b/examples/protocols/mqtt/ssl_ds/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y

--- a/examples/protocols/mqtt/ssl_psk/sdkconfig.defaults
+++ b/examples/protocols/mqtt/ssl_psk/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_TLS_PSK_VERIFICATION=y

--- a/examples/protocols/slip/slip_udp/sdkconfig.defaults
+++ b/examples/protocols/slip/slip_udp/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults to enable SLIP
 CONFIG_LWIP_SLIP_SUPPORT=y

--- a/examples/protocols/sockets/tcp_client_multi_net/sdkconfig.defaults
+++ b/examples/protocols/sockets/tcp_client_multi_net/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_EXAMPLE_CONNECT_WIFI=y
 CONFIG_EXAMPLE_CONNECT_ETHERNET=y

--- a/examples/provisioning/wifi_prov_mgr/sdkconfig.defaults
+++ b/examples/provisioning/wifi_prov_mgr/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Override some defaults so BT stack is enabled and
 CONFIG_BT_ENABLED=y
 CONFIG_BTDM_CTRL_MODE_BLE_ONLY=y

--- a/examples/security/flash_encryption/sdkconfig.defaults
+++ b/examples/security/flash_encryption/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # This example uses an extra partition to demonstrate encrypted/non-encrypted reads/writes.
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"

--- a/examples/storage/custom_flash_driver/sdkconfig.defaults
+++ b/examples/storage/custom_flash_driver/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_SPI_FLASH_OVERRIDE_CHIP_DRIVER_LIST=y

--- a/examples/storage/fatfsgen/sdkconfig.defaults
+++ b/examples/storage/fatfsgen/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/partition_api/partition_find/sdkconfig.defaults
+++ b/examples/storage/partition_api/partition_find/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/partition_api/partition_mmap/sdkconfig.defaults
+++ b/examples/storage/partition_api/partition_mmap/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/partition_api/partition_ops/sdkconfig.defaults
+++ b/examples/storage/partition_api/partition_ops/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/parttool/sdkconfig.defaults
+++ b/examples/storage/parttool/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/semihost_vfs/sdkconfig.defaults
+++ b/examples/storage/semihost_vfs/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # need this to detect that OpenOCD is connected
 CONFIG_ESP32_DEBUG_OCDAWARE=y

--- a/examples/storage/spiffs/sdkconfig.defaults
+++ b/examples/storage/spiffs/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/spiffsgen/sdkconfig.defaults
+++ b/examples/storage/spiffsgen/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/storage/wear_levelling/sdkconfig.defaults
+++ b/examples/storage/wear_levelling/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
 CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"

--- a/examples/system/app_trace_to_host/sdkconfig.defaults
+++ b/examples/system/app_trace_to_host/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable application tracing by default
 CONFIG_APPTRACE_DEST_JTAG=y
 CONFIG_APPTRACE_ENABLE=y

--- a/examples/system/console/advanced/sdkconfig.defaults
+++ b/examples/system/console/advanced/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Reduce bootloader log verbosity
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_BOOTLOADER_LOG_LEVEL=2

--- a/examples/system/console/advanced_usb_cdc/sdkconfig.defaults
+++ b/examples/system/console/advanced_usb_cdc/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Build for ESP32-S2 by default
 CONFIG_IDF_TARGET="esp32s2"
 

--- a/examples/system/console/basic/sdkconfig.defaults
+++ b/examples/system/console/basic/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Reduce bootloader log verbosity
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_BOOTLOADER_LOG_LEVEL=2

--- a/examples/system/deep_sleep/sdkconfig.defaults
+++ b/examples/system/deep_sleep/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_80=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=80
 CONFIG_ULP_COPROC_ENABLED=y

--- a/examples/system/efuse/sdkconfig.defaults
+++ b/examples/system/efuse/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_EFUSE_CUSTOM_TABLE=y
 CONFIG_EFUSE_VIRTUAL=y

--- a/examples/system/esp_timer/sdkconfig.defaults
+++ b/examples/system/esp_timer/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_TIMER_PROFILING=y

--- a/examples/system/freertos/real_time_stats/sdkconfig.defaults
+++ b/examples/system/freertos/real_time_stats/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_FREERTOS_USE_TRACE_FACILITY=y
 CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y

--- a/examples/system/gcov/sdkconfig.defaults
+++ b/examples/system/gcov/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_APPTRACE_DEST_JTAG=y
 # CONFIG_APPTRACE_DEST_NONE is not set
 CONFIG_APPTRACE_ENABLE=y

--- a/examples/system/gdbstub/sdkconfig.defaults
+++ b/examples/system/gdbstub/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # GDB Stub
 #

--- a/examples/system/heap_task_tracking/sdkconfig.defaults
+++ b/examples/system/heap_task_tracking/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_HEAP_POISONING_LIGHT=y
 CONFIG_HEAP_TASK_TRACKING=y

--- a/examples/system/himem/sdkconfig.defaults
+++ b/examples/system/himem/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_SPIRAM=y
 CONFIG_SPIRAM_BOOT_INIT=y
 CONFIG_SPIRAM_IGNORE_NOTFOUND=n

--- a/examples/system/ipc/ipc_isr/sdkconfig.defaults
+++ b/examples/system/ipc/ipc_isr/sdkconfig.defaults
@@ -1,0 +1,5 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").

--- a/examples/system/light_sleep/sdkconfig.defaults
+++ b/examples/system/light_sleep/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_80=y

--- a/examples/system/ota/advanced_https_ota/sdkconfig.defaults
+++ b/examples/system/ota/advanced_https_ota/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default sdkconfig parameters to use the OTA
 # partition table layout, with a 4MB flash size
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/examples/system/ota/native_ota_example/sdkconfig.defaults
+++ b/examples/system/ota/native_ota_example/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default sdkconfig parameters to use the OTA
 # partition table layout, with a 4MB flash size
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/examples/system/ota/otatool/sdkconfig.defaults
+++ b/examples/system/ota/otatool/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default sdkconfig parameters to use the OTA
 # partition table layout, with a 4MB flash size
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/examples/system/ota/pre_encrypted_ota/sdkconfig.defaults
+++ b/examples/system/ota/pre_encrypted_ota/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default sdkconfig parameters to use the OTA
 # partition table layout, with a 4MB flash size
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/examples/system/ota/simple_ota_example/sdkconfig.defaults
+++ b/examples/system/ota/simple_ota_example/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default sdkconfig parameters to use the OTA
 # partition table layout, with a 4MB flash size
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/examples/system/perfmon/sdkconfig.defaults
+++ b/examples/system/perfmon/sdkconfig.defaults
@@ -1,0 +1,5 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").

--- a/examples/system/startup_time/sdkconfig.defaults
+++ b/examples/system/startup_time/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Set flash configuration as fast as possible (Quad I/O 80MHz)
 #
 # (Not all hardware may support this configuration.)

--- a/examples/system/sysview_tracing/sdkconfig.defaults
+++ b/examples/system/sysview_tracing/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable single core mode by default
 CONFIG_MEMMAP_SMP=n
 CONFIG_FREERTOS_UNICORE=y

--- a/examples/system/sysview_tracing_heap_log/sdkconfig.defaults
+++ b/examples/system/sysview_tracing_heap_log/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable single core mode by default
 CONFIG_MEMMAP_SMP=n
 CONFIG_FREERTOS_UNICORE=y

--- a/examples/system/ulp_fsm/ulp/sdkconfig.defaults
+++ b/examples/system/ulp_fsm/ulp/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable ULP
 CONFIG_ULP_COPROC_ENABLED=y
 CONFIG_ULP_COPROC_TYPE_FSM=y

--- a/examples/system/ulp_fsm/ulp_adc/sdkconfig.defaults
+++ b/examples/system/ulp_fsm/ulp_adc/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable ULP
 CONFIG_ULP_COPROC_ENABLED=y
 CONFIG_ULP_COPROC_TYPE_FSM=y

--- a/examples/system/ulp_riscv/ds18b20_onewire/sdkconfig.defaults
+++ b/examples/system/ulp_riscv/ds18b20_onewire/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable ULP
 CONFIG_ULP_COPROC_ENABLED=y
 CONFIG_ULP_COPROC_RISCV=y

--- a/examples/system/ulp_riscv/gpio/sdkconfig.defaults
+++ b/examples/system/ulp_riscv/gpio/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable ULP
 CONFIG_ULP_COPROC_ENABLED=y
 CONFIG_ULP_COPROC_RISCV=y

--- a/examples/system/ulp_riscv/gpio_interrupt/sdkconfig.defaults
+++ b/examples/system/ulp_riscv/gpio_interrupt/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable ULP
 CONFIG_ULP_COPROC_ENABLED=y
 CONFIG_ULP_COPROC_TYPE_RISCV=y

--- a/examples/system/unit_test/test/sdkconfig.defaults
+++ b/examples/system/unit_test/test/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_TASK_WDT=n

--- a/examples/wifi/iperf/sdkconfig.defaults
+++ b/examples/wifi/iperf/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_MEMMAP_SMP=y
 
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096

--- a/examples/wifi/power_save/sdkconfig.defaults
+++ b/examples/wifi/power_save/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Use lower CPU frequency
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_80=y
 # Enable support for power management

--- a/examples/wifi/roaming/sdkconfig.defaults
+++ b/examples/wifi/roaming/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_WPA_11KV_SUPPORT=y
 CONFIG_WPA_SCAN_CACHE=y
 CONFIG_WPA_MBO_SUPPORT=y

--- a/examples/wifi/wifi_eap_fast/sdkconfig.defaults
+++ b/examples/wifi/wifi_eap_fast/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_WPA_MBEDTLS_TLS_CLIENT=n

--- a/examples/wifi/wifi_easy_connect/dpp-enrollee/sdkconfig.defaults
+++ b/examples/wifi/wifi_easy_connect/dpp-enrollee/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_WPA_DPP_SUPPORT=y

--- a/examples/zigbee/esp_zigbee_gateway/sdkconfig.defaults
+++ b/examples/zigbee/esp_zigbee_gateway/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 #
 # Partition Table
 #

--- a/examples/zigbee/esp_zigbee_rcp/sdkconfig.defaults
+++ b/examples/zigbee/esp_zigbee_rcp/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="esp32h2"
 
 #

--- a/examples/zigbee/light_sample/light_bulb/sdkconfig.defaults
+++ b/examples/zigbee/light_sample/light_bulb/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="esp32h2"
 
 #

--- a/examples/zigbee/light_sample/light_switch/sdkconfig.defaults
+++ b/examples/zigbee/light_sample/light_switch/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_IDF_TARGET="esp32h2"
 
 #

--- a/tools/test_apps/peripherals/usb/sdkconfig.defaults
+++ b/tools/test_apps/peripherals/usb/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Configure TinyUSB, it will be used to mock USB devices
 CONFIG_TINYUSB=y
 CONFIG_TINYUSB_MSC_ENABLED=y

--- a/tools/test_apps/security/secure_boot/sdkconfig.defaults
+++ b/tools/test_apps/security/secure_boot/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Default Secure Boot bootloader is too large to fit in default
 # bootloader size without adding 0x1000 bytes or reducing the log level.
 #

--- a/tools/test_apps/system/bootloader_sections/sdkconfig.defaults
+++ b/tools/test_apps/system/bootloader_sections/sdkconfig.defaults
@@ -1,1 +1,7 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_DUMP_RTL_FILES=y

--- a/tools/test_apps/system/eh_frame/sdkconfig.defaults
+++ b/tools/test_apps/system/eh_frame/sdkconfig.defaults
@@ -1,2 +1,8 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Enable eh_frame sections generation
 CONFIG_ESP_SYSTEM_USE_EH_FRAME=y

--- a/tools/test_apps/system/gdb_loadable_elf/sdkconfig.defaults
+++ b/tools/test_apps/system/gdb_loadable_elf/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_APP_BUILD_TYPE_ELF_RAM=y
 CONFIG_VFS_SUPPORT_TERMIOS=n
 CONFIG_NEWLIB_NANO_FORMAT=y

--- a/tools/test_apps/system/longjmp_test/sdkconfig.defaults
+++ b/tools/test_apps/system/longjmp_test/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_COMPILER_OPTIMIZATION_PERF=y
 
 CONFIG_ESP_INT_WDT=n

--- a/tools/test_apps/system/memprot/sdkconfig.defaults
+++ b/tools/test_apps/system/memprot/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_ESP_SYSTEM_MEMPROT_FEATURE=y
 CONFIG_ESP_SYSTEM_MEMPROT_FEATURE_LOCK=n
 CONFIG_ESP_SYSTEM_MEMPROT_TEST=y

--- a/tools/test_apps/system/panic/sdkconfig.defaults
+++ b/tools/test_apps/system/panic/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 # Flash DOUT mode (QEMU limitation)
 CONFIG_ESPTOOLPY_FLASHMODE_DOUT=y
 

--- a/tools/unit-test-app/sdkconfig.defaults
+++ b/tools/unit-test-app/sdkconfig.defaults
@@ -1,3 +1,9 @@
+# Defaults for generating a new "sdkconfig" file (project settings).
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
+#
+# NOTE - if this file changes, to get new defaults, you must erase any existing
+# "sdkconfig" file (this will undo manual settings from "idf.py menuconfig").
+
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 CONFIG_ESPTOOLPY_FLASHSIZE_DETECT=n


### PR DESCRIPTION
ESP-IDF's behavior for `sdkconfig.defaults` files can be confusing; if you edit the file after your first build (when `sdkconfig` is automatically generated) the edits have no effect.

This adds a short comment header to the `sdkconfig.defaults` file in example projects explaining the file and pointing to documentation (which seems helpful regardless) and calling out this particular gotcha. These examples get widely copied and adapted, so having a pointer comment seems helpful?

(Relevant to https://github.com/platformio/platform-espressif32/issues/847)