### PR TITLE
esp_sntp: Fix c++ compile issue in esp_sntp.h (IDFGH-9212) (IDFGH-9239)

### DIFF
--- a/components/lwip/include/apps/esp_sntp.h
+++ b/components/lwip/include/apps/esp_sntp.h
@@ -228,7 +228,7 @@ void esp_sntp_servermode_dhcp(bool enable);
 static inline __attribute__((deprecated("use esp_sntp_setoperatingmode() instead")))
 void sntp_setoperatingmode(u8_t operating_mode)
 {
-    esp_sntp_setoperatingmode(operating_mode);
+    esp_sntp_setoperatingmode((esp_sntp_operatingmode_t)operating_mode);
 }
 
 static inline __attribute__((deprecated("use esp_sntp_servermode_dhcp() instead")))


### PR DESCRIPTION
Added a cast to esp_sntp_operatingmode_t in sntp_setoperatingmode()'s call to esp_sntp_setoperatingmode(operating_mode).  Althouogh C doesn't require the cast, C++ does.  Otherwise you get...

error: invalid conversion from 'u8_t' {aka 'unsigned char'}
    to 'esp_sntp_operatingmode_t'