### PR TITLE
Verify w5500 chip properly (IDFGH-9158)

### DIFF
--- a/components/esp_eth/src/esp_eth_mac_w5500.c
+++ b/components/esp_eth/src/esp_eth_mac_w5500.c
@@ -230,8 +230,8 @@ static esp_err_t w5500_verify_id(emac_w5500_t *emac)
     esp_err_t ret = ESP_OK;
     uint8_t version = 0;
     ESP_GOTO_ON_ERROR(w5500_read(emac, W5500_REG_VERSIONR, &version, sizeof(version)), err, TAG, "read VERSIONR failed");
-    // W5500 doesn't have chip ID, we just print the version number instead
-    ESP_LOGI(TAG, "version=%x", version);
+    // W5500 doesn't have chip ID, we check the version number instead
+    ESP_GOTO_ON_FALSE(version == W5500_CHIP_VERSION, ESP_ERR_INVALID_VERSION, err, TAG, "invalid chip version, expected 0x%x, actual 0x%x", W5500_CHIP_VERSION, version);
 
 err:
     return ret;

--- a/components/esp_eth/src/w5500.h
+++ b/components/esp_eth/src/w5500.h
@@ -16,6 +16,8 @@
 #define W5500_BSB_OFFSET  (3)  // Block Select Bits offset
 #define W5500_RWB_OFFSET  (2)  // Read Write Bits offset
 
+#define W5500_CHIP_VERSION (0x4) // Chip version that VERSIONR returns
+
 #define W5500_BSB_COM_REG        (0x00)    // Common Register
 #define W5500_BSB_SOCK_REG(s)    ((s)*4+1) // Socket Register
 #define W5500_BSB_SOCK_TX_BUF(s) ((s)*4+2) // Socket TX Buffer


### PR DESCRIPTION
Datasheet says that 0x4 is only value returned. We should verify that we got correct one.
![image](https://user-images.githubusercontent.com/35471680/212736769-7b588c83-a3b0-4127-a60f-1564f337e67b.png)

Note: Currently trying to make W5500 work using `esp-idf-svc` in rust. SPI returns garbage data, but no clear error message is returned. So would be nice if we failed fast here.