### PR TITLE
[Heap Trace] Perf: use hash map to speed up leaks mode 34x (IDFGH-9425)

### DIFF
--- a/components/heap/include/esp_heap_trace.h
+++ b/components/heap/include/esp_heap_trace.h
@@ -41,6 +41,11 @@ typedef struct heap_trace_record_t {
 #endif // CONFIG_HEAP_TRACING_STANDALONE
 } heap_trace_record_t;
 
+typedef struct heap_trace_hashmap_entry_t {
+    void* address;                 ///< ptr returned by malloc/calloc/realloc
+    heap_trace_record_t* record;   ///< associated record
+} heap_trace_hashmap_entry_t;
+
 /**
  * @brief Stores information about the result of a heap trace.
  */
@@ -52,6 +57,8 @@ typedef struct {
     size_t capacity;                 ///< The capacity of the internal buffer
     size_t high_water_mark;          ///< The maximum value that 'count' got to
     size_t has_overflowed;           ///< True if the internal buffer overflowed at some point
+    size_t total_hashmap_hits;       ///< If hashmap is used, the total number of hits
+    size_t total_hashmap_miss;       ///< If hashmap is used, the total number of misses (possibly due to overflow)
 } heap_trace_summary_t;
 
 /**
@@ -70,6 +77,22 @@ typedef struct {
  *  - ESP_OK Heap tracing initialised successfully.
  */
 esp_err_t heap_trace_init_standalone(heap_trace_record_t *record_buffer, size_t num_records);
+
+
+/**
+ * @brief Provide a hashmap to greatly improve the performance of standalone heap trace leaks mode.
+ *
+ * This function must be called before heap_trace_start.
+ *
+ * @param entries_buffer Provide a buffer to use for heap trace hashmap.
+ * Note: External RAM is allowed, but it prevents recording allocations made from ISR's.
+ * @param num_entries Size of the entries_buffer. Should be greater than num_records, preferably 2-4x as large.
+ * @return
+ *  - ESP_ERR_NOT_SUPPORTED Project was compiled without heap tracing enabled in menuconfig.
+ *  - ESP_ERR_INVALID_STATE Heap tracing is currently in progress.
+ *  - ESP_OK Heap tracing initialised successfully.
+ */
+esp_err_t heap_trace_set_hashmap(heap_trace_hashmap_entry_t *entries_buffer, size_t num_entries);
 
 /**
  * @brief Initialise heap tracing in host-based mode.


### PR DESCRIPTION
**Previous PR:** https://github.com/espressif/esp-idf/pull/10521

This finishes the perf work on heap trace standalone. Leaks mode is now fast enough to be enabled in production, or during development!

Adds `esp_err_t heap_trace_set_hashmap(heap_trace_hashmap_entry_t *entries_buffer, size_t num_entries);`

### Motivation:
- leaks mode should be fast enough to be enabled *in production*
- users can leave this mode enabled after boot & print leaks automatically (or save a dump to disk) when a low ram threshold is hit
- if enabled _before_ boot, leaks mode is a simple tool to find ways to save heap memory. This PR makes that use case fast.

### Testing:
- tested on an esp32s3. 



# Perf:

Most importantly! using a map makes record add & remove O(1), so we don't see a performance cliff when an old allocation is freed. 34x faster!

**SPIRAM** (NUMTABLE 2500, NUMITER 2, NUMENTRY 6000, NUMREC 3000)
**total 41ms** // no trace
**total 3401ms** // standard trace
**total 109ms**  // with map

For internal ram and a more typical NUMTABLE 500, we are 1.8x faster with the hashmap. 

**internal memory:**
**total 665ms** // no trace
**total 1814ms** // standard trace
**total 1065ms** // with map

For SPIRAM, also NUMTABLE 500, I'm surprised its not as dramatic. But still ~1.4x faster.

**SPIRAM:**
**total 683ms** // no trace
**total 2118ms** // standard trace
**total 1491ms** // with map



```
    const int NUMREC = 600;
    const int NUMENTRY = 600;
    const int NUMTABLE = 500;
    const int NUMITER = 100;

    uint32_t caps = MALLOC_CAP_INTERNAL;
    heap_trace_record_t* r = heap_caps_calloc(NUMREC, sizeof(heap_trace_record_t), caps);
    heap_trace_hashmap_entry_t* e = heap_caps_calloc(NUMENTRY, sizeof(heap_trace_hashmap_entry_t), caps);
    void** table = (void**) calloc(NUMTABLE, sizeof(void*));

    for (int i = 0; i < 3; i++) {

        int64_t t0 = esp_timer_get_time();

        if (i == 1 || i == 2) {
            heap_trace_init_standalone(r, NUMREC);
            if (i == 2) {heap_trace_set_hashmap(e, NUMENTRY);}
            heap_trace_start(HEAP_TRACE_LEAKS);
        }

        for(int j = 0; j < NUMITER; j++) {
            for (int k = 0; k < NUMTABLE; k++) {table[k] = heap_caps_malloc(1000,caps);}
            for (int k = 0; k < NUMTABLE; k++) {free(table[k]);}
        }

        int64_t t1 = esp_timer_get_time();
        printf("total %llims\n", (t1 - t0) / 1000);
        if (i == 1 || i == 2) {
            heap_trace_stop();
            heap_trace_dump();
        }
    }
```