### PR TITLE
Add mcpwm_capture_channel_unregister_event_callbacks function (IDFGH-8013)

### DIFF
--- a/components/driver/include/driver/mcpwm_cap.h
+++ b/components/driver/include/driver/mcpwm_cap.h
@@ -182,7 +182,9 @@ esp_err_t mcpwm_capture_channel_register_event_callbacks(mcpwm_cap_channel_handl
  * @brief Unregister the MCPWM capture channel from user callbacks
  *
  * @param[in] cap_channel MCPWM capture channel handle, allocated by `mcpwm_new_capture_channel()`
- * @return always ESP_OK
+ * @return
+ *      - ESP_OK: Unregisted event callbacks successfully
+ *      - ESP_ERR_INVALID_ARG: Unregister event callbacks failed because of invalid argument
  */
 esp_err_t mcpwm_capture_channel_unregister_event_callbacks(mcpwm_cap_channel_handle_t cap_channel);
 

--- a/components/driver/include/driver/mcpwm_cap.h
+++ b/components/driver/include/driver/mcpwm_cap.h
@@ -179,6 +179,14 @@ typedef struct {
 esp_err_t mcpwm_capture_channel_register_event_callbacks(mcpwm_cap_channel_handle_t cap_channel, const mcpwm_capture_event_callbacks_t *cbs, void *user_data);
 
 /**
+ * @brief Unregister the MCPWM capture channel from user callbacks
+ *
+ * @param[in] cap_channel MCPWM capture channel handle, allocated by `mcpwm_new_capture_channel()`
+ * @return always ESP_OK
+ */
+esp_err_t mcpwm_capture_channel_unregister_event_callbacks(mcpwm_cap_channel_handle_t cap_channel);
+
+/**
  * @brief Trigger a catch by software
  *
  * @param[in] cap_channel MCPWM capture channel handle, allocated by `mcpwm_new_capture_channel()`

--- a/components/driver/mcpwm/mcpwm_cap.c
+++ b/components/driver/mcpwm/mcpwm_cap.c
@@ -334,6 +334,21 @@ esp_err_t mcpwm_capture_channel_register_event_callbacks(mcpwm_cap_channel_handl
     return ESP_OK;
 }
 
+
+esp_err_t mcpwm_capture_channel_unregister_event_callbacks(mcpwm_cap_channel_handle_t cap_channel) {
+    mcpwm_group_t *group = cap_channel->cap_timer->group;
+    mcpwm_hal_context_t *hal = &group->hal;
+    int cap_chan_id = cap_channel->cap_chan_id;
+    portENTER_CRITICAL(&group->spinlock);
+    mcpwm_ll_intr_enable(hal->dev, MCPWM_LL_EVENT_CAPTURE(cap_chan_id), false);
+    mcpwm_ll_intr_clear_status(hal->dev, MCPWM_LL_EVENT_CAPTURE(cap_chan_id));
+    portEXIT_CRITICAL(&group->spinlock);
+    cap_channel->on_cap = NULL;
+    cap_channel->user_data = NULL;
+    return ESP_OK;
+}
+
+
 esp_err_t mcpwm_capture_channel_trigger_soft_catch(mcpwm_cap_channel_handle_t cap_channel)
 {
     ESP_RETURN_ON_FALSE(cap_channel, ESP_ERR_INVALID_ARG, TAG, "invalid argument");

--- a/components/driver/mcpwm/mcpwm_cap.c
+++ b/components/driver/mcpwm/mcpwm_cap.c
@@ -336,6 +336,7 @@ esp_err_t mcpwm_capture_channel_register_event_callbacks(mcpwm_cap_channel_handl
 
 
 esp_err_t mcpwm_capture_channel_unregister_event_callbacks(mcpwm_cap_channel_handle_t cap_channel) {
+    ESP_RETURN_ON_FALSE(cap_channel, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
     mcpwm_group_t *group = cap_channel->cap_timer->group;
     mcpwm_hal_context_t *hal = &group->hal;
     int cap_chan_id = cap_channel->cap_chan_id;


### PR DESCRIPTION
This PR addresses the second part of #9520 that is
* mcpwm_capture_enable_channel != mcpwm_new_capture_channel
* mcpwm_capture_disable_channel != mcpwm_del_capture_channel

In my scenario, I turn the MCPWM capture on and off, and I don't want to allocate and free resources each time nor do I want to configure the GPIO and reset it many times, resulting in obsessive GPIO logging (see the linked issue for an example). Moreover, allocating and freeing MCPWM resources caused me an unidentified behavior in the logic of my app, and I cannot easily spot the source of the error. Turning on and off the callbacks doesn't produce such erroneous behavior and works as intended (equivalent to the old `mcpwm_capture_enable_channel` and `mcpwm_capture_disable_channel` API).

If you don't want to provide API to enable and disable a specific MCPWM channel, let at least the user register and unregister callbacks, which gives the user a taste of the legacy behavior.

-----

As for the first part of the linked above issue, calling `mcpwm_capture_channel_register_event_callbacks` and `mcpwm_capture_channel_unregister_event_callbacks` immediately after an MCPWM is initialized provides a workaround but does not, of course, solve the issue.


<details>
  <summary>Code with a workaround to the issue</summary>

```c
static void syncman_mcpwm_init(syncman_handle_t *shandle) {
    mcpwm_capture_timer_config_t cap_timer_conf = {
        .clk_src = MCPWM_CAPTURE_CLK_SRC_DEFAULT,
        .group_id = 0,
    };
    ESP_ERROR_CHECK(mcpwm_new_capture_timer(&cap_timer_conf, &shandle->cap_timer));
    ESP_ERROR_CHECK(mcpwm_capture_timer_enable(shandle->cap_timer));

    const Board_t *board = board_get();
    mcpwm_capture_channel_config_t channel_gps_conf = {
        .gpio_num = board->gps_gpio.pps,
        .prescale = 1,
        .flags.neg_edge = false,
        .flags.pos_edge = true,
        .flags.pull_up = false,
	.flags.pull_down = true,
    };
    ESP_ERROR_CHECK(mcpwm_new_capture_channel(shandle->cap_timer, &channel_gps_conf, &shandle->channel_gps));

    mcpwm_capture_channel_config_t channel_rtc_conf = {
        .gpio_num = board->rtc_gpio.sqw,
        .prescale = 1,
        .flags.neg_edge = true,
        .flags.pos_edge = false,
        .flags.pull_up = false,
	.flags.pull_down = false,
    };
    ESP_ERROR_CHECK(mcpwm_new_capture_channel(shandle->cap_timer, &channel_rtc_conf, &shandle->channel_rtc));
}

static void syncman_mcpwm_enable(syncman_handle_t *shandle) {
    ESP_LOGI(TAG, ">>> syncman_mcpwm_enable ENTER");
    mcpwm_capture_event_callbacks_t cbs = {
        .on_cap = ...,
    };
    ESP_ERROR_CHECK(mcpwm_capture_channel_register_event_callbacks(shandle->channel_gps, &cbs, (void*) shandle));
    ESP_ERROR_CHECK(mcpwm_capture_channel_register_event_callbacks(shandle->channel_rtc, &cbs, (void*) shandle));
    ESP_ERROR_CHECK(mcpwm_capture_timer_start(shandle->cap_timer));
    ESP_LOGI(TAG, "syncman_mcpwm_enable OK");
}

static void syncman_mcpwm_disable(syncman_handle_t *shandle) {
    mcpwm_capture_channel_unregister_event_callbacks(shandle->channel_gps);
    mcpwm_capture_channel_unregister_event_callbacks(shandle->channel_rtc);
    ESP_ERROR_CHECK(mcpwm_capture_timer_stop(shandle->cap_timer));
}

static void syncman_task() {
    syncman_mcpwm_init(shandle);

    // TODO: a workaround: enable & disable
    // without this workaround, gps_init() results in the error
    syncman_mcpwm_enable(shandle);
    syncman_mcpwm_disable(shandle);
   
    gps_init();
}
```

</details>

<details>
  <summary>intr_alloc debug logs</summary>

```
D (00:00:00.886) mcpwm: new group(0) at 0x3ffc8924
D (00:00:00.890) vfs_fat: vfs_fat_lseek: offset=0, filesize:=0
D (00:00:01.002) mcpwm: new capture timer at 0x3ffc88a4, in group (0)
D (00:00:01.002) vfs_fat: vfs_fat_lseek: offset=55, filesize:=55
I (00:00:01.104) gpio: GPIO[18]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 0| Pulldown: 1| Intr:0 
D (00:00:01.104) vfs_fat: vfs_fat_lseek: offset=129, filesize:=129
D (00:00:01.212) mcpwm: new capture channel (0,0) at 0x3ffb905c
D (00:00:01.213) vfs_fat: vfs_fat_lseek: offset=244, filesize:=244
I (00:00:01.312) gpio: GPIO[22]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0 
D (00:00:01.313) vfs_fat: vfs_fat_lseek: offset=312, filesize:=312
D (00:00:01.412) mcpwm: new capture channel (0,1) at 0x3ffb907c
D (00:00:01.412) vfs_fat: vfs_fat_lseek: offset=427, filesize:=427
I (00:00:01.512) syncman: >>> syncman_mcpwm_enable ENTER
D (00:00:01.512) vfs_fat: vfs_fat_lseek: offset=495, filesize:=495
D (1800) intr_alloc: get_available_int: try to find existing. Cpu: 0, Source: 39
D (1800) intr_alloc: get_free_int: start looking. Current cpu: 0
D (1800) intr_alloc: Int 0 reserved 2 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 1 reserved 2 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 2 reserved 0 priority 1 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: already in (non-shared) use.
D (1800) intr_alloc: Int 3 reserved 0 priority 1 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: already in (non-shared) use.
D (1800) intr_alloc: Int 4 reserved 2 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 5 reserved 2 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 6 reserved 2 priority 1 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 7 reserved 0 priority 1 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: special-purpose int
D (1800) intr_alloc: Int 8 reserved 2 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 9 reserved 0 priority 1 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: already in (non-shared) use.
D (1800) intr_alloc: Int 10 reserved 0 priority 1 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible trigger type
D (1800) intr_alloc: Int 11 reserved 0 priority 3 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: special-purpose int
D (1800) intr_alloc: Int 12 reserved 0 priority 1 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: already in (non-shared) use.
D (1800) intr_alloc: Int 13 reserved 0 priority 1 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: already in (non-shared) use.
D (1800) intr_alloc: Int 14 reserved 2 priority 7 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 15 reserved 0 priority 3 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: special-purpose int
D (1800) intr_alloc: Int 16 reserved 0 priority 5 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: special-purpose int
D (1800) intr_alloc: Int 17 reserved 0 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ...int 17 usable as a new shared int
D (1800) intr_alloc: Int 18 reserved 0 priority 1 LEVEL hasIsr 0
D (1800) intr_alloc: ...already have a shared int
D (1800) intr_alloc: Int 19 reserved 0 priority 2 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 20 reserved 0 priority 2 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 21 reserved 0 priority 2 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 22 reserved 2 priority 3 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 23 reserved 0 priority 3 LEVEL hasIsr 1
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 24 reserved 2 priority 4 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 25 reserved 2 priority 4 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 26 reserved 0 priority 5 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 27 reserved 2 priority 3 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 28 reserved 0 priority 4 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: incompatible priority
D (1800) intr_alloc: Int 29 reserved 0 priority 3 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: special-purpose int
D (1800) intr_alloc: Int 30 reserved 2 priority 4 EDGE hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: Int 31 reserved 2 priority 5 LEVEL hasIsr 0
D (1800) intr_alloc: ....Unusable: reserved
D (1800) intr_alloc: get_available_int: using int 17
D (2160) intr_alloc: Connected src 39 to int 17 (cpu 0)
D (2160) intr_alloc: get_available_int: try to find existing. Cpu: 0, Source: 39
D (2160) intr_alloc: get_avalible_int: existing vd found. intno: 17
D (2180) intr_alloc: Connected src 39 to int 17 (cpu 0)
I (00:00:01.998) syncman: syncman_mcpwm_enable OK
```

</details>
