### PR TITLE
Fix include order (IDFGH-9427)

### DIFF
--- a/examples/protocols/modbus/mb_example_common/include/modbus_params.h
+++ b/examples/protocols/modbus/mb_example_common/include/modbus_params.h
@@ -13,6 +13,8 @@
 #ifndef _DEVICE_PARAMS
 #define _DEVICE_PARAMS
 
+#include <stdint.h>
+
 // This file defines structure of modbus parameters which reflect correspond modbus address space
 // for each modbus register type (coils, discreet inputs, holding registers, input registers)
 #pragma pack(push, 1)

--- a/examples/protocols/modbus/mb_example_common/modbus_params.c
+++ b/examples/protocols/modbus/mb_example_common/modbus_params.c
@@ -7,7 +7,6 @@
  * Description:
  *   C file to define parameter storage instances
  *====================================================================================*/
-#include <stdint.h>
 #include "modbus_params.h"
 
 // Here are the user defined instances for device parameters packed by 1 byte


### PR DESCRIPTION
Types such as uint8_t are used in modbus_params.h. If we remove the source file from the project compilation will fail. This include approach is more accurate.

Please review and merge this pull request.