### PR TITLE
SPI fix DMA rxbuf size calculation (IDFGH-8793)

### DIFF
--- a/components/driver/spi_bus_lock.c
+++ b/components/driver/spi_bus_lock.c
@@ -212,7 +212,7 @@ struct spi_bus_lock_t {
 };
 
 struct spi_bus_lock_dev_t {
-    SemaphoreHandle_t   semphr;     ///< Binray semaphore to notify the device it claimed the bus
+    SemaphoreHandle_t   semphr;     ///< Binary semaphore to notify the device it claimed the bus
     spi_bus_lock_t*     parent;     ///< Pointer to parent spi_bus_lock_t
     uint32_t            mask;       ///< Bitwise OR-ed mask of the REQ, PEND, LOCK bits of this device
 };

--- a/components/driver/spi_master.c
+++ b/components/driver/spi_master.c
@@ -795,7 +795,7 @@ static SPI_MASTER_ISR_ATTR esp_err_t setup_priv_desc(spi_transaction_t *trans_de
     if (rcv_ptr && isdma && (!esp_ptr_dma_capable(rcv_ptr) || ((int)rcv_ptr % 4 != 0))) {
         //if rxbuf in the desc not DMA-capable, malloc a new one. The rx buffer need to be length of multiples of 32 bits to avoid heap corruption.
         ESP_LOGD(SPI_TAG, "Allocate RX buffer for DMA" );
-        rcv_ptr = heap_caps_malloc((trans_desc->rxlength + 31) / 8, MALLOC_CAP_DMA);
+        rcv_ptr = heap_caps_malloc(((trans_desc->rxlength + 31) / 32) * 4, MALLOC_CAP_DMA); // ((x+31)/32)*4 != (x+31)/8
         if (rcv_ptr == NULL) goto clean_up;
     }
     new_desc->buffer_to_rcv = rcv_ptr;


### PR DESCRIPTION
(x+31)/8 doesn't round to 4 bytes (32 bits), e.g. (16+31)/8=47/8=5,
where ((x+31)/32)*4 does round to 4 bytes: (16+31)/32=(47/32)*4=1*4=4