### PR TITLE
[protocomm] release memory on BLE provisioning stop

### DIFF
--- a/components/protocomm/src/transports/protocomm_ble.c
+++ b/components/protocomm/src/transports/protocomm_ble.c
@@ -610,14 +610,15 @@ esp_err_t protocomm_ble_stop(protocomm_t *pc)
         if (ret) {
             ESP_LOGE(TAG, "BLE stop failed");
         }
+        simple_ble_deinit();
 #else
 #ifdef CONFIG_WIFI_PROV_DISCONNECT_AFTER_PROV
         /* Keep BT stack on, but terminate the connection after provisioning */
-	ret = simple_ble_disconnect();
-	if (ret) {
-	    ESP_LOGE(TAG, "BLE disconnect failed");
-	}
-	simple_ble_deinit();
+        ret = simple_ble_disconnect();
+        if (ret)
+        {
+            ESP_LOGE(TAG, "BLE disconnect failed");
+        }
 #endif  // CONFIG_WIFI_PROV_DISCONNECT_AFTER_PROV
 #endif  // CONFIG_WIFI_PROV_KEEP_BLE_ON_AFTER_PROV
 


### PR DESCRIPTION
Using the heap tracing options, I found the following allocations not being released after provisioning is finished: 

```
80 bytes (@ 0x3d817a9c) allocated CPU 0 ccount 0x8422f7d0 caller 0x420170b4:0x42016aed
0x420170b4: simple_ble_init at C:/repos/v3/esp-idf/components/protocomm/src/simple_ble/simple_ble.c:186

0x42016aed: protocomm_ble_start at C:/repos/v3/esp-idf/components/protocomm/src/transports/protocomm_ble.c:531

384 bytes (@ 0x3d817af0) allocated CPU 0 ccount 0x84230fdc caller 0x420167ba:0x42016b59
0x420167ba: populate_gatt_db at C:/repos/v3/esp-idf/components/protocomm/src/transports/protocomm_ble.c:387

0x42016b59: protocomm_ble_start at C:/repos/v3/esp-idf/components/protocomm/src/transports/protocomm_ble.c:553

32 bytes (@ 0x3d81b188) allocated CPU 1 ccount 0x7c33dc5c caller 0x42017025:0x4201bec4
0x42017025: gatts_profile_event_handler at C:/repos/v3/esp-idf/components/protocomm/src/simple_ble/simple_ble.c:158 (discriminator 9)

0x4201bec4: btc_gatts_act_create_attr_tab at C:/repos/v3/esp-idf/components/bt/host/bluedroid/btc/profile/std/gatt/btc_gatts.c:422
```

In https://github.com/espressif/esp-idf/commit/eb490dc18edd42b851594f97a91a3d57f7e9ada1 an option was introduced to keep BT on after provisioning is done. Looking at the code, I suspect that the call to `simple_ble_deinit()` disappeared, which should release the 3 buffers mentioned above. 

On the contrary, I do not understand whether the call of `simple_ble_deinit()` was put intentionally in the case we want to keep the stack running. 

Unfortunately I cannot find the original MR linked in the commit (espressif/esp-idf!19263). 

FYI @KonssnoK 