### PR TITLE
doc: remove WEP as security mode (IDFGH-8565)

### DIFF
--- a/docs/en/api-reference/network/esp_wifi.rst
+++ b/docs/en/api-reference/network/esp_wifi.rst
@@ -12,7 +12,7 @@ The Wi-Fi libraries provide support for configuring and monitoring the {IDF_TARG
 - AP mode (aka Soft-AP mode or Access Point mode). Stations connect to the {IDF_TARGET_NAME}.
 - Station/AP-coexistence mode ({IDF_TARGET_NAME} is concurrently an access point and a station connected to another access point).
 
-- Various security modes for the above (WPA, WPA2, WEP, etc.)
+- Various security modes for the above (WPA2, WPA3, etc.)
 - Scanning for access points (active & passive scanning).
 - Promiscuous mode for monitoring of IEEE802.11 Wi-Fi packets.
 

--- a/docs/zh_CN/api-reference/network/esp_wifi.rst
+++ b/docs/zh_CN/api-reference/network/esp_wifi.rst
@@ -12,7 +12,7 @@ Wi-Fi 库支持配置及监控 {IDF_TARGET_NAME} Wi-Fi 连网功能。支持配�
 - AP 模式（即 Soft-AP 模式或接入点模式），此时基站连接到 {IDF_TARGET_NAME}。
 - station/AP 共存模式（{IDF_TARGET_NAME} 既是接入点，同时又作为基站连接到另外一个接入点）。
 
-- 上述模式的各种安全模式（WPA、WPA2 及 WEP 等）。
+- 上述模式的各种安全模式（WPA2、WPA3 等）。
 - 扫描接入点（包括主动扫描及被动扫描）。
 - 使用混杂模式监控 IEEE802.11 Wi-Fi 数据包。
 


### PR DESCRIPTION
## Summary

The documentation mentions WEP as security mode. WEP is deprecated and not connectable by default. So it should be removed.

## Reference

fixes #10014