### PR TITLE
Removed the 'configASSERT( xInheritanceOccurred == pdFALSE )' assertion from xQueueSemaphoreTake (IDFGH-8766)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/queue.c
+++ b/components/freertos/FreeRTOS-Kernel/queue.c
@@ -1693,15 +1693,6 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
             {
                 if( xTicksToWait == ( TickType_t ) 0 )
                 {
-                    /* For inheritance to have occurred there must have been an
-                     * initial timeout, and an adjusted timeout cannot become 0, as
-                     * if it were 0 the function would have exited. */
-                    #if ( configUSE_MUTEXES == 1 )
-                        {
-                            configASSERT( xInheritanceOccurred == pdFALSE );
-                        }
-                    #endif /* configUSE_MUTEXES */
-
                     /* The semaphore count was 0 and no block time is specified
                      * (or the block time has expired) so exit now. */
                     taskEXIT_CRITICAL( &( pxQueue->xQueueLock ) );


### PR DESCRIPTION
## FreeRTOS References:
Commit: FreeRTOS/FreeRTOS-Kernel@4e2bf2c639cf769aaf26b742e4c11892189ae057
Pull-Request: FreeRTOS/FreeRTOS-Kernel#576
Problem Description: https://forums.freertos.org/t/15967

This pull-request is purposed to copy the bugfix from the FreeRTOS Repo into esp-idf.
All credit goes to @Erlkoenig90.

## Original FreeRTOS Pull Request Description
Removed the 'configASSERT( xInheritanceOccurred == pdFALSE )' assertion from xQueueSemaphoreTake as the reasoning behind it is wrong; it can trigger on wrongly on highly-contested semaphores on multicore systems. See [the forum](https://forums.freertos.org/t/15967) for details.