### PR TITLE
Fix pre-commit hook (IDFGH-9328)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: flake8
         args: ['--config=.flake8', '--tee', '--benchmark']
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
This is just a suggestion, but a recent fix to the pre-commit hook changed isort revision to 5.12.0. However this version isn't compatible with python version 3.7 as listed by the release notes https://github.com/PyCQA/isort/releases/tag/5.12.0.
However I believe the oldest supported python version for esp-idf is 3.7.

There was a hot fix to the latest isort which still supports python version 3.7 to resolve the poetry dependency issue.
https://github.com/PyCQA/isort/releases/tag/5.11.5