### PR TITLE
[Stack Mirror] [v5.1] make corrupt backtraces not happen nearly as often (IDFGH-10257)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ if(NOT BOOTLOADER_BUILD)
         list(APPEND compile_options "-O2")
     endif()
 
+    if(CONFIG_COMPILER_STACK_MIRROR)
+        list(APPEND compile_options "-finstrument-functions")
+    endif()
+
 else()  # BOOTLOADER_BUILD
 
     if(CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_SIZE)

--- a/Kconfig
+++ b/Kconfig
@@ -454,6 +454,22 @@ mainmenu "Espressif IoT Development Framework Configuration"
             help
                 Stack smashing protection.
 
+        config COMPILER_STACK_MIRROR
+            prompt "Enable Stack Mirror"
+            bool
+            default "n"
+            help
+                Make corrupted backtraces much less likely by creating a dupliate copy of stack return
+                addresses in heap memory. Requires about 100 bytes of memory per thread.
+
+        config COMPILER_STACK_MIRROR_DEPTH
+            prompt "Stack Mirror Depth"
+            int
+            default 26
+            depends on COMPILER_STACK_MIRROR
+            help
+                The maximum depth of the stack mirror. 4 bytes are needed per depth.
+
         config COMPILER_WARN_WRITE_STRINGS
             bool "Enable -Wwrite-strings warning flag"
             default "n"

