### PR TITLE
essl_sdio: should be available even if platform can only be sdio master

### DIFF
--- a/components/esp_serial_slave_link/essl_sdio.c
+++ b/components/esp_serial_slave_link/essl_sdio.c
@@ -18,7 +18,6 @@
 #include "essl_internal.h"
 #include "soc/soc_caps.h"
 
-#if SOC_SDIO_SLAVE_SUPPORTED
 #include "soc/host_reg.h"
 
 static const char TAG[] = "essl_sdio";
@@ -458,5 +457,3 @@ void essl_sdio_reset_cnt(void *arg)
     ctx->rx_got_bytes = 0;
     ctx->tx_sent_buffers = 0;
 }
-
-#endif // #if SOC_SDIO_SLAVE_SUPPORTED


### PR DESCRIPTION
When using a ESP32S3 to control a ESP32 over ESSL/SDIO, compilation doesn't work:
```
/build/esp-idf/examples/sdio/host/main/app_main.c:202: undefined reference to `essl_sdio_init_dev'
```
but applying this patch let the magic happen.

Tested with examples from `examples/peripherals/sdio`

![image](https://user-images.githubusercontent.com/55736090/186486259-75b5f2ee-4c5f-4164-b85c-29a74389995a.png)

![image](https://user-images.githubusercontent.com/55736090/186486764-f51c9e68-d9c1-48eb-ac57-2bec80221f26.png)
