### PR TITLE
[Console] more secondary output choices (IDFGH-8525)

### DIFF
--- a/components/app_trace/Kconfig
+++ b/components/app_trace/Kconfig
@@ -53,7 +53,7 @@ menu "Application Level Tracing"
             bool "USB_CDC"
             select APPTRACE_ENABLE
             select APPTRACE_DEST_UART
-            depends on !ESP_CONSOLE_USB_CDC && (IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3) && !USB_ENABLED
+            depends on !ESP_CONSOLE_IS_USB_CDC_ENABLED && SOC_USB_OTG_SUPPORTED && !USB_ENABLED
 
         config APPTRACE_DEST_UART_NONE
             bool "None"

--- a/components/bootloader_support/src/bootloader_console.c
+++ b/components/bootloader_support/src/bootloader_console.c
@@ -37,16 +37,22 @@
 #include "esp_rom_sys.h"
 #include "esp_rom_caps.h"
 
-#ifdef CONFIG_ESP_CONSOLE_NONE
-void bootloader_console_init(void)
+//
+// None
+//
+#if CONFIG_ESP_CONSOLE_IS_NONE_ENABLED
+void bootloader_console_init_none(void)
 {
     esp_rom_install_channel_putc(1, NULL);
     esp_rom_install_channel_putc(2, NULL);
 }
-#endif // CONFIG_ESP_CONSOLE_NONE
+#endif // CONFIG_ESP_CONSOLE_IS_NONE_ENABLED
 
-#ifdef CONFIG_ESP_CONSOLE_UART
-void bootloader_console_init(void)
+//
+// UART
+//
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
+void bootloader_console_init_uart(void)
 {
     const int uart_num = CONFIG_ESP_CONSOLE_UART_NUM;
 
@@ -90,13 +96,16 @@ void bootloader_console_init(void)
 #endif
     esp_rom_uart_set_clock_baudrate(uart_num, clock_hz, CONFIG_ESP_CONSOLE_UART_BAUDRATE);
 }
-#endif // CONFIG_ESP_CONSOLE_UART
+#endif // CONFIG_ESP_CONSOLE_IS_UART_ENABLED
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+//
+// Usb CDC
+//
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 /* Buffer for CDC data structures. No RX buffer allocated. */
 static char s_usb_cdc_buf[ESP_ROM_CDC_ACM_WORK_BUF_MIN];
 
-void bootloader_console_init(void)
+void bootloader_console_init_usb_cdc(void)
 {
 #ifdef CONFIG_IDF_TARGET_ESP32S2
     /* ESP32-S2 specific patch to set the correct serial number in the descriptor.
@@ -109,12 +118,34 @@ void bootloader_console_init(void)
     esp_rom_uart_set_as_console(ESP_ROM_UART_USB);
     esp_rom_install_channel_putc(1, bootloader_console_write_char_usb);
 }
-#endif //CONFIG_ESP_CONSOLE_USB_CDC
+#endif // CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 
-#ifdef CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
-void bootloader_console_init(void)
+//
+// Usb Serial/JTAG
+//
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
+void bootloader_console_init_usb_serial_jtag(void)
 {
     UartDevice *uart = GetUartDevice();
     uart->buff_uart_no = ESP_ROM_USB_SERIAL_DEVICE_NUM;
 }
-#endif //CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
+
+//
+// Init All
+//
+void bootloader_console_init(void)
+{
+#if CONFIG_ESP_CONSOLE_IS_NONE_ENABLED
+    bootloader_console_init_none();
+#endif
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
+    bootloader_console_init_uart();
+#endif
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
+    bootloader_console_init_usb_cdc();
+#endif
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
+    bootloader_console_init_usb_serial_jtag();
+#endif
+}

--- a/components/bootloader_support/src/bootloader_console_loader.c
+++ b/components/bootloader_support/src/bootloader_console_loader.c
@@ -26,7 +26,7 @@
 #include "esp32s3/rom/usb/usb_persist.h"
 #endif
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 /* The following functions replace esp_rom_uart_putc, esp_rom_uart_tx_one_char,
  * and uart_tx_one_char_uart ROM functions. The main difference is that
  * uart_tx_one_char_uart calls cdc_acm_fifo_fill for each byte passed to it,
@@ -61,16 +61,16 @@ void bootloader_console_write_char_usb(char c)
         bootloader_console_write_one_char_usb(c);
     }
 }
-#endif //CONFIG_ESP_CONSOLE_USB_CDC
+#endif // CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 
 void bootloader_console_deinit(void)
 {
-#ifdef CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
     /* Ensure any buffered log output is displayed */
     esp_rom_uart_flush_tx(CONFIG_ESP_CONSOLE_UART_NUM);
-#endif // CONFIG_ESP_CONSOLE_UART
+#endif // CONFIG_ESP_CONSOLE_IS_UART_ENABLED
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
     bootloader_console_flush_usb();
     usb_dc_prepare_persist();
     chip_usb_set_persist_flags(USBDC_PERSIST_ENA);
@@ -79,5 +79,5 @@ void bootloader_console_deinit(void)
         usb_dc_check_poll_for_interrupts();
     }
     esp_rom_install_channel_putc(1, NULL);
