### PR TITLE
fix malloc(0) and heap_caps_alloc_failed() (IDFGH-8007)

### DIFF
--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -62,9 +62,9 @@ static void heap_caps_alloc_failed(size_t requested_size, uint32_t caps, const c
         alloc_failed_callback(requested_size, caps, function_name);
     }
 
-    #ifdef CONFIG_HEAP_ABORT_WHEN_ALLOCATION_FAILS
+#ifdef CONFIG_HEAP_ABORT_WHEN_ALLOCATION_FAILS
     esp_system_abort("Memory allocation failed");
-    #endif
+#endif
 }
 
 esp_err_t heap_caps_register_failed_alloc_callback(esp_alloc_failed_hook_t callback)
@@ -91,6 +91,10 @@ check for failure / call heap_caps_alloc_failed()
 IRAM_ATTR static void *heap_caps_malloc_base( size_t size, uint32_t caps)
 {
     void *ret = NULL;
+
+    if (size == 0) {
+        return NULL;
+    }
 
     if (size > HEAP_SIZE_MAX) {
         // Avoids int overflow when adding small numbers to size, or
@@ -161,7 +165,7 @@ IRAM_ATTR void *heap_caps_malloc( size_t size, uint32_t caps){
 
     void* ptr = heap_caps_malloc_base(size, caps);
 
-    if (!ptr){
+    if (!ptr && size > 0){
         heap_caps_alloc_failed(size, caps, __func__);
     }
 
@@ -196,13 +200,13 @@ IRAM_ATTR void *heap_caps_malloc_default( size_t size )
         } else {
             r=heap_caps_malloc_base( size, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM );
         }
-        if (r==NULL) {
+        if (r==NULL && size > 0) {
             //try again while being less picky
             r=heap_caps_malloc_base( size, MALLOC_CAP_DEFAULT );
         }
 
         // allocation failure?
-        if (r==NULL){
+        if (r==NULL && size > 0){
             heap_caps_alloc_failed(size, MALLOC_CAP_DEFAULT, __func__);
         }
 
@@ -259,7 +263,7 @@ IRAM_ATTR void *heap_caps_malloc_prefer( size_t size, size_t num, ... )
             break;
         }
     }
-    if (r == NULL){
+    if (r == NULL && size > 0){
         heap_caps_alloc_failed(size, caps, __func__);
     }
     va_end( argp );
@@ -282,7 +286,7 @@ IRAM_ATTR void *heap_caps_realloc_prefer( void *ptr, size_t size, size_t num, ..
             break;
         }
     }
-    if (r == NULL){
+    if (r == NULL && size > 0){
         heap_caps_alloc_failed(size, caps, __func__);
     }
     va_end( argp );
@@ -301,11 +305,11 @@ IRAM_ATTR void *heap_caps_calloc_prefer( size_t n, size_t size, size_t num, ... 
     while (num--) {
         caps = va_arg( argp, uint32_t );
         r = heap_caps_calloc_base( n, size, caps );
-        if (r != NULL){
+        if (r != NULL || size == 0){
             break;
         }
     }
-    if (r == NULL){
+    if (r == NULL && size > 0){
         heap_caps_alloc_failed(size, caps, __func__);
     }
     va_end( argp );
@@ -462,7 +466,7 @@ IRAM_ATTR void *heap_caps_calloc( size_t n, size_t size, uint32_t caps)
 {
     void* ptr = heap_caps_calloc_base(n, size, caps);
 
-    if (!ptr){
+    if (!ptr && size > 0){
         heap_caps_alloc_failed(size, caps, __func__);
     }
 
@@ -621,6 +625,10 @@ IRAM_ATTR void *heap_caps_aligned_alloc(size_t alignment, size_t size, uint32_t 
 
     //Alignment must be a power of two:
     if((alignment & (alignment - 1)) != 0) {
+        return NULL;
+    }
+
+    if (size == 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Don't call heap_caps_alloc_failed() for malloc(0) and calloc(0), because it is not an error.
Improve handling of malloc(0) and calloc(0).