### PR TITLE
Change placeholder in ESP_LOGD conditionally depending on FF_FS_EXFAT (IDFGH-7832)

### DIFF
--- a/components/fatfs/vfs/vfs_fat.c
+++ b/components/fatfs/vfs/vfs_fat.c
@@ -576,7 +576,11 @@ static off_t vfs_fat_lseek(void* ctx, int fd, off_t offset, int mode)
         return -1;
     }
 
+#if FF_FS_EXFAT
+    ESP_LOGD(TAG, "%s: offset=%ld, filesize:=%lld", __func__, new_pos, f_size(file));
+#else
     ESP_LOGD(TAG, "%s: offset=%ld, filesize:=%d", __func__, new_pos, f_size(file));
+#endif
     FRESULT res = f_lseek(file, new_pos);
     if (res != FR_OK) {
         ESP_LOGD(TAG, "%s: fresult=%d", __func__, res);


### PR DESCRIPTION
In case of using EXFAT by setting in ffconf.h:
`#define FF_FS_EXFAT    1`
the type FSIZE_t is changing from 4 to 8 bytes.

As a result,  ESP_LOGD() in vfs_fat_lseek() does not compile:
```
error: format '%d' expects argument of type 'int', but argument 8 has type 'FSIZE_t' {aka 'long long unsigned int'} [-Werror=format=]
     ESP_LOGD(TAG, "%s: offset=%ld, filesize:=%d", __func__, new_pos, f_size(file));
```

To solve the problem we need to change %d with %lld conditionally, depending on FF_FS_EXFAT.