### PR TITLE
Use correct recursive mutex for env and regular mutex for tz (IDFGH-9266)

### DIFF
--- a/components/newlib/locks.c
+++ b/components/newlib/locks.c
@@ -375,9 +375,9 @@ void esp_newlib_locks_init(void)
     extern _lock_t __sinit_lock;
     __sinit_lock = (_lock_t) &s_common_recursive_mutex;
     extern _lock_t __env_lock_object;
-    __env_lock_object = (_lock_t) &s_common_mutex;
+    __env_lock_object = (_lock_t) &s_common_recursive_mutex;
     extern _lock_t __tz_lock_object;
-    __tz_lock_object = (_lock_t) &s_common_recursive_mutex;
+    __tz_lock_object = (_lock_t) &s_common_mutex;
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
     /* Newlib 3.0.0 is used in ROM, the following lock symbols are defined: */
     extern _lock_t __sinit_recursive_mutex;


### PR DESCRIPTION
Newlib defines __env_lock_object as a recursive mutex and __tz_lock_object as a regular mutex, but when initialized in esp_newlib_locks_init, __env_lock_object gets initialized as a regular mutex (points to s_common_mutex) and __tz_lock_object gets initialized to a recursive mutex (s_common_recursive_mutex).

This causes a lot of panics due to various mutex ownership checks in the FreeRTOS code, but only seems to appear when there is a lot of usage of the __tz_lock_object and __env_lock_object. I believe this is also causing the crashes referred to in the issues: #10626 and #9441 

