### PR TITLE
Add ESP32-S3 to the default GPIOs used (IDFGH-9344)

### DIFF
--- a/examples/peripherals/spi_slave/README.md
+++ b/examples/peripherals/spi_slave/README.md
@@ -7,13 +7,13 @@ These two projects illustrate the SPI Slave driver. They're supposed to be flash
 
 The default GPIOs used in the example are the following:
 
-| Signal    | ESP32  | ESP32-S2 | ESP32-C3 | ESP32-C6 |
-|-----------|--------|----------|----------|----------|
-| Handshake | GPIO2  | GPIO2    | GPIO3    | GPIO15   |
-| MOSI      | GPIO12 | GPIO12   | GPIO7    | GPIO20   |
-| MISO      | GPIO13 | GPIO13   | GPIO2    | GPIO19   |
-| SCLK      | GPIO15 | GPIO15   | GPIO6    | GPIO18   |
-| CS        | GPIO14 | GPIO14   | GPIO10   | GPIO9    |
+| Signal    | ESP32  | ESP32-S2 | ESP32-S3 | ESP32-C3 | ESP32-C6 |
+|-----------|--------|----------|----------|----------|----------|
+| Handshake | GPIO2  | GPIO2    | GPIO2    | GPIO3    | GPIO15   |
+| MOSI      | GPIO12 | GPIO12   | GPIO11   | GPIO7    | GPIO20   |
+| MISO      | GPIO13 | GPIO13   | GPIO13   | GPIO2    | GPIO19   |
+| SCLK      | GPIO15 | GPIO15   | GPIO12   | GPIO6    | GPIO18   |
+| CS        | GPIO14 | GPIO14   | GPIO10   | GPIO10   | GPIO9    |
 
 
 Please run wires between the following GPIOs between the slave and master to make the example function:


### PR DESCRIPTION
From https://github.com/espressif/esp-idf/blob/d29e53dc0c59d1b1b01c5e2c3ca1b22113828587/examples/peripherals/spi_slave/receiver/main/app_main.c#L58-L63