### PR TITLE
Update esp_cpu.h to include esp_attr.h (IDFGH-10113)

### DIFF
--- a/components/esp_hw_support/include/esp_cpu.h
+++ b/components/esp_hw_support/include/esp_cpu.h
@@ -19,6 +19,7 @@
 #endif
 #include "esp_intr_alloc.h"
 #include "esp_err.h"
+#include "esp_attr.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
If esp_attr.h is not included then there are no definitions for the symbol 'FORCE_INLINE_ATTR'.