### PR TITLE
Enable support for C++23 in esp-idf

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -129,7 +129,7 @@ function(__build_set_lang_version)
         # Use latest supported versions.
         # Please update docs/en/api-guides/cplusplus.rst when changing this.
         set(c_std gnu17)
-        set(cxx_std gnu++20)
+        set(cxx_std gnu++23)
     else()
         enable_language(C CXX)
         # Building for Linux target, fall back to an older version of the standard
@@ -149,7 +149,7 @@ function(__build_set_lang_version)
                                 "${preferred_c_versions}. Please upgrade the host compiler.")
         endif()
 
-        set(preferred_cxx_versions gnu++20 gnu++2a gnu++17 gnu++14)
+        set(preferred_cxx_versions gnu++23 gnu++20 gnu++2a gnu++17 gnu++14)
         set(ver_found FALSE)
         foreach(cxx_version ${preferred_cxx_versions})
             check_cxx_compiler_flag("-std=${cxx_version}" ver_${cxx_version}_supported)


### PR DESCRIPTION
std::expected, std::to_underlying, modules and concepts were missing in the esp-idf and this change enables all of them.