### PR TITLE
[Console] fix: console deinit always deadlocks - adds ability to unblock linenoise (try 2) (IDFGH-9188)

### DIFF
--- a/components/driver/uart/include/driver/uart.h
+++ b/components/driver/uart/include/driver/uart.h
@@ -824,6 +824,17 @@ esp_err_t uart_wait_tx_idle_polling(uart_port_t uart_num);
 esp_err_t uart_set_loop_back(uart_port_t uart_num, bool loop_back_en);
 
 /**
+ * @brief Unblocks uart_read_bytes() if it is currently waiting to receive bytes.
+ *
+ * This will cause uart_read_bytes() to return -1 with errno set to EWOULDBLOCK.
+ *
+ * @return
+ *     - ESP_OK   Success
+ *     - ESP_INVALID_STATE If the Uart driver has not been installed
+ */
+esp_err_t uart_unblock_reads(uart_port_t uart_num);
+
+/**
   * @brief Configure behavior of UART RX timeout interrupt.
   *
   * When always_rx_timeout is true, timeout interrupt is triggered even if FIFO is full.

--- a/components/driver/uart/uart.c
+++ b/components/driver/uart/uart.c
@@ -1762,6 +1762,16 @@ esp_err_t uart_set_loop_back(uart_port_t uart_num, bool loop_back_en)
     return ESP_OK;
 }
 
+esp_err_t uart_unblock_reads(uart_port_t uart_num)
+{
+    if (p_uart_obj[uart_num]->rx_ring_buf == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    vRingbufferUnblockRx(p_uart_obj[uart_num]->rx_ring_buf);
+    return ESP_OK;
+}
+
 void uart_set_always_rx_timeout(uart_port_t uart_num, bool always_rx_timeout)
 {
     uint16_t rx_tout = uart_hal_get_rx_tout_thr(&(uart_context[uart_num].hal));

--- a/components/driver/usb_serial_jtag/include/driver/usb_serial_jtag.h
+++ b/components/driver/usb_serial_jtag/include/driver/usb_serial_jtag.h
@@ -48,6 +48,17 @@ typedef struct {
 esp_err_t usb_serial_jtag_driver_install(usb_serial_jtag_driver_config_t *usb_serial_jtag_config);
 
 /**
+ * @brief Unblocks usb_serial_jtag_read_bytes() if it is currently waiting to receive bytes.
+ *
+ *  This will cause usb_serial_jtag_read_bytes() to return -1 with errno set to EWOULDBLOCK.
+ *
+ * @return
+ *     - ESP_OK   Success
+ *     - ESP_INVALID_STATE If the Usb Serial JTAG driver has not been installed
+ */
+esp_err_t usb_serial_jtag_unblock_reads();
+
+/**
  * @brief USB_SERIAL_JTAG read bytes from USB_SERIAL_JTAG buffer
  *
  * @param buf     pointer to the buffer.

--- a/components/driver/usb_serial_jtag/usb_serial_jtag.c
+++ b/components/driver/usb_serial_jtag/usb_serial_jtag.c
@@ -132,6 +132,16 @@ _exit:
     return err;
 }
 
+esp_err_t usb_serial_jtag_unblock_reads()
+{
+    if (p_usb_serial_jtag_obj->rx_ring_buf == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    vRingbufferUnblockRx(p_usb_serial_jtag_obj->rx_ring_buf);
+    return ESP_OK;
+}
+
 int usb_serial_jtag_read_bytes(void* buf, uint32_t length, TickType_t ticks_to_wait)
 {
     uint8_t *data = NULL;

--- a/components/esp_ringbuf/include/freertos/ringbuf.h
+++ b/components/esp_ringbuf/include/freertos/ringbuf.h
@@ -507,6 +507,16 @@ void vRingbufferGetInfo(RingbufHandle_t xRingbuffer,
                         UBaseType_t *uxItemsWaiting);
 
 /**
+ * @brief   Unblock any read function that is currently waiting. example: xRingbufferReceiveUpTo()
+ *
+ * All read functions take a xTicksToWait argument, which can be set up to
+ * to infinity. This function will unblock any threads currently waiting.
+ *
+ * @param[in]   xRingbuffer     The ring buffer who's rx will be unblocked.
+ */
+void vRingbufferUnblockRx(RingbufHandle_t xRingbuffer);
+
+/**
  * @brief   Debugging function to print the internal pointers in the ring buffer
  *
  * @param   xRingbuffer Ring buffer to show


### PR DESCRIPTION
**Previous PR:** https://github.com/espressif/esp-idf/pull/9983

I am re-opening this PR to get more traction on it. 

This solves: https://github.com/espressif/esp-idf/issues/9974

**Motivation:**
- currently, console deinit causes a deadlock
- without deinit, we can't create consoles "as needed"
- for example, USB Serial JTAG console should be destroyed when entering USB host mode
- for example, "web" consoles should be destroyed when the browser window is closed