### PR TITLE
esp_psram: fix compile error for SPI PSRAM 2T mode (IDFGH-9149)

### DIFF
--- a/components/esp_psram/esp32/esp_psram_impl_quad.c
+++ b/components/esp_psram/esp32/esp_psram_impl_quad.c
@@ -19,6 +19,7 @@
 #include "esp32/rom/spi_flash.h"
 #include "esp32/rom/cache.h"
 #include "esp32/rom/efuse.h"
+#include "esp32/rom/gpio.h"
 #include "esp_rom_efuse.h"
 #include "soc/dport_reg.h"
 #include "soc/efuse_periph.h"


### PR DESCRIPTION
The following compile error occurred when SPI PSRAM 2T mode was enabled.
```
/opt/esp-idf/components/esp_psram/esp32/esp_psram_impl_quad.c: In function 'psram_2t_mode_enable':
/opt/esp-idf/components/esp_psram/esp32/esp_psram_impl_quad.c:593:5: error: implicit declaration of function 'GPIO_OUTPUT_SET'; did you mean 'GPIO_OUT_REG'? [-Werror=implicit-function-declaration]
  593 |     GPIO_OUTPUT_SET(D0WD_PSRAM_CS_IO, 1);
      |     ^~~~~~~~~~~~~~~
      |     GPIO_OUT_REG
cc1: some warnings being treated as errors
```
GPIO_OUTPUT_SET is defined here:
https://github.com/espressif/esp-idf/blob/db9586c53f31a65abf0a51cac7072d7750f7b073/components/esp_rom/include/esp32/rom/gpio.h#L48-L50
but esp_psram_impl_quad.c does not include esp32/rom/gpio.h.

This PR fixes this compile error by including esp32/rom/gpio.h in esp_psram_impl_quad.c.