### PR TITLE
fix usb resume bug on esp32sx (IDFGH-10000)

### DIFF
--- a/components/tinyusb/additions/src/portable/espressif/esp32sx/dcd_esp32sx.c
+++ b/components/tinyusb/additions/src/portable/espressif/esp32sx/dcd_esp32sx.c
@@ -193,6 +193,7 @@ void dcd_init(uint8_t rhport)
                  USB_RXFLVIMSK_M   |
                  USB_ERLYSUSPMSK_M |
                  USB_USBSUSPMSK_M  |
+                 USB_WKUPINTMSK_M  |
                  USB_USBRSTMSK_M   |
                  USB_ENUMDONEMSK_M |
                  USB_RESETDETMSK_M |
@@ -829,6 +830,7 @@ static void _dcd_int_handler(void* arg)
                   USB_GOUTNAKEFF    |
                   USB_ERLYSUSP_M    |
                   USB_USBSUSP_M     |
+                  USB_WKUPINT_M     |
                   USB_ISOOUTDROP_M  |
                   USB_EOPF_M        |
                   USB_EPMIS_M       |


### PR DESCRIPTION
I have encounter this issue on esp32s3 that my usb hid device can't recover from suspend state after computer went to sleep and waked up. After long time of debugging it turned out that we didn't handle resume interrupt in dcd file for esp32sx. The fix is straight forward. I add USB_WKUPINT related bits in function dcd_init and dcd_int_handler. Having tested on my esp32s3 hid keyboard, I think it also works for other USB devices using esp32sx. Please comment if you need me to do further testing.