### PR TITLE
lwip/config: add menuconfig option for setting LWIP_IPV6_DUP_DETECT_A…

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -179,6 +179,13 @@ menu "LWIP"
         help
             Set the maximum amount of pbufs waiting to be reassembled.
 
+    config LWIP_IPV6_DUP_DETECT_ATTEMPTS
+        int "Number of duplicate address detection attempts"
+        range 0 7
+        default 0
+        help
+            Set the number of duplicate address detection attempts.
+
     config LWIP_IP_FORWARD
         bool "Enable IP forwarding"
         default n

--- a/components/lwip/port/include/lwipopts.h
+++ b/components/lwip/port/include/lwipopts.h
@@ -1192,6 +1192,11 @@ static inline uint32_t timeout_from_offered(uint32_t lease, uint32_t min)
  */
 #define LWIP_ND6_NUM_NEIGHBORS          CONFIG_LWIP_IPV6_ND6_NUM_NEIGHBORS
 
+/**
+ * LWIP_IPV6_DUP_DETECT_ATTEMPTS: Number of duplicate address detection attempts
+ */
+#define LWIP_IPV6_DUP_DETECT_ATTEMPTS   CONFIG_LWIP_IPV6_DUP_DETECT_ATTEMPTS
+
 /*
    ---------------------------------------
    ---------- Hook options ---------------


### PR DESCRIPTION
…TTEMPTS

In my network, ipv6 address allocation to esp32 was unreliable. I'd to disable LWIP_IPV6_DUP_DETECT_ATTEMPTS to 0 to actually make esp32 ipv6 address assignment work reliably.

Signed-off-by: Amitesh Singh <singh.amitesh@gmail.com>