### PR TITLE
Enable missing Interrupts for half duplex mode (IDFGH-8202)

### DIFF
--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1690,7 +1690,7 @@ esp_err_t uart_set_mode(uart_port_t uart_num, uart_mode_t mode)
     }
     UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
     uart_hal_set_mode(&(uart_context[uart_num].hal), mode);
-    if (mode ==  UART_MODE_RS485_COLLISION_DETECT) {
+    if ((mode == UART_MODE_RS485_COLLISION_DETECT) || (mode == UART_MODE_RS485_HALF_DUPLEX)) {
         // This mode allows read while transmitting that allows collision detection
         p_uart_obj[uart_num]->coll_det_flg = false;
         // Enable collision detection interrupts


### PR DESCRIPTION
The mode UART_MODE_RS485_HALF_DUPLEX is capable of collision detection (given the required circuit), but the interrupts were not enabled. (See e.g. at function `uart_get_collision_flag()` about required modes for detection.