### PR TITLE
Fix references to IDF_ADD_PATHS_EXTRAS before being assigned

### DIFF
--- a/export.fish
+++ b/export.fish
@@ -37,7 +37,7 @@ function __main
     set -gx IDF_TOOLS_INSTALL_CMD "$IDF_PATH"/install.fish
     # Allow calling some IDF python tools without specifying the full path
     # "$IDF_PATH"/tools is already added by 'idf_tools.py export'
-    set IDF_ADD_PATHS_EXTRAS "$IDF_ADD_PATHS_EXTRAS":"$IDF_PATH"/components/espcoredump
+    set IDF_ADD_PATHS_EXTRAS "$IDF_PATH"/components/espcoredump
     set IDF_ADD_PATHS_EXTRAS "$IDF_ADD_PATHS_EXTRAS":"$IDF_PATH"/components/partition_table
     set IDF_ADD_PATHS_EXTRAS "$IDF_ADD_PATHS_EXTRAS":"$IDF_PATH"/components/app_update
 

--- a/export.sh
+++ b/export.sh
@@ -125,7 +125,7 @@ __main() {
     export IDF_TOOLS_INSTALL_CMD=${IDF_PATH}/install.sh
     # Allow calling some IDF python tools without specifying the full path
     # ${IDF_PATH}/tools is already added by 'idf_tools.py export'
-    IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/espcoredump"
+    IDF_ADD_PATHS_EXTRAS="${IDF_PATH}/components/espcoredump"
     IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/partition_table"
     IDF_ADD_PATHS_EXTRAS="${IDF_ADD_PATHS_EXTRAS}:${IDF_PATH}/components/app_update"
 


### PR DESCRIPTION
`IDF_ADD_PATHS_EXTRAS` is referenced before assignment in `export.sh` and `export.fish` after the changes in c7a70b6d0e36491c060a0befe3e5d71042843b90. This causes issues in shells with stricter settings (eg `bash` with `set -u`).