### PR TITLE
Fix possible conversion errors by using __builtin_ffsll (IDFGH-9541)

### DIFF
--- a/components/xtensa/include/xt_utils.h
+++ b/components/xtensa/include/xt_utils.h
@@ -152,7 +152,7 @@ FORCE_INLINE_ATTR void xt_utils_set_watchpoint(int wp_num,
 {
     // Initialize DBREAKC bits (see Table 4–143 or isa_rm.pdf)
     uint32_t dbreakc_reg = 0x3F;
-    dbreakc_reg = dbreakc_reg << (__builtin_ffs(size) - 1);
+    dbreakc_reg = dbreakc_reg << (__builtin_ffsll(size) - 1);
     dbreakc_reg = dbreakc_reg & 0x3F;
     if (on_read) {
         dbreakc_reg |= BIT(30);


### PR DESCRIPTION
Using C++20 with `-Wsign-conversion` causes my build to break as the function `xt_utils_set_watchpoint` takes `size` argument as of type `size_t` and passes it to `__builtin_ffs(unsigned int)`, which takes an `unsigned int` parameter.

Using the function `__builtin_ffsll`  instead should fix this.

Thank you for taking your time to review this pull request and have a great day!