### PR TITLE
Fix #10804 by running continuous ADC DMA in endless loop instead of restarting after each run to avoid losing samples (IDFGH-10140)

### DIFF
--- a/components/driver/deprecated/adc_dma_legacy.c
+++ b/components/driver/deprecated/adc_dma_legacy.c
@@ -376,15 +376,12 @@ static IRAM_ATTR bool s_adc_dma_intr(adc_digi_context_t *adc_digi_ctx)
         }
 
         ret = xRingbufferSendFromISR(adc_digi_ctx->ringbuf_hdl, current_desc->buffer, current_desc->dw0.length, &taskAwoken);
+        adc_hal_read_desc_finish (&adc_digi_ctx->hal);
+
         if (ret == pdFALSE) {
             //ringbuffer overflow
             adc_digi_ctx->ringbuf_overflow_flag = 1;
         }
-    }
-
-    if (status == ADC_HAL_DMA_DESC_NULL) {
-        //start next turns of dma operation
-        adc_hal_digi_start(&adc_digi_ctx->hal, adc_digi_ctx->rx_dma_buf);
     }
 
     return (taskAwoken == pdTRUE);

--- a/components/esp_adc/adc_continuous.c
+++ b/components/esp_adc/adc_continuous.c
@@ -93,6 +93,7 @@ static bool s_adc_dma_intr(adc_continuous_ctx_t *adc_digi_ctx);
 
 #if SOC_GDMA_SUPPORTED
 static bool adc_dma_in_suc_eof_callback(gdma_channel_handle_t dma_chan, gdma_event_data_t *event_data, void *user_data);
+static bool adc_dma_descr_err_callback(gdma_channel_handle_t dma_chan, void *user_data);
 #else
 static void adc_dma_intr_handler(void *arg);
 #endif
@@ -204,7 +205,8 @@ esp_err_t adc_continuous_new_handle(const adc_continuous_handle_cfg_t *hdl_confi
     gdma_apply_strategy(adc_ctx->rx_dma_channel, &strategy_config);
 
     gdma_rx_event_callbacks_t cbs = {
-        .on_recv_eof = adc_dma_in_suc_eof_callback
+        .on_recv_eof = adc_dma_in_suc_eof_callback,
+        .on_descr_err = adc_dma_descr_err_callback
     };
     gdma_register_rx_event_callbacks(adc_ctx->rx_dma_channel, &cbs, adc_ctx);
 
@@ -290,6 +292,13 @@ static IRAM_ATTR bool adc_dma_in_suc_eof_callback(gdma_channel_handle_t dma_chan
     ctx->rx_eof_desc_addr = event_data->rx_eof_desc_addr;
     return s_adc_dma_intr(user_data);
 }
+
+static bool adc_dma_descr_err_callback(gdma_channel_handle_t dma_chan, void *user_data)
+{
+    ESP_EARLY_LOGE(ADC_TAG, "GDMA descriptor error occurred, probable ADC data loss, CPU load too high?");
+    return false;
+}
+
 #else
 static IRAM_ATTR void adc_dma_intr_handler(void *arg)
 {
@@ -327,6 +336,7 @@ static IRAM_ATTR bool s_adc_dma_intr(adc_continuous_ctx_t *adc_digi_ctx)
         }
 
         ret = xRingbufferSendFromISR(adc_digi_ctx->ringbuf_hdl, current_desc->buffer, current_desc->dw0.length, &taskAwoken);
+        adc_hal_read_desc_finish (&adc_digi_ctx->hal);
         need_yield |= (taskAwoken == pdTRUE);
 
         if (adc_digi_ctx->cbs.on_conv_done) {
@@ -348,11 +358,6 @@ static IRAM_ATTR bool s_adc_dma_intr(adc_continuous_ctx_t *adc_digi_ctx)
                 }
             }
         }
-    }
-
-    if (status == ADC_HAL_DMA_DESC_NULL) {
-        //start next turns of dma operation
-        adc_hal_digi_start(&adc_digi_ctx->hal, adc_digi_ctx->rx_dma_buf);
     }
 
     return need_yield;

--- a/components/esp_hw_support/gdma.c
+++ b/components/esp_hw_support/gdma.c
@@ -101,12 +101,14 @@ struct gdma_tx_channel_t {
     gdma_channel_t base; // GDMA channel, base class
     void *user_data;     // user registered DMA event data
     gdma_event_callback_t on_trans_eof; // TX EOF callback
+    gdma_descr_err_callback_t on_descr_err; // Descriptor error callback
 };
 
 struct gdma_rx_channel_t {
     gdma_channel_t base; // GDMA channel, base class
     void *user_data;     // user registered DMA event data
     gdma_event_callback_t on_recv_eof; // RX EOF callback
+    gdma_descr_err_callback_t on_descr_err; // Descriptor error callback
 };
 
 static gdma_group_t *gdma_acquire_group_handle(int group_id);
