### PR TITLE
Make esp_app_desc a weak symbol (IDFGH-8433)

### DIFF
--- a/components/esp_app_format/esp_app_desc.c
+++ b/components/esp_app_format/esp_app_desc.c
@@ -12,7 +12,7 @@
 
 
 // Application version info
-const __attribute__((section(".rodata_desc"))) esp_app_desc_t esp_app_desc = {
+const __attribute__((weak)) __attribute__((section(".rodata_desc")))  esp_app_desc_t esp_app_desc = {
     .magic_word = ESP_APP_DESC_MAGIC_WORD,
 #ifdef CONFIG_APP_EXCLUDE_PROJECT_VER_VAR
     .version = "",


### PR DESCRIPTION
By doing so, the application will be able to define its own esp_app_desc generated at their discretion, with help of whatever build process they use, and removes the necessity to rebuild esp-idf every time only to have the esp_app_desc updated.

Removes the patch necessary for https://github.com/esp-rs/esp-idf-sys/pull/136, where we are building esp-idf and basically linking it as a static library. The process building the library doesn't have access to the real application version or the build time, since we are only rebuilding esp-idf if the sdkconfig changes.