### PR TITLE
component path relative to IDF (IDFGH-9429)

### DIFF
--- a/examples/bluetooth/nimble/ble_periodic_adv/CMakeLists.txt
+++ b/examples/bluetooth/nimble/ble_periodic_adv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
-set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/../common/nimble_peripheral_utils)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/bluetooth/nimble/common/nimble_peripheral_utils)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(ble_periodic_adv)

--- a/examples/bluetooth/nimble/ble_periodic_sync/CMakeLists.txt
+++ b/examples/bluetooth/nimble/ble_periodic_sync/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
-set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/../common/nimble_central_utils)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/bluetooth/nimble/common/nimble_central_utils)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(ble_periodic_sync)

--- a/examples/bluetooth/nimble/blecent/CMakeLists.txt
+++ b/examples/bluetooth/nimble/blecent/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/../common/nimble_central_utils)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/bluetooth/nimble/common/nimble_central_utils)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(blecent)

--- a/examples/bluetooth/nimble/bleprph/CMakeLists.txt
+++ b/examples/bluetooth/nimble/bleprph/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
-set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/../common/nimble_peripheral_utils)
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/bluetooth/nimble/common/nimble_peripheral_utils)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(bleprph)


### PR DESCRIPTION
Change the component path to relative to the IDF as the build will fail if the example is moved from its folder.