### PR TITLE
adc: esp32s2: fix unit to offset calculation (IDFGH-8226)

### DIFF
--- a/components/efuse/esp32s2/esp_efuse_rtc_table.c
+++ b/components/efuse/esp32s2/esp_efuse_rtc_table.c
@@ -97,6 +97,7 @@ int esp_efuse_rtc_table_read_calib_version(void)
 
 int esp_efuse_rtc_table_get_tag(int version, int adc_num, int atten, int extra_params)
 {
+    assert(adc_num <= ADC_UNIT_2);
     int index = (adc_num == ADC_UNIT_1) ? 0 : 1;
     int param_offset; // used to index which (adc_num, atten) array to use.
     if (version == 1 && extra_params == RTCCALIB_V1_PARAM_VLOW) { // Volage LOW, Version 1

--- a/components/esp_hw_support/adc_share_hw_ctrl.c
+++ b/components/esp_hw_support/adc_share_hw_ctrl.c
@@ -97,7 +97,7 @@ void adc_power_release(void)
 
 static inline uint32_t esp_efuse_rtc_calib_get_init_code(int version, uint32_t adc_unit, int atten)
 {
-    int tag = esp_efuse_rtc_table_get_tag(version, adc_unit + 1, atten, RTCCALIB_V2_PARAM_VINIT);
+    int tag = esp_efuse_rtc_table_get_tag(version, adc_unit, atten, RTCCALIB_V2_PARAM_VINIT);
     return esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
 }
 #endif


### PR DESCRIPTION
eFuse offset is screwed up on 4.4 to 5.0 transition

fix for https://github.com/espressif/esp-idf/issues/9705