### PR TITLE
[Heap Trace Standalone] fix terrible Leaks perf on large records by using doubly linked list (IDFGH-8690)

### DIFF
--- a/components/app_trace/heap_trace_tohost.c
+++ b/components/app_trace/heap_trace_tohost.c
@@ -69,7 +69,22 @@ esp_err_t heap_trace_get(size_t index, heap_trace_record_t *record)
     return ESP_ERR_NOT_SUPPORTED;
 }
 
+esp_err_t heap_trace_summary(heap_trace_summary_t* summary)
+{
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
 void heap_trace_dump(void)
+{
+    return;
+}
+
+void heap_trace_dump_internal_ram_only(void)
+{
+    return;
+}
+
+void heap_trace_dump_spi_ram_only(void)
 {
     return;
 }

--- a/components/heap/heap_trace_standalone.c
+++ b/components/heap/heap_trace_standalone.c
@@ -23,16 +23,39 @@ static portMUX_TYPE trace_mux = portMUX_INITIALIZER_UNLOCKED;
 static bool tracing;
 static heap_trace_mode_t mode;
 
-/* Buffer used for records, starting at offset 0
-*/
-static heap_trace_record_t *buffer;
-static size_t total_records;
+struct records_t {
 
-/* Count of entries logged in the buffer.
+    /* Buffer used for records, starting at offset 0 */
+    heap_trace_record_t *buffer;
 
-   Maximum total_records
-*/
-static size_t count;
+    /* capacity of the buffer */
+    size_t capacity;
+
+    /* Count of entries logged in the buffer.*/
+    size_t count;
+
+    /* During execution, we remember the minimum 
+       value of (capacity - count). This can help you
+       choose the right size for your buffer capacity.*/
+    size_t high_water_mark;
+
+    /* Has the buffer overflowed and lost trace entries? */
+    bool has_overflowed;
+};
+
+typedef struct records_t records_t;
+
+// Forward Defines
+static void drain_internal_cache();
+static void remove_record(records_t* r, int index);
+static void heap_trace_dump_base(bool internalRam, bool spiRam);
+
+/* The actual records. Only used as a 
+   temporary cache if SPI RAM is used */
+static records_t internal_records;
+
+/* Long term storage of records */
+static records_t spi_records;
 
 /* Actual number of allocations logged */
 static size_t total_allocations;
@@ -40,23 +63,49 @@ static size_t total_allocations;
 /* Actual number of frees logged */
 static size_t total_frees;
 
-/* Has the buffer overflowed and lost trace entries? */
-static bool has_overflowed = false;
-
-esp_err_t heap_trace_init_standalone(heap_trace_record_t *record_buffer, size_t num_records)
+esp_err_t heap_trace_init_standalone(heap_trace_record_t* record_buffer, size_t num_records)
 {
     if (tracing) {
         return ESP_ERR_INVALID_STATE;
     }
-    buffer = record_buffer;
-    total_records = num_records;
-    memset(buffer, 0, num_records * sizeof(heap_trace_record_t));
+
+    internal_records.buffer = record_buffer;
+    internal_records.capacity = num_records;
+    memset(internal_records.buffer, 0, num_records * sizeof(heap_trace_record_t));
+
+    spi_records.buffer = NULL;
+    spi_records.capacity = 0;
+
+    return ESP_OK;
+}
+
+
+esp_err_t heap_trace_init_standalone_with_spi_ram(
+    heap_trace_record_t *internal_record_buffer, size_t internal_num_records,
+    heap_trace_record_t *spi_record_buffer, size_t spi_num_records)
+{
+    if (tracing) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    internal_records.buffer = internal_record_buffer;
+    internal_records.capacity = internal_num_records;
+    memset(internal_records.buffer, 0, internal_num_records * sizeof(heap_trace_record_t));
+
+    spi_records.buffer = spi_record_buffer;
+    spi_records.capacity = spi_num_records;
+    memset(spi_records.buffer, 0, spi_num_records * sizeof(heap_trace_record_t));
+
     return ESP_OK;
 }
 
 esp_err_t heap_trace_start(heap_trace_mode_t mode_param)
 {
-    if (buffer == NULL || total_records == 0) {
+    if (internal_records.buffer == NULL || internal_records.capacity == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (spi_records.buffer && spi_records.capacity == 0) {
         return ESP_ERR_INVALID_STATE;
     }
 
@@ -64,10 +113,15 @@ esp_err_t heap_trace_start(heap_trace_mode_t mode_param)
 
     tracing = false;
     mode = mode_param;
-    count = 0;
+
+    internal_records.count = 0;
+    internal_records.has_overflowed = false;
+
+    spi_records.count = 0;
+    spi_records.has_overflowed = false;
+
     total_allocations = 0;
     total_frees = 0;
-    has_overflowed = false;
     heap_trace_resume();
 
     portEXIT_CRITICAL(&trace_mux);
@@ -85,17 +139,30 @@ static esp_err_t set_tracing(bool enable)
 
 esp_err_t heap_trace_stop(void)
 {
+    if(spi_records.capacity) {
+        drain_internal_cache();
+    }
     return set_tracing(false);
 }
 
 esp_err_t heap_trace_resume(void)
 {
+    if(spi_records.capacity) {
+        drain_internal_cache();
+    }
     return set_tracing(true);
 }
 
 size_t heap_trace_get_count(void)
 {
-    return count;
+    if(spi_records.capacity) {
+        drain_internal_cache();
+    }
+
+    records_t* r = spi_records.capacity ? 
+        &spi_records : &internal_records;
+
+    return r->count;
 }
 
 esp_err_t heap_trace_get(size_t index, heap_trace_record_t *record)
@@ -103,32 +170,101 @@ esp_err_t heap_trace_get(size_t index, heap_trace_record_t *record)
     if (record == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
+
+    if(spi_records.capacity) {
+        drain_internal_cache();
+    }
+
     esp_err_t result = ESP_OK;
 
     portENTER_CRITICAL(&trace_mux);
-    if (index >= count) {
+
+    records_t* r = spi_records.capacity ? 
+        &spi_records : &internal_records;
+
+    if (index >= r->count) {
         result = ESP_ERR_INVALID_ARG; /* out of range for 'count' */
     } else {
-        memcpy(record, &buffer[index], sizeof(heap_trace_record_t));
+        memcpy(record, &r->buffer[index], sizeof(heap_trace_record_t));
     }
+
     portEXIT_CRITICAL(&trace_mux);
     return result;
 }
 
-
-void heap_trace_dump(void)
+esp_err_t heap_trace_summary(heap_trace_summary_t* summary)
 {
+    if (summary == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    portENTER_CRITICAL(&trace_mux);
+    summary->mode = mode;
+    summary->total_allocations = total_allocations;
+    summary->total_frees = total_frees;
+    summary->internal_count = internal_records.count;
+    summary->internal_capacity = internal_records.capacity;
+    summary->internal_high_water_mark = internal_records.high_water_mark;
+    summary->internal_overflowed = internal_records.has_overflowed;
+    summary->spi_count = spi_records.count;
+    summary->spi_capacity = spi_records.capacity;
+    summary->spi_high_water_mark = spi_records.high_water_mark;
+    summary->spi_overflowed = spi_records.has_overflowed;
+    portEXIT_CRITICAL(&trace_mux);
+
+    return ESP_OK;
+}
+
+void heap_trace_dump_internal_ram_only(void) {
+    heap_trace_dump_base(true, false);
+}
+
+void heap_trace_dump_spi_ram_only(void) {
+    heap_trace_dump_base(false, true);
+}
+
+void heap_trace_dump(void) {
+    heap_trace_dump_base(true, true);
+}
+
+static void heap_trace_dump_base(bool internalRam, bool spiRam)
+{
+    if(spi_records.capacity) {
+        drain_internal_cache();
+    }
+
+    records_t* r = spi_records.capacity ? 
+        &spi_records : &internal_records;
+
     size_t delta_size = 0;
     size_t delta_allocs = 0;
-    printf("%u allocations trace (%u entry buffer)\n",
-           count, total_records);
-    size_t start_count = count;
-    for (int i = 0; i < count; i++) {
-        heap_trace_record_t *rec = &buffer[i];
+    size_t start_count = r->count;
 
-        if (rec->address != NULL) {
-            printf("%d bytes (@ %p) allocated CPU %d ccount 0x%08x caller ",
-                   rec->size, rec->address, rec->ccount & 1, rec->ccount & ~3);
+    printf("====== Heap Trace: %u records (%u capacity) ======\n",
+        r->count, r->capacity);
+
+    for (int i = 0; i < r->count; i++) {
+
+        heap_trace_record_t *rec = &r->buffer[i];
+
+        bool shouldPrint = rec->address != NULL &&
+            ((spiRam && internalRam) ||
+             (internalRam && esp_ptr_internal(rec->address)) ||
+             (spiRam && esp_ptr_external_ram(rec->address)));
+
+        if (shouldPrint) {
+
+            const char* label = "";
+            if (esp_ptr_internal(rec->address)) {
+                label = ", Internal";
+            }
+            if (esp_ptr_external_ram(rec->address)) {
+                label = ",   SPIRAM";
+            }
+
+            printf("%6d bytes (@ %p%s) allocated CPU %d ccount 0x%08x caller ",
+                   rec->size, rec->address, label, rec->ccount & 1, rec->ccount & ~3);
+
             for (int j = 0; j < STACK_DEPTH && rec->alloced_by[j] != 0; j++) {
                 printf("%p%s", rec->alloced_by[j],
                        (j < STACK_DEPTH - 1) ? ":" : "");
@@ -147,19 +283,104 @@ void heap_trace_dump(void)
             }
         }
     }
+
+    printf("====== Heap Trace Summary ======\n");
+
     if (mode == HEAP_TRACE_ALL) {
+        printf("Mode: Heap Trace All\n");
         printf("%u bytes alive in trace (%u/%u allocations)\n",
                delta_size, delta_allocs, heap_trace_get_count());
     } else {
+        printf("Mode: Heap Trace Leaks\n");
         printf("%u bytes 'leaked' in trace (%u allocations)\n", delta_size, delta_allocs);
     }
-    printf("total allocations %u total frees %u\n", total_allocations, total_frees);
-    if (start_count != count) { // only a problem if trace isn't stopped before dumping
+
+    printf("records: %u (%u capacity, %u high water mark)\n", r->count, r->capacity, r->high_water_mark);
+
+    if (spi_records.capacity) {
+        printf("internal records: (%u capacity, %u high water mark)\n", 
+            internal_records.capacity, internal_records.high_water_mark);
+    }
+
+    printf("total allocations: %u\n", total_allocations);
+    printf("total frees: %u\n", total_frees);
+
+    if (start_count != r->count) { // only a problem if trace isn't stopped before dumping
         printf("(NB: New entries were traced while dumping, so trace dump may have duplicate entries.)\n");
     }
-    if (has_overflowed) {
-        printf("(NB: Buffer has overflowed, so trace data is incomplete.)\n");
+    if (internal_records.has_overflowed) {
+        printf("(NB: Internal Buffer has overflowed, so trace data is incomplete.)\n");
     }
+    if (spi_records.has_overflowed) {
+        printf("(NB: SPI Buffer has overflowed, so trace data is incomplete.)\n");
+    }
+    printf("================================\n");
+}
+
+// Move from internal_records to spi_records
+static void drain_internal_cache()
+{
+    if(spi_records.capacity == 0 || spi_records.buffer == NULL) {
+        return;
+    }
+
+    portENTER_CRITICAL(&trace_mux);
+
+    // process in chronological order
+    for (int i = 0; i < internal_records.count; i++) {
+
+        heap_trace_record_t* rec = &internal_records.buffer[i];
+
+        if (rec->alloced_by[0]) {
+
+            if (spi_records.count < spi_records.capacity) {
+
+                // move the record into the SPI cache
+                heap_trace_record_t* spiRec = &spi_records.buffer[spi_records.count];
+                memcpy(spiRec, rec, sizeof(heap_trace_record_t));
+
+                spi_records.count++;
+
+                // high water mark
+                if (spi_records.count > spi_records.high_water_mark) {
+                    spi_records.high_water_mark = spi_records.count;
+                }
+
+            } else {
+                spi_records.has_overflowed = true;
+            }
+    
+        } else if (rec->freed_by[0]) {
+
+            // search backwards for the allocation record matching this free 
+            int i = -1;
+            if (spi_records.count > 0) {
+                for (i = spi_records.count - 1; i >= 0; i--) {
+                    if (spi_records.buffer[i].address == rec->address) {
+                        break;
+                    }
+                }
+            }
+
+            if (i >= 0) {
+
+                if (mode == HEAP_TRACE_ALL) {
+
+                    // copy 'freed_by' info
+                    memcpy(spi_records.buffer[i].freed_by, rec->freed_by, sizeof(void *) * STACK_DEPTH);
+
+                } else { // HEAP_TRACE_LEAKS
+
+                    // Leak trace mode, once an allocation is freed we remove it from the list
+                    remove_record(&spi_records, i);
+                }
+            }
+        }
+    }
+
+    internal_records.count = 0;
+
+    portEXIT_CRITICAL(&trace_mux);
 }
 
 /* Add a new allocation to the heap trace records */
@@ -170,9 +391,14 @@ static IRAM_ATTR void record_allocation(const heap_trace_record_t *record)
     }
 
     portENTER_CRITICAL(&trace_mux);
+
     if (tracing) {
-        if (count == total_records) {
-            has_overflowed = true;
+
+        // record into internal buffer
+        records_t* r = &internal_records;
+
+        if (r->count == r->capacity) {
+            r->has_overflowed = true;
             /* Move the whole buffer back one slot.
 
                This is a bit slow, compared to treating this buffer as a ringbuffer and rotating a head pointer.
@@ -180,19 +406,46 @@ static IRAM_ATTR void record_allocation(const heap_trace_record_t *record)
                However, ringbuffer code gets tricky when we remove elements in mid-buffer (for leak trace mode) while
                trying to keep track of an item count that may overflow.
             */
-            memmove(&buffer[0], &buffer[1], sizeof(heap_trace_record_t) * (total_records -1));
-            count--;
+            memmove(&r->buffer[0], &r->buffer[1], sizeof(heap_trace_record_t) * (r->capacity -1));
+            r->count--;
         }
+
         // Copy new record into place
-        memcpy(&buffer[count], record, sizeof(heap_trace_record_t));
-        count++;
+        memcpy(&r->buffer[r->count], record, sizeof(heap_trace_record_t));
+
+        r->count++;
+
+        // high water mark
+        if (r->count > r->high_water_mark) {
+            r->high_water_mark = r->count;
+        }
+
         total_allocations++;
     }
-    portEXIT_CRITICAL(&trace_mux);
-}
 
-// remove a record, used when freeing
-static void remove_record(int index);
+    portEXIT_CRITICAL(&trace_mux);
+
+    if (spi_records.capacity) {
+
+        void* func = record->alloced_by[0];
+
+        // Is the calling function in IRAM?
+        bool iram = 
+            esp_ptr_in_iram(func) ||
+            esp_ptr_in_dram(func) || 
+            esp_ptr_in_diram_dram(func) || 
+            esp_ptr_in_diram_iram(func) || 
+            esp_ptr_in_rtc_iram_fast(func) || 
+            esp_ptr_in_rtc_dram_fast(func) || 
+            esp_ptr_in_rtc_slow(func) || 
+            esp_ptr_internal(func) || 
+            esp_ptr_in_drom(func); 
+
+        if (iram == false) {
+            drain_internal_cache();
+        }
+    }
+}
 
 /* record a free event in the heap trace log
 
@@ -206,42 +459,86 @@ static IRAM_ATTR void record_free(void *p, void **callers)
     }
 
     portENTER_CRITICAL(&trace_mux);
-    if (tracing && count > 0) {
+
+    // record into internal buffer
+    records_t* r = &internal_records;
+
+    if (tracing) {
+
         total_frees++;
+
         /* search backwards for the allocation record matching this free */
-        int i;
-        for (i = count - 1; i >= 0; i--) {
-            if (buffer[i].address == p) {
-                break;
+        int i = -1;
+        if (r->count > 0) {
+            for (i = r->count - 1; i >= 0; i--) {
+                if (r->buffer[i].address == p) {
+                    break;
+                }
             }
         }
 
         if (i >= 0) {
+
             if (mode == HEAP_TRACE_ALL) {
-                memcpy(buffer[i].freed_by, callers, sizeof(void *) * STACK_DEPTH);
+                memcpy(r->buffer[i].freed_by, callers, sizeof(void *) * STACK_DEPTH);
             } else { // HEAP_TRACE_LEAKS
                 // Leak trace mode, once an allocation is freed we remove it from the list
-                remove_record(i);
+                remove_record(r, i);
+            }
+
+        } else if (spi_records.capacity > 0) {
+            if (r->count < r->capacity) {
+                // temporarily keep the 'free' in the internal cache.
+                // We'll search through the SPI records later.
+                heap_trace_record_t* rec = &r->buffer[r->count];
+                memset(rec, 0, sizeof(heap_trace_record_t));
+                memcpy(rec->freed_by, callers, sizeof(void *) * STACK_DEPTH);
+                rec->address = p;
+                r->count++;
+            } else {
+                r->has_overflowed = true;
             }
         }
     }
+
     portEXIT_CRITICAL(&trace_mux);
+
+    if (spi_records.capacity) {
+
+        void* func = callers[0];
+
+        // Is the calling function in IRAM?
+        bool iram = 
+            esp_ptr_in_iram(func) ||
+            esp_ptr_in_dram(func) || 
+            esp_ptr_in_diram_dram(func) || 
+            esp_ptr_in_diram_iram(func) || 
+            esp_ptr_in_rtc_iram_fast(func) || 
+            esp_ptr_in_rtc_dram_fast(func) || 
+            esp_ptr_in_rtc_slow(func) || 
+            esp_ptr_internal(func) || 
+            esp_ptr_in_drom(func); 
+
+        if (iram == false) {
+            drain_internal_cache();
+        }
+    }
 }
 
 /* remove the entry at 'index' from the ringbuffer of saved records */
-static IRAM_ATTR void remove_record(int index)
+static IRAM_ATTR void remove_record(records_t* r, int index)
 {
-    if (index < count - 1) {
+    if (index < r->count - 1) {
         // Remove the buffer entry from the list
-        memmove(&buffer[index], &buffer[index+1],
-                sizeof(heap_trace_record_t) * (total_records - index - 1));
+        memmove(&r->buffer[index], &r->buffer[index+1],
+                sizeof(heap_trace_record_t) * (r->capacity - index - 1));
     } else {
         // For last element, just zero it out to avoid ambiguity
-        memset(&buffer[index], 0, sizeof(heap_trace_record_t));
+        memset(&r->buffer[index], 0, sizeof(heap_trace_record_t));
     }
-    count--;
+    r->count--;
 }
 
 #include "heap_trace.inc"
 
-#endif /*CONFIG_HEAP_TRACING_STANDALONE*/
+#endif // CONFIG_HEAP_TRACING_STANDALONE

--- a/components/heap/include/esp_heap_trace.h
+++ b/components/heap/include/esp_heap_trace.h
@@ -31,10 +31,12 @@ typedef enum {
  */
 typedef struct {
     uint32_t ccount; ///< CCOUNT of the CPU when the allocation was made. LSB (bit value 1) is the CPU number (0 or 1).
-    void *address;   ///< Address which was allocated
+    void *address;   ///< Address which was allocated. If NULL, then this record is empty.
     size_t size;     ///< Size of the allocation
     void *alloced_by[CONFIG_HEAP_TRACING_STACK_DEPTH]; ///< Call stack of the caller which allocated the memory.
     void *freed_by[CONFIG_HEAP_TRACING_STACK_DEPTH];   ///< Call stack of the caller which freed the memory (all zero if not freed.)
+    struct heap_trace_record_t* next; ///< The next record (linked list)
+    struct heap_trace_record_t* prev; ///< The previous record (linked list)
 } heap_trace_record_t;
 
 /**

--- a/components/heap/include/esp_heap_trace.h
+++ b/components/heap/include/esp_heap_trace.h
@@ -1,16 +1,8 @@
-// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #include "sdkconfig.h"
@@ -46,6 +38,23 @@ typedef struct {
 } heap_trace_record_t;
 
 /**
+ * @brief Stores information about the result of a heap trace.
+ */
+typedef struct {
+    heap_trace_mode_t mode;          ///< The heap trace mode we just completed / are running
+    size_t total_allocations;        ///< The total number of allocations made during tracing
+    size_t total_frees;              ///< The total number of frees made during tracing
+    size_t internal_count;           ///< The number of records in the internal buffer
+    size_t internal_capacity;        ///< The capacity of the internal buffer
+    size_t internal_high_water_mark; ///< The maximum value that 'count' got to
+    size_t internal_overflowed;      ///< True if the internal buffer overflowed
+    size_t spi_count;                ///< The number of records in the spi buffer
+    size_t spi_capacity;             ///< The capacity of the spi buffer
+    size_t spi_high_water_mark;      ///< The maximum value that 'count' got to
+    size_t spi_overflowed;           ///< True if the spi buffer overflowed
+} heap_trace_summary_t;
+
+/**
  * @brief Initialise heap tracing in standalone mode.
  *
  * This function must be called before any other heap tracing functions.
@@ -61,6 +70,28 @@ typedef struct {
  *  - ESP_OK Heap tracing initialised successfully.
  */
 esp_err_t heap_trace_init_standalone(heap_trace_record_t *record_buffer, size_t num_records);
+
+/**
+ * @brief Initialise heap tracing in standalone mode with support for recording to SPI RAM
+ *
+ * This function must be called before any other heap tracing functions.
+ *
+ * To disable heap tracing and allow the buffer to be freed, stop tracing and then call heap_trace_init_standalone(NULL, 0);
+ *
+ * @param internal_record_buffer Provide a buffer to use for temporarily storing heap trace data. 
+ * Must remain valid any time heap tracing is enabled, meaning
+ * it must be allocated from internal memory not in PSRAM.
+ * @param internal_num_records Size of the internal heap trace buffer, as number of record structures.
+  * @param spi_record_buffer Provide a buffer to use for storing heap trace data. It should be allocated in SPI RAM.
+ * @param spi_num_records Size of the SPI RAM heap trace buffer, as number of record structures.
+ * @return
+ *  - ESP_ERR_NOT_SUPPORTED Project was compiled without heap tracing enabled in menuconfig.
+ *  - ESP_ERR_INVALID_STATE Heap tracing is currently in progress.
+ *  - ESP_OK Heap tracing initialised successfully.
+ */
+esp_err_t heap_trace_init_standalone_with_spi_ram(
+    heap_trace_record_t *internal_record_buffer, size_t internal_num_records,
+    heap_trace_record_t *spi_record_buffer, size_t spi_num_records);
 
 /**
  * @brief Initialise heap tracing in host-based mode.
@@ -117,7 +148,7 @@ esp_err_t heap_trace_stop(void);
 esp_err_t heap_trace_resume(void);
 
 /**
- * @brief Return number of records in the heap trace buffer
+ * @brief Return number of records in the heap trace buffer.
  *
  * It is safe to call this function while heap tracing is running.
  */
@@ -144,10 +175,31 @@ esp_err_t heap_trace_get(size_t index, heap_trace_record_t *record);
  *
  * @note It is safe to call this function while heap tracing is running, however in HEAP_TRACE_LEAK mode the dump may skip
  * entries unless heap tracing is stopped first.
- *
- *
  */
 void heap_trace_dump(void);
+
+/**
+ * @brief Same as heap_trace_dump() but will only log allocations in Internal-RAM 
+ *
+ * @note It is safe to call this function while heap tracing is running, however in HEAP_TRACE_LEAK mode the dump may skip
+ * entries unless heap tracing is stopped first.
+ */
+void heap_trace_dump_internal_ram_only(void);
+
+/**
+ * @brief Same as heap_trace_dump() but will only log allocations in SPI-RAM
+ *
+ * @note It is safe to call this function while heap tracing is running, however in HEAP_TRACE_LEAK mode the dump may skip
+ * entries unless heap tracing is stopped first.
+ */
+void heap_trace_dump_spi_ram_only(void);
+
+/**
+ * @brief Get summary information about the result of a heap trace
+ * 
+ *  @note It is safe to call this function while heap tracing is running.
+ */
+esp_err_t heap_trace_summary(heap_trace_summary_t* summary);
 
 #ifdef __cplusplus
 }

--- a/docs/en/api-reference/system/heap_debug.rst
+++ b/docs/en/api-reference/system/heap_debug.rst
@@ -181,7 +181,7 @@ Standalone Mode
 Once you've identified the code which you think is leaking:
 
 - In the project configuration menu, navigate to ``Component settings`` -> ``Heap Memory Debugging`` -> ``Heap tracing`` and select ``Standalone`` option (see :ref:`CONFIG_HEAP_TRACING_DEST`).
-- Call the function :cpp:func:`heap_trace_init_standalone` early in the program, to register a buffer which can be used to record the memory trace.
+- Call the function :cpp:func:`heap_trace_init_standalone` or `heap_trace_init_standalone_with_spi_ram` early in the program, to register a buffer which can be used to record the memory trace.
 - Call the function :cpp:func:`heap_trace_start` to begin recording all mallocs/frees in the system. Call this immediately before the piece of code which you suspect is leaking memory.
 - Call the function :cpp:func:`heap_trace_stop` to stop the trace once the suspect piece of code has finished executing.
 - Call the function :cpp:func:`heap_trace_dump` to dump the results of the heap trace.
@@ -253,6 +253,7 @@ In ``HEAP_TRACE_LEAKS`` mode, for each traced memory allocation which has not al
 
     - ``XX bytes`` is the number of bytes allocated
     - ``@ 0x...`` is the heap address returned from malloc/calloc.
+    - ``Internal`` or ``SPI-RAM`` is the general location of the allocated memory. 
     - ``CPU x`` is the CPU (0 or 1) running when the allocation was made.
     - ``ccount 0x...`` is the CCOUNT (CPU cycle count) register value when the allocation was mode. Is different for CPU 0 vs CPU 1.
     :CONFIG_IDF_TARGET_ARCH_XTENSA: - ``caller 0x...`` gives the call stack of the call to malloc()/free(), as a list of PC addresses. These can be decoded to source files and line numbers, as shown above.


### PR DESCRIPTION
This augments: https://github.com/espressif/esp-idf/pull/10127 (**Edit:** this PR will need to be rebased onto https://github.com/espressif/esp-idf/pull/10141)

**Leaks:** The original implementation `memmove()`'s the entire record buffer every time a record is freed. This is obviously terrible for perf.

**My ESP32-S3 was not useable after ~300 records in SPI ram.** 

With this change, I can keep `Heap Trace Standalone` enabled without a noticeable impact on perf, tested up to 2540 records!