### PR TITLE
Add missing comma (IDFGH-7928)

### DIFF
--- a/components/heap/port/esp32s3/memory_layout.c
+++ b/components/heap/port/esp32s3/memory_layout.c
@@ -70,7 +70,7 @@ const soc_memory_region_t soc_memory_regions[] = {
     { 0x3FCF0000, 0x8000,  0, 0},          //Level 9, DRAM
 #endif
 #if CONFIG_ESP32S3_DATA_CACHE_16KB
-    { 0x3C000000, 0x4000,  5, 0}
+    { 0x3C000000, 0x4000,  5, 0},
 #endif
 #ifdef CONFIG_ESP_SYSTEM_ALLOW_RTC_FAST_MEM_AS_HEAP
     { 0x600fe000, 0x2000,  6, 0}, //Fast RTC memory


### PR DESCRIPTION
Add missing comma when CONFIG_ESP32S3_DATA_CACHE_16KB is enabled