### PR TITLE
add sni support (IDFGH-8363)

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -57,6 +57,13 @@ menu "ESP-TLS"
         help
             Sets the session ticket timeout used in the tls server.
 
+    config ESP_TLS_SERVER_SNI_HOOK
+        bool "Server name identification hook"
+        depends on ESP_TLS_USING_MBEDTLS
+        help
+            Ability to configure and use an SNI Callback during server handshake,
+            to select a certificate to present to the client for example.
+
     config ESP_TLS_SERVER_MIN_AUTH_MODE_OPTIONAL
         bool "ESP-TLS Server: Set minimum Certificate Verification mode to Optional"
         depends on ESP_TLS_SERVER && ESP_TLS_USING_MBEDTLS

--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -57,12 +57,13 @@ menu "ESP-TLS"
         help
             Sets the session ticket timeout used in the tls server.
 
-    config ESP_TLS_SERVER_SNI_HOOK
-        bool "Server name identification hook"
+    config ESP_TLS_SERVER_CERT_SELECT_HOOK
+        bool "Certificate selection hook"
         depends on ESP_TLS_USING_MBEDTLS
         help
-            Ability to configure and use an SNI Callback during server handshake,
-            to select a certificate to present to the client for example.
+            Ability to configure and use a certificate selection callback during server handshake,
+            to select a certificate to present to the client based on the TLS extensions supplied in
+            the client hello (alpn, sni, etc).
 
     config ESP_TLS_SERVER_MIN_AUTH_MODE_OPTIONAL
         bool "ESP-TLS Server: Set minimum Certificate Verification mode to Optional"

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -594,6 +594,24 @@ esp_err_t esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg)
 #endif
 }
 
+#ifdef CONFIG_ESP_TLS_SERVER
+esp_err_t esp_tls_cfg_server_sni_init(esp_tls_cfg_server_t *cfg, esp_tls_server_sni_callback *cb, void *data)
+{
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+    if (!cfg) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    cfg->sni_callback = cb;
+    cfg->sni_callback_p_info = data;
+
+    return ESP_OK;
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+#endif
+
+#ifdef CONFIG_ESP_TLS_SERVER
 void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
 {
 #if defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
@@ -602,6 +620,7 @@ void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
     }
 #endif
 }
