### PR TITLE
log: add master log option (IDFGH-9721)

### DIFF
--- a/components/log/Kconfig
+++ b/components/log/Kconfig
@@ -84,6 +84,22 @@ menu "Log output"
         default 4 if LOG_MAXIMUM_LEVEL_DEBUG
         default 5 if LOG_MAXIMUM_LEVEL_VERBOSE
 
+    config LOG_MASTER_LEVEL
+        bool "Enable global master log level"
+        default "n"
+        help
+            Enables an additional global "master" log level check that occurs
+            before a log tag cache lookup. This is useful if you want to
+            compile in a lot of logs that are selectable at runtime, but avoid the
+            performance hit during periods where you don't want log output. Examples
+            include remote log forwarding, or disabling logs during a time-critical
+            or CPU-intensive section and re-enabling them later. Results in
+            larger program size depending on number of logs compiled in.
+
+            If enabled, defaults to LOG_DEFAULT_LEVEL and can be set using
+            esp_log_level_master_set().
+            This check takes precedence over ESP_LOG_LEVEL_LOCAL.
+
     config LOG_COLORS
         bool "Use ANSI terminal colors in log output"
         default "y"

--- a/components/log/include/esp_log.h
+++ b/components/log/include/esp_log.h
@@ -41,6 +41,25 @@ typedef int (*vprintf_like_t)(const char *, va_list);
  */
 extern esp_log_level_t esp_log_default_level;
 
+#ifdef CONFIG_LOG_MASTER_LEVEL
+/**
+ * @brief Master log level.
+ *
+ * Optional master log level to check against for ESP_LOGx macros before calling
+ * esp_log_write. Allows one to set a higher CONFIG_LOG_MAXIMUM_LEVEL but not
+ * impose a performance hit during normal operation (only when instructed). An
+ * application may set esp_log_level_master_set(level) to globally enforce a
+ * maximum log level. ESP_LOGx macros above this level will be skipped immediately,
+ * rather than calling esp_log_write and doing a cache hit.
+ *
+ * The tradeoff is increased application size.
+ */
+extern esp_log_level_t g_master_log_level;
+void esp_log_level_master_set(esp_log_level_t level);
+#else
+#define esp_log_level_master_set(level) do { } while(0)
+#endif //CONFIG_LOG_MASTER_LEVEL
+
 /**
  * @brief Set log level for given tag
  *
@@ -425,13 +444,19 @@ void esp_log_writev(esp_log_level_t level, const char* tag, const char* format, 
 #endif // !(defined(__cplusplus) && (__cplusplus >  201703L))
 
 /** runtime macro to output logs at a specified level. Also check the level with ``LOG_LOCAL_LEVEL``.
+ * If ``CONFIG_LOG_MASTER_LEVEL`` set, also check first against ``g_master_log_level``.
  *
  * @see ``printf``, ``ESP_LOG_LEVEL``
  */
+#ifdef CONFIG_LOG_MASTER_LEVEL
+#define ESP_LOG_LEVEL_LOCAL(level, tag, format, ...) do {               \
+        if ( (g_master_log_level >= level) && (LOG_LOCAL_LEVEL >= level) ) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
+    } while(0)
+#else
 #define ESP_LOG_LEVEL_LOCAL(level, tag, format, ...) do {               \
         if ( LOG_LOCAL_LEVEL >= level ) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
     } while(0)
-
+#endif //CONFIG_LOG_MASTER_LEVEL
 
 /**
  * @brief Macro to output logs when the cache is disabled. Log at ``ESP_LOG_ERROR`` level.

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -62,6 +62,9 @@ typedef struct uncached_tag_entry_ {
     char tag[0];    // beginning of a zero-terminated string
 } uncached_tag_entry_t;
 
+#ifdef CONFIG_LOG_MASTER_LEVEL
+esp_log_level_t g_master_log_level = CONFIG_LOG_DEFAULT_LEVEL;
+#endif
 esp_log_level_t esp_log_default_level = CONFIG_LOG_DEFAULT_LEVEL;
 static SLIST_HEAD(log_tags_head, uncached_tag_entry_) s_log_tags = SLIST_HEAD_INITIALIZER(s_log_tags);
 static cached_tag_entry_t s_log_cache[TAG_CACHE_SIZE];
@@ -90,6 +93,13 @@ vprintf_like_t esp_log_set_vprintf(vprintf_like_t func)
     esp_log_impl_unlock();
     return orig_func;
 }
+
+#ifdef CONFIG_LOG_MASTER_LEVEL
+void esp_log_level_master_set(esp_log_level_t level)
+{
+    g_master_log_level = level;
+}
+#endif
 
 void esp_log_level_set(const char *tag, esp_log_level_t level)
 {


### PR DESCRIPTION
see https://github.com/espressif/esp-idf/issues/11049

Adds optional `LOG_MASTER_LEVEL` Kconfig option to log component. Results in 100x performance increase on ESP32 at 240Mhz when logs are compiled in, but disabled at runtime. Useful in cases where you only want log output some of the time. Results in a non-negligible increase in code size with lots of logs enabled, but that is also when you have the most to gain performance-wise.

I have not added test cases pending feedback.

Other things worth considering:

- if this should/could be applied to the early log macros
- Putting this in the `noinit` section so setting is preserved across boots.

Test it out for yourself:

- Compile with Max/Default = LOG_LEVEL_DEBUG.

```c
#include <stdio.h>
#include "freertos/FreeRTOS.h"
#include "freertos/task.h"
#include "esp_log.h"

static const char * TAG = "sometag";

void app_main(void)
{
    ESP_LOGI(TAG, "app_main init");

    esp_log_level_set("*", ESP_LOG_NONE);

    const int64_t MEASUREMENTS = 1000;

    while (true) {
        vTaskDelay( 1000 / portTICK_PERIOD_MS );

        int64_t start = esp_timer_get_time();

        for (int retries = 0; retries < MEASUREMENTS; retries++) {
            ESP_LOGI(TAG, "some test data, %d, %d, %d", retries, MEASUREMENTS-retries, 12);
        }

        int64_t end = esp_timer_get_time();

        printf("%lld iterations took %lld microseconds (%lld microseconds per invocation)\n",
           MEASUREMENTS, (end - start), (end - start)/MEASUREMENTS);

        if (g_master_log_level == ESP_LOG_NONE) {
            g_master_log_level = ESP_LOG_DEBUG;
        } else {
            g_master_log_level = ESP_LOG_NONE;
        }
    }
}
```
