### PR TITLE
docs: correct ledc duty value range (IDFGH-10254)

### DIFF
--- a/components/driver/ledc/include/driver/ledc.h
+++ b/components/driver/ledc/include/driver/ledc.h
@@ -88,7 +88,7 @@ typedef struct {
     ledc_cb_event_t event;              /**< Event name */
     uint32_t speed_mode;                /**< Speed mode of the LEDC channel group */
     uint32_t channel;                   /**< LEDC channel (0 - LEDC_CHANNEL_MAX-1) */
-    uint32_t duty;                      /**< LEDC current duty of the channel, the range of duty is [0, (2**duty_resolution) - 1] */
+    uint32_t duty;                      /**< LEDC current duty of the channel, the range of duty is [0, (2**duty_resolution)] */
 } ledc_cb_param_t;
 
 /**
@@ -217,7 +217,7 @@ uint32_t ledc_get_freq(ledc_mode_t speed_mode, ledc_timer_t timer_num);
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution) - 1]
+ * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution)]
  * @param hpoint Set the LEDC hpoint value(max: 0xfffff)
  *
  * @return
@@ -248,7 +248,7 @@ int ledc_get_hpoint(ledc_mode_t speed_mode, ledc_channel_t channel);
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution) - 1]
+ * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution)]
  *
  * @return
  *     - ESP_OK Success
@@ -278,7 +278,7 @@ uint32_t ledc_get_duty(ledc_mode_t speed_mode, ledc_channel_t channel);
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param duty Set the start of the gradient duty, the range of duty setting is [0, (2**duty_resolution) - 1]
+ * @param duty Set the start of the gradient duty, the range of duty setting is [0, (2**duty_resolution)]
  * @param fade_direction Set the direction of the gradient
  * @param step_num Set the number of the gradient
  * @param duty_cycle_num Set how many LEDC tick each time the gradient lasts
@@ -384,7 +384,7 @@ esp_err_t ledc_bind_channel_timer(ledc_mode_t speed_mode, ledc_channel_t channel
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode. ,
  * @param channel LEDC channel index (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param target_duty Target duty of fading [0, (2**duty_resolution) - 1]
+ * @param target_duty Target duty of fading [0, (2**duty_resolution)]
  * @param scale Controls the increase or decrease step scale.
  * @param cycle_num increase or decrease the duty every cycle_num cycles
  *
@@ -407,7 +407,7 @@ esp_err_t ledc_set_fade_with_step(ledc_mode_t speed_mode, ledc_channel_t channel
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode. ,
  * @param channel LEDC channel index (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param target_duty Target duty of fading [0, (2**duty_resolution) - 1]
+ * @param target_duty Target duty of fading [0, (2**duty_resolution)]
  * @param max_fade_time_ms The maximum time of the fading ( ms ).
  *
  * @return
@@ -478,7 +478,7 @@ esp_err_t ledc_fade_stop(ledc_mode_t speed_mode, ledc_channel_t channel);
  *
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution) - 1]
+ * @param duty Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution)]
  * @param hpoint Set the LEDC hpoint value(max: 0xfffff)
  *
  */
@@ -491,7 +491,7 @@ esp_err_t ledc_set_duty_and_update(ledc_mode_t speed_mode, ledc_channel_t channe
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel index (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param target_duty Target duty of fading [0, (2**duty_resolution) - 1]
+ * @param target_duty Target duty of fading [0, (2**duty_resolution)]
  * @param max_fade_time_ms The maximum time of the fading ( ms ).
  * @param fade_mode choose blocking or non-blocking mode
  * @return
@@ -509,7 +509,7 @@ esp_err_t ledc_set_fade_time_and_start(ledc_mode_t speed_mode, ledc_channel_t ch
  *        Other duty operations will have to wait until the fade operation has finished.
  * @param speed_mode Select the LEDC channel group with specified speed mode. Note that not all targets support high speed mode.
  * @param channel LEDC channel index (0 - LEDC_CHANNEL_MAX-1), select from ledc_channel_t
- * @param target_duty Target duty of fading [0, (2**duty_resolution) - 1]
+ * @param target_duty Target duty of fading [0, (2**duty_resolution)]
  * @param scale Controls the increase or decrease step scale.
  * @param cycle_num increase or decrease the duty every cycle_num cycles
  * @param fade_mode choose blocking or non-blocking mode

--- a/components/driver/ledc/ledc.c
+++ b/components/driver/ledc/ledc.c
@@ -675,7 +675,7 @@ esp_err_t ledc_channel_config(const ledc_channel_config_t *ledc_conf)
 
     /*set channel parameters*/
     /*   channel parameters decide how the waveform looks like in one period*/
-    /*   set channel duty and hpoint value, duty range is (0 ~ ((2 ** duty_resolution) - 1)), max hpoint value is 0xfffff*/
+    /*   set channel duty and hpoint value, duty range is (0 ~ (2 ** duty_resolution)), max hpoint value is 0xfffff*/
     ledc_set_duty_with_hpoint(speed_mode, ledc_channel, duty, hpoint);
     /*update duty settings*/
     ledc_update_duty(speed_mode, ledc_channel);

--- a/docs/en/api-reference/peripherals/ledc.rst
+++ b/docs/en/api-reference/peripherals/ledc.rst
@@ -247,7 +247,7 @@ To set the duty cycle, use the dedicated function :cpp:func:`ledc_set_duty`. Aft
 
 Another way to set the duty cycle, as well as some other channel parameters, is by calling :cpp:func:`ledc_channel_config` covered in Section :ref:`ledc-api-configure-channel`.
 
-The range of the duty cycle values passed to functions depends on selected ``duty_resolution`` and should be from ``0`` to ``(2 ** duty_resolution) - 1``. For example, if the selected duty resolution is 10, then the duty cycle values can range from 0 to 1023. This provides the resolution of ~0.1%.
+The range of the duty cycle values passed to functions depends on selected ``duty_resolution`` and should be from ``0`` to ``(2 ** duty_resolution)``. For example, if the selected duty resolution is 10, then the duty cycle values can range from 0 to 1024. This provides the resolution of ~0.1%.
 
 
 Change PWM Duty Cycle using Hardware


### PR DESCRIPTION
As discussed e.g. [here](https://github.com/arendst/Tasmota/issues/18726#issuecomment-1564185309), the maximum value for `duty` in `ledc_set_duty_with_hpoint` is `2**duty_resolution`, not `2**duty_resolution - 1`. At the moment, the documentation is inconsistent; some places have the correct range, others do not.

The fact that `2**duty_resolution` is correct can also be seen in the [data sheet](https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf#ledpwm) of the ESP32 (see pages 383-384): Suppose `DUTY_RESOLUTION = 10` and `HPOINT = 0`. If `DUTY = 1023`, the PWM output goes high when the counter starts at 0, then it goes *low* when the counter reaches 1023, and goes back up high one tick later when the counter rolls back to 0. Therefore, a value of `DUTY=1023` corresponds to an output that is high 99.90 % of the time. To get an output that is high permanently, we need to set `DUTY=1024`.