### PR TITLE
hal/uart_ll.h: Fix compile with C++ (IDFGH-8661)

### DIFF
--- a/components/hal/esp32/include/hal/uart_ll.h
+++ b/components/hal/esp32/include/hal/uart_ll.h
@@ -111,7 +111,8 @@ FORCE_INLINE_ATTR void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint3
  */
 FORCE_INLINE_ATTR uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clk_div) div_reg = hw->clk_div;
+    typeof(hw->clk_div) div_reg;
+    div_reg.val = hw->clk_div.val;
     return ((sclk_freq << 4)) / ((div_reg.div_int << 4) | div_reg.div_frag);
 }
 
@@ -271,7 +272,8 @@ FORCE_INLINE_ATTR void uart_ll_txfifo_rst(uart_dev_t *hw)
 FORCE_INLINE_ATTR uint32_t uart_ll_get_rxfifo_len(uart_dev_t *hw)
 {
     uint32_t fifo_cnt = HAL_FORCE_READ_U32_REG_FIELD(hw->status, rxfifo_cnt);
-    typeof(hw->mem_rx_status) rx_status = hw->mem_rx_status;
+    typeof(hw->mem_rx_status) rx_status;
+    rx_status.val = hw->mem_rx_status.val;
     uint32_t len = 0;
 
     // When using DPort to read fifo, fifo_cnt is not credible, we need to calculate the real cnt based on the fifo read and write pointer.
@@ -331,9 +333,9 @@ FORCE_INLINE_ATTR void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *s
 {
     //workaround for hardware issue, when UART stop bit set as 2-bit mode.
     if(hw->rs485_conf.dl1_en == 1 && hw->conf0.stop_bit_num == 0x1) {
-        *stop_bit = UART_STOP_BITS_2;
+        *stop_bit = (uart_stop_bits_t)UART_STOP_BITS_2;
     } else {
-        *stop_bit = hw->conf0.stop_bit_num;
+        *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
     }
 }
 
@@ -364,7 +366,7 @@ FORCE_INLINE_ATTR void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_m
 FORCE_INLINE_ATTR void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if(hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -480,10 +482,10 @@ FORCE_INLINE_ATTR void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcont
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if(hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if(hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -738,7 +740,7 @@ FORCE_INLINE_ATTR uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 FORCE_INLINE_ATTR void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**
@@ -750,7 +752,8 @@ FORCE_INLINE_ATTR void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length
  */
 FORCE_INLINE_ATTR IRAM_ATTR bool uart_ll_is_tx_idle(uart_dev_t *hw)
 {
-    typeof(hw->status) status = hw->status;
+    typeof(hw->status) status;
+    status.val = hw->status.val;
     return ((status.txfifo_cnt == 0) && (status.st_utx_out == 0));
 }
 
@@ -802,7 +805,8 @@ FORCE_INLINE_ATTR void uart_ll_set_loop_back(uart_dev_t *hw, bool loop_back_en)
  */
 FORCE_INLINE_ATTR void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0) conf0_reg = hw->conf0;
+    typeof(hw->conf0) conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;

--- a/components/hal/esp32c2/include/hal/uart_ll.h
+++ b/components/hal/esp32c2/include/hal/uart_ll.h
@@ -175,7 +175,8 @@ static inline void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t 
  */
 static inline uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clk_div) div_reg = hw->clk_div;
+    typeof(hw->clk_div) div_reg;
+    div_reg.val = hw->clk_div.val;
     return ((sclk_freq << 4)) / (((div_reg.div_int << 4) | div_reg.div_frag) * (hw->clk_conf.sclk_div_num + 1));
 }
 
@@ -347,7 +348,7 @@ static inline void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t stop_b
  */
 static inline void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
 }
 
 /**
@@ -377,7 +378,7 @@ static inline void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_mode)
 static inline void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if (hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -493,10 +494,10 @@ static inline void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcontrol_
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if (hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if (hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -758,7 +759,7 @@ static inline uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 static inline void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**
@@ -829,7 +830,8 @@ static inline void uart_ll_xon_force_on(uart_dev_t *hw, bool always_on)
  */
 static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0) conf0_reg = hw->conf0;
+    typeof(hw->conf0) conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;

--- a/components/hal/esp32c3/include/hal/uart_ll.h
+++ b/components/hal/esp32c3/include/hal/uart_ll.h
@@ -178,7 +178,8 @@ static inline void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t 
  */
 static inline uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clk_div) div_reg = hw->clk_div;
