### PR TITLE
[esp-tls] Add addr_family option to esp_tls_cfg_t (IDFGH-9620)

### DIFF
--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -141,12 +141,24 @@ esp_tls_t *esp_tls_init(void)
     return tls;
 }
 
-static esp_err_t esp_tls_hostname_to_fd(const char *host, size_t hostlen, int port, struct sockaddr_storage *address, int* fd)
+static esp_err_t esp_tls_hostname_to_fd(const char *host, size_t hostlen, int port, esp_tls_addr_family_t addr_family, struct sockaddr_storage *address, int* fd)
 {
     struct addrinfo *address_info;
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
+
+    switch(addr_family) {
+        case ESP_TLS_AF_INET:
+            hints.ai_family = AF_INET;
+            break;
+        case ESP_TLS_AF_INET6:
+            hints.ai_family = AF_INET6;
+            break;
+        default:
+            hints.ai_family = AF_UNSPEC;
+            break;
+    }
+
     hints.ai_socktype = SOCK_STREAM;
 
     char *use_host = strndup(host, hostlen);
@@ -283,7 +295,7 @@ static inline esp_err_t tcp_connect(const char *host, int hostlen, int port, con
 {
     struct sockaddr_storage address;
     int fd;
-    esp_err_t ret = esp_tls_hostname_to_fd(host, hostlen, port, &address, &fd);
+    esp_err_t ret = esp_tls_hostname_to_fd(host, hostlen, port, cfg->addr_family, &address, &fd);
     if (ret != ESP_OK) {
         ESP_INT_EVENT_TRACKER_CAPTURE(error_handle, ESP_TLS_ERR_TYPE_SYSTEM, errno);
         return ret;

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -69,6 +69,15 @@ typedef struct tls_keep_alive_cfg {
     int keep_alive_count;                 /*!< Keep-alive packet retry send count */
 } tls_keep_alive_cfg_t;
 
+/*
+* @brief ESP-TLS Address families
+*/
+typedef enum esp_tls_addr_family {
+    ESP_TLS_AF_UNSPEC = 0,                /**< Unspecified address family. */
+    ESP_TLS_AF_INET,                      /**< IPv4 address family. */
+    ESP_TLS_AF_INET6,                     /**< IPv6 address family. */
+} esp_tls_addr_family_t;
+
 /**
  * @brief      ESP-TLS configuration parameters
  *
@@ -180,6 +189,8 @@ typedef struct esp_tls_cfg {
 #ifdef CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
     esp_tls_client_session_t *client_session; /*! Pointer for the client session ticket context. */
 #endif /* CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS */
+
+    esp_tls_addr_family_t addr_family;      /*!< The address family to use when connecting to a host. */
 } esp_tls_cfg_t;
 
 #ifdef CONFIG_ESP_TLS_SERVER


### PR DESCRIPTION
Presently, esp-tls effectively does not support IPV6, as reported here: https://github.com/espressif/esp-idf/issues/9920
Basically: if DNS is able to return A records, esp-tls will always try to use them even if ipv4 connectivity is not available. However, if an A lookup fails, an AAAA lookup is attempted next, and IPV6 can work.

This behavior comes from passing `AF_UNSPEC` to `getaddrinfo()` [here](https://github.com/espressif/esp-idf/blob/47852846d3e89580ef4da28210b6ffc1cb5eaa9d/components/esp-tls/esp_tls.c#L161), which causes it to prefer IPV4 over IPV6 [here](https://github.com/espressif/esp-lwip/blob/10197b212a95c49c733fb18ffed56cafb0d196d4/src/api/netdb.c#L333). [here](https://github.com/espressif/esp-lwip/blob/10197b212a95c49c733fb18ffed56cafb0d196d4/src/core/dns.c#L1684) is the spot in LwIP where an AAAA lookup is done only after an A lookup fails.

I see two options to improve this:
1. Teach `tcp_connect()` to  make a decision about which address family to connect to. Perhaps if the first call to  `connect()` returns `EHOSTUNREACH`, do a second lookup passing `AF_INET6`, and then make a second connection attempt if an AAAA record is returned.
1. Add a field to `esp_tls_cfg_t` that allows the user to explicitly specify whether to pass `AF_UNSPEC`, `AF_INET`, or `AF_INET6` to `getaddrinfo()`.


In this PR, I have implemented option 2. Here is how I am using it in the application I am currently working on:
``` cpp
#include "esp_tls.h"
#include "lwip/nd6.h"

esp_tls_cfg_t tls_cfg = {
  // insert config here
};

// Test if we have a default ipv6 route, and if so make the connection over ipv6
const ip_addr_t test_dst = IPADDR6_INIT_HOST(0x20010002, 0x0, 0x0, 0x0);
if (nd6_find_route(ip_2_ip6(&test_dst))) {
    tls_cfg.addr_family = ESP_TLS_AF_INET6;
}

esp_tls_t* tls = esp_tls_init();
esp_tls_conn_new_sync(...,  &tls_cfg, tls);
```


One might argue that instead of adding a field to `esp_tls_cfg_t`, we should add an argument to the `esp_tls_conn_new*()` functions. The documentation for `esp_tls_conn_new_sync()` suggests that the `cfg` field can be NULL if "If you wish to open non-TLS connection", though I'm not sure it actually handles a NULL input safely. And that is what the `is_plain_tcp` field is for anyways. My reason for preferring to add a cfg field is that it is backwards compatible: If the `esp_tls_cfg_t` is zero initialized, the field defaults to `ESP_TLS_AF_UNSPEC`, which gives exactly the same behavior as before.