### PR TITLE
NimBLE blufi inside custom application (IDFGH-8371)

### DIFF
--- a/components/bt/common/btc/profile/esp/blufi/include/esp_blufi.h
+++ b/components/bt/common/btc/profile/esp/blufi/include/esp_blufi.h
@@ -12,6 +12,7 @@
 
 #ifdef CONFIG_BT_NIMBLE_ENABLED
 #include "nimble/ble.h"
+#include "host/ble_gap.h"
 #include "modlog/modlog.h"
 #endif
 
@@ -80,5 +81,19 @@ void esp_blufi_adv_stop(void);
 void esp_blufi_adv_start(void);
 
 void esp_blufi_send_encap(void *arg);
+
+#ifdef CONFIG_BT_NIMBLE_ENABLED
+/**
+ * @brief Handle gap event for BluFi. 
+ *        This function can be called inside custom use gap event handler. 
+ *        It provide minimal event management for BluFi purpose.
+ * 
+ * @param[in] event The type of event being signalled.
+ * @param[in] arg Application-specified argument. Currently unused
+ * @return int 0 in case of success. 
+ *             Other in case of failure. 
+ */
+int esp_blufi_handle_gap_events(struct ble_gap_event *event, void *arg);
+#endif
 
 #endif/* _ESP_BLUFI_ */

--- a/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
+++ b/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
@@ -33,7 +33,6 @@
 #if (BLUFI_INCLUDED == TRUE)
 
 static uint8_t own_addr_type;
-static uint16_t  conn_handle;
 
 struct gatt_value gatt_values[SERVER_MAX_VALUES];
 const static char *TAG = "BLUFI_EXAMPLE";
@@ -265,7 +264,7 @@ esp_blufi_gap_event(struct ble_gap_event *event, void *arg)
 
             param.connect.conn_id = event->connect.conn_handle;
             /* save connection handle */
-            conn_handle = event->connect.conn_handle;
+            blufi_env.conn_id = event->connect.conn_handle;
             btc_transfer_context(&msg, &param, sizeof(esp_blufi_cb_param_t), NULL);
         }
         if (event->connect.status != 0) {
@@ -433,13 +432,13 @@ void esp_blufi_send_notify(void *arg)
     struct os_mbuf *om;
     om = ble_hs_mbuf_from_flat(pkts->pkt, pkts->pkt_len);
     int rc = 0;
-    rc = ble_gattc_notify_custom(conn_handle, gatt_values[1].val_handle, om);
+    rc = ble_gattc_notify_custom(blufi_env.conn_id, gatt_values[1].val_handle, om);
     assert(rc == 0);
 }
 
 void esp_blufi_disconnect(void)
 {
-    ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
+    ble_gap_terminate(blufi_env.conn_id, BLE_ERR_REM_USER_CONN_TERM);
 }
 
 void esp_blufi_adv_stop(void) {}

--- a/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
+++ b/components/bt/common/btc/profile/esp/blufi/nimble_host/esp_blufi.c
@@ -469,4 +469,72 @@ void esp_blufi_btc_deinit(void)
 {
     btc_deinit();
 }
