### PR TITLE
Support for Winbond 512 mbit and 1 gbit flash chips (IDFGH-7854)

### DIFF
--- a/components/spi_flash/spi_flash_chip_generic.c
+++ b/components/spi_flash/spi_flash_chip_generic.c
@@ -115,7 +115,16 @@ esp_err_t spi_flash_chip_generic_detect_size(esp_flash_t *chip, uint32_t *size)
         return ESP_ERR_FLASH_UNSUPPORTED_CHIP;
     }
 
-    *size = 1 << (id & 0xFF);
+    // Winbond W25Q512JV*Q/M and W25Q01JV*Q chips don't follow the same convention for including the size in the final
+    // byte of the ID
+    if ((id & 0xFFFF) == 0x4020 || (id & 0xFFFF) == 0x7020) {
+        *size = 0x4000000;
+    } else if ((id & 0xFFFF) == 0x4021) {
+        *size = 0x8000000;
+    } else {
+        *size = 1 << (id & 0xFF);
+    }
+
     return ESP_OK;
 }
 


### PR DESCRIPTION
Currently the flash detection logic doesn't work for Winbond chips 512 megabit and above. The bitwise math assumption that uses the last byte of the ID seems to work fine for all smaller chips but for some unknown reason there's not a clean increment of that value from 256 megabit (which has a last byte of 0x19) to 512 megabit (which has a last byte of 0x20). Seems possible this was a design mistake on Winbond's part that they now can't undo.

LittleFS has a handy list of Winbond IDs and sizes: https://github.com/PaulStoffregen/LittleFS/blob/d5de4cf8d1587aa8b2433962ea995d45a991b918/src/LittleFS.cpp#L46

This PR adds a special case for known Winbond 512 megabit and 1 gigabit flash chips mentioned in the above list. I've personally tested this against the W25Q512JVEQ chip on an ESP32-S3 and it resolves a bootloader failure that looks like this:

```
I (712) spi_flash: detected chip: winbond
I (716) spi_flash: flash io: dio
E (720) spi_flash: Detected size(0k) smaller than the size in the binary image header(16384k). Probe failed.
E (761) esp_core_dump_flash: Core dump flash config is corrupted! CRC=0x7bd5c66f instead of 0x0
```

This makes sense, because `1 << 0x20` == `4294967296` which, for a `uint32_t` like `size` would be the same as `0`.