### PR TITLE
[USB Serial/JTAG Driver] use time-limited blocking for TX (IDFGH-8700)

### DIFF
--- a/components/driver/usb_serial_jtag.c
+++ b/components/driver/usb_serial_jtag.c
@@ -17,6 +17,8 @@
 #include "soc/periph_defs.h"
 #include "esp_check.h"
 
+#define TX_DRIVER_FLUSH_TIMEOUT_MS 50
+
 // The hardware buffer max size is 64
 #define USB_SER_JTAG_ENDP_SIZE          (64)
 #define USB_SER_JTAG_RX_MAX_SIZE        (64)
@@ -32,6 +34,7 @@ typedef struct{
     // TX parameters
     uint32_t tx_buf_size;               /*!< TX buffer size */
     RingbufHandle_t tx_ring_buf;        /*!< TX ring buffer handler */
+    uint32_t tx_blocking_attempts;       /*!< TX number of times we've tried a blocking send */
 } usb_serial_jtag_obj_t;
 
 static usb_serial_jtag_obj_t *p_usb_serial_jtag_obj = NULL;
@@ -161,12 +164,32 @@ int usb_serial_jtag_write_bytes(const void* src, size_t size, TickType_t ticks_t
     ESP_RETURN_ON_FALSE(src != NULL, ESP_ERR_INVALID_ARG, USB_SERIAL_JTAG_TAG, "Invalid buffer pointer.");
     ESP_RETURN_ON_FALSE(p_usb_serial_jtag_obj != NULL, ESP_ERR_INVALID_ARG, USB_SERIAL_JTAG_TAG, "The driver hasn't been initialized");
 
-    const uint8_t *buff = (const uint8_t *)src;
-    // Blocking method, Sending data to ringbuffer, and handle the data in ISR.
-    xRingbufferSend(p_usb_serial_jtag_obj->tx_ring_buf, (void*) (buff), size, ticks_to_wait);
-    // Now trigger the ISR to read data from the ring buffer.
-    usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
-    return size;
+    usb_serial_jtag_obj_t* sjtag = p_usb_serial_jtag_obj;
+
+    // try to send without blocking
+    if (xRingbufferSend(sjtag->tx_ring_buf, (void*) (src), size, 0)){
+       goto success;
+    }
+
+    // If the ring buffer is full, try to send again with a short
+    // blocking delay, hoping for the buffer to become available soon.
+    // If we still fail, dont ever block again until the buffer has space again.
+    if (sjtag->tx_blocking_attempts == 0) {
+      if (xRingbufferSend(sjtag->tx_ring_buf, (void*) (src), size, TX_DRIVER_FLUSH_TIMEOUT_MS / portTICK_PERIOD_MS)){
+         goto success;
+      } else {
+         sjtag->tx_blocking_attempts++;
+      }
+    }
+
+   // tx failure
+   return 0;
+
+success:
+   // Now trigger the ISR to read more data from the ring buffer.
+   usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
+   sjtag->tx_blocking_attempts = 0;
+   return size;
 }
 
 esp_err_t usb_serial_jtag_driver_uninstall(void)

--- a/docs/en/api-guides/usb-serial-jtag-console.rst
+++ b/docs/en/api-guides/usb-serial-jtag-console.rst
@@ -53,26 +53,26 @@ The USB Serial/JTAG Controller is able to put the {IDF_TARGET_NAME} into downloa
 Limitations
 ===========
 
-There are several limitations to the USB console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
+There are several limitations to the USB Serial/JTAG console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
 
 {IDF_TARGET_BOOT_PIN:default = "Not Updated!", esp32c3 = "GPIO9", esp32s3 = "GPIO0"}
 
 1. If the application accidentally reconfigures the USB peripheral pins, or disables the USB Serial/JTAG Controller, the device will disappear from the system. After fixing the issue in the application, you will need to manually put the {IDF_TARGET_NAME} into download mode by pulling low {IDF_TARGET_BOOT_PIN} and resetting the chip.
 
-2. If the application enters deep sleep mode, USB CDC device will disappear from the system.
+2. If the application enters deep sleep mode, the USB Serial/JTAG device will disappear from the system.
 
-3. The behavior between an actual USB-to-serial bridge chip and the USB Serial/JTAG Controller is slightly different if the ESP-IDF application does not listen for incoming bytes. An USB-to-serial bridge chip will just send the bytes to a (not listening) chip, while the USB Serial/JTAG Controller will block until the application reads the bytes. This can lead to a non-responsive looking terminal program.
+3. The behavior between an actual USB-to-serial bridge chip and the USB Serial/JTAG Controller is slightly different. A USB-to-serial bridge chip will just send the bytes to a (not listening) chip, while the USB Serial/JTAG Controller will do a one-time wait of up to 50 milliseconds hoping for the terminal to read the bytes. This can add what appears to be a short "pause" in your ESP-IDF application.
 
-4. The USB CDC device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
+4. The USB Serial/JTAG device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
 
-5. The power consumption in sleep modes will be higher if the USB CDC device is in use.
+5. The power consumption in sleep modes will be higher if the USB Serial/JTAG device is in use.
 
-   This is because we want to keep the USB CDC device alive during software reset by default.
+   This is because we want to keep the USB Serial/JTAG device alive during software reset by default.
 
-   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB CDC device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB CDC port is really in use (like data transaction), therefore, if your USB CDC is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
+   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB Serial/JTAG device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB Serial/JTAG port is really in use (like data transaction), therefore, if your USB Serial/JTAG is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
 
    If you still want to keep low power consumption in sleep modes:
 
-    1. If you are not using the USB CDC port, you don't need to do anything. Software will detect if the CDC device is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
+    1. If you are not using the USB Serial/JTAG port, you don't need to do anything. Software will detect if the USB Serial/JTAG is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
 
-    2. If you are using the USB CDC port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB CDC device may be unplugged from the host.
+    2. If you are using the USB Serial/JTAG port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB Serial/JTAG device may be unplugged from the host.


### PR DESCRIPTION
Older PR: https://github.com/espressif/esp-idf/pull/10099

Tested working on a ESP32-S3.

Uses Ivan's suggestions for Usb Serial JTAG TX with the driver.

> Instead of introducing this new function, would it instead make more sense to fix the TX-blocking-indefinitely behavior?
> 
> This is already done in usb_serial_jtag_tx_char with the TX_FLUSH_TIMEOUT_US check, we exit and drop the character if the flush doesn't happen for too long.
> 
> Seems like the same behavior could be achieved in usbjtag_tx_char_via_driver, by passing pdMS_TO_TICKS(TX_FLUSH_TIMEOUT_US / 1000) instead of portMAX_DELAY?

