### PR TITLE
espcoredump: add log verbosity option (IDFGH-9191)

### DIFF
--- a/components/espcoredump/Kconfig
+++ b/components/espcoredump/Kconfig
@@ -122,4 +122,44 @@ menu "Core dump"
         default "disable" if ESP_COREDUMP_DECODE_DISABLE
         default "info" if ESP_COREDUMP_DECODE_INFO
 
+    config ESP_COREDUMP_LOG_LEVEL_OVERRIDE
+        bool "Override LOG_LOCAL_LEVEL"
+        default n
+        depends on !ESP_COREDUMP_ENABLE_TO_NONE
+        help
+            Core dump related functions might produce an unconveniently lot of
+            debug outputs when one sets the default log level to DEBUG or higher.
+            It is possible to suppress these debug outputs by enabling this and
+            selecting the log level accordingly.
+
+    choice ESP_COREDUMP_LOG_LEVEL
+        bool "Log verbosity for the core dump component"
+        default ESP_COREDUMP_LOG_LEVEL_INFO
+        depends on ESP_COREDUMP_LOG_LEVEL_OVERRIDE
+        help
+            Specify how much output to see for core dump component.
+
+        config ESP_COREDUMP_LOG_LEVEL_NONE
+            bool "No output"
+        config ESP_COREDUMP_LOG_LEVEL_ERROR
+            bool "Error"
+        config ESP_COREDUMP_LOG_LEVEL_WARN
+            bool "Warning"
+        config ESP_COREDUMP_LOG_LEVEL_INFO
+            bool "Info"
+        config ESP_COREDUMP_LOG_LEVEL_DEBUG
+            bool "Debug"
+        config ESP_COREDUMP_LOG_LEVEL_VERBOSE
+            bool "Verbose"
+    endchoice
+
+    config ESP_COREDUMP_LOG_LEVEL
+        int
+        default 0 if ESP_COREDUMP_LOG_LEVEL_NONE
+        default 1 if ESP_COREDUMP_LOG_LEVEL_ERROR
+        default 2 if ESP_COREDUMP_LOG_LEVEL_WARN
+        default 3 if ESP_COREDUMP_LOG_LEVEL_INFO
+        default 4 if ESP_COREDUMP_LOG_LEVEL_DEBUG
+        default 5 if ESP_COREDUMP_LOG_LEVEL_VERBOSE
+
 endmenu

--- a/components/espcoredump/include_core_dump/esp_core_dump_types.h
+++ b/components/espcoredump/include_core_dump/esp_core_dump_types.h
@@ -18,6 +18,11 @@ extern "C" {
 #include "esp_private/panic_internal.h"
 #include "core_dump_checksum.h"
 
+#ifdef CONFIG_ESP_COREDUMP_LOG_LEVEL
+#undef LOG_LOCAL_LEVEL
+#define LOG_LOCAL_LEVEL  CONFIG_ESP_COREDUMP_LOG_LEVEL
+#endif
+
 #define ESP_COREDUMP_LOG( level, format, ... )  if (LOG_LOCAL_LEVEL >= level)   { esp_rom_printf(DRAM_STR(format), esp_log_early_timestamp(), (const char *)TAG, ##__VA_ARGS__); }
 #define ESP_COREDUMP_LOGE( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_ERROR, LOG_FORMAT(E, format), ##__VA_ARGS__)
 #define ESP_COREDUMP_LOGW( format, ... )  ESP_COREDUMP_LOG(ESP_LOG_WARN, LOG_FORMAT(W, format), ##__VA_ARGS__)


### PR DESCRIPTION
Adds an option to override `LOG_LOCAL_LEVEL` in the espcoredump component. With this, the amount of logs generated when reading the coredump information from the partition (e.g. by `esp_core_dump_get_summary`) can be reduced. 

This PR addresses and solves #10573. 