### PR TITLE
Fix AP stop sending beacon during WPS on STA in wifi concurrent mode.

### DIFF
--- a/components/wpa_supplicant/esp_supplicant/src/esp_wps.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_wps.c
@@ -1864,7 +1864,7 @@ wifi_wps_scan_done(void *arg, STATUS status)
             sm->ignore_sel_reg = true;
             sm->wps_pin_war = false;
         }
-        ets_timer_arm(&sm->wps_scan_timer, 100, 0);
+        ets_timer_arm(&sm->wps_scan_timer, 300, 0);
     } else {
         return;
     }
@@ -1874,13 +1874,34 @@ void
 wifi_wps_scan_internal(void)
 {
     struct wps_sm *sm = gWpsSm;
+    int ret;
+    wifi_country_t country;
+    u8 scan_channel = 0;
+
+    // check country channel
+    ret = esp_wifi_get_country(&country);
+    if (ESP_OK != ret) {
+        wpa_printf(MSG_ERROR, "wps check wifi country: failed to get wifi country ret=%d", ret);
+    }
+    else {
+        scan_channel = sm->scan_cnt % (country.schan + country.nchan - 1) + 1;
+        if (scan_channel < country.schan)
+        	scan_channel = country.schan;
+    }
 
     sm->scan_cnt++;
     wpa_printf(MSG_DEBUG, "wifi_wps_scan : %d", sm->scan_cnt);
 
     typedef void (* scan_done_cb_t)(void *arg, STATUS status);
     extern int esp_wifi_promiscuous_scan_start(wifi_scan_config_t *config, scan_done_cb_t cb);
-    esp_wifi_promiscuous_scan_start(NULL, wifi_wps_scan_done);
+    wifi_scan_config_t scan_config = {
+        .channel = scan_channel,
+        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+        .show_hidden = 1,
+        .scan_time.active.min = 10,
+        .scan_time.active.max = 100
+	};
+    esp_wifi_promiscuous_scan_start(&scan_config, wifi_wps_scan_done);
 }
 
 void wifi_wps_scan(void)


### PR DESCRIPTION

https://github.com/espressif/esp-idf/issues/9825

Connection of STA (PC etc.) joined to AP (ESP32) may be lost when the following steps.

1. Boot in AP+STA mode.
2. Join some STA (PC etc.) to AP (ESP32). 
3. Start to WPS on STA (ESP32).

Since the channel is switched when scanning with WPS, AP mode beacons may not be sent.
As a result, STAs (PC etc.) connected in AP (ESP32) are disconnected.

Instead of scanning all channels at once, to take interval on each channel scan and gives AP mode the time to send beacon.
