### PR TITLE
[USB Serial/JTAG] [VFS] add flag if driver has ever received bytes (IDFGH-8651)

### DIFF
--- a/components/driver/include/driver/usb_serial_jtag.h
+++ b/components/driver/include/driver/usb_serial_jtag.h
@@ -72,6 +72,16 @@ int usb_serial_jtag_read_bytes(void* buf, uint32_t length, TickType_t ticks_to_w
  */
 int usb_serial_jtag_write_bytes(const void* src, size_t size, TickType_t ticks_to_wait);
 
+
+/**
+ * @brief Returns true if the USB Serial/JTAG Controller driver has ever
+ * received any bytes over its serial port since the driver was installed.
+ *
+ * This can be used as a simple way to determine that a serial
+ * console has definitely been attached at some point
+ */
+bool usb_serial_jtag_driver_has_received_bytes();
+
 /**
  * @brief Uninstall USB-SERIAL-JTAG driver.
  *


### PR DESCRIPTION
Related issue: https://github.com/espressif/esp-idf/issues/9366

This PR was spun out from https://github.com/espressif/esp-idf/pull/9983

introduces: `usb_serial_jtag_has_driver_received_bytes();`

I need a way to detect if a USB terminal is attached, so that I can decide which port to open my terminal on. If the user types a character over USB during boot, I open USB Console, otherwise I open UART Console.

(I also send a 'terminal probe request' during boot, so USB Console detection is automatic for most terminals 😊)

I like that this solution is less complex (i.e. more reliable) than calling `read()` or initializing `linenoise` or `esp_console`.