+    typeof(hw->clk_div) div_reg;
+    div_reg.val = hw->clk_div.val;
     return ((sclk_freq << 4)) / (((div_reg.div_int << 4) | div_reg.div_frag) * (HAL_FORCE_READ_U32_REG_FIELD(hw->clk_conf, sclk_div_num) + 1));
 }
 
@@ -350,7 +351,7 @@ static inline void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t stop_b
  */
 static inline void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
 }
 
 /**
@@ -380,7 +381,7 @@ static inline void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_mode)
 static inline void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if (hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -496,10 +497,10 @@ static inline void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcontrol_
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if (hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if (hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -761,7 +762,7 @@ static inline uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 static inline void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**
@@ -832,7 +833,8 @@ static inline void uart_ll_xon_force_on(uart_dev_t *hw, bool always_on)
  */
 static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0) conf0_reg = hw->conf0;
+    typeof(hw->conf0) conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;

--- a/components/hal/esp32c6/include/hal/uart_ll.h
+++ b/components/hal/esp32c6/include/hal/uart_ll.h
@@ -191,7 +191,8 @@ static inline void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t 
  */
 static inline uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clkdiv_sync) div_reg = hw->clkdiv_sync;
+    typeof(hw->clkdiv_sync) div_reg;
+    div_reg.val = hw->clkdiv_sync.val;
     return ((sclk_freq << 4)) / (((div_reg.clkdiv_int << 4) | div_reg.clkdiv_frag) * (HAL_FORCE_READ_U32_REG_FIELD(hw->clk_conf, sclk_div_num) + 1));
 }
 
@@ -368,7 +369,7 @@ static inline void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t stop_b
  */
 static inline void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0_sync.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0_sync.stop_bit_num;
 }
 
 /**
@@ -399,7 +400,7 @@ static inline void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_mode)
 static inline void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if (hw->conf0_sync.parity_en) {
-        *parity_mode = 0X2 | hw->conf0_sync.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0_sync.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -525,10 +526,10 @@ static inline void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcontrol_
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if (hw->hwfc_conf_sync.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if (hw->conf0_sync.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -835,7 +836,7 @@ static inline uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 static inline void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0_sync.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0_sync.bit_num;
 }
 
 /**
@@ -908,7 +909,8 @@ static inline void uart_ll_xon_force_on(uart_dev_t *hw, bool always_on)
  */
 static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0_sync) conf0_reg = hw->conf0_sync;
+    typeof(hw->conf0_sync) conf0_reg;
+    conf0_reg.val = hw->conf0_sync.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;
@@ -916,7 +918,8 @@ static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
     hw->conf0_sync.val = conf0_reg.val;
     uart_ll_update(0); // TODO: IDF-5338
 
-    typeof(hw->conf1) conf1_reg = hw->conf1;
+    typeof(hw->conf1) conf1_reg;
+    conf1_reg.val = hw->conf1.val;
     conf1_reg.rts_inv = (inv_mask & UART_SIGNAL_RTS_INV) ? 1 : 0;
     conf1_reg.dtr_inv = (inv_mask & UART_SIGNAL_DTR_INV) ? 1 : 0;
     conf1_reg.cts_inv = (inv_mask & UART_SIGNAL_CTS_INV) ? 1 : 0;

--- a/components/hal/esp32h2/include/hal/uart_ll.h
+++ b/components/hal/esp32h2/include/hal/uart_ll.h
@@ -178,7 +178,8 @@ static inline void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t 
  */
 static inline uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clk_div) div_reg = hw->clk_div;
+    typeof(hw->clk_div) div_reg;
+    div_reg.val = hw->clk_div.val;
     return ((sclk_freq << 4)) / (((div_reg.div_int << 4) | div_reg.div_frag) * (HAL_FORCE_READ_U32_REG_FIELD(hw->clk_conf, sclk_div_num) + 1));
 }
 
@@ -350,7 +351,7 @@ static inline void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t stop_b
  */
 static inline void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
 }
 
 /**
@@ -380,7 +381,7 @@ static inline void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_mode)
 static inline void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if (hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -496,10 +497,10 @@ static inline void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcontrol_
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if (hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if (hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -761,7 +762,7 @@ static inline uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 static inline void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**
@@ -832,7 +833,8 @@ static inline void uart_ll_xon_force_on(uart_dev_t *hw, bool always_on)
  */
 static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0) conf0_reg = hw->conf0;
+    typeof(hw->conf0) conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;

