### PR TITLE
[Panic] add user configurable reboot delay in seconds (IDFGH-8506)

### DIFF
--- a/components/esp_system/Kconfig
+++ b/components/esp_system/Kconfig
@@ -48,6 +48,14 @@ menu "ESP System Settings"
                 Invoke gdbstub on the serial port, allowing for gdb to attach to it and to do a debug on runtime.
     endchoice
 
+    config ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS
+        int "Panic reboot delay (Seconds)"
+        default 0
+        depends on ESP_SYSTEM_PANIC_PRINT_REBOOT || ESP_SYSTEM_PANIC_SILENT_REBOOT
+        help
+            After the panic handler executes, you can specify a number of seconds to
+            wait before the device reboots.
+
     config ESP_SYSTEM_SINGLE_CORE_MODE
         bool
         default n

--- a/components/esp_system/panic.c
+++ b/components/esp_system/panic.c
@@ -379,6 +379,27 @@ void esp_panic_handler(panic_info_t *info)
     wdt_hal_write_protect_enable(&rtc_wdt_ctx);
 #if CONFIG_ESP_SYSTEM_PANIC_PRINT_REBOOT || CONFIG_ESP_SYSTEM_PANIC_SILENT_REBOOT
 
+#if CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS
+
+    disable_all_wdts();
+
+    panic_print_str("Waiting to reboot...\r\n");
+
+    for(int i = 0; i < CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS; i++) {
+
+        // Display a progress countdown.
+        // Only print every 5th second so users terminal is still "calm".
+        if (i % 5 == 0) {
+            panic_print_dec(CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS - i);
+            panic_print_str(" seconds...\r\n");
+        }
+
+        esp_rom_delay_us(1000000);
+    }
+
+    esp_panic_handler_reconfigure_wdts();
+#endif /* CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS */
+
     if (esp_reset_reason_get_hint() == ESP_RST_UNKNOWN) {
         switch (info->exception) {
         case PANIC_EXCEPTION_IWDT:


### PR DESCRIPTION
Issue: https://github.com/espressif/esp-idf/issues/9462

Adds a **CONFIG_ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS** option to the panic handler.

Very simple change & tested on a ESP32-S3, and ESP32-S2.

Why?
 - **"print & reboot"** is annoying. Boot loops log way too much, forever & ever. There's no time to look at the stack trace. I always need to unplug the device, and then scroll back and look for the point it crashed.
 - **"print & halt"** is not good for production or beta testing. A device that does not reboot is not useable.

This middle approach is the best of both, especially for beta testing, and is sorely needed! =)