### PR TITLE
nimble: Make BT_NIMBLE_LEGACY_VHCI_ENABLE depend on BT_CONTROLLER_ENA… (IDFGH-8111)

### DIFF
--- a/components/bt/host/nimble/Kconfig.in
+++ b/components/bt/host/nimble/Kconfig.in
@@ -638,6 +638,7 @@ config BT_NIMBLE_USE_ESP_TIMER
 
 config BT_NIMBLE_LEGACY_VHCI_ENABLE
     bool
+    depends on BT_CONTROLLER_ENABLED
     default y if (IDF_TARGET_ESP32 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3)
     default n
     help


### PR DESCRIPTION
…BLED

No need to build esp_nimble_hci.c if BT_CONTROLLER_DISABLED=y.

Signed-off-by: Axel Lin <axel.lin@gmail.com>