### PR TITLE
Fix vfs uart_end_select() for concurrent calls to select() (IDFGH-8455)

### DIFF
--- a/components/vfs/test/test_vfs_select.c
+++ b/components/vfs/test/test_vfs_select.c
@@ -532,6 +532,10 @@ TEST_CASE("concurrent selects work", "[vfs]")
         TEST_ASSERT(FD_ISSET(uart_fd, &rdfds2));
         TEST_ASSERT_UNLESS(FD_ISSET(socket_fd, &rdfds2));
         TEST_ASSERT_UNLESS(FD_ISSET(dummy_socket_fd, &rdfds2));
+        char recv_message[sizeof(message)];
+        int read_bytes = read(uart_fd, recv_message, sizeof(message));
+        TEST_ASSERT_EQUAL(read_bytes, sizeof(message));
+        TEST_ASSERT_EQUAL_MEMORY(message, recv_message, sizeof(message));
 
         TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(param.sem, 1000 / portTICK_PERIOD_MS));
         vSemaphoreDelete(param.sem);


### PR DESCRIPTION
There seems to be a bug in the function uart_end_select(). Let's assume that there is a task A, which waits for data on UART1 using select, and task B similarly waits for data on (same or other) UART. In theory, those selects should not interfere much with each other. But they unfortunately do. When one of the select finishes, the function uart_end_select() unregisters notification callback for all UARTs. This is done despite the fact, that there is still the other select() running and waiting for different UART.

The first two commits add a new sub-test to "concurrent selects work" test case. This checks for the issue mentioned above. This test will fail with current versions of esp-idf, because second task will not be notified.

The third commit fixes the issue, so the modified test will pass again. To be honest, I am not very satisfied with the look of my fix, because it loops through all combinations of UART and registered select. So any ideas on how to clean it up are very welcomed.