### PR TITLE
Add `float` and `double` to nvs_partition_gen.py

### DIFF
--- a/components/nvs_flash/nvs_partition_generator/README.rst
+++ b/components/nvs_flash/nvs_partition_generator/README.rst
@@ -39,12 +39,13 @@ Each line of a CSV file should contain 4 parameters, separated by a comma. The t
       - 
     * - 3
       - Encoding
-      - Supported values are: ``u8``, ``i8``, ``u16``, ``i16``, ``u32``, ``i32``, ``u64``, ``i64``, ``string``, ``hex2bin``, ``base64``, and ``binary``. This specifies how actual data values are encoded in the resulting binary file. The difference between the ``string`` and ``binary`` encoding is that ``string`` data is terminated with a NULL character, whereas ``binary`` data is not.
-      - As of now, for the ``file`` type, only ``hex2bin``, ``base64``, ``string``, and ``binary`` encoding is supported.
+      - Supported values are: ``u8``, ``i8``, ``u16``, ``i16``, ``u32``, ``i32``, ``u64``, ``i64``, ``float``, ``double``, ``string``, ``hex2bin``, ``base64``, and ``binary``. This specifies how actual data values are encoded in the resulting binary file. The difference between the ``string`` and ``binary`` encoding is that ``string`` data is terminated with a NULL character, whereas ``binary`` data is not.
+      - As of now, for the ``file`` type, only ``hex2bin``, ``base64``, ``string``, and ``binary`` encoding is supported. ``float`` and ``double`` values are supported indirectly by converting them to ``binary`` before adding them.
     * - 4
       - Value
       - Data value
       - ``Encoding`` and ``Value`` cells for the ``namespace`` field type should be empty. ``Encoding`` and ``Value`` of ``namespace`` are fixed and are not configurable. Any values in these cells are ignored.
+      
       
 .. note:: The first line of the CSV file should always be the column header and it is not configurable.
 

--- a/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py
+++ b/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py
@@ -542,6 +542,13 @@ class NVS(object):
             if type(value) == bytes:
                 value = value.decode()
             value += '\0'
+        elif encoding == 'double':
+            # doubles are converted to bytes then written as a binary entry
+            encoding = 'binary'
+            value = struct.pack('<d', float(value))
+        elif encoding == 'float':
+            # floats are converted to bytes then written as a binary entry
+            value = struct.pack('<f', float(value))
 
         encoding = encoding.lower()
         varlen_encodings = {'string', 'binary', 'hex2bin', 'base64'}


### PR DESCRIPTION
This brings the partition generator up to compatibility with the [ESP32-Arduino Preferences](/../../espressif/arduino-esp32/blob/master/libraries/Preferences/) library.
Both types are converted to blobs then written as `binary` entries, same as the `Preferences` library does.