### PR TITLE
esp_ds: ignore releasing mutex if not called from same task (IDFGH-10131)

### DIFF
--- a/components/mbedtls/port/esp_ds/esp_rsa_sign_alt.c
+++ b/components/mbedtls/port/esp_ds/esp_rsa_sign_alt.c
@@ -94,8 +94,10 @@ esp_err_t esp_ds_init_data_ctx(esp_ds_data_ctx_t *ds_data)
 
 void esp_ds_release_ds_lock(void)
 {
-    /* Give back the semaphore (DS lock) */
-    xSemaphoreGive(s_ds_lock);
+    if (xSemaphoreGetMutexHolder(s_ds_lock) == xTaskGetCurrentTaskHandle()) {
+        /* Give back the semaphore (DS lock) */
+        xSemaphoreGive(s_ds_lock);
+    }
 }
 
 size_t esp_ds_get_keylen(void *ctx)


### PR DESCRIPTION
The mutex `s_ds_lock` in `esp_rsa_sign_alt.c` is always unlocked unconditionally whether or not it was locked before. In our case, working with multiple connections, this resulted in triggering the assertion in https://github.com/espressif/esp-idf/blob/54576b7528b182256c027de86eb605a172bc2821/components/freertos/FreeRTOS-Kernel/queue.c#L881-L885

When connecting, the mutex is locked in `esp_create_mbedtls_handle -> set_client_config -> set_pki_context -> esp_mbedtls_init_pk_ctx_for_ds -> esp_ds_init_data_ctx` but only if there is a client certificate or `ds_data` set. 

Unlocking the mutex is done unconditionally from multiple places, e.g. after handshake (`esp_mbedtls_handshake -> esp_ds_release_ds_lock`) or on cleanup (`esp_mbedtls_cleanup -> esp_ds_release_ds_lock`). 

Consider following scenario:

- Task 1 connects to MQTT broker, with client and server certificate
- Task 2 opens another connection, without client certificate (this task has higher priority than task 1)

This might trigger the following: 

- Task 1: Calls `esp_create_mbedtls_handle` with client certificate or `ds_data` fields filled -> locks mutex
- Task 2: Calls `esp_create_mbedtls_handle` without client certificate, thus not locking the mutex
- Task 2: Calls `esp_ds_release_ds_lock`, and the assertion will trigger because the mutex was locked by task 1, but the releasing task is different

FYI @KonssnoK 