### PR TITLE
Modifies the argument of the sizeof statement to a legitimate array name (IDFGH-9952)

### DIFF
--- a/components/app_trace/sys_view/ext/logging.c
+++ b/components/app_trace/sys_view/ext/logging.c
@@ -18,7 +18,7 @@ int esp_sysview_vprintf(const char * format, va_list args)
     portENTER_CRITICAL(&s_log_mutex);
     size_t len = vsnprintf(log_buffer, sizeof(log_buffer), format, args);
     if (len > sizeof(log_buffer) - 1) {
-        log_buffer[sizeof(log_buffer - 1)] = 0;
+        log_buffer[sizeof(log_buffer) - 1] = 0;
     }
     SEGGER_SYSVIEW_Print(log_buffer);
     portEXIT_CRITICAL(&s_log_mutex);


### PR DESCRIPTION
**问题描述**
在函数`esp_sysview_vprintf`中，因括号位置错误，导致`sizeof`语句**参数异常**，可能使数据写入异常。
**问题修改**
修改sizeof语句后括号位置，修改其参数为合法的数组名即可，即21行处：
`log_buffer[sizeof(log_buffer - 1)] = 0;` 修改为 `log_buffer[sizeof(log_buffer) - 1] = 0;`