### PR TITLE
Update #define BT_CONTROLLER_INIT_CONFIG_DEFAULT() (IDFGH-8441)

### DIFF
--- a/components/bt/include/esp32/include/esp_bt.h
+++ b/components/bt/include/esp32/include/esp_bt.h
@@ -186,7 +186,7 @@ the adv packet will be discarded until the memory is restored. */
 }
 
 #else
-#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use bt.h");
+#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use esp_bt.h");
 #endif
 
 /**

--- a/components/bt/include/esp32c3/include/esp_bt.h
+++ b/components/bt/include/esp32c3/include/esp_bt.h
@@ -184,7 +184,7 @@ typedef void (* esp_bt_hci_tl_callback_t) (void *arg, uint8_t status);
 }
 
 #else
-#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use bt.h");
+#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use esp_bt.h");
 #endif
 
 /**

--- a/components/bt/include/esp32s3/include/esp_bt.h
+++ b/components/bt/include/esp32s3/include/esp_bt.h
@@ -183,7 +183,7 @@ typedef void (* esp_bt_hci_tl_callback_t) (void *arg, uint8_t status);
 }
 
 #else
-#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use bt.h");
+#define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use esp_bt.h");
 #endif
 
 /**


### PR DESCRIPTION
Corrects header names in #define BT_CONTROLLER_INIT_CONFIG_DEFAULT() {0}; _Static_assert(0, "please enable bluetooth in menuconfig to use bt.h"); from "bt.h" to "esp_bt.h" for esp32, esp32c3, and esp32s3.