### PR TITLE
[Console Repl] USB Serial/JTAG default to non-blocking for TX (IDFGH-8653)

### DIFF
--- a/components/console/esp_console_repl.c
+++ b/components/console/esp_console_repl.c
@@ -162,8 +162,8 @@ esp_err_t esp_console_new_repl_usb_serial_jtag(const esp_console_dev_usb_serial_
         goto _exit;
     }
 
-    /* Tell vfs to use usb-serial-jtag driver */
-    esp_vfs_usb_serial_jtag_use_driver();
+    /* Tell vfs to use usb-serial-jtag driver for reads*/
+    esp_vfs_usb_serial_jtag_use_driver_for_rx();
 
     // setup history
     ret = esp_console_setup_history(repl_config->history_save_path, repl_config->max_history_len, &usb_serial_jtag_repl->repl_com);

--- a/components/vfs/include/esp_vfs_dev.h
+++ b/components/vfs/include/esp_vfs_dev.h
@@ -110,8 +110,30 @@ void esp_vfs_dev_uart_use_driver(int uart_num);
  * @brief set VFS to use USB-SERIAL-JTAG driver for reading and writing
  * @note application must configure USB-SERIAL-JTAG driver before calling these functions
  * With these functions, read and write are blocking and interrupt-driven.
+ * 
+ * @warning If there is no terminal *consuming* the bytes we are sending,
+ * sending data will block indefinitely, until a terminal attaches and consumes them.
+ * (i.e. printf & ESP_LOGI will block, pausing the application when the tx buffer becomes full)
  */
 void esp_vfs_usb_serial_jtag_use_driver(void);
+
+/**
+ * @brief set VFS to use USB-SERIAL-JTAG driver for writing.
+ * @note application must configure USB-SERIAL-JTAG driver before calling these functions
+ * With this function, read is blocking and interrupt-driven.
+ */
+void esp_vfs_usb_serial_jtag_use_driver_for_rx(void);
+
+/**
+ * @brief set VFS to use USB-SERIAL-JTAG driver for reading
+ * @note application must configure USB-SERIAL-JTAG driver before calling these functions
+ * With this function, write is blocking and interrupt-driven.
+ * 
+ * @warning If there is no terminal *consuming* the bytes we are sending,
+ * sending data will block indefinitely, until a terminal attaches and consumes them.
+ * (i.e. printf & ESP_LOGI will block, pausing the application when the tx buffer becomes full)
+ */
+void esp_vfs_usb_serial_jtag_use_driver_for_tx(void);
 
 /**
  * @brief set VFS to use simple functions for reading and writing UART

--- a/components/vfs/vfs_usb_serial_jtag.c
+++ b/components/vfs/vfs_usb_serial_jtag.c
@@ -417,6 +417,20 @@ void esp_vfs_usb_serial_jtag_use_nonblocking(void)
     _lock_release_recursive(&s_ctx.read_lock);
 }
 
+void esp_vfs_usb_serial_jtag_use_driver_for_rx(void)
+{
+    _lock_acquire_recursive(&s_ctx.read_lock);
+    s_ctx.rx_func = usbjtag_rx_char_via_driver;
+    _lock_release_recursive(&s_ctx.read_lock);
+}
+
+void esp_vfs_usb_serial_jtag_use_driver_for_tx(void)
+{
+    _lock_acquire_recursive(&s_ctx.write_lock);
+    s_ctx.tx_func = usbjtag_tx_char_via_driver;
+    _lock_release_recursive(&s_ctx.write_lock);
+}
+
 void esp_vfs_usb_serial_jtag_use_driver(void)
 {
     _lock_acquire_recursive(&s_ctx.read_lock);

--- a/docs/en/api-guides/usb-serial-jtag-console.rst
+++ b/docs/en/api-guides/usb-serial-jtag-console.rst
@@ -53,26 +53,24 @@ The USB Serial/JTAG Controller is able to put the {IDF_TARGET_NAME} into downloa
 Limitations
 ===========
 
-There are several limitations to the USB console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
+There are several limitations to the USB Serial/JTAG console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
 
 {IDF_TARGET_BOOT_PIN:default = "Not Updated!", esp32c3 = "GPIO9", esp32s3 = "GPIO0"}
 
 1. If the application accidentally reconfigures the USB peripheral pins, or disables the USB Serial/JTAG Controller, the device will disappear from the system. After fixing the issue in the application, you will need to manually put the {IDF_TARGET_NAME} into download mode by pulling low {IDF_TARGET_BOOT_PIN} and resetting the chip.
 
-2. If the application enters deep sleep mode, USB CDC device will disappear from the system.
+2. If the application enters deep sleep mode, the USB Serial/JTAG device will disappear from the system.
 
-3. The behavior between an actual USB-to-serial bridge chip and the USB Serial/JTAG Controller is slightly different if the ESP-IDF application does not listen for incoming bytes. An USB-to-serial bridge chip will just send the bytes to a (not listening) chip, while the USB Serial/JTAG Controller will block until the application reads the bytes. This can lead to a non-responsive looking terminal program.
+3. The USB Serial/JTAG device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
 
-4. The USB CDC device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
+4. The power consumption in sleep modes will be higher if the USB Serial/JTAG device is in use.
 
-5. The power consumption in sleep modes will be higher if the USB CDC device is in use.
+   This is because we want to keep the USB Serial/JTAG device alive during software reset by default.
 
-   This is because we want to keep the USB CDC device alive during software reset by default.
-
-   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB CDC device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB CDC port is really in use (like data transaction), therefore, if your USB CDC is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
+   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB Serial/JTAG device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB Serial/JTAG port is really in use (like data transaction), therefore, if your USB Serial/JTAG is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
 
    If you still want to keep low power consumption in sleep modes:
 
-    1. If you are not using the USB CDC port, you don't need to do anything. Software will detect if the CDC device is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
+    1. If you are not using the USB Serial/JTAG port, you don't need to do anything. Software will detect if the USB Serial/JTAG is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
 
-    2. If you are using the USB CDC port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB CDC device may be unplugged from the host.
+    2. If you are using the USB Serial/JTAG port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB Serial/JTAG device may be unplugged from the host.


### PR DESCRIPTION
This is the 2nd PR spun out from: https://github.com/espressif/esp-idf/pull/9983

- add `esp_vfs_usb_serial_jtag_use_driver_for_rx(); ` to keep TX in non-blocking mode
- **esp_console_repl.c** - use `esp_vfs_usb_serial_jtag_use_driver_for_rx();` by default. 

Users dont want to block the entire program when a USB terminal is not connected. This PR makes it the same behavior as UART Console, which is what the vast majority of users want, IMO. 

Note: even in non-blocking mode TX still blocks for 50ms to see if theres a chance the buffer will clear up, but it does not block again until there is space again. This is precisely the behavior most users want IMO.