### PR TITLE
Add function to just send a UART Break (without preceeding data) (IDFGH-9459)

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -540,6 +540,8 @@ int uart_write_bytes(uart_port_t uart_num, const void* src, size_t size);
  */
 int uart_write_bytes_with_break(uart_port_t uart_num, const void* src, size_t size, int brk_len);
 
+int uart_send_break(uart_port_t uart_num, int brk_len);
+
 /**
  * @brief UART read bytes from UART buffer
  *

--- a/components/driver/uart.c
+++ b/components/driver/uart.c
@@ -1239,6 +1239,29 @@ int uart_write_bytes_with_break(uart_port_t uart_num, const void *src, size_t si
     return uart_tx_all(uart_num, src, size, 1, brk_len);
 }
 
+int uart_send_break(uart_port_t uart_num, int brk_len)
+{
+    UART_CHECK((p_uart_obj[uart_num]->tx_buf_size == 0), "require tx_buf_size=0", (-1));
+    // lock for uart_tx
+    xSemaphoreTake(p_uart_obj[uart_num]->tx_mux, (portTickType)portMAX_DELAY);
+    p_uart_obj[uart_num]->coll_det_flg = false;
+
+    // semaphore for tx_fifo available
+    if (pdTRUE == xSemaphoreTake(p_uart_obj[uart_num]->tx_fifo_sem, (portTickType)portMAX_DELAY))
+    {
+        // uint32_t sent = uart_enable_tx_write_fifo(uart_num, (const uint8_t *)src, size);
+    }
+    uart_hal_clr_intsts_mask(&(uart_context[uart_num].hal), UART_INTR_TX_BRK_DONE);
+    UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
+    uart_hal_tx_break(&(uart_context[uart_num].hal), brk_len);
+    uart_hal_ena_intr_mask(&(uart_context[uart_num].hal), UART_INTR_TX_BRK_DONE);
+    UART_EXIT_CRITICAL(&(uart_context[uart_num].spinlock));
+    xSemaphoreTake(p_uart_obj[uart_num]->tx_brk_sem, (portTickType)portMAX_DELAY);
+    xSemaphoreGive(p_uart_obj[uart_num]->tx_fifo_sem);
+    xSemaphoreGive(p_uart_obj[uart_num]->tx_mux);
+    return 0;
+}
+
 static bool uart_check_buf_full(uart_port_t uart_num)
 {
     if (p_uart_obj[uart_num]->rx_buffer_full_flg) {


### PR DESCRIPTION
Added a function to just send a UART Break (without having to send data before the break).  
This would be useful for LIN bus and DMX512 protocols.  

**BTW, This code doesn't work yet.**  My hope is that someone can help me get this to actually work.
The code in this PR compiles, but when used it throws an assert.  I think it is something to do with the semaphores.

This would hopefully avoid the dreadful hacks that I am currently using to create a break:
```c
void LIN_driver_start_frame(uint8_t pid)
{
    uint8_t master_tx_buf[2];
    master_tx_buf[0] = 0x55; // sync byte
    master_tx_buf[1] = pid;

#if USE_SEND_BREAK_HACK_1
    /* Send break character */
    // this method sucks b/c it must send a dummy char before the break
    // Note: if use this, then +1 to LIN_IN_HEADER_SIZE for dummy byte.
    uart_write_bytes_with_break(lin_uart_num, &(char){0}, 1, LIN_BREAK_LEN);

#elif USE_SEND_BREAK_HACK2
    // this method really sucks because of a blocking delay!
    uart_set_line_inverse(lin_uart_num, UART_INVERSE_TXD);
    ets_delay_us(677);
    uart_set_line_inverse(lin_uart_num, UART_INVERSE_DISABLE);

#elif USE_SEND_BREAK_HACK3
    uart_hal_tx_break(UART2, 0); // crashes b/c of spinlock?
    uart_ll_tx_break(&UART2, 0); // crashes b/c of spinlock?

#elif USE_SEND_BREAK_HACK4 || 1
    // Temporarily change baudrate to slightly lower and send a 0 byte
    // to get the right baudrate, we want 9 bits (1 start + 8 data) to take the time of 13 bits (one break)
    uint32_t baudrate;
    uart_get_baudrate(lin_uart_num, &baudrate);
#define LIN_BREAK_BAUDRATE(BAUD) ((BAUD * 9) / 13)
    uart_set_baudrate(lin_uart_num, LIN_BREAK_BAUDRATE(baudrate));
    uart_write_bytes(lin_uart_num, &(char){0}, 1); // send a zero byte.  This call must be blocking.
    uart_wait_tx_done(lin_uart_num, 2);
    uart_wait_tx_done(lin_uart_num, 2);        // add 2nd uart_wait_tx_done per https://esp32.com/viewtopic.php?p=98456#p98456
    uart_set_baudrate(lin_uart_num, baudrate); // set baudrate back to normal after break is sent
    // we have to fake a break detect for the slave, since it doesn't detect it with this method.
    uart_event_t event = {.type = UART_BREAK};
    xQueueSend(lin_uart_event_queue, (void *)&event, 0);

#endif

    // Now send the sync and PID bytes
    uart_tx_chars(lin_uart_num, (char *)master_tx_buf, sizeof(master_tx_buf));
}
```
EDIT: these workarounds were discussed in this thread: https://esp32.com/viewtopic.php?f=13&t=8181