### PR TITLE
Tools: resolve symlinks in IDF_PATH when installing (IDFGH-7846)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 
 basedir=$(dirname "$0")
-IDF_PATH=$(cd "${basedir}"; pwd)
+IDF_PATH=$(cd "${basedir}"; pwd -P)
 export IDF_PATH
 
 echo "Detecting the Python interpreter"


### PR DESCRIPTION
Use `pwd -P` to resolve any symlinks in the current directory path.
This makes the behavior in the shell script similar to the idf_tools.py
code, which calls `os.path.realpath()`.  Without this, multiple entries
can get created in the `idfInstalled` dictionary in idf-env.json, and
the installed targets and features are not fully present in all entries.
This results in a broken installation, where `export.sh` cannot set up
the environment correctly afterwards.