+#endif
 
 /**
  * @brief      Create a server side TLS/SSL connection

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -594,24 +594,6 @@ esp_err_t esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg)
 #endif
 }
 
-#ifdef CONFIG_ESP_TLS_SERVER
-esp_err_t esp_tls_cfg_server_sni_init(esp_tls_cfg_server_t *cfg, esp_tls_server_sni_callback *cb, void *data)
-{
-#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-    if (!cfg) {
-        return ESP_ERR_INVALID_ARG;
-    }
-    cfg->sni_callback = cb;
-    cfg->sni_callback_p_info = data;
-
-    return ESP_OK;
-#else
-    return ESP_ERR_NOT_SUPPORTED;
-#endif
-}
-#endif
-
-#ifdef CONFIG_ESP_TLS_SERVER
 void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
 {
 #if defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
@@ -620,7 +602,6 @@ void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
     }
 #endif
 }
-#endif
 
 /**
  * @brief      Create a server side TLS/SSL connection

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -297,25 +297,6 @@ typedef struct esp_tls_cfg_server {
 esp_err_t esp_tls_cfg_server_session_tickets_init(esp_tls_cfg_server_t *cfg);
 
 /**
- * @brief Initialize the server side TLS server name identification hook
- *
- * This function initializes the server side tls server name identification hook
- * which is called during a client connect handshake, and has the ability to check
- * the advertised hostname and supply a specific certificate based on that for example.
- * Check https://mbed-tls.readthedocs.io/en/latest/kb/how-to/use-sni/#server-side for details.
- *
- * @param[in]  cfg server configuration as esp_tls_cfg_server_t
- * @param[in]  cb callback function pointer
- * @param[in]  data pointer to implementation specific data supplied as the first parameter of the callback
- * @return
- *             ESP_OK if setup succeeded
- *             ESP_ERR_INVALID_ARG if context is NULL
- *             ESP_ERR_NOT_SUPPORTED if server side sni is not available due to build configuration
- *             ESP_FAIL if setup failed
- */
-esp_err_t esp_tls_cfg_server_sni_init(esp_tls_cfg_server_t *cfg, esp_tls_server_sni_callback *cb, void *data);
-
-/**
  * @brief Free the server side TLS session ticket context
  *
  * @param cfg server configuration as esp_tls_cfg_server_t

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -567,7 +567,7 @@ esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
         }
     } else {
 #if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-        if ((cfg->sni_callback == NULL)) {
+        if (cfg->sni_callback == NULL) {
             ESP_LOGE(TAG, "Missing server certificate and/or key and no SNI callback is defined");
         } else {
             ESP_LOGD(TAG, "Missing server certificate and/or key, but SNI callback is defined. Callback MUST ALWAYS call mbedtls_ssl_set_hs_own_cert, or the handshake will abort!");

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -566,7 +566,16 @@ esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
             return esp_ret;
         }
     } else {
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+        if ((cfg->sni_callback == NULL)) {
+            ESP_LOGE(TAG, "Missing server certificate and/or key and no SNI callback is defined");
+        } else {
+            ESP_LOGD(TAG, "Missing server certificate and/or key, but SNI callback is defined. Callback MUST ALWAYS call mbedtls_ssl_set_hs_own_cert, or the handshake will abort!");
+            return ESP_OK;
+        }
+#else
         ESP_LOGE(TAG, "Missing server certificate and/or key");
+#endif
         return ESP_ERR_INVALID_STATE;
     }
 
@@ -787,6 +796,14 @@ int esp_mbedtls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
         tls->conn_state = ESP_TLS_FAIL;
         return -1;
     }
+
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+    if (cfg->sni_callback != NULL) {
+        ESP_LOGI(TAG, "Initializing server side SNI callback");
+        mbedtls_ssl_conf_sni(&tls->conf, cfg->sni_callback, cfg->sni_callback_p_info);
+    }
+#endif
+
     tls->read = esp_mbedtls_read;
     tls->write = esp_mbedtls_write;
     int ret;

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -96,6 +96,11 @@ struct httpd_ssl_config {
 
     /** User callback for esp_https_server */
     esp_https_server_user_cb *user_cb;
+
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+    esp_tls_server_sni_callback *sni_callback; /*!< Server Name Identification callback to use */
+    void *sni_callback_p_info;                 /*!< Data to pass to the SNI callback. */
+#endif
 };
 
 typedef struct httpd_ssl_config httpd_ssl_config_t;

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -97,10 +97,10 @@ struct httpd_ssl_config {
     /** User callback for esp_https_server */
     esp_https_server_user_cb *user_cb;
 
-#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-    esp_tls_server_sni_callback *sni_callback; /*!< Server Name Identification callback to use */
-    void *sni_callback_p_info;                 /*!< Data to pass to the SNI callback. */
+#if defined(CONFIG_ESP_TLS_SERVER_CERT_SELECT_HOOK)
+    esp_tls_handshake_callback cert_select_cb; /*!< Certificate selection callback to use */
 #endif
+    void *ssl_userdata; /*!< user data to add to the ssl context  */
 };
 
 typedef struct httpd_ssl_config httpd_ssl_config_t;

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -214,24 +214,18 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
     }
 
 #if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-    if (config->sni_callback) {
-        if (esp_tls_cfg_server_sni_init(cfg, config->sni_callback, config->sni_callback_p_info) != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to init server side SNI");
-            free(ssl_ctx);
-            free(cfg);
-            return NULL;
-        };
-    }
+    cfg->sni_callback = config->sni_callback
+    cfg->sni_callback_p_info = config->sni_callback_p_info
 #endif
 
     ssl_ctx->tls_cfg = cfg;
     ssl_ctx->user_cb = config->user_cb;
 
 /* cacert = CA which signs client cert, or client cert itself */
