### PR TITLE
Wording change (IDFGH-9801)

### DIFF
--- a/examples/provisioning/wifi_prov_mgr/main/Kconfig.projbuild
+++ b/examples/provisioning/wifi_prov_mgr/main/Kconfig.projbuild
@@ -77,7 +77,7 @@ menu "Example Configuration"
     config EXAMPLE_PROV_MGR_MAX_RETRY_CNT
         int
         default 5
-        prompt "Max WiFi connection retries before reseting the provisioning state machine"
+        prompt "Max WiFi connection retries before resetting the provisioning state machine"
         depends on EXAMPLE_RESET_PROV_MGR_ON_FAILURE
         help
             Set the Maximum retry limit to avoid trying to connect to an AP that is not within reach or if credentials

--- a/examples/provisioning/wifi_prov_mgr/main/Kconfig.projbuild
+++ b/examples/provisioning/wifi_prov_mgr/main/Kconfig.projbuild
@@ -69,18 +69,18 @@ menu "Example Configuration"
     config EXAMPLE_RESET_PROV_MGR_ON_FAILURE
         bool
         default y
-        prompt "Reset provisioned credentials and state machine after session failure"
+        prompt "Reset provisioned credentials and state machine after WiFi connection failure"
         help
-            Enable reseting provisioned credentials and state machine after session failure.
-            This will restart the provisioning service after retries are exhausted.
+            Enable reseting provisioned credentials and state machine after connection retry limit has been reached.
+            This will restart the provisioning service after WiFi connection retries are exhausted.
 
     config EXAMPLE_PROV_MGR_MAX_RETRY_CNT
         int
         default 5
-        prompt "Max retries before reseting provisioning state machine"
+        prompt "Max WiFi connection retries before reseting the provisioning state machine"
         depends on EXAMPLE_RESET_PROV_MGR_ON_FAILURE
         help
-            Set the Maximum retry to avoid reconnecting to an inexistent AP or if credentials
+            Set the Maximum retry limit to avoid trying to connect to an AP that is not within reach or if credentials
             are misconfigured. Provisioned credentials are erased and internal state machine
             is reset after this threshold is reached.
 

--- a/examples/provisioning/wifi_prov_mgr/main/app_main.c
+++ b/examples/provisioning/wifi_prov_mgr/main/app_main.c
@@ -181,8 +181,8 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         ESP_LOGI(TAG, "Connected with IP Address:" IPSTR, IP2STR(&event->ip_info.ip));
         /* Signal main application to continue execution */
         xEventGroupSetBits(wifi_event_group, WIFI_CONNECTED_EVENT);
-#ifdef CONFIG_EXAMPLE_PROV_TRANSPORT_BLE
     } else if (event_base == PROTOCOMM_TRANSPORT_BLE_EVENT) {
+#ifdef CONFIG_EXAMPLE_PROV_TRANSPORT_BLE
         switch (event_id) {
             case PROTOCOMM_TRANSPORT_BLE_CONNECTED:
                 ESP_LOGI(TAG, "BLE transport: Connected!");


### PR DESCRIPTION
Change the description of EXAMPLE_RESET_PROV_MGR_ON_FAILURE to be more clear
I find the original wording misleading as the option not only resets during the provisioning session, but also any time later if the the ESP can not connect to the provisioned WiFi AP.

(As any radio communications have down times per se, not sure if such an automatism would be useful in production by the way)