### PR TITLE
hal/uart_ll.h: Fix compile with C++ (ESP32-S3/H2) (IDFGH-9255)

### DIFF
--- a/components/hal/esp32h2/include/hal/uart_ll.h
+++ b/components/hal/esp32h2/include/hal/uart_ll.h
@@ -191,7 +191,8 @@ static inline void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t 
  */
 static inline uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    typeof(hw->clkdiv_sync) div_reg = hw->clkdiv_sync;
+    typeof(hw->clkdiv_sync) div_reg;
+    div_reg.val = hw->clkdiv_sync.val;
     return ((sclk_freq << 4)) / (((div_reg.clkdiv_int << 4) | div_reg.clkdiv_frag) * (HAL_FORCE_READ_U32_REG_FIELD(hw->clk_conf, sclk_div_num) + 1));
 }
 
@@ -908,7 +909,8 @@ static inline void uart_ll_xon_force_on(uart_dev_t *hw, bool always_on)
  */
 static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    typeof(hw->conf0_sync) conf0_reg = hw->conf0_sync;
+    typeof(hw->conf0_sync) conf0_reg;
+    conf0_reg.val = hw->conf0_sync.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;
@@ -916,7 +918,8 @@ static inline void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
     hw->conf0_sync.val = conf0_reg.val;
     uart_ll_update(0); // TODO: IDF-5338
 
-    typeof(hw->conf1) conf1_reg = hw->conf1;
+    typeof(hw->conf1) conf1_reg;
+    conf1_reg.val = hw->conf1.val;
     conf1_reg.rts_inv = (inv_mask & UART_SIGNAL_RTS_INV) ? 1 : 0;
     conf1_reg.dtr_inv = (inv_mask & UART_SIGNAL_DTR_INV) ? 1 : 0;
     conf1_reg.cts_inv = (inv_mask & UART_SIGNAL_CTS_INV) ? 1 : 0;

--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -151,7 +151,8 @@ FORCE_INLINE_ATTR void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint3
  */
 FORCE_INLINE_ATTR uint32_t uart_ll_get_baudrate(uart_dev_t *hw, uint32_t sclk_freq)
 {
-    uart_clkdiv_reg_t div_reg = hw->clkdiv;
+    uart_clkdiv_reg_t div_reg;
+    div_reg.val = hw->clkdiv.val;
     return ((sclk_freq << 4)) /
         (((div_reg.clkdiv << 4) | div_reg.clkdiv_frag) * (HAL_FORCE_READ_U32_REG_FIELD(hw->clk_conf, sclk_div_num) + 1));
 }
@@ -791,7 +792,8 @@ FORCE_INLINE_ATTR void uart_ll_set_loop_back(uart_dev_t *hw, bool loop_back_en)
  */
 FORCE_INLINE_ATTR void uart_ll_inverse_signal(uart_dev_t *hw, uint32_t inv_mask)
 {
-    uart_conf0_reg_t conf0_reg = hw->conf0;
+    uart_conf0_reg_t conf0_reg;
+    conf0_reg.val = hw->conf0.val;
     conf0_reg.irda_tx_inv = (inv_mask & UART_SIGNAL_IRDA_TX_INV) ? 1 : 0;
     conf0_reg.irda_rx_inv = (inv_mask & UART_SIGNAL_IRDA_RX_INV) ? 1 : 0;
     conf0_reg.rxd_inv = (inv_mask & UART_SIGNAL_RXD_INV) ? 1 : 0;


### PR DESCRIPTION
I'm including `<hal/uart_ll.h>` in my C++ application because I need to bypass the uart driver. The inline functions in the header file fail to compile as C++.

With xtensa-esp32s2-elf-g++ (crosstool-NG esp-2021r2-patch3) 8.4.0 it doesn't allow copying the union like this:

```
hal/uart_ll.h: In function 'uint32_t uart_ll_get_baudrate(uart_dev_t*)':
hal/uart_ll.h:181:37: error: no matching function for call to 'uart_clkdiv_reg_t(volatile uart_clkdiv_reg_t&)'
     uart_clkdiv_reg_t div_reg = hw->clkdiv;
                                     ^~~~~~
hal/uart_ll.h: In function 'void uart_ll_inverse_signal(uart_dev_t*, uint32_t)':
hal/uart_ll.h:822:38: error: no matching function for call to 'uart_conf0_reg_t(volatile uart_conf0_reg_t&)'
     uart_conf0_reg_t conf0_reg = hw->conf0;
                                      ^~~~~
```

There are some instances of incompatibility specific to the ESP32-S3/H2 header files that the [previous commit](10106) didn't resolve.