### PR TITLE
test_nvs_host: fix asan reported bugs (IDFGH-9860)

### DIFF
--- a/components/nvs_flash/test_nvs_host/test_nvs.cpp
+++ b/components/nvs_flash/test_nvs_host/test_nvs.cpp
@@ -39,6 +39,13 @@ void dumpBytes(const uint8_t *data, size_t count)
     }
 }
 
+bool memeq(void *a, size_t a_len, void *b, size_t b_len)
+{
+    if (a_len != b_len) {
+        return false;
+    }
+    return memcmp(a, b, a_len) == 0;
+}
 
 TEST_CASE("Page handles invalid CRC of variable length items", "[nvs][cur]")
 {
@@ -793,12 +800,12 @@ TEST_CASE("Check that NVS supports old blob format without blob index", "[nvs]")
     size_t buflen = 64;
     uint8_t hexdata[] = {0x01, 0x02, 0x03, 0xab, 0xcd, 0xef};
     TEST_ESP_OK( nvs_get_blob(handle, "dummyHex2BinKey", buf, &buflen));
-    CHECK(memcmp(buf, hexdata, buflen) == 0);
+    CHECK(memeq(buf, buflen, hexdata, sizeof(hexdata)));
 
     buflen = 64;
     uint8_t base64data[] = {'1', '2', '3', 'a', 'b', 'c'};
     TEST_ESP_OK( nvs_get_blob(handle, "dummyBase64Key", buf, &buflen));
-    CHECK(memcmp(buf, base64data, buflen) == 0);
+    CHECK(memeq(buf, buflen, base64data, sizeof(base64data)));
 
     nvs::Page p;
     p.load(&part, 0);
@@ -822,7 +829,7 @@ TEST_CASE("Check that NVS supports old blob format without blob index", "[nvs]")
     /* Read the blob in new format and check the contents*/
     buflen = 64;
     TEST_ESP_OK( nvs_get_blob(handle, "dummyBase64Key", buf, &buflen));
-    CHECK(memcmp(buf, base64data, buflen) == 0);
+    CHECK(memeq(buf, buflen, base64data, sizeof(base64data)));
 
     TEST_ESP_OK(nvs_flash_deinit_partition(part.get_partition_name()));
 }
