### PR TITLE
build: make default warnings as errors (IDFGH-9945)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,11 @@ if(CONFIG_COMPILER_DISABLE_GCC12_WARNINGS)
                                 "-Wno-use-after-free")
 endif()
 
+if(CONFIG_COMPILER_DISABLE_DEFAULT_ERRORS)
+    list(APPEND compile_options "-Wno-error"
+                                "-Werror=all")
+endif()
+
 # GCC-specific options
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     list(APPEND compile_options "-fstrict-volatile-bitfields"

--- a/Kconfig
+++ b/Kconfig
@@ -504,6 +504,19 @@ mainmenu "Espressif IoT Development Framework Configuration"
 
                 This option can be enabled for RISC-V targets only.
 
+        config COMPILER_DISABLE_DEFAULT_ERRORS
+            bool "Disabe errors for default warnings"
+            default "n"
+            help
+                Enable this option if you want to not consider default warnings as errors,
+                especially when upgrading IDF.
+
+                This is a temporary flag that could help to allow upgrade while having
+                some time to address the warnings raised by those default warnings.
+                Alternatives are: 1) fix code (preferred),  2) remove specific warnings
+                or 3) do not consider specific warnings as error.
+
+
         config COMPILER_DISABLE_GCC12_WARNINGS
             bool "Disable new warnings introduced in GCC 12"
             default "n"

--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -99,12 +99,13 @@ function(__build_set_default_build_specifications)
                                     "-fdata-sections"
                                     # warning-related flags
                                     "-Wall"
-                                    "-Werror=all"
+                                    "-Werror"
                                     "-Wno-error=unused-function"
                                     "-Wno-error=unused-variable"
                                     "-Wno-error=unused-but-set-variable"
                                     "-Wno-error=deprecated-declarations"
                                     "-Wextra"
+                                    "-Wno-error=extra"
                                     "-Wno-unused-parameter"
                                     "-Wno-sign-compare"
                                     # ignore multiple enum conversion warnings since gcc 11

--- a/tools/idf_py_actions/hints.yml
+++ b/tools/idf_py_actions/hints.yml
@@ -296,6 +296,11 @@
     hint: "OpenOCD process does not have permissions to access the USB JTAG/serial device. Please use 'LIBUSB_DEBUG=1 idf.py openocd' to find out the device name and check its access rights."
 
 -
+    re: "-Werror=(address-of-packed-member|aggressive-loop-optimizations|attribute-warning|builtin-macro-redefined|cpp|designated-init|deprecated-declarations|discarded-array-qualifiers|discarded-qualifiers|div-by-zero|endif-labels|free-nonheap-object|if-not-aligned|ignored-attributes|incompatible-pointer-types|int-conversion|int-to-pointer-cast|lto-type-mismatch|multichar|overflow|override-init-side-effects|packed-bitfield-compat|pointer-compare|pointer-to-int-cast|return-local-addr|scalar-storage-order|shift-count-negative|shift-count-overflow|sizeof-array-argument|stringop-truncation| switch-bool|switch-outside-range|varargs)"
+    hint: "The error(s) '{}' may appear after IDF upgrade since previous versions were not considering those warnings as errors.\nTo suppress these warnings use 'idf.py menuconfig' to enable configure option 'Compiler options' -> 'Disabe errors for default warnings'\nPlease note that this is not a permanent solution, and this option will be removed in a future update of the ESP-IDF.\nIt is strongly recommended to fix all warnings, as they may indicate potential issues!"
+    match_to_output: True
+
+-
     re: "(-Werror=address|-Werror=use-after-free)"
     hint: "The warning(s) '{}' may appear after compiler update above GCC-12\nTo suppress these warnings use 'idf.py menuconfig' to enable configure option 'Compiler options' -> 'Disable new warnings introduced in GCC 12'\nPlease note that this is not a permanent solution, and this option will be removed in a future update of the ESP-IDF.\nIt is strongly recommended to fix all warnings, as they may indicate potential issues!"
     match_to_output: True


### PR DESCRIPTION
The `-Werror=all` activates error for all warnings in `-Wall`, however, it does not activate error for other default warnings, such as:
- `int-conversion` (pointer from integer w/o a cast)
- `incompatible-pointer-types`
- `discarded-qualifiers`

Which are IMO even more important that `-Wall`.

This commit fixes that by activating error for all warnings (i.e. from `-Wall` and default ones) and removing those from `-Wextra`, as the culprit commit seemed to address.

Fixes: 60f29236f6 "Build system: Raise warning level" (2016-11-16)