### PR TITLE
[BT] btc_spp_write mem leak

### DIFF
--- a/components/bt/host/bluedroid/bta/include/bta/bta_sys.h
+++ b/components/bt/host/bluedroid/bta/include/bta/bta_sys.h
@@ -221,7 +221,7 @@ extern void bta_sys_register(UINT8 id, const tBTA_SYS_REG *p_reg);
 extern void bta_sys_deregister(UINT8 id);
 extern BOOLEAN bta_sys_is_register(UINT8 id);
 extern UINT16 bta_sys_get_sys_features(void);
-extern void bta_sys_sendmsg(void *p_msg);
+extern BOOLEAN bta_sys_sendmsg(void *p_msg);
 extern void bta_sys_start_timer(TIMER_LIST_ENT *p_tle, UINT16 type, INT32 timeout_ms);
 extern void bta_sys_stop_timer(TIMER_LIST_ENT *p_tle);
 extern void bta_sys_free_timer(TIMER_LIST_ENT *p_tle);

--- a/components/bt/host/bluedroid/bta/jv/bta_jv_api.c
+++ b/components/bt/host/bluedroid/bta/jv/bta_jv_api.c
@@ -1156,8 +1156,9 @@ tBTA_JV_STATUS BTA_JvRfcommWrite(UINT32 handle, UINT32 req_id, int len, UINT8 *p
         p_msg->p_data = p_data;
         p_msg->len = len;
         APPL_TRACE_API( "write ok");
-        bta_sys_sendmsg(p_msg);
-        status = BTA_JV_SUCCESS;
+        if (bta_sys_sendmsg(p_msg)) {
+            status = BTA_JV_SUCCESS;
+        }
     }
     return (status);
 }

--- a/components/bt/host/bluedroid/bta/sys/bta_sys_main.c
+++ b/components/bt/host/bluedroid/bta/sys/bta_sys_main.c
@@ -564,10 +564,10 @@ BOOLEAN bta_sys_is_register(UINT8 id)
 **                  API functions and call-in functions.
 **
 **
-** Returns          void
+** Returns          true if message is posted to BTA, false otherwise
 **
 *******************************************************************************/
-void bta_sys_sendmsg(void *p_msg)
+BOOLEAN bta_sys_sendmsg(void *p_msg)
 {
     // There is a race condition that occurs if the stack is shut down while
     // there is a procedure in progress that can schedule a task via this
@@ -575,7 +575,9 @@ void bta_sys_sendmsg(void *p_msg)
     // it gets used here; hence we check for NULL before using it.
     if (btu_task_post(SIG_BTU_BTA_MSG, p_msg, OSI_THREAD_MAX_TIMEOUT) == false) {
         osi_free(p_msg);
+        return FALSE;
     }
+    return TRUE;
 }
 
 /*******************************************************************************

--- a/components/bt/host/bluedroid/btc/profile/std/spp/btc_spp.c
+++ b/components/bt/host/bluedroid/btc/profile/std/spp/btc_spp.c
@@ -895,7 +895,12 @@ static void btc_spp_write(btc_spp_args_t *arg)
             }
         } else {
             if (fixed_queue_enqueue(slot->tx.queue, arg->write.p_data, 0)) {
-                BTA_JvRfcommWrite(arg->write.handle, slot->id, arg->write.len, arg->write.p_data);
+                if (BTA_JvRfcommWrite(arg->write.handle, slot->id, arg->write.len, arg->write.p_data) == BTA_JV_SUCCESS) {
+                    arg->write.p_data = NULL; // arg->write.p_data passed to tBTA_JV_API_RFCOMM_WRITE::p_data, set it to NULL to prevent freeing
+                } else {
+                    arg->write.p_data = fixed_queue_try_remove_from_queue(slot->tx.queue, arg->write.p_data);
+                    ret = ESP_SPP_FAILURE;
+                }
             } else {
                 ret = ESP_SPP_NO_RESOURCE;
             }
@@ -953,6 +958,12 @@ void btc_spp_arg_deep_free(btc_msg_t *msg)
     case BTC_SPP_ACT_START_DISCOVERY:
         if (arg->start_discovery.p_uuid_list) {
             osi_free(arg->start_discovery.p_uuid_list);
+        }
+        break;
+    case BTC_SPP_ACT_WRITE:
+        if (arg->write.p_data) {
+            osi_free(arg->write.p_data);
+            arg->write.p_data = NULL;
         }
         break;
     default:


### PR DESCRIPTION
Fix potential memory leak in `btc_spp_write()`.
`btc_spp_arg_deep_free()` doesn't free `write.p_data` allocated in `btc_spp_arg_deep_copy()`. 
Cases of memory leak:
- btc_spp_write() fails
- fixed_queue_enqueue() fails 

Memory will be freed if `BTA_JvRfcommWrite()` fails when connection is closed (BTA_JV_RFCOMM_CLOSE_EVT).
If `BTA_JvRfcommWrite()` fails, it would be better to pull data from queue and free it in `btc_spp_arg_deep_free()` when `btc_spp_write()` returns.