### PR TITLE
Fix to allow streaming of PUT data in the HTTP_EVENT_HEADERS_SENT callback (IDFGH-9813)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1381,8 +1381,8 @@ static esp_err_t esp_http_client_request_send(esp_http_client_handle_t client, i
 
     client->data_written_index = 0;
     client->data_write_left = client->post_len;
-    http_dispatch_event(client, HTTP_EVENT_HEADERS_SENT, NULL, 0);
     client->state = HTTP_STATE_REQ_COMPLETE_HEADER;
+    http_dispatch_event(client, HTTP_EVENT_HEADERS_SENT, NULL, 0);
     return ESP_OK;
 }
 


### PR DESCRIPTION
Setting the state to HTTP_STATE_REQ_COMPLETE_HEADER prior to calling the HTTP_EVENT_HEADERS_SENT callback allows streaming of PUT data in the callback.