### PR TITLE
[Argtable3] stack corruption for long arguments (IDFGH-8566)

### DIFF
--- a/components/console/argtable3/argtable3.c
+++ b/components/console/argtable3/argtable3.c
@@ -509,11 +509,11 @@ static void arg_cat(char** pdest, const char* src, size_t* pndest) {
     char* end = dest + *pndest;
 
     /*locate null terminator of dest string */
-    while (dest < end && *dest != 0)
+    while (dest < end-1 && *dest != 0)
         dest++;
 
     /* concat src string to dest string */
-    while (dest < end && *src != 0)
+    while (dest < end-1 && *src != 0)
         *dest++ = *src++;
 
     /* null terminate dest string */


### PR DESCRIPTION
For large command line arguments, 200 chars or greater, arg_cat writes out of bounds.

```
/api/auth/upload-public-keys: excess option 
4ac8821c6f79d5d06092a864886f70d4bd83d81ca1e50f08288df9034964d380171dda6d1d7dd73ecblecdd343424da87d6a65d21775e9
3082094202010030001010105000482092c308200002820201009280201587ba727d9a5c3eae900106827a4211

Stack smashing protect failure!

abort () was called at PC 0x42004d2f on core 1

0x42004d2f: stack chk fail at /esp-idf/components/esp_system/stack_check.c:36

0x40376473: panic abort at /esp-idf/components/esp_system/panic.c:455

0x40384a49: esp_system_abort at /esp-idf/components/esp_system/esp_system.c:128

0x4038fad5: abort at /esp-idf/components/newlib/abort.c:46

0x42004d2f: _ stack chk fail at /esp-idf/components/esp_system/stack_check.c:36

0x420e9025: arg_print _option at /esp-idf/components/console/argtable3/argtable.c:4527

0x420e9096: arg_str_errorfnat/esp-idf/components/console/argtable3/argtable3.c:3679

0x42082708: arg_print_errors at /esp-idf/components/console/argtable3/argtable3.c:1768

0x42011816: cd standard handler api isonTo]son(int, char**) at /common/api/coms/pd console handlers. cpp:306

0x420809d: esp console run at /esp-idf/components/console/commands.c:196

ommon/api/xcoms/p console task.cpp: 392
®x40389f4e: vPortTaskWrapper at /esp-idf/components/freertos/port/xtensa/port.c:131
ELF file SHA256: c881812bac619916
```