### PR TITLE
Update esp_hid component to register GATTC callback (IDFGH-10009)

### DIFF
--- a/components/esp_hid/src/ble_hidh.c
+++ b/components/esp_hid/src/ble_hidh.c
@@ -660,6 +660,13 @@ esp_err_t esp_ble_hidh_init(const esp_hidh_config_t *config)
             break;
         }
 
+        ret = esp_ble_gattc_register_callback(esp_hidh_gattc_event_handler);
+        if (ret != ESP_OK)
+        {
+            ESP_LOGE(TAG, "esp_ble_gattc_register_callback failed!");
+            break;
+        }
+
         ret = esp_ble_gattc_app_register(0);
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "esp_ble_gattc_app_register failed!");

--- a/examples/bluetooth/esp_hid_host/main/esp_hid_host_main.c
+++ b/examples/bluetooth/esp_hid_host/main/esp_hid_host_main.c
@@ -138,9 +138,6 @@ void app_main(void)
     ESP_ERROR_CHECK( ret );
     ESP_LOGI(TAG, "setting hid gap, mode:%d", HID_HOST_MODE);
     ESP_ERROR_CHECK( esp_hid_gap_init(HID_HOST_MODE) );
-#if CONFIG_BT_BLE_ENABLED
-    ESP_ERROR_CHECK( esp_ble_gattc_register_callback(esp_hidh_gattc_event_handler) );
-#endif /* CONFIG_BT_BLE_ENABLED */
     esp_hidh_config_t config = {
         .callback = hidh_callback,
         .event_stack_size = 4096,


### PR DESCRIPTION
example for hid devices registers the ble gattc callback but it would seem to make scenes to hide this in the HID component
Update example to reflect this change

Hopefully I am not misunderstanding something here thanks 