### PR TITLE
don't treat timeout as error in send_cmd_send_op_cond (IDFGH-10020)

### DIFF
--- a/components/sdmmc/sdmmc_cmd.c
+++ b/components/sdmmc/sdmmc_cmd.c
@@ -143,7 +143,7 @@ esp_err_t sdmmc_send_cmd_send_op_cond(sdmmc_card_t* card, uint32_t ocr, uint32_t
         }
 
         if (err != ESP_OK) {
-            if (--err_cnt == 0) {
+            if (err != ESP_ERR_TIMEOUT && --err_cnt == 0) {
                 ESP_LOGD(TAG, "%s: sdmmc_send_app_cmd err=0x%x", __func__, err);
                 goto done;
             } else {


### PR DESCRIPTION
`send_cmd_send_op_cond` allows for multiple retries before `ESP_ERR_TIMEOUT` is returned and a different number of errors that are ignored before the last error is returned. If `ESP_ERR_TIMEOUT` is treated like any other error, the number of retries is limited by the number of errors that can happen. This makes `nretries` useless.