### PR TITLE
tools: Docker: install build-essential apt package (IDFGH-9402)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN : \
   && apt-get install -y \
     apt-utils \
     bison \
+    build-essential \
     ca-certificates \
     ccache \
     check \


### PR DESCRIPTION
Before this change, it was not possible to build an application with target `linux` in Docker.

For example, building `examples/build_system/cmake/linux_host_app`:

```
docker run -t -e IDF_TARGET="linux" -v "$PWD/examples/build_system/cmake/linux_host_app:/app/linux_host_app" -w "/app/linux_host_app" espressif/idf:v5.0 /bin/bash -c 'git config --global --add safe.directory "*" && idf.py build'
```

results in the following error:

```
CMake Error at /opt/esp/idf/tools/cmake/build.cmake:129 (enable_language):
  No CMAKE_CXX_COMPILER could be found.
```

This commit adds the `build-essential` package to the list of apt packages to install, which allows the example above to build successfully.