### PR TITLE
[flash] Implement generic read register (IDFGH-8082)

### DIFF
--- a/components/hal/include/hal/spi_flash_types.h
+++ b/components/hal/include/hal/spi_flash_types.h
@@ -158,9 +158,9 @@ struct spi_flash_host_driver_s {
      */
     void (*erase_block)(spi_flash_host_inst_t *host, uint32_t start_address);
     /**
-     * Read the status of the flash chip.
+     * Read the register of the flash chip.
      */
-    esp_err_t (*read_status)(spi_flash_host_inst_t *host, uint8_t *out_sr);
+    esp_err_t (*read_register)(spi_flash_host_inst_t *host, uint8_t reg_id, uint8_t *out_sr);
     /**
      * Disable write protection.
      */

--- a/components/spi_flash/include/memspi_host_driver.h
+++ b/components/spi_flash/include/memspi_host_driver.h
@@ -15,7 +15,7 @@
         .erase_chip = spi_flash_hal_erase_chip, \
         .erase_sector = spi_flash_hal_erase_sector, \
         .erase_block = spi_flash_hal_erase_block, \
-        .read_status = memspi_host_read_status_hs, \
+        .read_register = memspi_host_read_register_hs, \
         .set_write_protect = spi_flash_hal_set_write_protect, \
         .supports_direct_write = spi_flash_hal_supports_direct_write, \
         .supports_direct_read = spi_flash_hal_supports_direct_read, \
@@ -82,7 +82,7 @@ esp_err_t memspi_host_read_id_hs(spi_flash_host_inst_t *host, uint32_t *id);
  *  - ESP_OK: if success
  *  - or other cases from ``spi_hal_common_command``
  */
-esp_err_t memspi_host_read_status_hs(spi_flash_host_inst_t *host, uint8_t *out_sr);
+esp_err_t memspi_host_read_register_hs(spi_flash_host_inst_t *host, uint8_t reg_id, uint8_t *out_sr);
 
 /**
  * Flush the cache (if needed) after the contents are modified.

--- a/components/spi_flash/include/spi_flash_chip_driver.h
+++ b/components/spi_flash/include/spi_flash_chip_driver.h
@@ -31,10 +31,6 @@ typedef struct {
 } flash_chip_op_timeout_t;
 
 typedef enum {
-    SPI_FLASH_REG_STATUS = 1,
-} spi_flash_register_t;
-
-typedef enum {
    SPI_FLASH_CHIP_CAP_SUSPEND = BIT(0),            ///< Flash chip support suspend feature.
    SPI_FLASH_CHIP_CAP_32MB_SUPPORT = BIT(1),       ///< Flash chip driver support flash size larger than 32M Bytes.
    SPI_FLASH_CHIP_CAP_UNIQUE_ID = BIT(2),          ///< Flash chip driver support read the flash unique id.
@@ -186,10 +182,13 @@ struct spi_flash_chip_t {
      */
     esp_err_t (*read_id)(esp_flash_t *chip, uint32_t* out_chip_id);
 
+    /** Address of the status register. 0 if not required.*/
+    uint8_t status_reg_id;
+
     /*
      * Read the requested register (status, etc.).
      */
-    esp_err_t (*read_reg)(esp_flash_t *chip, spi_flash_register_t reg_id, uint32_t* out_reg);
+    esp_err_t (*read_reg)(esp_flash_t *chip, uint8_t reg_id, uint32_t* out_reg);
 
     /** Yield to other tasks. Called during erase operations. */
     esp_err_t (*yield)(esp_flash_t *chip, uint32_t wip);

--- a/components/spi_flash/include/spi_flash_chip_generic.h
+++ b/components/spi_flash/include/spi_flash_chip_generic.h
@@ -201,7 +201,7 @@ esp_err_t spi_flash_chip_generic_get_write_protect(esp_flash_t *chip, bool *out_
  * @param out_reg    Output of the register value
  * @return esp_err_t Error code passed from the ``read_status`` function of host driver.
  */
-esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, spi_flash_register_t reg_id, uint32_t* out_reg);
+esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, uint8_t reg_id, uint32_t* out_reg);
 
 /**
  * @brief Read flash status via the RDSR command and wait for bit 0 (write in

--- a/components/spi_flash/memspi_host_driver.c
+++ b/components/spi_flash/memspi_host_driver.c
@@ -42,7 +42,7 @@ static const spi_flash_host_driver_t esp_flash_gpspi_host = {
         .erase_chip = memspi_host_erase_chip,
         .erase_sector = memspi_host_erase_sector,
         .erase_block = memspi_host_erase_block,
-        .read_status = memspi_host_read_status_hs,
+        .read_register = memspi_host_read_register_hs,
         .set_write_protect = memspi_host_set_write_protect,
         .supports_direct_write = spi_flash_hal_gpspi_supports_direct_write,
         .supports_direct_read = spi_flash_hal_gpspi_supports_direct_read,
@@ -108,7 +108,7 @@ esp_err_t memspi_host_read_id_hs(spi_flash_host_inst_t *host, uint32_t *id)
     return ESP_OK;
 }
 
-esp_err_t memspi_host_read_status_hs(spi_flash_host_inst_t *host, uint8_t *out_sr)
+esp_err_t memspi_host_read_register_hs(spi_flash_host_inst_t *host, uint8_t reg_id, uint8_t *out_sr)
 {
     //NOTE: we do have a read id function, however it doesn't work in high freq
     uint32_t stat_buf = 0;
@@ -117,6 +117,12 @@ esp_err_t memspi_host_read_status_hs(spi_flash_host_inst_t *host, uint8_t *out_s
         .miso_data = ((uint8_t*) &stat_buf),
         .miso_len = 1
     };
+
+    if(reg_id != 0) {
+        t.mosi_data = ((uint8_t*) &reg_id);
+        t.mosi_len = 1;
+    }
+
     esp_err_t err = host->driver->common_command(host, &t);
     if (err != ESP_OK) {
         return err;

--- a/components/spi_flash/spi_flash_chip_boya.c
+++ b/components/spi_flash/spi_flash_chip_boya.c
@@ -78,6 +78,7 @@ const spi_flash_chip_t esp_flash_chip_boya = {
     .set_io_mode = spi_flash_chip_generic_set_io_mode,
     .get_io_mode = spi_flash_chip_generic_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_gd.c
+++ b/components/spi_flash/spi_flash_chip_gd.c
@@ -139,6 +139,7 @@ const spi_flash_chip_t esp_flash_chip_gd = {
     .set_io_mode = spi_flash_chip_gd_set_io_mode,
     .get_io_mode = spi_flash_chip_gd_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_generic.c
+++ b/components/spi_flash/spi_flash_chip_generic.c
@@ -379,7 +379,7 @@ esp_err_t spi_flash_chip_generic_get_write_protect(esp_flash_t *chip, bool *out_
     esp_err_t err = ESP_OK;
     uint32_t status;
     assert(out_write_protect!=NULL);
-    err = chip->chip_drv->read_reg(chip, SPI_FLASH_REG_STATUS, &status);
+    err = chip->chip_drv->read_reg(chip, chip->chip_drv->status_reg_id, &status);
     if (err != ESP_OK) {
         return err;
     }
@@ -388,9 +388,9 @@ esp_err_t spi_flash_chip_generic_get_write_protect(esp_flash_t *chip, bool *out_
     return err;
 }
 
-esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, spi_flash_register_t reg_id, uint32_t* out_reg)
+esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, uint8_t reg_id, uint32_t* out_reg)
 {
-    return chip->host->driver->read_status(chip->host, (uint8_t*)out_reg);
+    return chip->host->driver->read_register(chip->host, reg_id, (uint8_t*)out_reg);
 }
 
 esp_err_t spi_flash_chip_generic_yield(esp_flash_t* chip, uint32_t wip)
@@ -440,7 +440,7 @@ esp_err_t spi_flash_chip_generic_wait_idle(esp_flash_t *chip, uint32_t timeout_u
         }
 
         uint32_t read;
-        esp_err_t err = chip->chip_drv->read_reg(chip, SPI_FLASH_REG_STATUS, &read);
+        esp_err_t err = chip->chip_drv->read_reg(chip, chip->chip_drv->status_reg_id, &read);
         if (err != ESP_OK) {
             return err;
         }
@@ -629,6 +629,7 @@ const spi_flash_chip_t esp_flash_chip_generic = {
     .set_io_mode = spi_flash_chip_generic_set_io_mode,
     .get_io_mode = spi_flash_chip_generic_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_issi.c
+++ b/components/spi_flash/spi_flash_chip_issi.c
@@ -102,6 +102,7 @@ const spi_flash_chip_t esp_flash_chip_issi = {
     .set_io_mode = spi_flash_chip_issi_set_io_mode,
     .get_io_mode = spi_flash_chip_issi_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_mxic.c
+++ b/components/spi_flash/spi_flash_chip_mxic.c
@@ -86,6 +86,7 @@ const spi_flash_chip_t esp_flash_chip_mxic = {
     .set_io_mode = spi_flash_chip_mxic_set_io_mode,
     .get_io_mode = spi_flash_chip_mxic_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_mxic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_mxic_opi.c
+++ b/components/spi_flash/spi_flash_chip_mxic_opi.c
@@ -122,7 +122,7 @@ esp_err_t spi_flash_chip_mxic_opi_read_id(esp_flash_t *chip, uint32_t* out_chip_
     return ESP_OK;
 }
 
-esp_err_t spi_flash_chip_mxic_opi_read_reg(esp_flash_t *chip, spi_flash_register_t reg_id, uint32_t* out_reg)
+esp_err_t spi_flash_chip_mxic_opi_read_reg(esp_flash_t *chip, uint8_t reg_id, uint32_t* out_reg)
 {
     uint32_t stat_buf = 0;
     uint32_t length_zoom;
@@ -149,7 +149,7 @@ esp_err_t spi_flash_chip_mxic_opi_get_write_protect(esp_flash_t *chip, bool *out
     esp_err_t err = ESP_OK;
     uint32_t status;
     assert(out_write_protected!=NULL);
-    err = chip->chip_drv->read_reg(chip, SPI_FLASH_REG_STATUS, &status);
+    err = chip->chip_drv->read_reg(chip, chip->chip_drv->status_reg_id, &status);
     if (err != ESP_OK) {
         return err;
     }
@@ -410,6 +410,7 @@ const spi_flash_chip_t esp_flash_chip_mxic_opi = {
     .set_io_mode = spi_flash_chip_xmic_opi_set_io_mode,
     .get_io_mode = spi_flash_chip_mxic_opi_get_io_mode,
 
+    .status_reg_id = 0,
     .read_id = spi_flash_chip_mxic_opi_read_id,
     .read_reg = spi_flash_chip_mxic_opi_read_reg,
     .yield = spi_flash_chip_generic_yield,

--- a/components/spi_flash/spi_flash_chip_th.c
+++ b/components/spi_flash/spi_flash_chip_th.c
@@ -69,6 +69,7 @@ const spi_flash_chip_t esp_flash_chip_th = {
     .set_io_mode = spi_flash_chip_generic_set_io_mode,
     .get_io_mode = spi_flash_chip_generic_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,

--- a/components/spi_flash/spi_flash_chip_winbond.c
+++ b/components/spi_flash/spi_flash_chip_winbond.c
@@ -23,6 +23,7 @@
 #define REGION_32BIT(start, len)    ((start) + (len) > (1<<24))
 #define ADDR_32BIT(addr)            (addr >= (1<<24))
 
+#define W25N_FAMILY 0xEFAA
 
 static const char TAG[] = "chip_wb";
 
@@ -37,6 +38,11 @@ esp_err_t spi_flash_chip_winbond_probe(esp_flash_t *chip, uint32_t flash_id)
     const uint8_t MFG_ID = 0xEF;
     if (flash_id >> 16 != MFG_ID) {
         return ESP_ERR_NOT_FOUND;
+    }
+
+    if ((flash_id >> 8) == W25N_FAMILY) {
+        // Overwrite the status register ID
+        ((spi_flash_chip_t*)chip->chip_drv)->status_reg_id = 0xC0;
     }
 
     return ESP_OK;
@@ -191,6 +197,7 @@ const spi_flash_chip_t esp_flash_chip_winbond = {
     .set_io_mode = spi_flash_chip_generic_set_io_mode,
     .get_io_mode = spi_flash_chip_generic_get_io_mode,
 
+    .status_reg_id = 0,
     .read_reg = spi_flash_chip_generic_read_reg,
     .yield = spi_flash_chip_generic_yield,
     .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,


### PR DESCRIPTION
As per title,
The current read_status register needs to be expanded to a more generic "Read register" in order to support latest winbond flash.

(And probably also other brands?)

If you find a better way of updating the status register address depending on the flash family please let me know.