### PR TITLE
[Stack Mirror] prevent corrupted backtraces (IDFGH-9635)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ if(NOT BOOTLOADER_BUILD)
         list(APPEND compile_options "-O2")
     endif()
 
+    if(CONFIG_COMPILER_STACK_MIRROR)
+        list(APPEND compile_options "-finstrument-functions")
+    endif()
+
 else()  # BOOTLOADER_BUILD
 
     if(CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_SIZE)

--- a/Kconfig
+++ b/Kconfig
@@ -478,6 +478,20 @@ mainmenu "Espressif IoT Development Framework Configuration"
             help
                 Stack smashing protection.
 
+        config COMPILER_STACK_MIRROR
+            bool
+            default "y"
+            help
+                Create a dupliate copy of stack return addresses in heap memory, making corrupted
+                backtraces much less likely. Requires a few hundred bytes of memory per thread.
+        
+        config COMPILER_STACK_MIRROR_DEPTH
+            int
+            default 42
+            depends on COMPILER_STACK_MIRROR
+            help
+                The maximum depth of the stack mirror. 4 bytes are needed per depth.
+
         config COMPILER_WARN_WRITE_STRINGS
             bool "Enable -Wwrite-strings warning flag"
             default "n"

--- a/components/esp_system/CMakeLists.txt
+++ b/components/esp_system/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
             "startup.c"
             "system_time.c"
             "stack_check.c"
+            "stack_mirror.c"
             "ubsan.c"
             "xt_wdt.c"
             "debug_stubs.c")

--- a/components/esp_system/include/esp_private/stack_mirror.h
+++ b/components/esp_system/include/esp_private/stack_mirror.h
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if CONFIG_COMPILER_STACK_MIRROR
+void stack_mirror_print_backtrace(bool panic);
+#endif

--- a/components/esp_system/port/arch/xtensa/debug_helpers.c
+++ b/components/esp_system/port/arch/xtensa/debug_helpers.c
@@ -14,6 +14,7 @@
 #include "soc/soc_memory_layout.h"
 #include "esp_cpu_utils.h"
 #include "esp_private/panic_internal.h"
+#include "esp_private/stack_mirror.h"
 
 #include "xtensa/xtensa_context.h"
 
@@ -99,5 +100,11 @@ esp_err_t IRAM_ATTR esp_backtrace_print(int depth)
     //Initialize stk_frame with first frame of stack
     esp_backtrace_frame_t start = { 0 };
     esp_backtrace_get_start(&(start.pc), &(start.sp), &(start.next_pc));
-    return esp_backtrace_print_from_frame(depth, &start, false);
+    esp_err_t err = esp_backtrace_print_from_frame(depth, &start, false);
+#if CONFIG_COMPILER_STACK_MIRROR
+    if (err != ESP_OK) {
+        stack_mirror_print_backtrace(false);
+    }
+#endif // CONFIG_COMPILER_STACK_MIRROR
+    return err;
 }

--- a/components/esp_system/port/arch/xtensa/panic_arch.c
+++ b/components/esp_system/port/arch/xtensa/panic_arch.c
@@ -12,6 +12,7 @@
 
 #include "esp_private/panic_internal.h"
 #include "esp_private/panic_reason.h"
+#include "esp_private/stack_mirror.h"
 #include "soc/soc.h"
 
 #include "esp_private/cache_err_int.h"
@@ -467,5 +468,10 @@ void panic_print_backtrace(const void *f, int core)
 {
     XtExcFrame *xt_frame = (XtExcFrame *) f;
     esp_backtrace_frame_t frame = {.pc = xt_frame->pc, .sp = xt_frame->a1, .next_pc = xt_frame->a0, .exc_frame = xt_frame};
-    esp_backtrace_print_from_frame(100, &frame, true);
+    esp_err_t err = esp_backtrace_print_from_frame(100, &frame, true);
+#if CONFIG_COMPILER_STACK_MIRROR
+    if (err != ESP_OK) {
+        stack_mirror_print_backtrace(true);
+    }
+#endif // CONFIG_COMPILER_STACK_MIRROR
 }

