### PR TITLE
Implement descriptor error callback for GDMA (IDFGH-10236)

### DIFF
--- a/components/esp_hw_support/dma/gdma_priv.h
+++ b/components/esp_hw_support/dma/gdma_priv.h
@@ -76,12 +76,14 @@ struct gdma_tx_channel_t {
     gdma_channel_t base; // GDMA channel, base class
     void *user_data;     // user registered DMA event data
     gdma_event_callback_t on_trans_eof; // TX EOF callback
+    gdma_descr_err_callback_t on_descr_err; // Descriptor error callback
 };
 
 struct gdma_rx_channel_t {
     gdma_channel_t base; // GDMA channel, base class
     void *user_data;     // user registered DMA event data
     gdma_event_callback_t on_recv_eof; // RX EOF callback
+    gdma_descr_err_callback_t on_descr_err; // Descriptor error callback
 };
 
 #ifdef __cplusplus

--- a/components/esp_hw_support/include/esp_private/gdma.h
+++ b/components/esp_hw_support/include/esp_private/gdma.h
@@ -74,12 +74,25 @@ typedef struct {
 typedef bool (*gdma_event_callback_t)(gdma_channel_handle_t dma_chan, gdma_event_data_t *event_data, void *user_data);
 
 /**
+ * @brief Type of GDMA descriptor error callback
+ * @param dma_chan GDMA channel handle, created from `gdma_new_channel`
+ * @param user_data User registered data from `gdma_register_tx_event_callbacks` or `gdma_register_rx_event_callbacks`
+ *
+ * @return Whether a task switch is needed after the callback function returns,
+ *         this is usually due to the callback wakes up some high priority task.
+ *
+ */
+typedef bool (*gdma_descr_err_callback_t)(gdma_channel_handle_t dma_chan, void *user_data);
+
+
+/**
  * @brief Group of supported GDMA TX callbacks
  * @note The callbacks are all running under ISR environment
  *
  */
 typedef struct {
     gdma_event_callback_t on_trans_eof; /*!< Invoked when TX engine meets EOF descriptor */
+    gdma_descr_err_callback_t on_descr_err; /*!< Invoked when DMA encounters a descriptor error */
 } gdma_tx_event_callbacks_t;
 
 /**
@@ -89,6 +102,7 @@ typedef struct {
  */
 typedef struct {
     gdma_event_callback_t on_recv_eof; /*!< Invoked when RX engine meets EOF descriptor */
+    gdma_descr_err_callback_t on_descr_err; /*!< Invoked when DMA encounters a descriptor error */
 } gdma_rx_event_callbacks_t;
 
 /**


### PR DESCRIPTION
As discussed in #11411 this PR adds a callback to the GDMA driver for the `DESCR_ERR` GDMA interrupt called `on_descr_err`. This can be used to debug drivers that use GDMA (such as adc_continuous) in a circular modes by detecting overruns.

The interrupt is only enabled if the callback is specified.