### PR TITLE
Fillter out the wps credential with unsupported band. (IDFGH-8370)

### DIFF
--- a/components/wpa_supplicant/src/wps/wps_enrollee.c
+++ b/components/wpa_supplicant/src/wps/wps_enrollee.c
@@ -672,6 +672,27 @@ static int wps_process_cred_e(struct wps_data *wps, const u8 *cred,
 		goto _out;
 	}
 
+	//Check RF Bands
+	if(attr->rf_bands!=NULL)
+	{
+		u8 rf_bands = *attr->rf_bands;
+		if((rf_bands & 0x01)==0) // 0x01(Bit0) means 2.4GHz
+		{
+			wpa_printf(MSG_INFO, "WPS: Reject Credential "
+				   "due to unsupported RF Bands.");
+			ret = -2;
+			goto _out;
+		}
+	}
+	//Check Channel
+	if(wps->cred.ap_channel>14)
+	{
+		wpa_printf(MSG_INFO, "WPS: Reject Credential "
+					"due to unsupported channel.");
+		ret = -2;
+		goto _out;
+	}
+
 	if (os_memcmp(wps->cred.mac_addr, wps->wps->dev.mac_addr, ETH_ALEN) !=
 	    0) {
 		wpa_printf(MSG_DEBUG,  "WPS: MAC Address in the Credential ("


### PR DESCRIPTION
#9726 
Some access point passes the 5GHz band credential in 2.4GHz wps procedure.
ESP32 can filter out the unnecessary credentials by the attribute of rf_bands or ap_channel.
But this way is not perfect, because rf_bands and ap_channel is optional attribute.
Although, this is helpful for application .
ESP32 won't have to try worthless 5GHz band credential. 