### PR TITLE
Update tools.json (IDFGH-9701)

### DIFF
--- a/tools/tools.json
+++ b/tools/tools.json
@@ -987,9 +987,10 @@
         "all"
       ],
       "version_cmd": [
-        ""
+        "true",
+        "--version"
       ],
-      "version_regex": "",
+      "version_regex": "(.?)",
       "versions": [
         {
           "any": {


### PR DESCRIPTION
This fixes a hang on macOS, where the installation just sits there and does nothing. It was spinning because the version check for the esp-rom-elfs at https://github.com/espressif/esp-rom-elfs

