### PR TITLE
Fix usb enumeration stage error for some device (IDFGH-9778)

### DIFF
--- a/components/usb/hub.c
+++ b/components/usb/hub.c
@@ -164,6 +164,7 @@ typedef struct {
     uint8_t iProduct;               /**< Index of the Product string descriptor */
     uint8_t iSerialNumber;          /**< Index of the Serial Number string descriptor */
     uint8_t str_desc_bLength;       /**< Saved bLength from getting a short string descriptor */
+    uint8_t bConfigurationValue;    /**< Device's current configuration number */
 } enum_ctrl_t;
 
 typedef struct {
@@ -365,7 +366,7 @@ static bool enum_stage_transfer(enum_ctrl_t *enum_ctrl)
             break;
         }
         case ENUM_STAGE_SET_CONFIG: {
-            USB_SETUP_PACKET_INIT_SET_CONFIG((usb_setup_packet_t *)transfer->data_buffer, ENUM_CONFIG_INDEX + 1);
+            USB_SETUP_PACKET_INIT_SET_CONFIG((usb_setup_packet_t *)transfer->data_buffer, enum_ctrl->bConfigurationValue);
             transfer->num_bytes = sizeof(usb_setup_packet_t);   //No data stage
             enum_ctrl->expect_num_bytes = 0;    //OUT transfer. No need to check number of bytes returned
             break;
@@ -516,6 +517,7 @@ static bool enum_stage_transfer_check(enum_ctrl_t *enum_ctrl)
         case ENUM_STAGE_CHECK_FULL_CONFIG_DESC: {
             //Fill configuration descriptor into the device object
             const usb_config_desc_t *config_desc = (usb_config_desc_t *)(transfer->data_buffer + sizeof(usb_setup_packet_t));
+            enum_ctrl->bConfigurationValue = config_desc->bConfigurationValue;
             ESP_ERROR_CHECK(usbh_hub_enum_fill_config_desc(enum_ctrl->dev_hdl, config_desc));
             ret = true;
             break;


### PR DESCRIPTION
Fix enumeration process crashed with stall status when enumerating devices which return `bConfigurationValue` with non standard value in the configuration description.

I encounter the bug when I try to connect a serial device from Netchip Technology. The device responses the request for first configuration with bConfigurationValue = 2. But in current code, the `config_num` is hardcoded to be `ENUM_CONFIG_INDEX + 1` which is 1.

```
❯ lsusb -vd 0525:a4a7

Bus 001 Device 050: ID 0525:a4a7 Netchip Technology, Inc. Linux-USB Serial Gadget (CDC ACM mode)
Couldn't open device, some information will be missing
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            2 Communications
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0        64
  idVendor           0x0525 Netchip Technology, Inc.
  idProduct          0xa4a7 Linux-USB Serial Gadget (CDC ACM mode)
  bcdDevice           24.18
  iManufacturer           1 Linux 2.6.39 with atmel_usba_udc
  iProduct                2 Gadget Serial v2.4
  iSerial                 0 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x004b
    bNumInterfaces          2
    bConfigurationValue     2
    iConfiguration          3 
    bmAttributes         0xc0
      Self Powered
    MaxPower                2mA
    Interface Association:
      bLength                 8
      bDescriptorType        11
      bFirstInterface         0
      bInterfaceCount         2
      bFunctionClass          2 Communications
      bFunctionSubClass       2 Abstract (modem)
      bFunctionProtocol       1 AT-commands (v.25ter)
      iFunction               6 
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         2 Communications
      bInterfaceSubClass      2 Abstract (modem)
      bInterfaceProtocol      1 AT-commands (v.25ter)
      iInterface              4 
      CDC Header:
        bcdCDC               1.10
      CDC Call Management:
        bmCapabilities       0x00
        bDataInterface          1
      CDC ACM:
        bmCapabilities       0x02
          line coding and serial state
      CDC Union:
        bMasterInterface        0
        bSlaveInterface         1 
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x83  EP 3 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x000a  1x 10 bytes
        bInterval               9
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        1
      bAlternateSetting       0
      bNumEndpoints           2
      bInterfaceClass        10 CDC Data
      bInterfaceSubClass      0 
      bInterfaceProtocol      0 
      iInterface              5 
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x02  EP 2 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               0

```

Here is the pcapng when I connect the device into PC.
[usbmon.zip](https://github.com/espressif/esp-idf/files/11138530/usbmon.zip)