-#endif
+#endif // CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 }

--- a/components/console/esp_console.h
+++ b/components/console/esp_console.h
@@ -76,7 +76,7 @@ typedef struct {
     int rx_gpio_num; //!< GPIO number for RX path, -1 means using default one
 } esp_console_dev_uart_config_t;
 
-#ifdef CONFIG_ESP_CONSOLE_UART_CUSTOM
+#if CONFIG_ESP_CONSOLE_UART_CUSTOM || CONFIG_ESP_CONSOLE_SECONDARY_UART_CUSTOM
 #define ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT()       \
 {                                                   \
     .channel = CONFIG_ESP_CONSOLE_UART_NUM,         \
@@ -108,7 +108,7 @@ typedef struct {
 {                                            \
 }
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 /**
  * @brief Parameters for console device: USB-SERIAL-JTAG
  *
@@ -121,7 +121,7 @@ typedef struct {
 
 #define ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT() {}
 
-#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 
 /**
  * @brief initialize console module
@@ -348,7 +348,7 @@ esp_err_t esp_console_new_repl_uart(const esp_console_dev_uart_config_t *dev_con
  */
 esp_err_t esp_console_new_repl_usb_cdc(const esp_console_dev_usb_cdc_config_t *dev_config, const esp_console_repl_config_t *repl_config, esp_console_repl_t **ret_repl);
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 /**
  * @brief Establish a console REPL (Read-eval-print loop) environment over USB-SERIAL-JTAG
  *
@@ -369,7 +369,7 @@ esp_err_t esp_console_new_repl_usb_cdc(const esp_console_dev_usb_cdc_config_t *d
  *      - ESP_FAIL Parameter error
  */
 esp_err_t esp_console_new_repl_usb_serial_jtag(const esp_console_dev_usb_serial_jtag_config_t *dev_config, const esp_console_repl_config_t *repl_config, esp_console_repl_t **ret_repl);
-#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 
 /**
  * @brief Start REPL environment

--- a/components/console/esp_console_repl.c
+++ b/components/console/esp_console_repl.c
@@ -49,9 +49,9 @@ typedef struct {
 static void esp_console_repl_task(void *args);
 static esp_err_t esp_console_repl_uart_delete(esp_console_repl_t *repl);
 static esp_err_t esp_console_repl_usb_cdc_delete(esp_console_repl_t *repl);
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 static esp_err_t esp_console_repl_usb_serial_jtag_delete(esp_console_repl_t *repl);
-#endif //CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 static esp_err_t esp_console_common_init(size_t max_cmdline_length, esp_console_repl_com_t *repl_com);
 static esp_err_t esp_console_setup_prompt(const char *prompt, esp_console_repl_com_t *repl_com);
 static esp_err_t esp_console_setup_history(const char *history_path, uint32_t max_history_len, esp_console_repl_com_t *repl_com);
@@ -120,7 +120,7 @@ _exit:
     return ret;
 }
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 esp_err_t esp_console_new_repl_usb_serial_jtag(const esp_console_dev_usb_serial_jtag_config_t *dev_config, const esp_console_repl_config_t *repl_config, esp_console_repl_t **ret_repl)
 {
     esp_console_repl_universal_t *usb_serial_jtag_repl = NULL;
@@ -198,7 +198,7 @@ _exit:
     }
     return ret;
 }
-#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 
 esp_err_t esp_console_new_repl_uart(const esp_console_dev_uart_config_t *dev_config, const esp_console_repl_config_t *repl_config, esp_console_repl_t **ret_repl)
 {
@@ -442,7 +442,7 @@ _exit:
     return ret;
 }
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 static esp_err_t esp_console_repl_usb_serial_jtag_delete(esp_console_repl_t *repl)
 {
     esp_err_t ret = ESP_OK;
@@ -462,7 +462,7 @@ static esp_err_t esp_console_repl_usb_serial_jtag_delete(esp_console_repl_t *rep
 _exit:
     return ret;
 }
-#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 
 static void esp_console_repl_task(void *args)
 {

--- a/components/esp_gdbstub/esp32c3/gdbstub_esp32c3.c
+++ b/components/esp_gdbstub/esp32c3/gdbstub_esp32c3.c
@@ -55,6 +55,7 @@ void esp_gdbstub_target_init()
 {
 }
 
+// Note: we only interact with the primary console
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
 
 int esp_gdbstub_getchar()

--- a/components/esp_gdbstub/esp32c6/gdbstub_esp32c6.c
+++ b/components/esp_gdbstub/esp32c6/gdbstub_esp32c6.c
@@ -55,6 +55,7 @@ void esp_gdbstub_target_init()
 {
 }
 
+// Note: we only interact with the primary console
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
 
 int esp_gdbstub_getchar()

--- a/components/esp_gdbstub/esp32h2/gdbstub_esp32h2.c
+++ b/components/esp_gdbstub/esp32h2/gdbstub_esp32h2.c
@@ -54,6 +54,7 @@ void esp_gdbstub_target_init()
 {
 }
 
+// Note: we only interact with the primary console
 #if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
 
 int esp_gdbstub_getchar()

--- a/components/esp_pm/pm_impl.c
+++ b/components/esp_pm/pm_impl.c
@@ -729,6 +729,7 @@ int esp_pm_impl_get_cpu_freq(pm_mode_t mode)
 
 void esp_pm_impl_init(void)
 {
+// Note: we only interact with the primary console
 #if defined(CONFIG_ESP_CONSOLE_UART)
     //This clock source should be a source which won't be affected by DFS
     uart_sclk_t clk_source = UART_SCLK_DEFAULT;

--- a/components/esp_system/Kconfig
+++ b/components/esp_system/Kconfig
@@ -220,49 +220,92 @@ menu "ESP System Settings"
             - On chips with an USB serial/JTAG debug controller, selecting the option
               for that redirects output to the CDC/ACM (serial port emulation) component
               of that device.
+
         config ESP_CONSOLE_UART_DEFAULT
             bool "Default: UART0"
+
         config ESP_CONSOLE_USB_CDC
             bool "USB CDC"
             # && !TINY_USB is because the ROM CDC driver is currently incompatible with TinyUSB.
-            depends on (IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3)  && !TINY_USB
+            depends on SOC_USB_OTG_SUPPORTED  && !TINY_USB
+
         config ESP_CONSOLE_USB_SERIAL_JTAG
             bool "USB Serial/JTAG Controller"
             select ESPTOOLPY_NO_STUB if IDF_TARGET_ESP32C3  #ESPTOOL-252
-            depends on IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3
+            depends on SOC_USB_SERIAL_JTAG_SUPPORTED
+
         config ESP_CONSOLE_UART_CUSTOM
             bool "Custom UART"
+
         config ESP_CONSOLE_NONE
             bool "None"
     endchoice
 
     choice ESP_CONSOLE_SECONDARY
-        depends on IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32C3
-        prompt "Channel for console secondary output"
-        default ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+        prompt "Channel for console secondary output" if !ESP_CONSOLE_NONE
+        default ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG if SOC_USB_SERIAL_JTAG_SUPPORTED
+        default ESP_CONSOLE_SECONDARY_NONE
         help
-            This secondary option supports output through other specific port like USB_SERIAL_JTAG
-            when UART0 port as a primary is selected but not connected. This secondary output currently only supports
-            non-blocking mode without using REPL. If you want to output in blocking mode with REPL or
-            input through this secondary port, please change the primary config to this port
-            in `Channel for console output` menu.
+            This secondary output currently only supports non-blocking mode without using REPL. 
+            If you want to output in blocking mode with REPL or input through this secondary port, 
+            please change the primary config to this port in `Channel for console output` menu.
+
         config ESP_CONSOLE_SECONDARY_NONE
             bool "No secondary console"
+
+        config ESP_CONSOLE_SECONDARY_UART_DEFAULT
+            bool "Default: UART0"
+            depends on !ESP_CONSOLE_UART_DEFAULT && !ESP_CONSOLE_UART_CUSTOM
+
+        config ESP_CONSOLE_SECONDARY_USB_CDC
+            bool "USB CDC"
+            depends on SOC_USB_OTG_SUPPORTED && !ESP_CONSOLE_USB_CDC && !TINY_USB
+
         config ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
-            bool "USB_SERIAL_JTAG PORT"
-            depends on !ESP_CONSOLE_USB_SERIAL_JTAG
-            help
-                This option supports output through USB_SERIAL_JTAG port when the UART0 port is not connected.
-                The output currently only supports non-blocking mode without using the console.
-                If you want to output in blocking mode with REPL or input through USB_SERIAL_JTAG port,
-                please change the primary config to ESP_CONSOLE_USB_SERIAL_JTAG above.
+            bool "USB Serial/JTAG Controller"
+            depends on SOC_USB_SERIAL_JTAG_SUPPORTED && !ESP_CONSOLE_USB_SERIAL_JTAG
+        
+        config ESP_CONSOLE_SECONDARY_UART_CUSTOM
+            bool "Custom UART"
+            depends on !ESP_CONSOLE_UART_DEFAULT && !ESP_CONSOLE_UART_CUSTOM
     endchoice
 
-
     config ESP_CONSOLE_UART
-        # Internal option, indicates that console UART is used (and not USB, for example)
+        # Internal option, if primary uart is enabled
         bool
         default y if ESP_CONSOLE_UART_DEFAULT || ESP_CONSOLE_UART_CUSTOM
+
+    config ESP_CONSOLE_SECONDARY_UART
+        # Internal option, if secondary uart is enabled
+        bool
+        default y if ESP_CONSOLE_SECONDARY_UART_DEFAULT || ESP_CONSOLE_SECONDARY_UART_CUSTOM
+
+    config ESP_CONSOLE_IS_UART_ENABLED
+        # Internal option, indicates that either the primary or secondary
+        # Uart Console is enabled
+        bool
+        default y if ESP_CONSOLE_UART_DEFAULT || ESP_CONSOLE_UART_CUSTOM
+        default y if ESP_CONSOLE_SECONDARY_UART_DEFAULT || ESP_CONSOLE_SECONDARY_UART_CUSTOM
+
+    config ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
+        # Internal option, indicates that either the primary or secondary
+        # Usb Serial/JTAG Console is enabled
+        bool
+        default y if ESP_CONSOLE_USB_SERIAL_JTAG 
+        default y if ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+
+    config ESP_CONSOLE_IS_USB_CDC_ENABLED
+        # Internal option, indicates that either the primary or secondary
+        # USB CDC Console is enabled
+        bool
+        default y if ESP_CONSOLE_USB_CDC
+        default y if ESP_CONSOLE_SECONDARY_USB_CDC
+
+    config ESP_CONSOLE_IS_NONE_ENABLED
+        # Internal option, indicates that neither 
+        # the primary nor secondary are enabled
+        bool
+        default y if ESP_CONSOLE_NONE && ESP_CONSOLE_SECONDARY_NONE
 
     config ESP_CONSOLE_MULTIPLE_UART
         bool
@@ -270,7 +313,7 @@ menu "ESP System Settings"
 
     choice ESP_CONSOLE_UART_NUM
         prompt "UART peripheral to use for console output (0-1)"
-        depends on ESP_CONSOLE_UART_CUSTOM && ESP_CONSOLE_MULTIPLE_UART
+        depends on (ESP_CONSOLE_UART_CUSTOM || ESP_CONSOLE_SECONDARY_UART_CUSTOM) && ESP_CONSOLE_MULTIPLE_UART
         default ESP_CONSOLE_UART_CUSTOM_NUM_0
         help
             This UART peripheral is used for console output from the ESP-IDF Bootloader and the app.
@@ -289,7 +332,7 @@ menu "ESP System Settings"
 
     config ESP_CONSOLE_UART_NUM
         int
-        default 0 if ESP_CONSOLE_UART_DEFAULT
+        default 0 if ESP_CONSOLE_UART_DEFAULT || ESP_CONSOLE_SECONDARY_UART_DEFAULT
         default 0 if !ESP_CONSOLE_MULTIPLE_UART
         default 0 if ESP_CONSOLE_UART_CUSTOM_NUM_0
         default 1 if ESP_CONSOLE_UART_CUSTOM_NUM_1
@@ -313,7 +356,7 @@ menu "ESP System Settings"
 
     config ESP_CONSOLE_UART_RX_GPIO
         int "UART RX on GPIO#"
-        depends on ESP_CONSOLE_UART_CUSTOM
+        depends on ESP_CONSOLE_UART_CUSTOM || ESP_CONSOLE_SECONDARY_UART_CUSTOM
         range 0 46
         default 3 if IDF_TARGET_ESP32
         default 19 if IDF_TARGET_ESP32C2
@@ -332,8 +375,7 @@ menu "ESP System Settings"
 
     config ESP_CONSOLE_UART_BAUDRATE
         int
-        prompt "UART console baud rate" if ESP_CONSOLE_UART_CUSTOM
-        depends on ESP_CONSOLE_UART
+        prompt "UART console baud rate" if ESP_CONSOLE_UART_CUSTOM || ESP_CONSOLE_SECONDARY_UART_CUSTOM
         default 74880 if (IDF_TARGET_ESP32C2 && XTAL_FREQ_26)
         default 115200
         range 1200 4000000 if !PM_ENABLE
@@ -353,7 +395,7 @@ menu "ESP System Settings"
 
     config ESP_CONSOLE_USB_CDC_RX_BUF_SIZE
         int "Size of USB CDC RX buffer"
-        depends on ESP_CONSOLE_USB_CDC
+        depends on ESP_CONSOLE_IS_USB_CDC_ENABLED
         default 64
         range 4 16384
         help
@@ -362,7 +404,7 @@ menu "ESP System Settings"
 
     config ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
         bool "Enable esp_rom_printf / ESP_EARLY_LOG via USB CDC"
-        depends on ESP_CONSOLE_USB_CDC
+        depends on ESP_CONSOLE_IS_USB_CDC_ENABLED
         default n
         help
             If enabled, esp_rom_printf and ESP_EARLY_LOG output will also be sent over USB CDC.

--- a/components/esp_system/include/esp_private/usb_console.h
+++ b/components/esp_system/include/esp_private/usb_console.h
@@ -58,6 +58,8 @@ ssize_t esp_usb_console_available_for_read(void);
 
 bool esp_usb_console_write_available(void);
 
+bool esp_usb_console_read_available(void);
+
 esp_err_t esp_usb_console_set_cb(esp_usb_console_cb_t rx_cb, esp_usb_console_cb_t tx_cb, void* arg);
 
 #ifdef __cplusplus

--- a/components/esp_system/panic.c
+++ b/components/esp_system/panic.c
@@ -55,7 +55,7 @@
 #include "esp_gdbstub.h"
 #endif
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG || CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 #include "hal/usb_serial_jtag_ll.h"
 #endif
 
@@ -70,7 +70,7 @@ static wdt_hal_context_t rtc_wdt_ctx = {.inst = WDT_RWDT, .rwdt_dev = &RTCCNTL};
 
 #if !CONFIG_ESP_SYSTEM_PANIC_SILENT_REBOOT
 
-#if CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
 static uart_hal_context_t s_panic_uart = { .dev = CONFIG_ESP_CONSOLE_UART_NUM == 0 ? &UART0 :&UART1 };
 
 static void panic_print_char_uart(const char c)
@@ -79,18 +79,18 @@ static void panic_print_char_uart(const char c)
     while (!uart_hal_get_txfifo_len(&s_panic_uart));
     uart_hal_write_txfifo(&s_panic_uart, (uint8_t *) &c, 1, &sz);
 }
-#endif // CONFIG_ESP_CONSOLE_UART
+#endif // CONFIG_ESP_CONSOLE_IS_UART_ENABLED
 
 
-#if CONFIG_ESP_CONSOLE_USB_CDC
-static void panic_print_char_usb_cdc(const char c)
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
+void panic_print_char_usb_cdc(const char c)
 {
     esp_usb_console_write_buf(&c, 1);
     /* result ignored */
 }
-#endif // CONFIG_ESP_CONSOLE_USB_CDC
+#endif // CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
 
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG || CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 //Timeout; if there's no host listening, the txfifo won't ever
 //be writable after the first packet.
 
@@ -108,18 +108,17 @@ static void panic_print_char_usb_serial_jtag(const char c)
         s_usbserial_timeout = 0;
     }
 }
