### PR TITLE
[Linenoise 2] multi-console support & support for replacing stdin/stdout (IDFGH-8546)

### DIFF
--- a/components/console/commands.c
+++ b/components/console/commands.c
@@ -42,9 +42,6 @@ static SLIST_HEAD(cmd_list_, cmd_item_) s_cmd_list;
 /** run-time configuration options */
 static esp_console_config_t s_config;
 
-/** temporary buffer used for command line parsing */
-static char *s_tmp_line_buf;
-
 static const cmd_item_t *find_command_by_name(const char *name);
 
 esp_err_t esp_console_init(const esp_console_config_t *config)
@@ -52,27 +49,15 @@ esp_err_t esp_console_init(const esp_console_config_t *config)
     if (!config) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (s_tmp_line_buf) {
-        return ESP_ERR_INVALID_STATE;
-    }
     memcpy(&s_config, config, sizeof(s_config));
     if (s_config.hint_color == 0) {
         s_config.hint_color = ANSI_COLOR_DEFAULT;
-    }
-    s_tmp_line_buf = calloc(config->max_cmdline_length, 1);
-    if (s_tmp_line_buf == NULL) {
-        return ESP_ERR_NO_MEM;
     }
     return ESP_OK;
 }
 
 esp_err_t esp_console_deinit(void)
 {
-    if (!s_tmp_line_buf) {
-        return ESP_ERR_INVALID_STATE;
-    }
-    free(s_tmp_line_buf);
-    s_tmp_line_buf = NULL;
     cmd_item_t *it, *tmp;
     SLIST_FOREACH_SAFE(it, &s_cmd_list, next, tmp) {
         SLIST_REMOVE(&s_cmd_list, it, cmd_item_, next);
@@ -184,27 +169,32 @@ static const cmd_item_t *find_command_by_name(const char *name)
 
 esp_err_t esp_console_run(const char *cmdline, int *cmd_ret)
 {
-    if (s_tmp_line_buf == NULL) {
-        return ESP_ERR_INVALID_STATE;
+    char* tmp_line_buf = calloc(s_config.max_cmdline_length, 1);
+    if (tmp_line_buf == NULL) {
+        return ESP_ERR_NO_MEM;
     }
     char **argv = (char **) calloc(s_config.max_cmdline_args, sizeof(char *));
     if (argv == NULL) {
+        free(tmp_line_buf);
         return ESP_ERR_NO_MEM;
     }
-    strlcpy(s_tmp_line_buf, cmdline, s_config.max_cmdline_length);
+    strlcpy(tmp_line_buf, cmdline, s_config.max_cmdline_length);
 
-    size_t argc = esp_console_split_argv(s_tmp_line_buf, argv,
+    size_t argc = esp_console_split_argv(tmp_line_buf, argv,
                                          s_config.max_cmdline_args);
     if (argc == 0) {
+        free(tmp_line_buf);
         free(argv);
         return ESP_ERR_INVALID_ARG;
     }
     const cmd_item_t *cmd = find_command_by_name(argv[0]);
     if (cmd == NULL) {
+        free(tmp_line_buf);
         free(argv);
         return ESP_ERR_NOT_FOUND;
     }
     *cmd_ret = (*cmd->func)(argc, argv);
+    free(tmp_line_buf);
     free(argv);
     return ESP_OK;
 }

--- a/components/console/linenoise/linenoise.h
+++ b/components/console/linenoise/linenoise.h
@@ -51,6 +51,11 @@ typedef struct linenoiseCompletions {
   char **cvec;
 } linenoiseCompletions;
 
+//
+// linenoise() is equivalent to calling
+// linenoise2() with stdin & stdout
+//
+
 typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
 typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);
@@ -59,21 +64,56 @@ void linenoiseSetHintsCallback(linenoiseHintsCallback *);
 void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
-int linenoiseProbe(void);
-char *linenoise(const char *prompt);
-void linenoiseFree(void *ptr);
-int linenoiseHistoryAdd(const char *line);
-int linenoiseHistorySetMaxLen(int len);
-int linenoiseHistorySave(const char *filename);
-int linenoiseHistoryLoad(const char *filename);
-void linenoiseHistoryFree(void);
-void linenoiseClearScreen(void);
-void linenoiseSetMultiLine(int ml);
-void linenoiseSetDumbMode(int set);
-bool linenoiseIsDumbMode(void);
-void linenoisePrintKeyCodes(void);
-void linenoiseAllowEmpty(bool);
-int linenoiseSetMaxLineLen(size_t len);
+int   linenoiseProbe(void);
+char* linenoise(const char *prompt);
+void  linenoiseFree(void *ptr);
+int   linenoiseHistoryAdd(const char *line);
+int   linenoiseHistorySetMaxLen(int len);
+int   linenoiseHistorySave(const char *filename);
+int   linenoiseHistoryLoad(const char *filename);
+void  linenoiseHistoryFree(void);
+void  linenoiseClearScreen(void);
+void  linenoiseSetMultiLine(int ml);
+void  linenoiseSetDumbMode(int set);
+bool  linenoiseIsDumbMode(void);
+void  linenoisePrintKeyCodes(void);
+void  linenoiseAllowEmpty(bool);
+int   linenoiseSetMaxLineLen(size_t len);
+
+//
+// Linenoise 2 
+//
+// Supports replacing stdin/stdout 
+// with a terminal of your choosing
+//
+
+struct linenoise_t;
+typedef struct linenoise_t* linenoiseHandle_t;
+
+linenoiseHandle_t linenoise2Create();
+
+void  linenoise2SetCompletionCallback(linenoiseHandle_t handle, linenoiseCompletionCallback *);
+void  linenoise2SetHintsCallback(linenoiseHandle_t handle, linenoiseHintsCallback *);
+void  linenoise2SetFreeHintsCallback(linenoiseHandle_t handle, linenoiseFreeHintsCallback *);
+void  linenoise2AddCompletion(linenoiseCompletions *, const char *);
+
+int   linenoise2Probe(linenoiseHandle_t handle);
+char* linenoise2(linenoiseHandle_t handle, const char *prompt);
+void  linenoise2SetFpIn(linenoiseHandle_t handle, FILE* fpIn);
+void  linenoise2SetFpOut(linenoiseHandle_t handle, FILE* fpOut);
+int   linenoise2HistoryAdd(linenoiseHandle_t handle, const char *line);
+int   linenoise2HistorySetMaxLen(linenoiseHandle_t handle, int len);
+int   linenoise2HistorySave(linenoiseHandle_t handle, const char *filename);
+int   linenoise2HistoryLoad(linenoiseHandle_t handle, const char *filename);
+void  linenoise2HistoryFree(linenoiseHandle_t handle);
+void  linenoise2ClearScreen(linenoiseHandle_t handle);
+void  linenoise2SetMultiLine(linenoiseHandle_t handle, int ml);
+void  linenoise2SetDumbMode(linenoiseHandle_t handle, int set);
+bool  linenoise2IsDumbMode(linenoiseHandle_t handle);
+void  linenoise2PrintKeyCodes(linenoiseHandle_t handle);
+void  linenoise2AllowEmpty(linenoiseHandle_t handle, bool);
+int   linenoise2SetMaxLineLen(linenoiseHandle_t handle, size_t len);
+void  linenoise2Free(void* ptr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
❌ **Rejected. This PR has been closed in favor of a new PR: https://github.com/espressif/esp-idf/pull/10526** ❌

Related Issue: https://github.com/espressif/esp-idf/issues/9986

**This is definitely an optional PR. Linenoise is already an easy dependency for users to replace if they want to add this functionality. Still, I wanted to share these changes in hopes that Espressif or others may find them useful.**

**Note:** this PR also incorporates the same EWOULDBLOCK linenoise changes from this other PR: https://github.com/espressif/esp-idf/pull/9983

Features:
- support multiple instances of Linenoise, in order to support multiple consoles
- backwards compatible, no code changes required for linenoise1 users
- *optional* **Linenoise2 API** to support linenoise handles, and replacing stdin/stdout 
- in `commands.c`, support calling `esp_console_run()` on multiple independent threads.

Tested:
- on ESP32-S3
- both smart & dumb linenoise modes
- both stdin/stdout, and /dev/usbserjtag

