### PR TITLE
Fix for continious ADC example (IDFGH-10071)

### DIFF
--- a/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
+++ b/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
@@ -32,7 +32,12 @@
 
 #define EXAMPLE_READ_LEN                    256
 
+#if CONFIG_IDF_TARGET_ESP32
+static adc_channel_t channel[2] = {ADC_CHANNEL_6, ADC_CHANNEL_7};
+#else
 static adc_channel_t channel[2] = {ADC_CHANNEL_2, ADC_CHANNEL_3};
+#endif
+
 
 static TaskHandle_t s_task_handle;
 static const char *TAG = "EXAMPLE";

--- a/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
+++ b/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
@@ -20,14 +20,14 @@
 #define EXAMPLE_ADC_ATTEN                   ADC_ATTEN_DB_0
 #define EXAMPLE_ADC_BIT_WIDTH               SOC_ADC_DIGI_MAX_BITWIDTH
 
-#if CONFIG_IDF_TARGET_ESP32
-#define EXAMPLE_ADC_OUTPUT_TYPE ADC_DIGI_OUTPUT_FORMAT_TYPE1
-#define EXAMPLE_ADC_GET_CHANNEL(p_data) ((p_data)->type1.channel)
-#define EXAMPLE_ADC_GET_DATA(p_data) ((p_data)->type1.data)
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define EXAMPLE_ADC_OUTPUT_TYPE             ADC_DIGI_OUTPUT_FORMAT_TYPE1
+#define EXAMPLE_ADC_GET_CHANNEL(p_data)     ((p_data)->type1.channel)
+#define EXAMPLE_ADC_GET_DATA(p_data)        ((p_data)->type1.data)
 #else
-#define EXAMPLE_ADC_OUTPUT_TYPE ADC_DIGI_OUTPUT_FORMAT_TYPE2
-#define EXAMPLE_ADC_GET_CHANNEL(p_data) ((p_data)->type2.channel)
-#define EXAMPLE_ADC_GET_DATA(p_data) ((p_data)->type2.data)
+#define EXAMPLE_ADC_OUTPUT_TYPE             ADC_DIGI_OUTPUT_FORMAT_TYPE2
+#define EXAMPLE_ADC_GET_CHANNEL(p_data)     ((p_data)->type2.channel)
+#define EXAMPLE_ADC_GET_DATA(p_data)        ((p_data)->type2.data)
 #endif
 
 #define EXAMPLE_READ_LEN                    256

--- a/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
+++ b/examples/peripherals/adc/continuous_read/main/continuous_read_main.c
@@ -20,23 +20,19 @@
 #define EXAMPLE_ADC_ATTEN                   ADC_ATTEN_DB_0
 #define EXAMPLE_ADC_BIT_WIDTH               SOC_ADC_DIGI_MAX_BITWIDTH
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
-#define EXAMPLE_ADC_OUTPUT_TYPE             ADC_DIGI_OUTPUT_FORMAT_TYPE1
-#define EXAMPLE_ADC_GET_CHANNEL(p_data)     ((p_data)->type1.channel)
-#define EXAMPLE_ADC_GET_DATA(p_data)        ((p_data)->type1.data)
+#if CONFIG_IDF_TARGET_ESP32
+#define EXAMPLE_ADC_OUTPUT_TYPE ADC_DIGI_OUTPUT_FORMAT_TYPE1
+#define EXAMPLE_ADC_GET_CHANNEL(p_data) ((p_data)->type1.channel)
+#define EXAMPLE_ADC_GET_DATA(p_data) ((p_data)->type1.data)
 #else
-#define EXAMPLE_ADC_OUTPUT_TYPE             ADC_DIGI_OUTPUT_FORMAT_TYPE2
-#define EXAMPLE_ADC_GET_CHANNEL(p_data)     ((p_data)->type2.channel)
-#define EXAMPLE_ADC_GET_DATA(p_data)        ((p_data)->type2.data)
+#define EXAMPLE_ADC_OUTPUT_TYPE ADC_DIGI_OUTPUT_FORMAT_TYPE2
+#define EXAMPLE_ADC_GET_CHANNEL(p_data) ((p_data)->type2.channel)
+#define EXAMPLE_ADC_GET_DATA(p_data) ((p_data)->type2.data)
 #endif
 
 #define EXAMPLE_READ_LEN                    256
 
-#if CONFIG_IDF_TARGET_ESP32
-static adc_channel_t channel[2] = {ADC_CHANNEL_6, ADC_CHANNEL_7};
-#else
 static adc_channel_t channel[2] = {ADC_CHANNEL_2, ADC_CHANNEL_3};
-#endif
 
 static TaskHandle_t s_task_handle;
 static const char *TAG = "EXAMPLE";
@@ -122,7 +118,7 @@ void app_main(void)
             if (ret == ESP_OK) {
                 ESP_LOGI("TASK", "ret is %x, ret_num is %"PRIu32" bytes", ret, ret_num);
                 for (int i = 0; i < ret_num; i += SOC_ADC_DIGI_RESULT_BYTES) {
-                    adc_digi_output_data_t *p = (void*)&result[i];
+                    adc_digi_output_data_t *p = (adc_digi_output_data_t*)&result[i];
                     uint32_t chan_num = EXAMPLE_ADC_GET_CHANNEL(p);
                     uint32_t data = EXAMPLE_ADC_GET_DATA(p);
                     /* Check the channel number validation, the data is invalid if the channel num exceed the maximum channel */


### PR DESCRIPTION
The example has syntax error converting void* to adc_digi_output_data_t*