@@ -431,6 +433,7 @@ esp_err_t gdma_register_tx_event_callbacks(gdma_channel_handle_t dma_chan, gdma_
     pair = dma_chan->pair;
     group = pair->group;
     gdma_tx_channel_t *tx_chan = __containerof(dma_chan, gdma_tx_channel_t, base);
+    uint32_t intrMask = GDMA_LL_EVENT_TX_EOF;
 
 #if CONFIG_GDMA_ISR_IRAM_SAFE
     if (cbs->on_trans_eof) {
@@ -444,12 +447,17 @@ esp_err_t gdma_register_tx_event_callbacks(gdma_channel_handle_t dma_chan, gdma_
     // lazy install interrupt service
     ESP_GOTO_ON_ERROR(gdma_install_tx_interrupt(tx_chan), err, TAG, "install interrupt service failed");
 
+    // Always enable EOF interrupt, only enable descriptor error interrupt if callback is given
+    if (cbs->on_descr_err != NULL)
+        intrMask |= GDMA_LL_EVENT_TX_DESC_ERROR;
+
     // enable/disable GDMA interrupt events for TX channel
     portENTER_CRITICAL(&pair->spinlock);
-    gdma_ll_tx_enable_interrupt(group->hal.dev, pair->pair_id, GDMA_LL_EVENT_TX_EOF, cbs->on_trans_eof != NULL);
+    gdma_ll_tx_enable_interrupt(group->hal.dev, pair->pair_id, intrMask, cbs->on_trans_eof != NULL);
     portEXIT_CRITICAL(&pair->spinlock);
 
     tx_chan->on_trans_eof = cbs->on_trans_eof;
+    tx_chan->on_descr_err = cbs->on_descr_err;
     tx_chan->user_data = user_data;
 
     ESP_GOTO_ON_ERROR(esp_intr_enable(dma_chan->intr), err, TAG, "enable interrupt failed");
@@ -467,6 +475,7 @@ esp_err_t gdma_register_rx_event_callbacks(gdma_channel_handle_t dma_chan, gdma_
     pair = dma_chan->pair;
     group = pair->group;
     gdma_rx_channel_t *rx_chan = __containerof(dma_chan, gdma_rx_channel_t, base);
+    uint32_t intrMask = GDMA_LL_EVENT_RX_SUC_EOF;
 
 #if CONFIG_GDMA_ISR_IRAM_SAFE
     if (cbs->on_recv_eof) {
@@ -480,12 +489,17 @@ esp_err_t gdma_register_rx_event_callbacks(gdma_channel_handle_t dma_chan, gdma_
     // lazy install interrupt service
     ESP_GOTO_ON_ERROR(gdma_install_rx_interrupt(rx_chan), err, TAG, "install interrupt service failed");
 
+    // Always enable EOF interrupt, only enable descriptor error interrupt if callback is given
+    if (cbs->on_descr_err != NULL)
+        intrMask |= GDMA_LL_EVENT_RX_DESC_ERROR;
+
     // enable/disable GDMA interrupt events for RX channel
     portENTER_CRITICAL(&pair->spinlock);
-    gdma_ll_rx_enable_interrupt(group->hal.dev, pair->pair_id, GDMA_LL_EVENT_RX_SUC_EOF, cbs->on_recv_eof != NULL);
+    gdma_ll_rx_enable_interrupt(group->hal.dev, pair->pair_id, intrMask, cbs->on_recv_eof != NULL);
     portEXIT_CRITICAL(&pair->spinlock);
 
     rx_chan->on_recv_eof = cbs->on_recv_eof;
+    rx_chan->on_descr_err = cbs->on_descr_err;
     rx_chan->user_data = user_data;
 
     ESP_GOTO_ON_ERROR(esp_intr_enable(dma_chan->intr), err, TAG, "enable interrupt failed");
@@ -769,6 +783,13 @@ static void IRAM_ATTR gdma_default_rx_isr(void *args)
             }
         }
     }
+    if (intr_status & GDMA_LL_EVENT_RX_DESC_ERROR) {
+        if (rx_chan && rx_chan->on_descr_err) {
+            if (rx_chan->on_descr_err(&rx_chan->base, rx_chan->user_data)) {
+                need_yield = true;
+            }
+        }
+    }
 
     if (need_yield) {
         portYIELD_FROM_ISR();
@@ -796,7 +817,13 @@ static void IRAM_ATTR gdma_default_tx_isr(void *args)
             }
         }
     }
-
+    if (intr_status & GDMA_LL_EVENT_TX_DESC_ERROR) {
+        if (tx_chan && tx_chan->on_descr_err) {
+            if (tx_chan->on_descr_err(&tx_chan->base, tx_chan->user_data)) {
+                need_yield = true;
+            }
+        }
+    }
     if (need_yield) {
         portYIELD_FROM_ISR();
     }

--- a/components/esp_hw_support/include/esp_private/gdma.h
+++ b/components/esp_hw_support/include/esp_private/gdma.h
@@ -73,12 +73,25 @@ typedef struct {
 typedef bool (*gdma_event_callback_t)(gdma_channel_handle_t dma_chan, gdma_event_data_t *event_data, void *user_data);
 
 /**
+ * @brief Type of GDMA descriptor error callback
+ * @param dma_chan GDMA channel handle, created from `gdma_new_channel`
+ * @param user_data User registered data from `gdma_register_tx_event_callbacks` or `gdma_register_rx_event_callbacks`
+ *
+ * @return Whether a task switch is needed after the callback function returns,
+ *         this is usually due to the callback wakes up some high priority task.
+ *
+ */
+typedef bool (*gdma_descr_err_callback_t)(gdma_channel_handle_t dma_chan, void *user_data);
+
+
+/**
  * @brief Group of supported GDMA TX callbacks
  * @note The callbacks are all running under ISR environment
  *
  */
 typedef struct {
     gdma_event_callback_t on_trans_eof; /*!< Invoked when TX engine meets EOF descriptor */
+    gdma_descr_err_callback_t on_descr_err; /*!< Invoked when DMA encounters a descriptor error */
 } gdma_tx_event_callbacks_t;
 
 /**
@@ -88,6 +101,7 @@ typedef struct {
  */
 typedef struct {
     gdma_event_callback_t on_recv_eof; /*!< Invoked when RX engine meets EOF descriptor */
+    gdma_descr_err_callback_t on_descr_err; /*!< Invoked when DMA encounters a descriptor error */
 } gdma_rx_event_callbacks_t;
 
 /**

--- a/components/hal/adc_hal.c
+++ b/components/hal/adc_hal.c
@@ -250,7 +250,7 @@ static void adc_hal_digi_dma_link_descriptors(dma_descriptor_t *desc, uint8_t *d
         data_buf += size;
         n++;
     }
-    desc[n-1].next = NULL;
+    desc[n-1].next = desc;
 }
 
 void adc_hal_digi_start(adc_hal_dma_ctx_t *hal, uint8_t *data_buf)
@@ -301,6 +301,11 @@ adc_hal_dma_desc_status_t adc_hal_get_reading_result(adc_hal_dma_ctx_t *hal, con
     *cur_desc = hal->cur_desc_ptr;
 
     return ADC_HAL_DMA_DESC_VALID;
+}
+
+void adc_hal_read_desc_finish(adc_hal_dma_ctx_t *hal) {
+    // Allow DMA to re-use descriptor.
+    hal->cur_desc_ptr->dw0.owner = 1;
 }
 
 void adc_hal_digi_clr_intr(adc_hal_dma_ctx_t *hal, uint32_t mask)

--- a/components/hal/include/hal/adc_hal.h
+++ b/components/hal/include/hal/adc_hal.h
@@ -186,7 +186,7 @@ bool adc_hal_check_event(adc_hal_dma_ctx_t *hal, uint32_t mask);
 #endif
 
 /**
- * @brief Get the ADC reading result
+ * @brief Get the ADC reading result. Call adc_hal_read_desc_finish after using the descriptor.
  *
  * @param      hal           Context of the HAL
  * @param      eof_desc_addr The last descriptor that is finished by HW. Should be got from DMA
@@ -195,6 +195,14 @@ bool adc_hal_check_event(adc_hal_dma_ctx_t *hal, uint32_t mask);
  * @return                   See ``adc_hal_dma_desc_status_t``
  */
 adc_hal_dma_desc_status_t adc_hal_get_reading_result(adc_hal_dma_ctx_t *hal, const intptr_t eof_desc_addr, dma_descriptor_t **cur_desc);
+
+/**
+ * @brief Finishes reading the current descriptor and frees it for repeated usage by DMA.
+ *
+ * @param      hal           Context of the HAL
+ */
+void adc_hal_read_desc_finish(adc_hal_dma_ctx_t *hal);
+
 
 /**
  * @brief Clear interrupt


### PR DESCRIPTION
This fixes #10804 by running the ADC DMA in a continuous loop.

* A function `adc_hal_read_desc_finish` is introduced to set a DMA descriptor's `owner` field to `1` such that it can be re-used by DMA.
* A new DMA callback function `on_descr_err` is added for the `DSCR_ERR` interrput. The interrupt is only enabled if the callback is specified. The continuous ADC driver uses this to print an error to  detect DMA buffer overruns.