### PR TITLE
Fix emac ext struct for C++ (IDFGH-10003)

### DIFF
--- a/components/soc/esp32/include/soc/emac_ext_struct.h
+++ b/components/soc/esp32/include/soc/emac_ext_struct.h
@@ -11,7 +11,7 @@ extern "C" {
 
 #include <stdint.h>
 
-typedef volatile struct emac_ext_dev_t {
+typedef volatile struct {
     union {
         struct {
             uint32_t div_num : 4;


### PR DESCRIPTION
For some reason this did not compile under C++ because of double definitions