### PR TITLE
bt member typo (IDFGH-7987)

### DIFF
--- a/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
+++ b/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
@@ -2908,7 +2908,7 @@ static UINT8 bta_dm_authorize_cback (BD_ADDR bd_addr, DEV_CLASS dev_class, BD_NA
 
         if (p_result && p_result->status == BTM_SUCCESS) {
             BCM_STRNCPY_S((char *)sec_event.cfm_req.bd_name, (char *)p_result->remote_bd_name, BD_NAME_LEN);
-            sec_event.pin_req.bd_name[BD_NAME_LEN] = '\0';
+            sec_event.cfm_req.bd_name[BD_NAME_LEN] = '\0';
         } else { /* No name found */
             sec_event.cfm_req.bd_name[0] = '\0';
         }


### PR DESCRIPTION
Terminate sec_event.cfm_req.bd_name string, not sec_event.pin_req.bd_name