### PR TITLE
Make custom bootloader message match actual output (IDFGH-9834)

### DIFF
--- a/examples/custom_bootloader/bootloader_override/README.md
+++ b/examples/custom_bootloader/bootloader_override/README.md
@@ -23,7 +23,7 @@ idf.py flash
 
 This custom bootloader does not do more than the older bootloader, it only prints an extra message on start up:
 ```
-[boot] Custom bootloader has been initialized correctly.
+[boot] Custom bootloader message defined in the KConfig file.
 ```
 
 ## Organisation of this example


### PR DESCRIPTION
Fixes the custom bootloader README.md so that the example output matches what will actually be output by default in the custom bootloader.