--- a/components/hal/esp32s2/include/hal/uart_ll.h
+++ b/components/hal/esp32s2/include/hal/uart_ll.h
@@ -109,7 +109,8 @@ FORCE_INLINE_ATTR void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint3
  */
 FORCE_INLINE_ATTR uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clk_div) div_reg = hw->clk_div;
+    typeof(hw->clk_div) div_reg;
+    div_reg.val = hw->clk_div.val;
     return ((sclk_freq << 4)) / ((div_reg.div_int << 4) | div_reg.div_frag);
 }
 
@@ -285,7 +286,7 @@ FORCE_INLINE_ATTR void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t st
  */
 FORCE_INLINE_ATTR void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
 }
 
 /**
@@ -315,7 +316,7 @@ FORCE_INLINE_ATTR void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_m
 FORCE_INLINE_ATTR void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if(hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -431,10 +432,10 @@ FORCE_INLINE_ATTR void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcont
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if(hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if(hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -689,7 +690,7 @@ FORCE_INLINE_ATTR uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 FORCE_INLINE_ATTR void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**
@@ -752,7 +753,8 @@ FORCE_INLINE_ATTR void uart_ll_set_loop_back(uart_dev_t *hw, bool loop_back_en)
  */
 FORCE_INLINE_ATTR void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0) conf0_reg = hw->conf0;
+    typeof(hw->conf0) conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;

--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -324,7 +324,7 @@ FORCE_INLINE_ATTR void uart_ll_set_stop_bits(uart_dev_t *hw, uart_stop_bits_t st
  */
 FORCE_INLINE_ATTR void uart_ll_get_stop_bits(uart_dev_t *hw, uart_stop_bits_t *stop_bit)
 {
-    *stop_bit = hw->conf0.stop_bit_num;
+    *stop_bit = (uart_stop_bits_t)hw->conf0.stop_bit_num;
 }
 
 /**
@@ -354,7 +354,7 @@ FORCE_INLINE_ATTR void uart_ll_set_parity(uart_dev_t *hw, uart_parity_t parity_m
 FORCE_INLINE_ATTR void uart_ll_get_parity(uart_dev_t *hw, uart_parity_t *parity_mode)
 {
     if (hw->conf0.parity_en) {
-        *parity_mode = 0X2 | hw->conf0.parity;
+        *parity_mode = (uart_parity_t)(0x2 | hw->conf0.parity);
     } else {
         *parity_mode = UART_PARITY_DISABLE;
     }
@@ -469,10 +469,10 @@ FORCE_INLINE_ATTR void uart_ll_get_hw_flow_ctrl(uart_dev_t *hw, uart_hw_flowcont
 {
     *flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
     if (hw->conf1.rx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_RTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_RTS);
     }
     if (hw->conf0.tx_flow_en) {
-        *flow_ctrl |= UART_HW_FLOWCTRL_CTS;
+        *flow_ctrl = (uart_hw_flowcontrol_t)((unsigned int)(*flow_ctrl) | (unsigned int)UART_HW_FLOWCTRL_CTS);
     }
 }
 
@@ -728,7 +728,7 @@ FORCE_INLINE_ATTR uint32_t uart_ll_get_wakeup_thrd(uart_dev_t *hw)
  */
 FORCE_INLINE_ATTR void uart_ll_get_data_bit_num(uart_dev_t *hw, uart_word_length_t *data_bit)
 {
-    *data_bit = hw->conf0.bit_num;
+    *data_bit = (uart_word_length_t)hw->conf0.bit_num;
 }
 
 /**


### PR DESCRIPTION
I'm including `<hal/uart_ll.h>` in my C++ application because I need to bypass the uart driver. The inline functions in the header file fail to compile as C++.

With xtensa-esp32s2-elf-g++ (crosstool-NG esp-2021r2-patch3) 8.4.0 it doesn't allow copying the union like this:
```
hal/uart_ll.h:131:39: error: binding reference of type 'const uart_dev_s::<unnamed union>&' to 'volatile uart_dev_s::<unnamed union>' discards qualifiers
     typeof(hw->clk_div) div_reg = hw->clk_div;
hal/uart_ll.h:131:39: error: cannot bind rvalue reference of type 'uart_dev_s::<unnamed union>&&' to lvalue of type 'volatile uart_dev_s::<unnamed union>'
     typeof(hw->clk_div) div_reg = hw->clk_div;
```
All of the enums need explicit casts for conversion to/from integers.