@@ -886,21 +893,21 @@ static void check_nvs_part_gen_args(SpiFlashEmulator *spi_flash_emulator,
     size_t buflen = 64;
     int j;
     TEST_ESP_OK( nvs_get_blob(handle, "dummyHex2BinKey", buf, &buflen));
-    CHECK(memcmp(buf, hexdata, buflen) == 0);
+    CHECK(memeq(buf, buflen, hexdata, sizeof(hexdata)));
 
     uint8_t base64data[] = {'1', '2', '3', 'a', 'b', 'c'};
     TEST_ESP_OK( nvs_get_blob(handle, "dummyBase64Key", buf, &buflen));
-    CHECK(memcmp(buf, base64data, buflen) == 0);
+    CHECK(memeq(buf, buflen, base64data, sizeof(base64data)));
 
     buflen = 64;
     uint8_t hexfiledata[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
     TEST_ESP_OK( nvs_get_blob(handle, "hexFileKey", buf, &buflen));
-    CHECK(memcmp(buf, hexfiledata, buflen) == 0);
+    CHECK(memeq(buf, buflen, hexfiledata, sizeof(hexfiledata)));
 
     buflen = 64;
     uint8_t strfiledata[64] = "abcdefghijklmnopqrstuvwxyz\0";
     TEST_ESP_OK( nvs_get_str(handle, "stringFileKey", buf, &buflen));
-    CHECK(memcmp(buf, strfiledata, buflen) == 0);
+    CHECK(memeq(buf, buflen, strfiledata, sizeof(strfiledata)));
 
     char bin_data[5200];
     size_t bin_len = sizeof(bin_data);
@@ -909,7 +916,7 @@ static void check_nvs_part_gen_args(SpiFlashEmulator *spi_flash_emulator,
     file.open(filename);
     file.read(binfiledata,5200);
     TEST_ESP_OK( nvs_get_blob(handle, "binFileKey", bin_data, &bin_len));
-    CHECK(memcmp(bin_data, binfiledata, bin_len) == 0);
+    CHECK(memeq(bin_data, bin_len, binfiledata, sizeof(binfiledata)));
 
     file.close();
 
@@ -971,21 +978,21 @@ static void check_nvs_part_gen_args_mfg(SpiFlashEmulator *spi_flash_emulator,
     buflen = 64;
     int j;
     TEST_ESP_OK( nvs_get_blob(handle, "dummyHex2BinKey", buf, &buflen));
-    CHECK(memcmp(buf, hexdata, buflen) == 0);
+    CHECK(memeq(buf, buflen, hexdata, sizeof(hexdata)));
 
     uint8_t base64data[] = {'1', '2', '3', 'a', 'b', 'c'};
     TEST_ESP_OK( nvs_get_blob(handle, "dummyBase64Key", buf, &buflen));
-    CHECK(memcmp(buf, base64data, buflen) == 0);
+    CHECK(memeq(buf, buflen, base64data, sizeof(base64data)));
 
     buflen = 64;
     uint8_t hexfiledata[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
     TEST_ESP_OK( nvs_get_blob(handle, "hexFileKey", buf, &buflen));
-    CHECK(memcmp(buf, hexfiledata, buflen) == 0);
+    CHECK(memeq(buf, buflen, hexfiledata, sizeof(hexfiledata)));
 
     buflen = 64;
     uint8_t strfiledata[64] = "abcdefghijklmnopqrstuvwxyz\0";
     TEST_ESP_OK( nvs_get_str(handle, "stringFileKey", buf, &buflen));
-    CHECK(memcmp(buf, strfiledata, buflen) == 0);
+    CHECK(memeq(buf, buflen, strfiledata, sizeof(strfiledata)));
 
     char bin_data[5200];
     size_t bin_len = sizeof(bin_data);
@@ -994,7 +1001,7 @@ static void check_nvs_part_gen_args_mfg(SpiFlashEmulator *spi_flash_emulator,
     file.open(filename);
     file.read(binfiledata,5200);
     TEST_ESP_OK( nvs_get_blob(handle, "binFileKey", bin_data, &bin_len));
-    CHECK(memcmp(bin_data, binfiledata, bin_len) == 0);
+    CHECK(memeq(bin_data, bin_len, binfiledata, sizeof(binfiledata)));
 
     file.close();
 

--- a/components/nvs_flash/test_nvs_host/test_spi_flash_emulation.cpp
+++ b/components/nvs_flash/test_nvs_host/test_spi_flash_emulation.cpp
@@ -85,7 +85,7 @@ TEST_CASE("EMU raw read function works", "[spi_flash_emu]")
     uint32_t read_value = 0;
     CHECK(esp_partition_write(&f.esp_part, 0, &value, sizeof(value)) == ESP_OK);
 
-    CHECK(esp_partition_read_raw(&f.esp_part, 0, &read_value, sizeof(&read_value)) == ESP_OK);
+    CHECK(esp_partition_read_raw(&f.esp_part, 0, &read_value, sizeof(read_value)) == ESP_OK);
 
     CHECK(read_value == 0xdeadbeef);
 }
@@ -97,7 +97,7 @@ TEST_CASE("EMU raw write function works", "[spi_flash_emu]")
     uint32_t read_value = 0;
     CHECK(esp_partition_write_raw(&f.esp_part, 0, &value, sizeof(value)) == ESP_OK);
 
-    CHECK(esp_partition_read(&f.esp_part, 0, &read_value, sizeof(&read_value)) == ESP_OK);
+    CHECK(esp_partition_read(&f.esp_part, 0, &read_value, sizeof(read_value)) == ESP_OK);
 
     CHECK(read_value == 0xdeadbeef);
 }


### PR DESCRIPTION
 - Use of `sizeof(uint32_t *)` instead of `sizeof(uint32_t)` in arguments
 - Use of `memcmp` without checking that length agreed (add `memeq`)

These were observed when running these tests built with clang 14 on a MacOS 12.6.3 system (Xcode 13.1). I suspect some of them will appear on any system where `uint32_t *` and `uint32_t` are different sizes, and where reading some data _should_ cause the test to fail (due to lack of certain python tooling)