### PR TITLE
allow https server to accept and pass thru alpn protocols (IDFGH-8686)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -152,6 +152,7 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     .user_cb = NULL,                              \
     .ssl_userdata = NULL,                         \
     .cert_select_cb = NULL                        \
+    .alpn_protos = NULL                           \
 }
 
 /**

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -99,6 +99,8 @@ struct httpd_ssl_config {
 
     void *ssl_userdata; /*!< user data to add to the ssl context  */
     esp_tls_handshake_callback cert_select_cb; /*!< Certificate selection callback to use */
+
+    const char** alpn_protos; /*!< Application protocols the server supports in order of prefernece. Used for negotiating during the TLS handshake, first one the client supports is selected. The data structure must live as long as the https server itself! */
 };
 
 typedef struct httpd_ssl_config httpd_ssl_config_t;

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -212,6 +212,9 @@ static httpd_ssl_ctx_t *create_secure_context(const struct httpd_ssl_config *con
 
     cfg->userdata = config->ssl_userdata;
 
+
+    cfg->alpn_protos = config->alpn_protos;
+
 #if defined(CONFIG_ESP_TLS_SERVER_CERT_SELECT_HOOK)
     cfg->cert_select_cb = config->cert_select_cb;
 #endif


### PR DESCRIPTION
One can now specify what alpn protocols the https server should accept traffic for. Necessary for implementing the tls-alpn-01 challenge for acme.