### PR TITLE
[BT] list fix (IDFGH-8921)

### DIFF
--- a/components/bt/common/osi/list.c
+++ b/components/bt/common/osi/list.c
@@ -181,20 +181,19 @@ bool list_remove(list_t *list, void *data)
     }
 
     if (list->head->data == data) {
-        list_node_t *next = list_free_node(list, list->head);
         if (list->tail == list->head) {
-            list->tail = next;
+            list->tail = NULL;
         }
-        list->head = next;
+        list->head = list_free_node(list, list->head);
         return true;
     }
 
     for (list_node_t *prev = list->head, *node = list->head->next; node; prev = node, node = node->next)
         if (node->data == data) {
-            prev->next = list_free_node(list, node);
             if (list->tail == node) {
                 list->tail = prev;
             }
+            prev->next = list_free_node(list, node);
             return true;
         }
 
@@ -211,20 +210,19 @@ bool list_delete(list_t *list, void *data)
     }
 
     if (list->head->data == data) {
-        list_node_t *next = list_delete_node(list, list->head);
         if (list->tail == list->head) {
-            list->tail = next;
+            list->tail = NULL;
         }
-        list->head = next;
+        list->head = list_delete_node(list, list->head);
         return true;
     }
 
     for (list_node_t *prev = list->head, *node = list->head->next; node; prev = node, node = node->next)
         if (node->data == data) {
-            prev->next = list_delete_node(list, node);
             if (list->tail == node) {
                 list->tail = prev;
             }
+            prev->next = list_delete_node(list, node);
             return true;
         }
 


### PR DESCRIPTION
Fix use after free in `list_remove()` and `list_delete()`. 
`list->head` / `node` are freed in `list_free_node()` / `list_delete_node()` and used after that to check if they are equal to `list->tail`.

Just a notice that hypothetical change in `fixed_queue_new()` form `list_new(NULL)` to `list_new(osi_free)` would lead to use after free of data returned by `fixed_queue_dequeue()` and `fixed_queue_try_remove_from_queue()`. In that case `list_remove(`) should be replaced with `list_delete()` in `fixed_queue_dequeue()` and `fixed_queue_try_remove_from_queue()`.