### PR TITLE
[Heap Trace Standalone] increase Kconfig max stack depth (IDFGH-10245)

### DIFF
--- a/components/heap/Kconfig
+++ b/components/heap/Kconfig
@@ -47,7 +47,7 @@ menu "Heap memory debugging"
         int "Heap tracing stack depth"
         range 0 0 if IDF_TARGET_ARCH_RISCV # Disabled for RISC-V due to `__builtin_return_address` limitation
         default 0 if IDF_TARGET_ARCH_RISCV
-        range 0 10
+        range 0 32
         default 2
         depends on HEAP_TRACING
         help

--- a/components/heap/include/heap_trace.inc
+++ b/components/heap/include/heap_trace.inc
@@ -68,9 +68,31 @@ static IRAM_ATTR __attribute__((noinline)) void get_call_stack(void **callers)
     TEST_STACK(7);
     TEST_STACK(8);
     TEST_STACK(9);
+    TEST_STACK(10);
+    TEST_STACK(11);
+    TEST_STACK(12);
+    TEST_STACK(13);
+    TEST_STACK(14);
+    TEST_STACK(15);
+    TEST_STACK(16);
+    TEST_STACK(17);
+    TEST_STACK(18);
+    TEST_STACK(19);
+    TEST_STACK(20);
+    TEST_STACK(21);
+    TEST_STACK(22);
+    TEST_STACK(23);
+    TEST_STACK(24);
+    TEST_STACK(25);
+    TEST_STACK(26);
+    TEST_STACK(27);
+    TEST_STACK(28);
+    TEST_STACK(29);
+    TEST_STACK(30);
+    TEST_STACK(31);
 }
 
-_Static_assert(STACK_DEPTH >= 0 && STACK_DEPTH <= 10, "CONFIG_HEAP_TRACING_STACK_DEPTH must be in range 0-10");
+_Static_assert(STACK_DEPTH >= 0 && STACK_DEPTH <= 32, "CONFIG_HEAP_TRACING_STACK_DEPTH must be in range 0-32");
 
 
 typedef enum {


### PR DESCRIPTION
Increase max stack depth from 10 -> 32

10 is too small a maximum, and is preventing me from knowing who is calling the function that is leaking.