-    if(config->cacert_pem != NULL && config->cacert_len > 0) {
+    if (config->cacert_pem != NULL && config->cacert_len > 0) {
         cfg->cacert_buf = (unsigned char *)malloc(config->cacert_len);
 
-        if(cfg->cacert_buf) {
+        if (cfg->cacert_buf) {
             memcpy((char *) cfg->cacert_buf, config->cacert_pem, config->cacert_len);
             cfg->cacert_bytes = config->cacert_len;
         } else {
@@ -243,10 +237,10 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
     }
 
 /* servercert = cert of server itself */
-    if(config->servercert != NULL && config->servercert_len > 0) {
+    if (config->servercert != NULL && config->servercert_len > 0) {
         cfg->servercert_buf = (unsigned char *)malloc(config->servercert_len);
 
-        if(cfg->servercert_buf) {
+        if (cfg->servercert_buf) {
             memcpy((char *) cfg->servercert_buf, config->servercert, config->servercert_len);
             cfg->servercert_bytes = config->servercert_len;
         } else {
@@ -292,17 +286,22 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
         } else {
 #if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
             if (config->sni_callback == NULL) {
-#endif
+                ESP_LOGE(TAG, "No Server key supplied and no SNI hook is present");
+                free((void *) cfg->servercert_buf);
+                free((void *) cfg->cacert_buf);
+                free(cfg);
+                free(ssl_ctx);
+                return NULL;
+            } else {
+                ESP_LOGW(TAG, "Server key not supplied, make sure to supply it in the SNI hook");
+            }
+#else
             ESP_LOGE(TAG, "No Server key supplied");
             free((void *) cfg->servercert_buf);
             free((void *) cfg->cacert_buf);
             free(cfg);
             free(ssl_ctx);
             return NULL;
-#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-            } else {
-            ESP_LOGW(TAG, "Server key not supplied, make sure to supply it in the SNI hook!");
-            }
 #endif
         }
     }

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -214,8 +214,8 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
     }
 
 #if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
-    cfg->sni_callback = config->sni_callback
-    cfg->sni_callback_p_info = config->sni_callback_p_info
+    cfg->sni_callback = config->sni_callback;
+    cfg->sni_callback_p_info = config->sni_callback_p_info;
 #endif
 
     ssl_ctx->tls_cfg = cfg;

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -213,50 +213,99 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
         }
     }
 
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+    if (config->sni_callback) {
+        if (esp_tls_cfg_server_sni_init(cfg, config->sni_callback, config->sni_callback_p_info) != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to init server side SNI");
+            free(ssl_ctx);
+            free(cfg);
+            return NULL;
+        };
+    }
+#endif
+
     ssl_ctx->tls_cfg = cfg;
     ssl_ctx->user_cb = config->user_cb;
 
 /* cacert = CA which signs client cert, or client cert itself */
-    if(config->cacert_pem != NULL) {
+    if(config->cacert_pem != NULL && config->cacert_len > 0) {
         cfg->cacert_buf = (unsigned char *)malloc(config->cacert_len);
-        if (!cfg->cacert_buf) {
-            ESP_LOGE(TAG, "Could not allocate memory");
+
+        if(cfg->cacert_buf) {
+            memcpy((char *) cfg->cacert_buf, config->cacert_pem, config->cacert_len);
+            cfg->cacert_bytes = config->cacert_len;
+        } else {
+            ESP_LOGE(TAG, "Could not allocate memory for client certificate authority");
             free(cfg);
             free(ssl_ctx);
             return NULL;
         }
-        memcpy((char *)cfg->cacert_buf, config->cacert_pem, config->cacert_len);
-        cfg->cacert_bytes = config->cacert_len;
     }
 
 /* servercert = cert of server itself */
-    cfg->servercert_buf = (unsigned char *)malloc(config->servercert_len);
-    if (!cfg->servercert_buf) {
-        ESP_LOGE(TAG, "Could not allocate memory");
-        free((void *)cfg->cacert_buf);
+    if(config->servercert != NULL && config->servercert_len > 0) {
+        cfg->servercert_buf = (unsigned char *)malloc(config->servercert_len);
+
+        if(cfg->servercert_buf) {
+            memcpy((char *) cfg->servercert_buf, config->servercert, config->servercert_len);
+            cfg->servercert_bytes = config->servercert_len;
+        } else {
+            ESP_LOGE(TAG, "Could not allocate memory for server certificate");
+            free((void *) cfg->cacert_buf);
+            free(cfg);
+            free(ssl_ctx);
+            return NULL;
+        }
+    } else {
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+        if (config->sni_callback == NULL) {
+#endif
+        ESP_LOGE(TAG, "No Server certificate supplied");
+        free((void *) cfg->cacert_buf);
         free(cfg);
         free(ssl_ctx);
         return NULL;
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+        } else {
+            ESP_LOGW(TAG, "Server certificate not supplied, make sure to supply it in the SNI hook!");
+        }
+#endif
     }
-    memcpy((char *)cfg->servercert_buf, config->servercert, config->servercert_len);
-    cfg->servercert_bytes = config->servercert_len;
 
     /* Pass on secure element boolean */
     cfg->use_secure_element = config->use_secure_element;
     if (!cfg->use_secure_element) {
-        cfg->serverkey_buf = (unsigned char *)malloc(config->prvtkey_len);
-        if (!cfg->serverkey_buf) {
-            ESP_LOGE(TAG, "Could not allocate memory");
-            free((void *)cfg->servercert_buf);
-            free((void *)cfg->cacert_buf);
+        if (config->prvtkey_pem != NULL && config->prvtkey_len > 0) {
+            cfg->serverkey_buf = (unsigned char *) malloc(config->prvtkey_len);
+
+            if (cfg->serverkey_buf) {
+                memcpy((char *) cfg->serverkey_buf, config->prvtkey_pem, config->prvtkey_len);
+                cfg->serverkey_bytes = config->prvtkey_len;
+            } else {
+                ESP_LOGE(TAG, "Could not allocate memory for server key");
+                free((void *) cfg->servercert_buf);
+                free((void *) cfg->cacert_buf);
+                free(cfg);
+                free(ssl_ctx);
+                return NULL;
+            }
+        } else {
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+            if (config->sni_callback == NULL) {
+#endif
+            ESP_LOGE(TAG, "No Server key supplied");
+            free((void *) cfg->servercert_buf);
+            free((void *) cfg->cacert_buf);
             free(cfg);
             free(ssl_ctx);
             return NULL;
+#if defined(CONFIG_ESP_TLS_SERVER_SNI_HOOK)
+            } else {
+            ESP_LOGW(TAG, "Server key not supplied, make sure to supply it in the SNI hook!");
+            }
+#endif
         }
     }
-
-    memcpy((char *)cfg->serverkey_buf, config->prvtkey_pem, config->prvtkey_len);
-    cfg->serverkey_bytes = config->prvtkey_len;
 
     return ssl_ctx;
 }


### PR DESCRIPTION
This PR adds full server side SNI support.

- Server side SNI is only supported by mbedTLS.
- A new KConfig value has been introduced, it depends on mbedTLS being selected
- the sni callback and the supplied data can be used to select a certificate based on the incoming SNI header containing the host the client is looking for.
- pkey, cert, client verification ca bundle, authmode can also be selected: https://mbed-tls.readthedocs.io/en/latest/kb/how-to/use-sni/#server-side
- a TLS server can now be initialized WITHOUT a pkey and a certificate as long as SNI is enabled, and an SNI callback is set up. A warning will be issued that handshakes will fail unless the SNI callback sets up the pkey and cert to use for each handshake.
- Using this mechanism the server certificate and private key can be changed without restarting the server, allowing the certificate to be updated without reboots (certificate renewal for example)