### PR TITLE
Bugfix: Fix compile error for ESP32 FSM ULP ADC Example (IDFGH-9623)

### DIFF
--- a/examples/system/ulp_fsm/ulp_adc/main/ulp_adc_example_main.c
+++ b/examples/system/ulp_fsm/ulp_adc/main/ulp_adc_example_main.c
@@ -72,8 +72,8 @@ static void init_ulp_program(void)
     //-------------ADC1 Channel Config---------------//
     // Note: when changing channel here, also change 'adc_channel' constant in adc.S
     adc_oneshot_chan_cfg_t config = {
-        .bitwidth = ADC_BITWIDTH_DEFAULT,
         .atten = ADC_ATTEN_DB_11,
+        .bitwidth = ADC_BITWIDTH_DEFAULT,
     };
     ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_handle, ADC_CHANNEL_6, &config));
 


### PR DESCRIPTION
The order of the initializers for the  `adc_oneshot_chan_cfg_t ` in the `ulp_adc` example must be changed to

```
  adc_oneshot_chan_cfg_t config = {
      .atten = ADC_ATTEN_DB_11,
      .bitwidth = ADC_BITWIDTH_DEFAULT,
  };
```

in order to compile the code with C++ 20 and above.