### PR TITLE
Fix export.sh failure if python 2.x is unavailable (IDFGH-8261)

### DIFF
--- a/export.fish
+++ b/export.fish
@@ -47,7 +47,7 @@ function __main
     set -x PATH "$IDF_ADD_PATHS_EXTRAS":"$PATH"
 
     echo "Checking if Python packages are up to date..."
-    python "$IDF_PATH"/tools/idf_tools.py check-python-dependencies || return 1
+    "$ESP_PYTHON" "$IDF_PATH"/tools/idf_tools.py check-python-dependencies || return 1
 
     set added_path_variables
     for entry in $PATH;

--- a/export.sh
+++ b/export.sh
@@ -134,9 +134,8 @@ __main() {
     eval "${idf_exports}"
     export PATH="${IDF_ADD_PATHS_EXTRAS}:${PATH}"
 
-    __verbose "Using Python interpreter in $(which python)"
     __verbose "Checking if Python packages are up to date..."
-    python "${IDF_PATH}/tools/idf_tools.py" check-python-dependencies || return 1
+    "$ESP_PYTHON" "${IDF_PATH}/tools/idf_tools.py" check-python-dependencies || return 1
 
     if [ -n "$BASH" ]
     then


### PR DESCRIPTION
In the latest release of macOS (and probable some other recent *nixes as well?) `python` is no longer available by default, only `python3`. This causes `export.sh` to fail as it still had a reference to plain `python`. This now works as expected.