### PR TITLE
[USB Serial/JTAG Driver] use time-limited blocking for TX (IDFGH-8776)

### DIFF
--- a/components/driver/include/driver/usb_serial_jtag.h
+++ b/components/driver/include/driver/usb_serial_jtag.h
@@ -35,7 +35,9 @@ typedef struct {
  * USB-SERIAL-JTAG driver's ISR will be attached to the same CPU core that calls this function. Thus, users
  * should ensure that the same core is used when calling `usb_serial_jtag_driver_uninstall()`.
  *
- * @note  Blocking mode will result in usb_serial_jtag_write_bytes() blocking until all bytes have been written to the TX FIFO.
+ * @note  Blocking mode will result in usb_serial_jtag_write_bytes() blocking for a
+ * short period if the TX FIFO if full. It will not block again until the buffer
+ * has some space available again.
  *
  * @param usb_serial_jtag_driver_config_t Configuration for usb_serial_jtag driver.
  *
@@ -65,7 +67,7 @@ int usb_serial_jtag_read_bytes(void* buf, uint32_t length, TickType_t ticks_to_w
  *
  * @param src   data buffer address
  * @param size  data length to send
- * @param ticks_to_wait Timeout in RTOS ticks
+ * @param ticks_to_wait Maximum timeout in RTOS ticks
  *
  * @return
  *     - The number of bytes pushed to the TX FIFO

--- a/components/vfs/vfs_usb_serial_jtag.c
+++ b/components/vfs/vfs_usb_serial_jtag.c
@@ -404,7 +404,8 @@ static int usbjtag_rx_char_via_driver(int fd)
 static void usbjtag_tx_char_via_driver(int fd, int c)
 {
     char ch = (char) c;
-    usb_serial_jtag_write_bytes(&ch, 1, portMAX_DELAY);
+    TickType_t ticks = (TX_FLUSH_TIMEOUT_US / 1000) / portTICK_PERIOD_MS;
+    usb_serial_jtag_write_bytes(&ch, 1, ticks);
 }
 
 void esp_vfs_usb_serial_jtag_use_nonblocking(void)

--- a/docs/en/api-guides/usb-serial-jtag-console.rst
+++ b/docs/en/api-guides/usb-serial-jtag-console.rst
@@ -53,26 +53,28 @@ The USB Serial/JTAG Controller is able to put the {IDF_TARGET_NAME} into downloa
 Limitations
 ===========
 
-There are several limitations to the USB console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
+There are several limitations to the USB Serial/JTAG console feature. These may or may not be significant, depending on the type of application being developed, and the development workflow.
 
 {IDF_TARGET_BOOT_PIN:default = "Not Updated!", esp32c3 = "GPIO9", esp32s3 = "GPIO0"}
 
 1. If the application accidentally reconfigures the USB peripheral pins, or disables the USB Serial/JTAG Controller, the device will disappear from the system. After fixing the issue in the application, you will need to manually put the {IDF_TARGET_NAME} into download mode by pulling low {IDF_TARGET_BOOT_PIN} and resetting the chip.
 
-2. If the application enters deep sleep mode, USB CDC device will disappear from the system.
+2. If the application enters deep sleep mode, the USB Serial/JTAG device will disappear from the system.
 
-3. The behavior between an actual USB-to-serial bridge chip and the USB Serial/JTAG Controller is slightly different if the ESP-IDF application does not listen for incoming bytes. An USB-to-serial bridge chip will just send the bytes to a (not listening) chip, while the USB Serial/JTAG Controller will block until the application reads the bytes. This can lead to a non-responsive looking terminal program.
+3. For data sent in the direction of ESP32 to PC Terminal (e.g. stdout, logs), the ESP32 first writes to a small internal buffer. If this buffer becomes full (for example, if no PC Terminal is connected), the ESP32 will do a one-time wait of 50ms hoping for the PC Terminal to request the data. This can appear as a very brief 'pause' in your application.
 
-4. The USB CDC device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
+4. For data sent in the PC Terminal to ESP32 direction (e.g. console commands), many PC Terminals will wait for the ESP32 to ingest the bytes before allowing you to sending more data. This is in contrast to using a USB-to-Serial (UART) bridge chip, which will always ingest the bytes and send them to a (possibly not listening) ESP32.
 
-5. The power consumption in sleep modes will be higher if the USB CDC device is in use.
+5. The USB Serial/JTAG device won't work in sleep modes as normal due to the lack of APB clock in sleep modes. This includes deep-sleep, light-sleep (automataic light-sleep as well).
 
-   This is because we want to keep the USB CDC device alive during software reset by default.
+6. The power consumption in sleep modes will be higher if the USB Serial/JTAG device is in use.
 
-   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB CDC device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB CDC port is really in use (like data transaction), therefore, if your USB CDC is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
+   This is because we want to keep the USB Serial/JTAG device alive during software reset by default.
+
+   However there is an issue that this might also increase the power consumption in sleep modes. This is because the software keeps a clock source on during the reset to keep the USB Serial/JTAG device alive. As a side-effect, the clock is also kept on during sleep modes. There is one exception: the clock will only be kept on when your USB Serial/JTAG port is really in use (like data transaction), therefore, if your USB Serial/JTAG is connected to power bank or battery, etc., instead of a valid USB host (for example, a PC), the power consumption will not increase.
 
    If you still want to keep low power consumption in sleep modes:
 
-    1. If you are not using the USB CDC port, you don't need to do anything. Software will detect if the CDC device is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
+    1. If you are not using the USB Serial/JTAG port, you don't need to do anything. Software will detect if the USB Serial/JTAG is connected to a valid host before going to sleep, and keep the clocks only when the host is connected. Otherwise the clocks will be turned off as normal.
 
-    2. If you are using the USB CDC port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB CDC device may be unplugged from the host.
+    2. If you are using the USB Serial/JTAG port, please disable the menuconfig option ``CONFIG_RTC_CLOCK_BBPLL_POWER_ON_WITH_USB``. The clock will be switched off as normal during software reset and in sleep modes. In these cases, the USB Serial/JTAG device may be unplugged from the host.


### PR DESCRIPTION
Older PR: https://github.com/espressif/esp-idf/pull/10099

Tested working on a ESP32-S3.

Uses Ivan's suggestions for Usb Serial JTAG TX with the driver.

> Instead of introducing this new function, would it instead make more sense to fix the TX-blocking-indefinitely behavior?
> 
> This is already done in usb_serial_jtag_tx_char with the TX_FLUSH_TIMEOUT_US check, we exit and drop the character if the flush doesn't happen for too long.
> 
> Seems like the same behavior could be achieved in usbjtag_tx_char_via_driver, by passing pdMS_TO_TICKS(TX_FLUSH_TIMEOUT_US / 1000) instead of portMAX_DELAY?