### PR TITLE
examples: avoid the divide by zero error (IDFGH-9968)

### DIFF
--- a/examples/protocols/icmp_echo/main/echo_example_main.c
+++ b/examples/protocols/icmp_echo/main/echo_example_main.c
@@ -50,11 +50,18 @@ static void cmd_ping_on_ping_end(esp_ping_handle_t hdl, void *args)
     uint32_t transmitted;
     uint32_t received;
     uint32_t total_time_ms;
+    uint32_t loss;
+
     esp_ping_get_profile(hdl, ESP_PING_PROF_REQUEST, &transmitted, sizeof(transmitted));
     esp_ping_get_profile(hdl, ESP_PING_PROF_REPLY, &received, sizeof(received));
     esp_ping_get_profile(hdl, ESP_PING_PROF_IPADDR, &target_addr, sizeof(target_addr));
     esp_ping_get_profile(hdl, ESP_PING_PROF_DURATION, &total_time_ms, sizeof(total_time_ms));
-    uint32_t loss = (uint32_t)((1 - ((float)received) / transmitted) * 100);
+
+    if (transmitted > 0) {
+        loss = (uint32_t)((1 - ((float)received) / transmitted) * 100);
+    } else {
+        loss = 0;
+    }
     if (IP_IS_V4(&target_addr)) {
         printf("\n--- %s ping statistics ---\n", inet_ntoa(*ip_2_ip4(&target_addr)));
     } else {


### PR DESCRIPTION
If there are network problems, ICMP packets for the ping utility couldn't be transmitted. Trying to do the loss calculation results in an invalid loss value.

```-
esp> ping 192.168.1.1
E (308805) ping_sock: send error=0
esp> From 192.168.1.1 icmp_seq=1 timeout
E (309805) ping_sock: send error=0
From 192.168.1.1 icmp_seq=2 timeout
E (310805) ping_sock: send error=0
From 192.168.1.1 icmp_seq=3 timeout
E (311805) ping_sock: send error=0
From 192.168.1.1 icmp_seq=4 timeout
E (312805) ping_sock: send error=0
From 192.168.1.1 icmp_seq=5 timeout

--- 192.168.1.1 ping statistics ---
0 packets transmitted, 0 received, 4294967295% packet loss, time 4994ms
```