--- a/components/esp_system/stack_mirror.c
+++ b/components/esp_system/stack_mirror.c
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_heap_caps.h"
+#include "esp_private/panic_internal.h"
+#include "esp_cpu_utils.h"
+
+#if CONFIG_COMPILER_STACK_MIRROR
+
+#define STACK_MIRROR_TLS_INDEX 1
+
+#define STACK_MIRROR_MAGIC 128975098
+
+/* This function attribute tells GCC to call the given function
+   before every function call in the program. */
+void __cyg_profile_func_enter(void *func, void *caller) __attribute__((no_instrument_function));
+void __cyg_profile_func_exit(void *func, void *caller) __attribute__((no_instrument_function));
+
+typedef struct {
+    uint32_t pc;
+    uint32_t sp;
+} frame_t;
+
+typedef struct {
+    uint32_t magic;
+    uint32_t depth;
+    frame_t backtrace[CONFIG_COMPILER_STACK_MIRROR_DEPTH];
+} stack_mirror_t;
+
+static void IRAM_ATTR print_str(const char* str, bool panic)
+{
+    if (panic) {
+        panic_print_str(str);
+    } else {
+        esp_rom_printf(str);
+    }
+}
+
+static void IRAM_ATTR print_entry(uint32_t pc, uint32_t sp, bool panic)
+{
+    if (panic) {
+        panic_print_str(" 0x");
+        panic_print_hex(pc);
+        panic_print_str(":0x");
+        panic_print_hex(sp);
+    } else {
+        esp_rom_printf(" 0x%08X:0x%08X", pc, sp);
+    }
+}
+
+
+static void delete(int tlsIndex, void* val)
+{
+    free(val);
+}
+
+static void push_frame(uint32_t pc, uint32_t sp)
+{
+    stack_mirror_t* m = (stack_mirror_t*) 
+        pvTaskGetThreadLocalStoragePointer(NULL, STACK_MIRROR_TLS_INDEX);
+    if (!m) {
+        m = (stack_mirror_t*) heap_caps_calloc(sizeof(stack_mirror_t), 1, MALLOC_CAP_INTERNAL);
+        m->magic = STACK_MIRROR_MAGIC;
+        if (m) {
+            vTaskSetThreadLocalStoragePointerAndDelCallback(NULL, STACK_MIRROR_TLS_INDEX, m, delete);
+        }
+    }
+    if (m) {
+        if (m->depth < CONFIG_COMPILER_STACK_MIRROR_DEPTH) {
+            m->backtrace[m->depth].pc = pc;
+            m->backtrace[m->depth].sp = sp;
+        }
+        m->depth++;
+    }
+}
+
+static void pop_frame()
+{
+    stack_mirror_t* m = (stack_mirror_t*) 
+        pvTaskGetThreadLocalStoragePointer(NULL, STACK_MIRROR_TLS_INDEX);
+    if (m) {
+        m->depth--;
+    }
+}
+
+void __cyg_profile_func_enter(void *func, void *caller)
+{
+    uint32_t pc = (uint32_t) __builtin_return_address(0);
+    uint32_t sp = (uint32_t) __builtin_frame_address(0);
+    push_frame(pc, sp);
+}
+
+void __cyg_profile_func_exit(void *func, void *caller)
+{
+    pop_frame();
+}
+
+void stack_mirror_print_backtrace(bool panic)
+{
+    stack_mirror_t* m = (stack_mirror_t*) 
+        pvTaskGetThreadLocalStoragePointer(NULL, STACK_MIRROR_TLS_INDEX);
+
+    print_str("\r\n\r\nBacktrace (Mirror):", panic);
+
+    if (m == NULL) {
+
+        print_str("\r\nNot Set", panic);
+
+    } else if (esp_ptr_internal(m) == false) {
+
+        print_str("\r\nInvalid Ptr", panic);
+
+    } else if (m->depth == 0) {
+
+        print_str("\r\nEmpty", panic);
+
+    } else if (m->magic != STACK_MIRROR_MAGIC) {
+
+        print_str("\r\nInvalid Magic", panic);
+
+    } else {
+
+        if (m->depth >= CONFIG_COMPILER_STACK_MIRROR_DEPTH) {
+            print_str("\r\nBACKTRACE INCOMPLETE", panic);
+        }
+
+        for (int i = m->depth - 1; i >= 0; i--) {
+
+            uint32_t pc = m->backtrace[i].pc;
+            uint32_t sp = m->backtrace[i].pc;
+
+            print_entry(pc, sp, panic);
+
+            bool corrupted = !(
+                esp_stack_ptr_is_sane(sp) && 
+                esp_ptr_executable((void *)esp_cpu_process_stack_pc(pc))
+            );
+
+            if (corrupted) {
+                print_str(" |<-CORRUPTED", panic);
+                break;
+            }
+        }
+    }
+
+    print_str("\r\n\r\n", panic);
+
+    return;
+}
+
+#endif // CONFIG_COMPILER_STACK_MIRROR

--- a/components/freertos/Kconfig
+++ b/components/freertos/Kconfig
@@ -80,12 +80,17 @@ menu "FreeRTOS"
             int "configNUM_THREAD_LOCAL_STORAGE_POINTERS"
             range 1 256
             default 1
+            default 2 if COMPILER_STACK_MIRROR
             help
                 Set the number of thread local storage pointers in each task (see
                 configNUM_THREAD_LOCAL_STORAGE_POINTERS documentation for more details).
 
-                Note: In ESP-IDF, this value must be at least 1. Index 0 is reserved for use by the pthreads API
-                thread-local-storage. Other indexes can be used for any desired purpose.
+                This value must be at least 1.
+                If stack mirrors are enabled, this value must be at least 2.
+                Index 0 is reserved for use by the pthreads API thread-local-storage.
+                Index 1 is reserved for use by the stack mirror pointer (if enabled).
+
+                Other indexes can be used for any desired purpose.
 
         config FREERTOS_IDLE_TASK_STACKSIZE
             int "configMINIMAL_STACK_SIZE (Idle task stack size)"


### PR DESCRIPTION
❌ **Edit: closing this PR in favor of a new PR** https://github.com/espressif/esp-idf/pulls ❌

Fix corrupted backtraces by keeping a mirrored copy of the backtrace during execution.

**Related issue:** https://github.com/espressif/esp-idf/issues/10976

**This is a WIP PR. Not yet working. But it is "code complete" from a design standpoint.**

Currently this PR does not build on v5.0, see https://github.com/espressif/esp-idf/issues/10983. I was also hitting an issue similar to https://github.com/espressif/esp-idf/issues/6914 sometimes too. `master` might be in a bad state.

On v4.4.4, it builds and runs, but hits an illegal instruction. It seems `-finstrument-functions` might not be supported in the xtensa GCC compiler? **Edit:** Fixed, I needed to put all functions in IRAM...





