### PR TITLE
Fix typo in Linux/macOS getting started docs (IDFGH-10119)

### DIFF
--- a/docs/en/get-started/linux-macos-start-project.rst
+++ b/docs/en/get-started/linux-macos-start-project.rst
@@ -61,7 +61,7 @@ If the previous steps have been done correctly, the following menu appears:
 
     Project configuration - Home window
 
-You are using this menu to set up project specific variables, e.g., Wi-Fi network name and password, the processor speed, etc. Setting up the project with menuconfig may be skipped for "hello_word", since this example runs with default configuration.
+You are using this menu to set up project specific variables, e.g., Wi-Fi network name and password, the processor speed, etc. Setting up the project with menuconfig may be skipped for "hello_world", since this example runs with default configuration.
 
 .. only:: esp32
 


### PR DESCRIPTION
`hello_word` -> `hello_world`