### PR TITLE
fix(c++): invalid conversion from int to enumeration (IDFGH-10115)

### DIFF
--- a/components/esp_netif/include/esp_netif_sntp.h
+++ b/components/esp_netif/include/esp_netif_sntp.h
@@ -44,16 +44,16 @@ typedef void (*esp_sntp_time_cb_t)(struct timeval *tv);
  *
  */
 #define ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(servers_in_list, list_of_servers)   {   \
-            .smooth_sync = false,                   \
-            .server_from_dhcp = false,              \
-            .wait_for_sync = true,                  \
-            .start = true,                          \
-            .sync_cb = NULL,                        \
-            .renew_servers_after_new_IP = false,    \
-            .ip_event_to_renew = 0,                 \
-            .index_of_first_server = 0,             \
-            .num_of_servers = (servers_in_list),    \
-            .servers = list_of_servers,             \
+            .smooth_sync = false,                       \
+            .server_from_dhcp = false,                  \
+            .wait_for_sync = true,                      \
+            .start = true,                              \
+            .sync_cb = NULL,                            \
+            .renew_servers_after_new_IP = false,        \
+            .ip_event_to_renew = IP_EVENT_STA_GOT_IP,   \
+            .index_of_first_server = 0,                 \
+            .num_of_servers = (servers_in_list),        \
+            .servers = list_of_servers,                 \
 }
 
 /**


### PR DESCRIPTION
Conversions from int to enum in C++ are not allowed.

```c++
/esp-idf/components/esp_netif/include/esp_netif_sntp.h:53:34: error: invalid conversion from 'int' to 'ip_event_t' [-fpermissive]
   53 |             .ip_event_to_renew = 0,                 \
      |                                  ^
      |                                  |
      |                                  int
/esp-idf/components/esp_netif/include/esp_netif_sntp.h:63:13: note: in expansion of macro 'ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE'
   63 |             ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(1, {server})
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
net.hpp:166:44: note: in expansion of macro 'ESP_NETIF_SNTP_DEFAULT_CONFIG'
  166 |                 esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
```

Use the first enum instead.

```c++
/** IP event declarations */
typedef enum {
    IP_EVENT_STA_GOT_IP,               /*!< station got IP from connected AP */
    IP_EVENT_STA_LOST_IP,              /*!< station lost IP and the IP is reset to 0 */
    IP_EVENT_AP_STAIPASSIGNED,         /*!< soft-AP assign an IP to a connected station */
    IP_EVENT_GOT_IP6,                  /*!< station or ap or ethernet interface v6IP addr is preferred */
    IP_EVENT_ETH_GOT_IP,               /*!< ethernet got IP from connected AP */
    IP_EVENT_ETH_LOST_IP,              /*!< ethernet lost IP and the IP is reset to 0 */
    IP_EVENT_PPP_GOT_IP,               /*!< PPP interface got IP */
    IP_EVENT_PPP_LOST_IP,              /*!< PPP interface lost IP */
} ip_event_t;
```
