### PR TITLE
Add user_data accessor and mutator to esp_http_client (IDFGH-9337)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -413,6 +413,28 @@ esp_err_t esp_http_client_set_authtype(esp_http_client_handle_t client, esp_http
     return ESP_OK;
 }
 
+esp_err_t esp_http_client_get_user_data(esp_http_client_handle_t client, void ** data)
+{
+  if (NULL == client || NULL == data) {
+    ESP_LOGE(TAG, "client or data must not be NULL");
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  *data = client->user_data;
+  return ESP_OK;
+}
+
+esp_err_t esp_http_client_set_user_data(esp_http_client_handle_t client, void * data)
+{
+  if (NULL == client) {
+    ESP_LOGE(TAG, "client must not be NULL");
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  client->user_data = data;
+  return ESP_OK;
+}
+
 static esp_err_t _set_config(esp_http_client_handle_t client, const esp_http_client_config_t *config)
 {
     esp_err_t ret = ESP_OK;

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -365,6 +365,34 @@ esp_err_t esp_http_client_set_password(esp_http_client_handle_t client, const ch
 esp_err_t esp_http_client_set_authtype(esp_http_client_handle_t client, esp_http_client_auth_type_t auth_type);
 
 /**
+ * @brief      Get http request user_data.
+ *             The value stored from the esp_http_client_config_t will be written
+ *             to the address passed into data.
+ *
+ * @param[in]  client     The esp_http_client handle
+ * @param[in]  data       A pointer to the pointer that will be set to user_data.
+ *
+ * @return
+ *     - ESP_OK
+ *     - ESP_ERR_INVALID_ARG
+ */
+esp_err_t esp_http_client_get_user_data(esp_http_client_handle_t client, void ** data);
+
+/**
+ * @brief      Set http request user_data.
+ *             The value passed in +data+ will be available during event callbacks.
+ *             No memory management will be performed on the user's behalf.
+ *
+ * @param[in]  client     The esp_http_client handle
+ * @param[in]  data       The pointer to store
+ *
+ * @return
+ *     - ESP_OK
+ *     - ESP_ERR_INVALID_ARG
+ */
+esp_err_t esp_http_client_set_user_data(esp_http_client_handle_t client, void * data);
+
+/**
  * @brief      Get HTTP client session errno
  *
  * @param[in]  client  The esp_http_client handle


### PR DESCRIPTION
This PR adds functions to access the `user_data` struct member that gets passed to client events. This allows long-lived `esp_http_client_event_t` objects to vary their behavior across multiple requests, e.g. storing each response in a different location.