### PR TITLE
Remove semicolons from ESP_IP4ADDR_INIT and ESP_IP6ADDR_INIT macros (IDFGH-10189)

### DIFF
--- a/components/esp_netif/include/esp_netif_ip_addr.h
+++ b/components/esp_netif/include/esp_netif_ip_addr.h
@@ -79,8 +79,8 @@ extern "C" {
 
 #define ESP_IP4TOADDR(a,b,c,d) esp_netif_htonl(ESP_IP4TOUINT32(a, b, c, d))
 
-#define ESP_IP4ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V4, .u_addr = { .ip4 = { .addr = ESP_IP4TOADDR(a, b, c, d) }}};
-#define ESP_IP6ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V6, .u_addr = { .ip6 = { .addr = { a, b, c, d }, .zone = 0 }}};
+#define ESP_IP4ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V4, .u_addr = { .ip4 = { .addr = ESP_IP4TOADDR(a, b, c, d) }}}
+#define ESP_IP6ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V6, .u_addr = { .ip6 = { .addr = { a, b, c, d }, .zone = 0 }}}
 
 #ifndef IP4ADDR_STRLEN_MAX
 #define IP4ADDR_STRLEN_MAX  16


### PR DESCRIPTION
There are structs like `esp_netif_dns_info_t` that have member for generic ip for which the presence of semicolons is problematic, because when trying to initialize an `ip` member with one of these macros it results in a syntax error since semicolon is used within curly braces.

Problematic case example:
```
esp_netif_dns_info_t my_dns = {.ip = ESP_IP4ADDR_INIT(0, 0, 0, 0)};
```
Here `ESP_IP4ADDR_INIT` expands to expression with semicolon at the end which is a syntax error.

It's also not possible to do something like:
```
esp_netif_dns_info_t my_dns;
my_dns.ip = ESP_IP4ADDR_INIT(0, 0, 0, 0)
```
because that would be other syntax error (initialization of struct that was already created).