### PR TITLE
[flash] Winbond W25N support (IDFGH-8091)

### DIFF
--- a/components/spi_flash/CMakeLists.txt
+++ b/components/spi_flash/CMakeLists.txt
@@ -51,6 +51,7 @@ else()
         "spi_flash_chip_boya.c"
         "spi_flash_chip_mxic_opi.c"
         "spi_flash_chip_th.c"
+        "spi_flash_chip_winbond_w25n.c"
         "memspi_host_driver.c")
 
     list(APPEND cache_srcs

--- a/components/spi_flash/include/spi_flash_chip_driver.h
+++ b/components/spi_flash/include/spi_flash_chip_driver.h
@@ -1,16 +1,8 @@
-// Copyright 2015-2019 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include "esp_flash.h"
@@ -30,9 +22,7 @@ typedef struct {
     uint32_t page_program_timeout;  ///< Timeout for page program operation
 } flash_chip_op_timeout_t;
 
-typedef enum {
-    SPI_FLASH_REG_STATUS = 1,
-} spi_flash_register_t;
+#define SPI_FLASH_REG_STATUS (1)
 
 typedef enum {
    SPI_FLASH_CHIP_CAP_SUSPEND = BIT(0),            ///< Flash chip support suspend feature.
@@ -189,7 +179,7 @@ struct spi_flash_chip_t {
     /*
      * Read the requested register (status, etc.).
      */
-    esp_err_t (*read_reg)(esp_flash_t *chip, spi_flash_register_t reg_id, uint32_t* out_reg);
+    esp_err_t (*read_reg)(esp_flash_t *chip, uint8_t reg_id, uint32_t* out_reg);
 
     /** Yield to other tasks. Called during erase operations. */
     esp_err_t (*yield)(esp_flash_t *chip, uint32_t wip);

--- a/components/spi_flash/include/spi_flash_chip_generic.h
+++ b/components/spi_flash/include/spi_flash_chip_generic.h
@@ -1,16 +1,8 @@
-// Copyright 2015-2019 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 
@@ -201,7 +193,7 @@ esp_err_t spi_flash_chip_generic_get_write_protect(esp_flash_t *chip, bool *out_
  * @param out_reg    Output of the register value
  * @return esp_err_t Error code passed from the ``read_status`` function of host driver.
  */
-esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, spi_flash_register_t reg_id, uint32_t* out_reg);
+esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, uint8_t reg_id, uint32_t* out_reg);
 
 /**
  * @brief Read flash status via the RDSR command and wait for bit 0 (write in

--- a/components/spi_flash/include/spi_flash_chip_winbond_w25n.h
+++ b/components/spi_flash/include/spi_flash_chip_winbond_w25n.h
@@ -16,4 +16,4 @@
  * default autodetection, this is used as a catchall if a more specific chip_drv
  * is not found.
  */
-extern const spi_flash_chip_t esp_flash_chip_winbond;
+extern const spi_flash_chip_t esp_flash_chip_winbond_w25n;

--- a/components/spi_flash/spi_flash_chip_drivers.c
+++ b/components/spi_flash/spi_flash_chip_drivers.c
@@ -13,6 +13,7 @@
 #include "spi_flash_chip_winbond.h"
 #include "spi_flash_chip_boya.h"
 #include "spi_flash_chip_th.h"
+#include "spi_flash_chip_winbond_w25n.h"
 #include "sdkconfig.h"
 
 #if !CONFIG_SPI_FLASH_OVERRIDE_CHIP_DRIVER_LIST
@@ -36,6 +37,7 @@ static const spi_flash_chip_t *default_registered_chips[] = {
     &esp_flash_chip_mxic,
 #endif
 #ifdef CONFIG_SPI_FLASH_SUPPORT_WINBOND_CHIP
+    &esp_flash_chip_winbond_w25n,
     &esp_flash_chip_winbond,
 #endif
 #ifdef CONFIG_SPI_FLASH_SUPPORT_BOYA_CHIP

--- a/components/spi_flash/spi_flash_chip_generic.c
+++ b/components/spi_flash/spi_flash_chip_generic.c
@@ -388,7 +388,7 @@ esp_err_t spi_flash_chip_generic_get_write_protect(esp_flash_t *chip, bool *out_
     return err;
 }
 
-esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, spi_flash_register_t reg_id, uint32_t* out_reg)
+esp_err_t spi_flash_chip_generic_read_reg(esp_flash_t* chip, uint8_t reg_id, uint32_t* out_reg)
 {
     return chip->host->driver->read_status(chip->host, (uint8_t*)out_reg);
 }

--- a/components/spi_flash/spi_flash_chip_mxic_opi.c
+++ b/components/spi_flash/spi_flash_chip_mxic_opi.c
@@ -1,16 +1,8 @@
-// Copyright 2015-2020 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <stdlib.h>
 #include "spi_flash_chip_generic.h"
@@ -122,7 +114,7 @@ esp_err_t spi_flash_chip_mxic_opi_read_id(esp_flash_t *chip, uint32_t* out_chip_
     return ESP_OK;
 }
 
-esp_err_t spi_flash_chip_mxic_opi_read_reg(esp_flash_t *chip, spi_flash_register_t reg_id, uint32_t* out_reg)
+esp_err_t spi_flash_chip_mxic_opi_read_reg(esp_flash_t *chip, uint8_t reg_id, uint32_t* out_reg)
 {
     uint32_t stat_buf = 0;
     uint32_t length_zoom;

--- a/components/spi_flash/spi_flash_chip_winbond_w25n.c
+++ b/components/spi_flash/spi_flash_chip_winbond_w25n.c
@@ -1,0 +1,196 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h> // For MIN/MAX
+#include "esp_log.h"
+#include "spi_flash_chip_generic.h"
+#include "spi_flash_defs.h"
+
+#define W25N_FAMILY 0xFEAA
+
+//static const char TAG[] = "chip_w25n";
+
+/* Driver for Winbond flash chip */
+static esp_err_t spi_flash_command_w25n_program(esp_flash_t *chip, const void *buffer, uint32_t address, uint32_t length);
+static esp_err_t spi_flash_command_w25n_erase_block(esp_flash_t *chip, uint32_t start_address);
+
+esp_err_t spi_flash_chip_w25n_probe(esp_flash_t *chip, uint32_t flash_id)
+{
+    /* Check manufacturer and product IDs match our desired masks */
+    const uint8_t MFG_ID = 0xEF;
+    if (flash_id >> 16 != MFG_ID) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    if ((flash_id >> 8) != W25N_FAMILY) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t spi_flash_chip_w25n_reset(esp_flash_t *chip)
+{
+    //this is written following the winbond spec..
+    spi_flash_trans_t t;
+    esp_err_t err;
+    t = (spi_flash_trans_t) {
+        .command = 0xFF,
+    };
+    err = chip->host->driver->common_command(chip->host, &t);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = chip->chip_drv->wait_idle(chip, chip->chip_drv->timeout->idle_timeout);
+    return err;
+}
+
+esp_err_t spi_flash_chip_w25n_page_program(esp_flash_t *chip, const void *buffer, uint32_t address, uint32_t length)
+{
+    esp_err_t err;
+
+    err = chip->chip_drv->wait_idle(chip, chip->chip_drv->timeout->idle_timeout);
+
+    if (err == ESP_OK) {
+        // Perform the actual Page Program command
+        err = spi_flash_command_w25n_program(chip, buffer, address, length);
+        if (err != ESP_OK) {
+            return err;
+        }
+
+        err = chip->chip_drv->wait_idle(chip, chip->chip_drv->timeout->page_program_timeout);
+    }
+    return err;
+}
+
+esp_err_t spi_flash_chip_w25n_erase_block(esp_flash_t *chip, uint32_t start_address)
+{
+    esp_err_t err = chip->chip_drv->set_chip_write_protect(chip, false);
+    if (err == ESP_OK) {
+        err = chip->chip_drv->wait_idle(chip, chip->chip_drv->timeout->idle_timeout);
+    }
+
+    if (err == ESP_OK) {
+        err = spi_flash_command_w25n_erase_block(chip, start_address);
+        if (err != ESP_OK) {
+            return err;
+        }
+        //to save time, flush cache here
+        if (chip->host->driver->flush_cache) {
+            err = chip->host->driver->flush_cache(chip->host, start_address, chip->chip_drv->block_erase_size);
+            if (err != ESP_OK) {
+                return err;
+            }
+        }
+        err = chip->chip_drv->wait_idle(chip, chip->chip_drv->timeout->block_erase_timeout);
+    }
+    return err;
+}
+
+esp_err_t spi_flash_chip_w25n_read_reg(esp_flash_t* chip, uint8_t reg_id, uint32_t* out_reg)
+{
+    uint32_t stat_buf = 0;
+
+    if (reg_id == SPI_FLASH_REG_STATUS) {
+        // We use the default status address to identify if we need to query the status
+        // We need to do this because read_reg it's used by non-overriden generic functions
+        reg_id = 0xC0;
+    }
+
+    spi_flash_trans_t t = {
+        .command = CMD_RDSR,
+        .mosi_data = ((uint8_t*) &reg_id),
+        .mosi_len = 1,
+        .miso_data = ((uint8_t*) &stat_buf),
+        .miso_len = 1
+    };
+
+    esp_err_t err = chip->host->driver->common_command(chip->host, &t);
+    if (err != ESP_OK) {
+        return err;
+    }
+    *out_reg = stat_buf;
+    return ESP_OK;
+}
+
+spi_flash_caps_t spi_flash_chip_w25n_get_caps(esp_flash_t *chip)
+{
+    // For generic part flash capability, take the XMC chip as reference.
+    spi_flash_caps_t caps_flags = 0;
+
+    // flash read unique id.
+    caps_flags |= SPI_FLASH_CHIP_CAP_UNIQUE_ID;
+    return caps_flags;
+}
+
+static const char chip_name[] = "winbond_w25n";
+
+// The issi chip can use the functions for generic chips except from set read mode and probe,
+// So we only replace these two functions.
+const spi_flash_chip_t esp_flash_chip_winbond_w25n = {
+    .name = chip_name,
+    .timeout = &spi_flash_chip_generic_timeout,
+    .probe = spi_flash_chip_w25n_probe,
+    .reset = spi_flash_chip_w25n_reset,
+    .detect_size = spi_flash_chip_generic_detect_size,
+    .erase_chip = NULL,
+    .erase_sector = NULL,
+    .erase_block = spi_flash_chip_w25n_erase_block,
+    .block_erase_size = 128 * 1024,
+
+    .get_chip_write_protect = spi_flash_chip_generic_get_write_protect,
+    .set_chip_write_protect = spi_flash_chip_generic_set_write_protect,
+
+    .num_protectable_regions = 0,
+    .protectable_regions = NULL,
+    .get_protected_regions = NULL,
+    .set_protected_regions = NULL,
+
+    .read = spi_flash_chip_generic_read,
+    .write = spi_flash_chip_generic_write,
+    .program_page = spi_flash_chip_w25n_page_program,
+    .page_size = 2048,
+    .write_encrypted = spi_flash_chip_generic_write_encrypted,
+
+    .wait_idle = spi_flash_chip_generic_wait_idle,
+    .set_io_mode = spi_flash_chip_generic_set_io_mode,
+    .get_io_mode = spi_flash_chip_generic_get_io_mode,
+
+    .read_reg = spi_flash_chip_w25n_read_reg,
+    .yield = spi_flash_chip_generic_yield,
+    .sus_setup = spi_flash_chip_generic_suspend_cmd_conf,
+    .read_unique_id = spi_flash_chip_generic_read_unique_id,
+    .get_chip_caps = spi_flash_chip_w25n_get_caps,
+    .config_host_io_mode = spi_flash_chip_generic_config_host_io_mode,
+};
+
+
+static esp_err_t spi_flash_command_w25n_program(esp_flash_t *chip, const void *buffer, uint32_t address, uint32_t length)
+{
+    spi_flash_trans_t t = {
+        .command = CMD_PROGRAM_PAGE,
+        .address_bitlen = 16,
+        .address = address,
+        .mosi_len = length,
+        .mosi_data = buffer,
+    };
+    return chip->host->driver->common_command(chip->host, &t);
+}
+
+esp_err_t spi_flash_command_w25n_erase_block(esp_flash_t *chip, uint32_t start_address)
+{
+    // 128KB block erase
+    spi_flash_trans_t t = {
+        .command = CMD_LARGE_BLOCK_ERASE,
+        .dummy_bitlen = 8,
+        .address_bitlen = 16,
+        .address = start_address, // Page address
+    };
+    return chip->host->driver->common_command(chip->host, &t);
+}

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -1285,12 +1285,9 @@ components/soc/soc_include_legacy_warn.c
 components/spi_flash/cache_utils.h
 components/spi_flash/include/esp_spi_flash_counters.h
 components/spi_flash/include/spi_flash_chip_boya.h
-components/spi_flash/include/spi_flash_chip_driver.h
 components/spi_flash/include/spi_flash_chip_gd.h
-components/spi_flash/include/spi_flash_chip_generic.h
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
-components/spi_flash/include/spi_flash_chip_winbond.h
 components/spi_flash/sim/SpiFlash.cpp
 components/spi_flash/sim/flash_mock.cpp
 components/spi_flash/sim/flash_mock_util.c
@@ -1300,7 +1297,6 @@ components/spi_flash/spi_flash_chip_boya.c
 components/spi_flash/spi_flash_chip_gd.c
 components/spi_flash/spi_flash_chip_issi.c
 components/spi_flash/spi_flash_chip_mxic.c
-components/spi_flash/spi_flash_chip_mxic_opi.c
 components/spi_flash/spi_flash_chip_winbond.c
 components/spi_flash/test/test_esp_flash.c
 components/spi_flash/test/test_flash_encryption.c


### PR DESCRIPTION
As per title, support for winbond W25N family.
Since there are multiple changes from normal winbond devices, it was easier to generate a new driver.

We are still testing the code to see if we missed some implementation changes.

Replace 
https://github.com/espressif/esp-idf/pull/9582