+
+int esp_blufi_handle_gap_events(struct ble_gap_event *event, void *arg)
+{
+    struct ble_gap_conn_desc desc;
+    int rc;
+
+    if (event != NULL) {
+        switch (event->type) {
+        case BLE_GAP_EVENT_CONNECT:
+            if (event->connect.status == 0) {
+                btc_msg_t msg;
+                esp_blufi_cb_param_t param;
+
+                blufi_env.is_connected = true;
+                blufi_env.recv_seq = blufi_env.send_seq = 0;
+                blufi_env.conn_id                       = event->connect.conn_handle;
+
+                msg.sig = BTC_SIG_API_CB;
+                msg.pid = BTC_PID_BLUFI;
+                msg.act = ESP_BLUFI_EVENT_BLE_CONNECT;
+
+                rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+                assert(rc == 0);
+                memcpy(param.connect.remote_bda, desc.peer_id_addr.val, sizeof(esp_bd_addr_t));
+
+                param.connect.conn_id = event->connect.conn_handle;
+                btc_transfer_context(&msg, &param, sizeof(esp_blufi_cb_param_t), NULL);
+            }
+            return 0;
+        case BLE_GAP_EVENT_DISCONNECT: {
+            btc_msg_t msg;
+            esp_blufi_cb_param_t param;
+
+            blufi_env.is_connected = false;
+            blufi_env.recv_seq = blufi_env.send_seq = 0;
+            blufi_env.sec_mode                      = 0x0;
+            blufi_env.offset                        = 0;
+
+            memcpy(blufi_env.remote_bda,
+                   event->disconnect.conn.peer_id_addr.val,
+                   sizeof(esp_bd_addr_t));
+
+            if (blufi_env.aggr_buf != NULL) {
+                osi_free(blufi_env.aggr_buf);
+                blufi_env.aggr_buf = NULL;
+            }
+
+            msg.sig = BTC_SIG_API_CB;
+            msg.pid = BTC_PID_BLUFI;
+            msg.act = ESP_BLUFI_EVENT_BLE_DISCONNECT;
+            memcpy(param.disconnect.remote_bda,
+                   event->disconnect.conn.peer_id_addr.val,
+                   sizeof(esp_bd_addr_t));
+            btc_transfer_context(&msg, &param, sizeof(esp_blufi_cb_param_t), NULL);
+            return 0;
+        }
+
+        case BLE_GAP_EVENT_MTU:
+            blufi_env.frag_size = (event->mtu.value < BLUFI_MAX_DATA_LEN ? event->mtu.value :
+                                   BLUFI_MAX_DATA_LEN) -
+                                  BLUFI_MTU_RESERVED_SIZE;
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
 #endif


### PR DESCRIPTION
### Adding a function in order to be able to use BluFi with Nimble inside custom BLE application

- This PR remove `conn_handle` local variable inside esp_blufi.c for NimBLE Profile and replace it by `blufi_env.conn_id`.

- Introduce `int esp_blufi_handle_gap_events(struct ble_gap_event *event, void *arg);` in order to be able to use BluFi with custom user gap handler.

Usage : 

1. Configure BluFi by calling dedicated functions:
    - `esp_blufi_register_callbacks`
    - `esp_blufi_btc_init`
    - `esp_blufi_gatt_svr_init`
    - `esp_blufi_profile_init`

1. Configure your custom NimBLE Application

1. Simply add `esp_blufi_handle_gap_events` inside your custom gap event handler

For example :

```
int custom_application_gap_handler(struct ble_gap_event *event, void *arg)
{
    struct ble_gap_conn_desc desc;

    ((void)arg); // Unused parameter arg

    if (event == NULL) {
        ESP_LOGE(TAG, "NULL GAP event pointer!");
        return -1;
    }

    /* Handle gap events for BluFi */
    esp_blufi_handle_gap_events(event, arg);

    switch (event->type) {

    /* A new connection was established or a connection attempt failed. */
    case BLE_GAP_EVENT_CONNECT: {
        ESP_LOGI(TAG,
                 "Connection %s; status=%d ",
                 event->connect.status == 0 ? "established" : "failed",
                 event->connect.status);

        /* Connection success */
        if (event->connect.status == 0) {
            int rc;
            /* Get connection descriptor */
            if (ble_gap_conn_find(event->connect.conn_handle, &desc) == 0) {
                /* Printing connection descriptor */
                ble_server_internal_print_conn_desc(&desc);
            } else {
                ESP_LOGE(TAG, "Fail to get connection descriptor!");
            }

            /* Initiate gap security */
            rc = ble_gap_security_initiate(event->connect.conn_handle);
            if (rc == 0) {
                ESP_LOGI(TAG, "Successfully initiate gap security!");
            } else if (rc == BLE_HS_ENOTCONN) {
                ESP_LOGE(TAG, "There is no connection with the specified handle!");
            } else if (rc == BLE_HS_EALREADY) {
                ESP_LOGE(TAG, "A security procedure is already in progress!");
            } else {
                ESP_LOGE(TAG, "Fail to initiate gap security!");
            }
        }

        /* Connection failed */
        if (event->connect.status != 0) {
            /* Resume advertising */
            if (ble_server_internal_advertising_start() != ESP_OK) {
                ESP_LOGE(TAG, "Fail to enable advertising");
            }
        }
        break;
    }

    /* A disconnection event occur */
    case BLE_GAP_EVENT_DISCONNECT:
        ESP_LOGI(TAG, "Disconnect; reason=%d ", event->disconnect.reason);
        ble_server_internal_print_conn_desc(&event->disconnect.conn);

        /* Connection terminated, resume advertising. */
        if (ble_server_internal_advertising_start() != ESP_OK) {
            ESP_LOGE(TAG, "Fail to enable advertising");
        }

        break;

  /* Other events management */
 default:
 
        break;
    }
    return 0;
}
```

 