--- a/components/esp_hw_support/include/esp_cpu.h
+++ b/components/esp_hw_support/include/esp_cpu.h
@@ -120,6 +120,9 @@ void esp_cpu_wait_for_intr(void);
  *
  * @return The current core's ID [0..SOC_CPU_CORES_NUM - 1]
  */
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 FORCE_INLINE_ATTR __attribute__((pure)) int esp_cpu_get_core_id(void)
 {
     //Note: Made "pure" to optimize for single core target

--- a/components/esp_hw_support/include/hal/cpu_ll.h
+++ b/components/esp_hw_support/include/hal/cpu_ll.h
@@ -20,6 +20,9 @@ Note: This is a compatibility header. Call the interfaces in esp_cpu.h instead
 extern "C" {
 #endif
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 FORCE_INLINE_ATTR __attribute__((deprecated)) __attribute__((pure)) uint32_t cpu_ll_get_core_id(void)
 {
     return esp_cpu_get_core_id();

--- a/components/esp_hw_support/include/spinlock.h
+++ b/components/esp_hw_support/include/spinlock.h
@@ -63,6 +63,7 @@ static inline void __attribute__((always_inline)) spinlock_initialize(spinlock_t
  * @param lock - target spinlock object
  * @param timeout - cycles to wait, passing SPINLOCK_WAIT_FOREVER blocs indefinitely
  */
+
 static inline bool __attribute__((always_inline)) spinlock_acquire(spinlock_t *lock, int32_t timeout)
 {
 #if !CONFIG_FREERTOS_UNICORE && !BOOTLOADER_BUILD

--- a/components/esp_system/CMakeLists.txt
+++ b/components/esp_system/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
             "startup.c"
             "system_time.c"
             "stack_check.c"
+            "stack_mirror.c"
             "ubsan.c"
             "xt_wdt.c"
             "debug_stubs.c")

--- a/components/esp_system/include/esp_private/stack_mirror.h
+++ b/components/esp_system/include/esp_private/stack_mirror.h
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if CONFIG_COMPILER_STACK_MIRROR
+void stack_mirror_enable();
+void stack_mirror_print_backtrace(bool panic);
+#endif

--- a/components/esp_system/port/arch/xtensa/debug_helpers.c
+++ b/components/esp_system/port/arch/xtensa/debug_helpers.c
@@ -14,6 +14,7 @@
 #include "soc/soc_memory_layout.h"
 #include "esp_cpu_utils.h"
 #include "esp_private/panic_internal.h"
+#include "esp_private/stack_mirror.h"
 
 #include "xtensa/xtensa_context.h"
 
@@ -86,6 +87,9 @@ esp_err_t IRAM_ATTR esp_backtrace_print_from_frame(int depth, const esp_backtrac
     esp_err_t ret = ESP_OK;
     if (corrupted) {
         print_str(" |<-CORRUPTED", panic);
+#ifndef CONFIG_COMPILER_STACK_MIRROR
+        print_str("\r\nTurn on Stack Mirroring to avoid corruption", panic);
+#endif
         ret =  ESP_FAIL;
     } else if (stk_frame.next_pc != 0) {    //Backtrace continues
         print_str(" |<-CONTINUES", panic);
@@ -99,5 +103,11 @@ esp_err_t IRAM_ATTR esp_backtrace_print(int depth)
     //Initialize stk_frame with first frame of stack
     esp_backtrace_frame_t start = { 0 };
     esp_backtrace_get_start(&(start.pc), &(start.sp), &(start.next_pc));
-    return esp_backtrace_print_from_frame(depth, &start, false);
+    esp_err_t err = esp_backtrace_print_from_frame(depth, &start, false);
+#if CONFIG_COMPILER_STACK_MIRROR
+    if (err != ESP_OK) {
+        stack_mirror_print_backtrace(false);
+    }
+#endif
+    return err;
 }

--- a/components/esp_system/port/arch/xtensa/panic_arch.c
+++ b/components/esp_system/port/arch/xtensa/panic_arch.c
@@ -11,6 +11,7 @@
 #include "esp_debug_helpers.h"
 
 #include "esp_private/panic_internal.h"
+#include "esp_private/stack_mirror.h"
 #include "esp_private/panic_reason.h"
 #include "soc/soc.h"
 
@@ -467,5 +468,9 @@ void panic_print_backtrace(const void *f, int core)
 {
     XtExcFrame *xt_frame = (XtExcFrame *) f;
     esp_backtrace_frame_t frame = {.pc = xt_frame->pc, .sp = xt_frame->a1, .next_pc = xt_frame->a0, .exc_frame = xt_frame};
-    esp_backtrace_print_from_frame(100, &frame, true);
+    if (esp_backtrace_print_from_frame(100, &frame, true) != ESP_OK) {
+#if CONFIG_COMPILER_STACK_MIRROR
+        stack_mirror_print_backtrace(true);
+#endif
+    }
 }

--- a/components/esp_system/stack_mirror.c
+++ b/components/esp_system/stack_mirror.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_heap_caps.h"
+#include "esp_cpu_utils.h"
+#include "esp_private/panic_internal.h"
+#include "esp_memory_utils.h"
+
+#if CONFIG_COMPILER_STACK_MIRROR
+
+#define STACK_MIRROR_MAGIC 139871234
+
+static uint32_t enabled;
+
+static void IRAM_ATTR print_str(const char* str, bool panic)
+{
+    if (panic) {
+        panic_print_str(str);
+    } else {
+        esp_rom_printf(str);
+    }
+}
+
+static void IRAM_ATTR print_entry(uint32_t pc, bool panic)
+{
+    if (panic) {
+        panic_print_str(" 0x");
+        panic_print_hex(pc);
+    } else {
+        esp_rom_printf(" 0x%08X", pc);
+    }
+}
+
+extern void xt_unhandled_exception(XtExcFrame *frame);
+
+
+/*
+__cyg_profile_func_enter: gcc inserts a call to this function
+at the start of every function.
+
+__attribute__((no_instrument_function)): any function used by
+__cyg_profile_func_enter must be annoted with this attribute.
+This tells GCC to not insert instrumentation calls, which
+which would cause an infinite loop
+*/
+IRAM_ATTR __attribute__((no_instrument_function, noinline))
+void __cyg_profile_func_enter(void *func, void *callsite)
+{
+    if (enabled == STACK_MIRROR_MAGIC) {
+        esp_stack_mirror_t *m = pvTaskGetStackMirrorPointer();
+        if (func == xt_unhandled_exception) {
+            // dont add to the stack trace after we already hit panic.
+            m->panicing = true;
+        }
+        if (!m->panicing) {
+            if (m->depth < CONFIG_COMPILER_STACK_MIRROR_DEPTH) {
+                m->backtrace[m->depth] = (uint32_t) func;
+            }
+            m->depth++;
+        }
+    }
+}
+
+/*
+__cyg_profile_func_exit: gcc inserts a call to this function
+at the end of every function.
+
+__attribute__((no_instrument_function)): any function used by
+__cyg_profile_func_exit must be annoted with this attribute.
+This tells GCC to not insert instrumentation calls, which
+would cause an infinite loop
+*/
+IRAM_ATTR __attribute__((no_instrument_function, noinline))
+void __cyg_profile_func_exit(void *func, void *callsite)
+{
+    if (enabled == STACK_MIRROR_MAGIC) {
+        esp_stack_mirror_t *m = pvTaskGetStackMirrorPointer();
+        if (!m->panicing && m->depth > 0) {
+            m->depth--;
+        }
+    }
+}
+
+void IRAM_ATTR stack_mirror_print_backtrace(bool panic)
+{
+    esp_stack_mirror_t *m = pvTaskGetStackMirrorPointer();
+
+    print_str("\r\nBacktrace (Mirror):", panic);
+
+    if (m == NULL) {
+
+        print_str("\r\nNot Set", panic);
+
+    } else if (esp_ptr_internal(m) == false) {
+
+        print_str("\r\nInvalid Ptr", panic);
+
+    } else if (m->depth == 0) {
+
+        print_str("\r\nEmpty", panic);
+
+    } else {
+
+        uint32_t depth = m->depth;
+
+        if (depth >= CONFIG_COMPILER_STACK_MIRROR_DEPTH) {
+            print_str("\r\nBACKTRACE INCOMPLETE", panic);
+            depth = CONFIG_COMPILER_STACK_MIRROR_DEPTH;
+        }
+
+        for (int i = depth - 1; i >= 0; i--) {
+
+            uint32_t pc = m->backtrace[i];
+
+            print_entry(pc, panic);
+
+            bool corrupted = !esp_ptr_executable((void *)esp_cpu_process_stack_pc(pc));
+
+            if (corrupted) {
+                print_str(" |<-CORRUPTED", panic);
+                break;
+            }
+        }
+    }
+
+    print_str("\r\n\r\n", panic);
+
+    return;
+}
+
+void stack_mirror_enable()
+{
+    enabled = STACK_MIRROR_MAGIC;
+}
+
+#endif // CONFIG_COMPILER_STACK_MIRROR

--- a/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/FreeRTOS.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/FreeRTOS.h
@@ -1258,6 +1258,12 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_POSIX_ERRNO == 1 )
         int iDummy22;
     #endif
+    #if CONFIG_COMPILER_STACK_MIRROR
+        uint32_t uDummy23;
+        uint32_t uDummy24;
+        uint32_t uDummy25[CONFIG_COMPILER_STACK_MIRROR_DEPTH];
+    #endif
+
 } StaticTask_t;
 
 /*

--- a/components/freertos/FreeRTOS-Kernel-SMP/portable/riscv/include/freertos/portmacro.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/portable/riscv/include/freertos/portmacro.h
@@ -224,6 +224,9 @@ static inline void __attribute__((always_inline)) vPortYieldCore( BaseType_t xCo
 
 // ----------------------- System --------------------------
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 static inline BaseType_t __attribute__((always_inline)) xPortGetCoreID( void )
 {
     return (BaseType_t) esp_cpu_get_core_id();

--- a/components/freertos/FreeRTOS-Kernel-SMP/portable/xtensa/include/freertos/portmacro.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/portable/xtensa/include/freertos/portmacro.h
@@ -252,6 +252,9 @@ static inline void __attribute__((always_inline)) vPortYieldFromISR( void )
 
 // ----------------------- System --------------------------
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 static inline BaseType_t __attribute__((always_inline)) xPortGetCoreID( void )
 {
     return (BaseType_t) esp_cpu_get_core_id();

--- a/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h
@@ -1271,6 +1271,11 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_POSIX_ERRNO == 1 )
         int iDummy22;
     #endif
+    #if CONFIG_COMPILER_STACK_MIRROR
+        uint32_t uDummy23;
+        uint32_t uDummy24;
+        uint32_t uDummy25[CONFIG_COMPILER_STACK_MIRROR_DEPTH];
+    #endif
 } StaticTask_t;
 
 /*

--- a/components/freertos/FreeRTOS-Kernel/include/freertos/task.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/task.h
@@ -1965,6 +1965,16 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
  */
 uint8_t * pxTaskGetStackStart( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
+#if CONFIG_COMPILER_STACK_MIRROR
+typedef struct {
+    uint32_t panicing;
+    uint32_t depth;
+    uint32_t backtrace[CONFIG_COMPILER_STACK_MIRROR_DEPTH];
+} esp_stack_mirror_t;
+
+esp_stack_mirror_t *pvTaskGetStackMirrorPointer();
+#endif // CONFIG_COMPILER_STACK_MIRROR
+
 /* When using trace macros it is sometimes necessary to include task.h before
  * FreeRTOS.h.  When this is done TaskHookFunction_t will not yet have been defined,
  * so the following two prototypes will cause a compilation error.  This can be

--- a/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos/portmacro.h
+++ b/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos/portmacro.h
@@ -555,6 +555,9 @@ extern void vPortCleanUpTCB ( void *pxTCB );
 
 // --------------------- Interrupts ------------------------
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 static inline UBaseType_t __attribute__((always_inline)) xPortSetInterruptMaskFromISR(void)
 {
     UBaseType_t prev_int_level = XTOS_SET_INTLEVEL(XCHAL_EXCM_LEVEL);
@@ -562,6 +565,9 @@ static inline UBaseType_t __attribute__((always_inline)) xPortSetInterruptMaskFr
     return prev_int_level;
 }
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 static inline void __attribute__((always_inline)) vPortClearInterruptMaskFromISR(UBaseType_t prev_level)
 {
     portbenchmarkINTERRUPT_RESTORE(prev_level);
@@ -626,7 +632,10 @@ FORCE_INLINE_ATTR bool xPortCanYield(void)
 
 // ----------------------- System --------------------------
 
-FORCE_INLINE_ATTR BaseType_t xPortGetCoreID(void)
+#if CONFIG_COMPILER_STACK_MIRROR
+    __attribute__((no_instrument_function))
+#endif
+FORCE_INLINE_ATTR BaseType_t IRAM_ATTR xPortGetCoreID(void)
 {
     return (BaseType_t) esp_cpu_get_core_id();
 }

--- a/components/freertos/app_startup.c
+++ b/components/freertos/app_startup.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,7 @@
 #include "freertos/portmacro.h"
 #include "esp_private/esp_int_wdt.h"
 #include "esp_private/crosscore_int.h"
+#include "esp_private/stack_mirror.h"
 #include "esp_task_wdt.h"
 #include "esp_freertos_hooks.h"
 #include "esp_heap_caps_init.h"
@@ -198,6 +199,10 @@ static void main_task(void* args)
 #endif
     ESP_ERROR_CHECK(esp_task_wdt_init(&twdt_config));
 #endif // CONFIG_ESP_TASK_WDT
+
+#if CONFIG_COMPILER_STACK_MIRROR
+    stack_mirror_enable();
+#endif
 
     /*
     Note: Be careful when changing the "Calling app_main()" log below as multiple pytest scripts expect this log as a

--- a/components/xtensa/include/xt_utils.h
+++ b/components/xtensa/include/xt_utils.h
@@ -24,6 +24,9 @@ extern "C" {
  *
  * ------------------------------------------------------------------------------------------------------------------ */
 
+#if CONFIG_COMPILER_STACK_MIRROR
+    IRAM_ATTR __attribute__((no_instrument_function))
+#endif
 FORCE_INLINE_ATTR __attribute__((pure)) uint32_t xt_utils_get_core_id(void)
 {
     /*


### PR DESCRIPTION
**Previous v4.4 PR:** https://github.com/espressif/esp-idf/pull/10984

This PR is just for reference, moving this work to a more recent branch. @Dazza0 mentioned wanting to change the implementation. 

**I don't expect us to merge this as is, given Dazzo0's comments.** Though we totally could, and just improve it later.

**please see the discussion in the v4.4 PR:** https://github.com/espressif/esp-idf/pull/10984