### PR TITLE
Make export.fish exit with SUCCESS exit code (IDFGH-9460)

### DIFF
--- a/export.fish
+++ b/export.fish
@@ -1,10 +1,5 @@
 # This script should be sourced, not executed.
 
-# `idf_tools.py export --deactivate` create statement, with keyword unset, but fish shell support only `set --erase variable`
-function unset
-    set --erase $argv
-end
-
 function __main
     set script_dir (dirname (realpath (status -f)))
     if not set -q IDF_PATH

--- a/export.fish
+++ b/export.fish
@@ -106,6 +106,3 @@ if test $click_version -lt 8
 else
     eval (env _IDF.PY_COMPLETE=fish_source idf.py)
 end
-
-
-set -e __main

--- a/export.fish
+++ b/export.fish
@@ -101,3 +101,5 @@ if test $click_version -lt 8
 else
     eval (env _IDF.PY_COMPLETE=fish_source idf.py)
 end
+
+functions -e __main


### PR DESCRIPTION
The export.fish script currently exits with an exit code of 4. Thus, any checks that make sure the `source` command exited successfully (exit code equal to zero) always fail. This was due to the last line trying to erase the `__main` function using the `set -e` command. In fish, you can only erase _variables_ using the `set` command. By changing the last line to erase the `__main` function with the `functions -e` command, the script now exits with an exit code of 0 instead of 4.

Also, while looking at the script, I noticed that the `unset` function seemed to be unused. My understanding was that the author of the script opted to directly use the `set -e` command in the script instead of the `unset` function, leaving it unused. 