### PR TITLE
Move xSemaphoreGive out of configASSERT (IDFGH-7988)

### DIFF
--- a/components/esp_ringbuf/ringbuf.c
+++ b/components/esp_ringbuf/ringbuf.c
@@ -1354,12 +1354,12 @@ BaseType_t xRingbufferAddToQueueSetRead(RingbufHandle_t xRingbuffer, QueueSetHan
     BaseType_t xReturn;
     portENTER_CRITICAL(&pxRingbuffer->mux);
     //Cannot add semaphore to queue set if semaphore is not empty. Temporarily hold semaphore
-    BaseType_t xHoldSemaphore = xSemaphoreTake(rbGET_RX_SEM_HANDLE(pxRingbuffer), 0);
+    BaseType_t result = xSemaphoreTake(rbGET_RX_SEM_HANDLE(pxRingbuffer), 0);
     xReturn = xQueueAddToSet(rbGET_RX_SEM_HANDLE(pxRingbuffer), xQueueSet);
-    if (xHoldSemaphore == pdTRUE) {
+    if (result == pdTRUE) {
         //Return semaphore if temporarily held
-        xHoldSemaphore = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
-        configASSERT(xHoldSemaphore == pdTRUE);
+        result = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
+        configASSERT(result == pdTRUE);
     }
     portEXIT_CRITICAL(&pxRingbuffer->mux);
     return xReturn;
@@ -1381,12 +1381,12 @@ BaseType_t xRingbufferRemoveFromQueueSetRead(RingbufHandle_t xRingbuffer, QueueS
     BaseType_t xReturn;
     portENTER_CRITICAL(&pxRingbuffer->mux);
     //Cannot remove semaphore from queue set if semaphore is not empty. Temporarily hold semaphore
-    BaseType_t xHoldSemaphore = xSemaphoreTake(rbGET_RX_SEM_HANDLE(pxRingbuffer), 0);
+    BaseType_t result = xSemaphoreTake(rbGET_RX_SEM_HANDLE(pxRingbuffer), 0);
     xReturn = xQueueRemoveFromSet(rbGET_RX_SEM_HANDLE(pxRingbuffer), xQueueSet);
-    if (xHoldSemaphore == pdTRUE) {
+    if (result == pdTRUE) {
         //Return semaphore if temporarily held
-        xHoldSemaphore = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
-        configASSERT(xHoldSemaphore == pdTRUE);
+        result = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
+        configASSERT(result == pdTRUE);
     }
     portEXIT_CRITICAL(&pxRingbuffer->mux);
     return xReturn;

--- a/components/esp_ringbuf/ringbuf.c
+++ b/components/esp_ringbuf/ringbuf.c
@@ -1358,7 +1358,8 @@ BaseType_t xRingbufferAddToQueueSetRead(RingbufHandle_t xRingbuffer, QueueSetHan
     xReturn = xQueueAddToSet(rbGET_RX_SEM_HANDLE(pxRingbuffer), xQueueSet);
     if (xHoldSemaphore == pdTRUE) {
         //Return semaphore if temporarily held
-        configASSERT(xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer)) == pdTRUE);
+        xHoldSemaphore = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
+        configASSERT(xHoldSemaphore == pdTRUE);
     }
     portEXIT_CRITICAL(&pxRingbuffer->mux);
     return xReturn;
@@ -1384,7 +1385,8 @@ BaseType_t xRingbufferRemoveFromQueueSetRead(RingbufHandle_t xRingbuffer, QueueS
     xReturn = xQueueRemoveFromSet(rbGET_RX_SEM_HANDLE(pxRingbuffer), xQueueSet);
     if (xHoldSemaphore == pdTRUE) {
         //Return semaphore if temporarily held
-        configASSERT(xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer)) == pdTRUE);
+        xHoldSemaphore = xSemaphoreGive(rbGET_RX_SEM_HANDLE(pxRingbuffer));
+        configASSERT(xHoldSemaphore == pdTRUE);
     }
     portEXIT_CRITICAL(&pxRingbuffer->mux);
     return xReturn;


### PR DESCRIPTION
xSemaphoreGive won't be executed in configASSERT and semaphore will stay locked if NDEBUG (idf v5) or CONFIG_FREERTOS_ASSERT_DISABLE (idf v3, v4) are defined.