### PR TITLE
examples/bluedroid/gattc_demo.c - Use correct struct type (IDFGH-9899)

### DIFF
--- a/examples/bluetooth/bluedroid/ble/gatt_client/main/gattc_demo.c
+++ b/examples/bluetooth/bluedroid/ble/gatt_client/main/gattc_demo.c
@@ -130,7 +130,7 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
             break;
         }
         ESP_LOGI(GATTC_TAG, "discover service complete conn_id %d", param->dis_srvc_cmpl.conn_id);
-        esp_ble_gattc_search_service(gattc_if, param->cfg_mtu.conn_id, &remote_filter_service_uuid);
+        esp_ble_gattc_search_service(gattc_if, param->dis_srvc_cmpl.conn_id, &remote_filter_service_uuid);
         break;
     case ESP_GATTC_CFG_MTU_EVT:
         if (param->cfg_mtu.status != ESP_GATT_OK){


### PR DESCRIPTION
If the event is `ESP_GATTC_DIS_SRVC_CMPL_EVT` , then the struct should be `gattc_dis_srvc_cmpl_evt_param` as per https://github.com/espressif/esp-idf/blob/f404fe96b17692e3f1de536a3d73a180cdb53b42/components/bt/host/bluedroid/api/include/api/esp_gattc_api.h#L243-L249

Currently it is using `gattc_cfg_mtu_evt_param` , which is defined as https://github.com/espressif/esp-idf/blob/f404fe96b17692e3f1de536a3d73a180cdb53b42/components/bt/host/bluedroid/api/include/api/esp_gattc_api.h#L98-L105

Through coincidence, it does work since in memory the field `.conn_id` is at the same offset. However I think it is better to use the correct struct type , so it is less confusing to someone reading the example.