### PR TITLE
upgrade ccache installed version to 4.6.2 (IDFGH-8160)

### DIFF
--- a/tools/tools.json
+++ b/tools/tools.json
@@ -947,7 +947,7 @@
       "description": "Ccache (compiler cache)",
       "export_paths": [
         [
-          "ccache-4.3-windows-64"
+          "ccache-4.6.2-windows-x86_64"
         ]
       ],
       "export_vars": {
@@ -975,12 +975,12 @@
       "version_regex": "ccache version ([0-9.]+)",
       "versions": [
         {
-          "name": "4.3",
+          "name": "4.6.2",
           "status": "recommended",
           "win64": {
-            "sha256": "a9cacae73c3906d8193456328bee74f7748cb1559a32eaced9ee78eadd416105",
-            "size": 1550675,
-            "url": "https://github.com/ccache/ccache/releases/download/v4.3/ccache-4.3-windows-64.zip"
+            "sha256": "bf230b0936962eae43a3410d6477a7d0b9308e29f89a3091881d22e2502604c5",
+            "size": 1957177,
+            "url": "https://github.com/ccache/ccache/releases/download/v4.6.2/ccache-4.6.2-windows-x86_64.zip"
           }
         }
       ]


### PR DESCRIPTION
- primary reason: 4.6.2 fixes errors if the user's home directory contains a space
- alternative fix: the CCACHE_DIR env var can be set to something without a space in it, or set to TMP which properly escapes the home dir name
- there may be other issues with spaces in filenames on builds in other parts of ESP-IDF, see https://github.com/espressif/esp-idf/issues/8364 for more info.  Espressif is saying v5.0 is required for those other fixes, so I suggest only merging this with that version. I am testing with 4.4.2 and it works great over here

tested locally on windows only, use at your own risk