### PR TITLE
Set `errno` in `adjtime` (IDFGH-8915)

### DIFF
--- a/components/newlib/time.c
+++ b/components/newlib/time.c
@@ -139,6 +139,7 @@ int adjtime(const struct timeval *delta, struct timeval *outdelta)
     }
     return 0;
 #else
+    errno = ENOSYS;
     return -1;
 #endif
 }

--- a/components/newlib/time.c
+++ b/components/newlib/time.c
@@ -123,6 +123,7 @@ int adjtime(const struct timeval *delta, struct timeval *outdelta)
         int64_t sec  = delta->tv_sec;
         int64_t usec = delta->tv_usec;
         if(llabs(sec) > ((INT_MAX / 1000000L) - 1L)) {
+            errno = EINVAL;
             return -1;
         }
         /*


### PR DESCRIPTION
In contrast to other time function implementations (e.g. `settimeofday`) and its [man page](https://man7.org/linux/man-pages/man3/adjtime.3.html#RETURN_VALUE), `adjtime` does not set `errno` in case it fails.

There are two possible scenarios for `adjtime` to fail at the moment:

1) the provided adjustment delta is too large -> `errno` should be set to `EINVAL` according to the [man page](https://man7.org/linux/man-pages/man3/adjtime.3.html#ERRORS)
2) newlib time function implementations are disabled -> other functions (e.g. `settimeofday`) return `ENOSYS` in this case

This pull request fixes both.

Maybe this is something that should also be fixed in some of the older stable releases which are still in maintenance period. What do you think? I would love to see it fixed for v4.4 at least, which is the version I discovered this on 😉  