### PR TITLE
Add git-lfs to docker container (IDFGH-8060)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN : \
     curl \
     flex \
     git \
+    git-lfs \
     gperf \
     lcov \
     libbsd-dev \


### PR DESCRIPTION
I propose to add git-lfs to the docker container to support pulling git repositories and submodules which use [Git LFS](https://git-lfs.github.com/).