### PR TITLE
Tools: fix a crash in idf_monitor.py (IDFGH-7859)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -234,7 +234,8 @@ class SerialMonitor(Monitor):
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore
         """ Use 'with self' to temporarily disable monitoring behaviour """
         self.console_reader.start()
-        self.serial_reader.gdb_exit = self.gdb_helper.gdb_exit  # write gdb_exit flag
+        if self.elf_exists:
+            self.serial_reader.gdb_exit = self.gdb_helper.gdb_exit  # write gdb_exit flag
         self.serial_reader.start()
 
     def _pre_start(self) -> None:


### PR DESCRIPTION
If self.elf_exists is false, self.gdb_helper is None, which caused this
code to crash.  It looks like this guard was missed in e30329ffe21f.

Previously the code could crash like this:

    Traceback (most recent call last):
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 376, in <module>
        main()
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 367, in main
        monitor.main_loop()
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 163, in main_loop
        self._main_loop()
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 268, in _main_loop
        super()._main_loop()
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 203, in _main_loop
        self.serial_handler.handle_commands(data, self.target, self.run_make, self.console_reader,
      File "/usr/local/src/esp-idf/tools/idf_monitor_base/serial_handler.py", line 203, in handle_commands
        run_make_func('encrypted-flash' if self.encrypted else 'flash')
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 150, in run_make
        run_make(target, self.make, self.console, self.console_parser, self.event_queue, self.cmd_queue,
      File "/usr/local/src/esp-idf/tools/idf_monitor.py", line 237, in __exit__
        self.serial_reader.gdb_exit = self.gdb_helper.gdb_exit  # write gdb_exit flag
    AttributeError: 'NoneType' object has no attribute 'gdb_exit'