### PR TITLE
Fix a race-condition in esp_ipc_isr (IDFGH-10179)

### DIFF
--- a/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S
+++ b/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S
@@ -96,6 +96,7 @@ esp_ipc_isr_handler:
 
     /* set the start flag */
     movi    a0, esp_ipc_isr_start_fl
+    memw
     s32i    a0, a0, 0
 
     /* Call the esp_ipc_function(void* arg) */
@@ -113,6 +114,7 @@ esp_ipc_isr_handler:
 
     /* set the end flag */
     movi    a0, esp_ipc_isr_end_fl
+    memw
     s32i    a0, a0, 0
 
     /* restore a0 */

--- a/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S
+++ b/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S
@@ -23,6 +23,7 @@
 esp_ipc_isr_waiting_for_finish_cmd:
     /* waiting for the finish command */
 .check_finish_cmd:
+    memw
     l32i    a3, a2, 0
     beqz    a3, .check_finish_cmd
     ret


### PR DESCRIPTION
The race condition is very unlikely on real hardware but can be observed with qemu under heavy load.
Also add missing `memw` instructions which are generated by the C compiler but absent in the assembly code.

Fix #11433
See issue for discussion