-#endif //CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG || CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
-
+#endif // CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
 
 void panic_print_char(const char c)
 {
-#if CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
     panic_print_char_uart(c);
 #endif
-#if CONFIG_ESP_CONSOLE_USB_CDC
+#if CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED
     panic_print_char_usb_cdc(c);
 #endif
-#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG || CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+#if CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED
     panic_print_char_usb_serial_jtag(c);
 #endif
 }
@@ -177,7 +176,7 @@ void esp_panic_handler_reconfigure_wdts(void)
 {
     wdt_hal_context_t wdt0_context = {.inst = WDT_MWDT0, .mwdt_dev = &TIMERG0};
 #if SOC_TIMER_GROUPS >= 2
-	// IDF-3825
+    // IDF-3825
     wdt_hal_context_t wdt1_context = {.inst = WDT_MWDT1, .mwdt_dev = &TIMERG1};
 #endif
 

--- a/components/esp_system/port/cpu_start.c
+++ b/components/esp_system/port/cpu_start.c
@@ -150,10 +150,10 @@ void IRAM_ATTR call_start_cpu1(void)
 
     bootloader_init_mem();
 
-#if CONFIG_ESP_CONSOLE_NONE
+#if CONFIG_ESP_CONSOLE_IS_NONE_ENABLED
     esp_rom_install_channel_putc(1, NULL);
     esp_rom_install_channel_putc(2, NULL);
-#else // CONFIG_ESP_CONSOLE_NONE
+#else // CONFIG_ESP_CONSOLE_IS_NONE_ENABLED
     esp_rom_install_uart_printf();
     esp_rom_uart_set_as_console(CONFIG_ESP_CONSOLE_UART_NUM);
 #endif
@@ -517,7 +517,7 @@ void IRAM_ATTR call_start_cpu0(void)
     core_intr_matrix_clear();
 
 #ifndef CONFIG_IDF_ENV_FPGA // TODO: on FPGA it should be possible to configure this, not currently working with APB_CLK_FREQ changed
-#ifdef CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_IS_UART_ENABLED
     uint32_t clock_hz = esp_clk_apb_freq();
 #if ESP_ROM_UART_CLK_IS_XTAL
     clock_hz = esp_clk_xtal_freq(); // From esp32-s3 on, UART clock source is selected to XTAL in ROM

--- a/components/esp_system/port/soc/esp32s2/CMakeLists.txt
+++ b/components/esp_system/port/soc/esp32s2/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 add_prefix(srcs "${CMAKE_CURRENT_LIST_DIR}/" ${srcs})
 
 target_sources(${COMPONENT_LIB} PRIVATE ${srcs})
-if(CONFIG_ESP_CONSOLE_USB_CDC)
+if(CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED)
     target_sources(${COMPONENT_LIB} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/usb_console.c")
 endif()
 

--- a/components/esp_system/port/soc/esp32s2/usb_console.c
+++ b/components/esp_system/port/soc/esp32s2/usb_console.c
@@ -60,7 +60,7 @@ static esp_timer_handle_t s_restart_timer;
 
 static const char* TAG = "usb_console";
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
 static portMUX_TYPE s_write_lock = portMUX_INITIALIZER_UNLOCKED;
 void esp_usb_console_write_char(char c);
 #define ISR_FLAG  ESP_INTR_FLAG_IRAM
@@ -286,7 +286,7 @@ esp_err_t esp_usb_console_init(void)
     /* Enable the interrupt handler */
     esp_intr_enable(s_usb_int_handle);
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
     /* Install esp_rom_printf handler */
     ets_install_putc1(&esp_usb_console_write_char);
 #endif // CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
@@ -431,7 +431,7 @@ bool esp_usb_console_write_available(void)
 }
 
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
 /* Used as an output function by esp_rom_printf.
  * The LF->CRLF replacement logic replicates the one in esp_rom_uart_putc.
  * Not static to allow placement into IRAM by ldgen.

--- a/components/esp_system/port/soc/esp32s3/CMakeLists.txt
+++ b/components/esp_system/port/soc/esp32s3/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 add_prefix(srcs "${CMAKE_CURRENT_LIST_DIR}/" ${srcs})
 
 target_sources(${COMPONENT_LIB} PRIVATE ${srcs})
-if(CONFIG_ESP_CONSOLE_USB_CDC)
+if(CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED)
     target_sources(${COMPONENT_LIB} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/usb_console.c")
 endif()
 

--- a/components/esp_system/port/soc/esp32s3/usb_console.c
+++ b/components/esp_system/port/soc/esp32s3/usb_console.c
@@ -52,7 +52,7 @@ static esp_usb_console_cb_t s_rx_cb;
 static esp_usb_console_cb_t s_tx_cb;
 static void *s_cb_arg;
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
 static portMUX_TYPE s_write_lock = portMUX_INITIALIZER_UNLOCKED;
 void esp_usb_console_write_char(char c);
 #define ISR_FLAG  ESP_INTR_FLAG_IRAM
@@ -249,7 +249,7 @@ esp_err_t esp_usb_console_init(void)
     /* Enable the interrupt handler */
     esp_intr_enable(s_usb_int_handle);
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
     /* Install esp_rom_printf handler */
     ets_install_putc1(&esp_usb_console_write_char);
 #endif // CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
@@ -379,7 +379,7 @@ bool esp_usb_console_write_available(void)
 }
 
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
+#if CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF
 /* Used as an output function by esp_rom_printf.
  * The LF->CRLF replacement logic replicates the one in esp_rom_uart_putc.
  * Not static to allow placement into IRAM by ldgen.

--- a/components/esp_system/startup.c
+++ b/components/esp_system/startup.c
@@ -301,7 +301,7 @@ static void do_core_init(void)
     assert(vfs_err == ESP_OK && "Failed to register vfs console");
 #endif
 
-#if defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_NONE)
+#if defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_IS_NONE_ENABLED)
     const static char *default_stdio_dev = "/dev/console/";
     esp_reent_init(_GLOBAL_REENT);
     _GLOBAL_REENT->_stdin  = fopen(default_stdio_dev, "r");
@@ -321,9 +321,9 @@ static void do_core_init(void)
     __swsetup_r(_GLOBAL_REENT, _GLOBAL_REENT->_stderr);
     __swsetup_r(_GLOBAL_REENT, _GLOBAL_REENT->_stdin);
 #endif // ESP_ROM_NEEDS_SWSETUP_WORKAROUND
-#else // defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_NONE)
+#else // defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_IS_NONE_ENABLED)
     _REENT_SMALL_CHECK_INIT(_GLOBAL_REENT);
-#endif // defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_NONE)
+#endif // defined(CONFIG_VFS_SUPPORT_IO) && !defined(CONFIG_ESP_CONSOLE_IS_NONE_ENABLED)
 
     esp_err_t err __attribute__((unused));
 

--- a/components/vfs/CMakeLists.txt
+++ b/components/vfs/CMakeLists.txt
@@ -12,11 +12,11 @@ idf_component_register(SRCS ${sources}
                        PRIV_INCLUDE_DIRS private_include
                        PRIV_REQUIRES ${pr})
 
-if(CONFIG_ESP_CONSOLE_USB_CDC)
+if(CONFIG_ESP_CONSOLE_IS_USB_CDC_ENABLED)
     target_sources(${COMPONENT_LIB} PRIVATE "vfs_cdcacm.c")
 endif()
 
-if(CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG OR CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+if(CONFIG_ESP_CONSOLE_IS_USB_SERIAL_JTAG_ENABLED)
     target_sources(${COMPONENT_LIB} PRIVATE "vfs_usb_serial_jtag.c")
 endif()
 

--- a/components/vfs/vfs_console.c
+++ b/components/vfs/vfs_console.c
@@ -31,7 +31,7 @@ typedef struct {
 
 #if CONFIG_VFS_SUPPORT_IO
 // Primary register part.
-#ifdef CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_UART
 const static char *primary_path = "/dev/uart";
 #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
 const static char *primary_path = "/dev/usbserjtag";
@@ -40,7 +40,9 @@ const static char *primary_path = "/dev/cdcacm";
 #endif
 
 // Secondary register part.
-#if CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+#if (CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG || \
+     CONFIG_ESP_CONSOLE_SECONDARY_UART || \
+     CONFIG_ESP_CONSOLE_SECONDARY_USB_CDC)
 const static char *secondary_path = "/dev/secondary";
 static int secondary_vfs_index;
 #endif // Secondary part
@@ -63,6 +65,10 @@ int console_open(const char * path, int flags, int mode)
 // Secondary port open
 #if CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
     vfs_console.fd_secondary = get_vfs_for_path(secondary_path)->vfs.open("/", flags, mode);
+#elif CONFIG_ESP_CONSOLE_SECONDARY_UART
+    vfs_console.fd_secondary = get_vfs_for_path(secondary_path)->vfs.open("/"STRINGIFY(CONFIG_ESP_CONSOLE_UART_NUM), flags, mode);
+#elif CONFIG_ESP_CONSOLE_SECONDARY_USB_CDC
+    vfs_console.fd_secondary = get_vfs_for_path(secondary_path)->vfs.open("/", flags, mode);
 #endif
     return 0;
 }
@@ -71,7 +77,9 @@ ssize_t console_write(int fd, const void *data, size_t size)
 {
     // All function calls are to primary, except from write and close, which will be forwarded to both primary and secondary.
     get_vfs_for_index(primary_vfs_index)->vfs.write(vfs_console.fd_primary, data, size);
-#if CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
+#if (CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG || \
+     CONFIG_ESP_CONSOLE_SECONDARY_UART || \
+     CONFIG_ESP_CONSOLE_SECONDARY_USB_CDC)
     get_vfs_for_index(secondary_vfs_index)->vfs.write(vfs_console.fd_secondary, data, size);
 #endif
     return size;
@@ -185,7 +193,7 @@ esp_err_t esp_vfs_console_register(void)
 {
     esp_err_t err = ESP_OK;
 // Primary register part.
-#ifdef CONFIG_ESP_CONSOLE_UART
+#if CONFIG_ESP_CONSOLE_UART
     const esp_vfs_t *uart_vfs = esp_vfs_uart_get_vfs();
     err = esp_vfs_register_common(primary_path, strlen(primary_path), uart_vfs, NULL, &primary_vfs_index);
 #elif CONFIG_ESP_CONSOLE_USB_CDC
@@ -207,6 +215,18 @@ esp_err_t esp_vfs_console_register(void)
 #if CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG
     const esp_vfs_t *usb_serial_jtag_vfs = esp_vfs_usb_serial_jtag_get_vfs();
     err = esp_vfs_register_common(secondary_path, strlen(secondary_path), usb_serial_jtag_vfs, NULL, &secondary_vfs_index);
+    if(err != ESP_OK) {
+        return err;
+    }
+#elif CONFIG_ESP_CONSOLE_SECONDARY_UART
+    const esp_vfs_t *uart_vfs = esp_vfs_uart_get_vfs();
+    err = esp_vfs_register_common(secondary_path, strlen(secondary_path), uart_vfs, NULL, &secondary_vfs_index);
+    if(err != ESP_OK) {
+        return err;
+    }
+#elif CONFIG_ESP_CONSOLE_SECONDARY_USB_CDC
+    const esp_vfs_t *cdcacm_vfs = esp_vfs_cdcacm_get_vfs();
+    err = esp_vfs_register_common(secondary_path, strlen(secondary_path), cdcacm_vfs, NULL, &secondary_vfs_index);
     if(err != ESP_OK) {
         return err;
     }

--- a/examples/system/console/advanced/main/console_example_main.c
+++ b/examples/system/console/advanced/main/console_example_main.c
@@ -23,7 +23,7 @@
 #include "cmd_wifi.h"
 #include "cmd_nvs.h"
 
-#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+#if CONFIG_ESP_CONSOLE_USB_CDC
 #error This example is incompatible with USB CDC console. Please try "console_usb" example instead.
 #endif // CONFIG_ESP_CONSOLE_USB_CDC
 


### PR DESCRIPTION
Related Issue: https://github.com/espressif/esp-idf/issues/9877

**2 commits:**
- [[Panic] also print to secondary USB Serial/JTAG Console](https://github.com/espressif/esp-idf/pull/9979/commits/70b94b1fb4fe18441f378de2c5eb85f400ac37da)
- [[Console] more secondary output choices](https://github.com/espressif/esp-idf/pull/9979/commits/39e1d5a5490b9847c9dd7ce7de76b4b05973969a)

## panic.c - Separate PR: https://github.com/espressif/esp-idf/pull/10027
 log to the secondary console as well

## Kconfig
Add `UART` and `USB CDC` "Seconday Console" options to **kConfig** & implement.

>     choice ESP_CONSOLE_SECONDARY
> 
>         config ESP_CONSOLE_SECONDARY_UART_DEFAULT
>             bool "UART"
>             depends on ! ESP_CONSOLE_UART_DEFAULT && ! ESP_CONSOLE_UART_CUSTOM
> 
>         config ESP_CONSOLE_SECONDARY_USB_CDC
>             bool "USB CDC"
>             depends on ! ESP_CONSOLE_USB_CDC

Just like before, it is only shown if it is not the primary console.

Tested on an ESP32-S3.
