### PR TITLE
lwip: fix dhcp_server path (IDFGH-9309)

### DIFF
--- a/components/lwip/CMakeLists.txt
+++ b/components/lwip/CMakeLists.txt
@@ -156,7 +156,7 @@ if(CONFIG_LWIP_DHCPS)
 endif()
 
 if(CONFIG_LWIP_DHCP_RESTORE_LAST_IP)
-    list(APPEND srcs "port/esp32/netif/dhcp_state.c")
+    list(APPEND srcs "port/esp32xx/netif/dhcp_state.c")
 endif()
 
 idf_component_register(SRCS "${srcs}"


### PR DESCRIPTION
The path for dhcp_server.c has changed from esp32/ to esp32xx/

This fixes the build when CONFIG_LWIP_DHCP_RESTORE_LAST_IP is enabled, and closes #10678