### PR TITLE
[AES] Timeout: return error dont abort (IDFGH-9265)

### DIFF
--- a/components/mbedtls/port/aes/dma/esp_aes.c
+++ b/components/mbedtls/port/aes/dma/esp_aes.c
@@ -209,14 +209,14 @@ static esp_err_t esp_aes_isr_initialise( void )
 #endif // CONFIG_MBEDTLS_AES_USE_INTERRUPT
 
 /* Wait for AES hardware block operation to complete */
-static void esp_aes_dma_wait_complete(bool use_intr, lldesc_t *output_desc)
+static int esp_aes_dma_wait_complete(bool use_intr, lldesc_t *output_desc)
 {
 #if defined (CONFIG_MBEDTLS_AES_USE_INTERRUPT)
     if (use_intr) {
-        if (!xSemaphoreTake(op_complete_sem, 2000 / portTICK_PERIOD_MS)) {
+        if (!xSemaphoreTake(op_complete_sem, 5000 / portTICK_PERIOD_MS)) {
             /* indicates a fundamental problem with driver */
             ESP_LOGE("AES", "Timed out waiting for completion of AES Interrupt");
-            abort();
+            return -1;
         }
 #ifdef CONFIG_PM_ENABLE
         esp_pm_lock_release(s_pm_cpu_lock);
@@ -230,6 +230,7 @@ static void esp_aes_dma_wait_complete(bool use_intr, lldesc_t *output_desc)
     aes_hal_wait_done();
 
     esp_aes_wait_dma_done(output_desc);
+    return 0;
 }
 
 
@@ -436,7 +437,12 @@ static int esp_aes_process_dma(esp_aes_context *ctx, const unsigned char *input,
     }
 
     aes_hal_transform_dma_start(blocks);
-    esp_aes_dma_wait_complete(use_intr, out_desc_tail);
+
+    if (esp_aes_dma_wait_complete(use_intr, out_desc_tail) < 0) {
+        ESP_LOGE(TAG, "esp_aes_dma_wait_complete failed");
+        ret = -1;
+        goto cleanup;
+    }
 
 #if (CONFIG_SPIRAM && SOC_PSRAM_DMA_CAPABLE)
     if (block_bytes > 0) {
@@ -561,7 +567,11 @@ int esp_aes_process_dma_gcm(esp_aes_context *ctx, const unsigned char *input, un
 
     aes_hal_transform_dma_gcm_start(blocks);
 
-    esp_aes_dma_wait_complete(use_intr, out_desc_head);
+    if(esp_aes_dma_wait_complete(use_intr, out_desc_head) < 0){
+        ESP_LOGE(TAG, "esp_aes_dma_wait_complete failed");
+        ret = -1;
+        goto cleanup;
+    }
 
     aes_hal_transform_dma_finish();
 


### PR DESCRIPTION
Related Issue: https://github.com/espressif/esp-idf/issues/10647

Replace abort with an error. 

"Fundamental problems" should not be happening on consumer devices, but yet they are...

I don't see any downside to an error code here.

