### PR TITLE
Fix a bug in bluedroid when multiple SDP records are created (IDFGH-9219)

### DIFF
--- a/components/bt/host/bluedroid/bta/include/bta/bta_sdp_api.h
+++ b/components/bt/host/bluedroid/bta/include/bta/bta_sdp_api.h
@@ -40,12 +40,12 @@ typedef UINT8 tBTA_SDP_STATUS;
 
 /* SDP I/F callback events */
 /* events received by tBTA_SDP_DM_CBACK */
-#define BTA_SDP_ENABLE_EVT               0  /* SDP service enabled*/
-#define BTA_SDP_DISENABLE_EVT            1  /* SDP service disenabled*/
+#define BTA_SDP_ENABLE_EVT               0  /* SDP service enabled */
+#define BTA_SDP_DISENABLE_EVT            1  /* SDP service disenabled */
 #define BTA_SDP_SEARCH_EVT               2  /* SDP search started */
 #define BTA_SDP_SEARCH_COMP_EVT          3  /* SDP search complete */
 #define BTA_SDP_CREATE_RECORD_USER_EVT   4  /* SDP create record complete */
-#define BTA_SDP_REMOVE_RECORD_USER_EVT   5  /* SDP remove reocrd complete */
+#define BTA_SDP_REMOVE_RECORD_USER_EVT   5  /* SDP remove record complete */
 #define BTA_SDP_MAX_EVT                  6  /* max number of SDP events */
 
 #define BTA_SDP_MAX_RECORDS 15
@@ -61,10 +61,16 @@ typedef struct {
     bluetooth_sdp_record records[BTA_SDP_MAX_RECORDS];
 } tBTA_SDP_SEARCH_COMP;
 
+/* data associated with BTA_SDP_CREATE_RECORD_USER_EVT */
+typedef struct {
+    tBTA_SDP_STATUS     status;
+    int                 handle;
+} tBTA_SDP_CREATE_RECORD_USER;
+
 typedef union {
     tBTA_SDP_STATUS              status;            /* BTA_SDP_SEARCH_EVT */
     tBTA_SDP_SEARCH_COMP         sdp_search_comp;   /* BTA_SDP_SEARCH_COMP_EVT */
-    int                          handle;
+    tBTA_SDP_CREATE_RECORD_USER  sdp_create_record; /* BTA_SDP_CREATE_RECORD_USER_EVT */
 } tBTA_SDP;
 
 /* SDP DM Interface callback */

--- a/components/bt/host/bluedroid/bta/sdp/bta_sdp_act.c
+++ b/components/bt/host/bluedroid/bta/sdp/bta_sdp_act.c
@@ -546,9 +546,9 @@ void bta_sdp_search(tBTA_SDP_MSG *p_data)
 
 /*******************************************************************************
 **
-** Function     bta_sdp_record
+** Function     bta_sdp_create_record
 **
-** Description  Discovers all sdp records for an uuid on remote device
+** Description  Creates an SDP record for a handle
 **
 ** Returns      void
 **
@@ -556,19 +556,19 @@ void bta_sdp_search(tBTA_SDP_MSG *p_data)
 void bta_sdp_create_record(tBTA_SDP_MSG *p_data)
 {
     APPL_TRACE_DEBUG("%s() event: %d\n", __func__, p_data->record.hdr.event);
-    tBTA_SDP bta_sdp;
+    tBTA_SDP_CREATE_RECORD_USER bta_sdp = {0};
     bta_sdp.status = BTA_SDP_SUCCESS;
     bta_sdp.handle = (int)p_data->record.user_data;
     if (bta_sdp_cb.p_dm_cback) {
-        bta_sdp_cb.p_dm_cback(BTA_SDP_CREATE_RECORD_USER_EVT, &bta_sdp, p_data->record.user_data);
+        bta_sdp_cb.p_dm_cback(BTA_SDP_CREATE_RECORD_USER_EVT, (tBTA_SDP *)&bta_sdp, p_data->record.user_data);
     }
 }
 
 /*******************************************************************************
 **
-** Function     bta_sdp_create_record
+** Function     bta_sdp_remove_record
 **
-** Description  Discovers all sdp records for an uuid on remote device
+** Description  Removes an SDP record
 **
 ** Returns      void
 **

--- a/components/bt/host/bluedroid/btc/profile/std/sdp/btc_sdp.c
+++ b/components/bt/host/bluedroid/btc/profile/std/sdp/btc_sdp.c
@@ -1111,7 +1111,7 @@ void btc_sdp_cb_handler(btc_msg_t *msg)
         btc_sdp_cb_to_app(ESP_SDP_DEINIT_EVT, &param);
         break;
     case BTA_SDP_SEARCH_COMP_EVT:
-        param.search.status = p_data->status;
+        param.search.status = p_data->sdp_search_comp.status;
         if (param.search.status == ESP_SDP_SUCCESS) {
             memcpy(param.search.remote_addr, p_data->sdp_search_comp.remote_addr, sizeof(BD_ADDR));
             memcpy(&param.search.sdp_uuid, &p_data->sdp_search_comp.uuid, sizeof(tSDP_UUID));
@@ -1131,8 +1131,8 @@ void btc_sdp_cb_handler(btc_msg_t *msg)
         }
         break;
     case BTA_SDP_CREATE_RECORD_USER_EVT:
-        param.create_record.status = p_data->status;
-        param.create_record.record_handle = p_data->handle;
+        param.create_record.status = p_data->sdp_create_record.status;
+        param.create_record.record_handle = p_data->sdp_create_record.handle;
         btc_sdp_cb_to_app(ESP_SDP_CREATE_RECORD_COMP_EVT, &param);
         break;
     case BTA_SDP_REMOVE_RECORD_USER_EVT:


### PR DESCRIPTION
## Definition of the bug fixed by this PR
When creating multiple SDP records using the `esp_sdp_create_record()` function, the first call raises the `ESP_SDP_CREATE_RECORD_COMP_EVT` event with an status of `ESP_SDP_SUCCESS`, as expected.  
However, the following calls to register other SDP records generate events where the `status` and the `handle` parameters of the `esp_sdp_cb_param_t->create_record` struct have the same value, so the status is not considered a success and SDP records are not actually created, **making it impossible to define more than one SDP record**.  
This happens because those values are set in the function `bta_sdp_create_record()`, where a `tBTA_SDP` union is declared and two of its possible values are written at the same time (`status` and `handle`).

For reference, this was the `tBTA_SDP` definition:

```c
typedef union {
    tBTA_SDP_STATUS              status;            /* BTA_SDP_SEARCH_EVT */
    tBTA_SDP_SEARCH_COMP         sdp_search_comp;   /* BTA_SDP_SEARCH_COMP_EVT */
    int                          handle;
} tBTA_SDP;
```

And this is the relevant code of the `bta_sdp_create_record()` function where the status was overwritten:

```c
void bta_sdp_create_record(tBTA_SDP_MSG *p_data)
{
    // [...]
    tBTA_SDP bta_sdp;
    bta_sdp.status = BTA_SDP_SUCCESS;
    bta_sdp.handle = (int)p_data->record.user_data;  // <-- Overwrites the 'bta_sdp.status' value
    // [...]
}
```

## How the bug was fixed
 This PR fixes this situation by creating a `tBTA_SDP_CREATE_RECORD_USER` struct with the two required values (mimicking the already defined `tBTA_SDP_SEARCH_COMP` struct), so setting the SDP record `handle` doesn't overwrite the `status` value.