### PR TITLE
Fixed: BluFi module link error(C++ hybrid compilation) (IDFGH-8087)

### DIFF
--- a/components/bt/common/btc/profile/esp/blufi/include/blufi_int.h
+++ b/components/bt/common/btc/profile/esp/blufi/include/blufi_int.h
@@ -9,6 +9,11 @@
 
 #include "btc/btc_task.h"
 #include "esp_blufi_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if (BLUFI_INCLUDED == TRUE)
 
 #define BTC_BLUFI_GREAT_VER   0x01  //Version + Subversion
@@ -190,5 +195,10 @@ void btc_blufi_cb_deep_copy(btc_msg_t *msg, void *p_dest, void *p_src);
 
 void btc_blufi_cb_deep_free(btc_msg_t *msg);
 
-#endif /* __BLUFI_INT_H__ */
-#endif  ///BLUFI_INCLUDED == TRUE
+#endif ///BLUFI_INCLUDED == TRUE
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __BLUFI_INT_H__ */

--- a/components/bt/common/btc/profile/esp/blufi/include/esp_blufi.h
+++ b/components/bt/common/btc/profile/esp/blufi/include/esp_blufi.h
@@ -19,6 +19,11 @@
 #include "esp_gap_ble_api.h"
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BLUFI_APP_UUID      0xFFFF
 #define BLUFI_DEVICE_NAME            "BLUFI_DEVICE"
 
@@ -80,4 +85,7 @@ void esp_blufi_adv_start(void);
 
 void esp_blufi_send_encap(void *arg);
 
+#ifdef __cplusplus
+}
+#endif
 #endif/* _ESP_BLUFI_ */

--- a/components/bt/common/btc/profile/esp/include/btc_blufi_prf.h
+++ b/components/bt/common/btc/profile/esp/include/btc_blufi_prf.h
@@ -21,6 +21,11 @@
 #define ESP_BLUFI_SUCCESS 0x00
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BT_BD_ADDR_STR         "%02x:%02x:%02x:%02x:%02x:%02x"
 #define BT_BD_ADDR_HEX(addr)   addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]
 
@@ -100,4 +105,7 @@ void btc_blufi_call_deep_free(btc_msg_t *msg);
 
 uint16_t btc_blufi_get_version(void);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* __BTC_BLUFI_PRF_H__ */


### PR DESCRIPTION
in same embed platform like platformIO, when use esp32  blufi module compile is ok , but link is fail.
root cause: Name Mangling