### PR TITLE
esp_system: Add reset reasons for USB_UART and USB_JTAG (IDFGH-9601)

### DIFF
--- a/components/esp_system/include/esp_system.h
+++ b/components/esp_system/include/esp_system.h
@@ -33,6 +33,8 @@ typedef enum {
     ESP_RST_DEEPSLEEP,  //!< Reset after exiting deep sleep mode
     ESP_RST_BROWNOUT,   //!< Brownout reset (software or hardware)
     ESP_RST_SDIO,       //!< Reset over SDIO
+    ESP_RST_USB_UART,   //!< Reset via USB UART peripheral
+    ESP_RST_USB_JTAG,   //!< Reset via USB JTAG peripheral
 } esp_reset_reason_t;
 
 /**

--- a/components/esp_system/port/soc/esp32c3/reset_reason.c
+++ b/components/esp_system/port/soc/esp32c3/reset_reason.c
@@ -53,6 +53,12 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     case RESET_REASON_SYS_BROWN_OUT:
         return ESP_RST_BROWNOUT;
 
+    case RESET_REASON_CORE_USB_UART:
+        return ESP_RST_USB_UART;
+
+    case RESET_REASON_CORE_USB_JTAG:
+        return ESP_RST_USB_JTAG;
+
     default:
         return ESP_RST_UNKNOWN;
     }

--- a/components/esp_system/port/soc/esp32c6/reset_reason.c
+++ b/components/esp_system/port/soc/esp32c6/reset_reason.c
@@ -50,6 +50,12 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     case RESET_REASON_SYS_BROWN_OUT:
         return ESP_RST_BROWNOUT;
 
+    case RESET_REASON_CORE_USB_UART:
+        return ESP_RST_USB_UART;
+
+    case RESET_REASON_CORE_USB_JTAG:
+        return ESP_RST_USB_JTAG;
+
     default:
         return ESP_RST_UNKNOWN;
     }

--- a/components/esp_system/port/soc/esp32h2/reset_reason.c
+++ b/components/esp_system/port/soc/esp32h2/reset_reason.c
@@ -50,6 +50,12 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     case RESET_REASON_SYS_BROWN_OUT:
         return ESP_RST_BROWNOUT;
 
+    case RESET_REASON_CORE_USB_UART:
+        return ESP_RST_USB_UART;
+
+    case RESET_REASON_CORE_USB_JTAG:
+        return ESP_RST_USB_JTAG;
+
     default:
         return ESP_RST_UNKNOWN;
     }

--- a/components/esp_system/port/soc/esp32h4/reset_reason.c
+++ b/components/esp_system/port/soc/esp32h4/reset_reason.c
@@ -50,6 +50,12 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     case RESET_REASON_SYS_BROWN_OUT:
         return ESP_RST_BROWNOUT;
 
+    case RESET_REASON_CORE_USB_UART:
+        return ESP_RST_USB_UART;
+
+    case RESET_REASON_CORE_USB_JTAG:
+        return ESP_RST_USB_JTAG;
+
     default:
         return ESP_RST_UNKNOWN;
     }

--- a/components/esp_system/port/soc/esp32s3/reset_reason.c
+++ b/components/esp_system/port/soc/esp32s3/reset_reason.c
@@ -58,6 +58,12 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     case RESET_REASON_SYS_BROWN_OUT:
         return ESP_RST_BROWNOUT;
 
+    case RESET_REASON_CORE_USB_UART:
+        return ESP_RST_USB_UART;
+
+    case RESET_REASON_CORE_USB_JTAG:
+        return ESP_RST_USB_JTAG;
+
     default:
         return ESP_RST_UNKNOWN;
     }


### PR DESCRIPTION
ESP32 C3, C6, H2, H4 and S3 all have an SOC reset reason for USB UART and USB JTAG resets, but as these are not available in `esp_reset_reason_t`, `ESP_RST_UNKNOWN` is set instead. This is particularly unintuitive during development when it is one of the most common reset reasons.

This PR adds these to `esp_reset_reason_t`. There may be other reset reasons that should also be added, but these seem like a priority to me.