### PR TITLE
lwip: port: freertos: Use libc malloc for all allocations

### DIFF
--- a/components/lwip/port/freertos/sys_arch.c
+++ b/components/lwip/port/freertos/sys_arch.c
@@ -205,7 +205,7 @@ sys_sem_free(sys_sem_t *sem)
 err_t
 sys_mbox_new(sys_mbox_t *mbox, int size)
 {
-  *mbox = mem_malloc(sizeof(struct sys_mbox_s));
+  *mbox = malloc(sizeof(struct sys_mbox_s));
   if (*mbox == NULL){
     LWIP_DEBUGF(ESP_THREAD_SAFE_DEBUG, ("fail to new *mbox\n"));
     return ERR_MEM;
@@ -517,7 +517,7 @@ sys_thread_sem_free(void* data) // destructor for TLS semaphore
 sys_sem_t*
 sys_thread_sem_init(void)
 {
-  sys_sem_t *sem = (sys_sem_t*)mem_malloc(sizeof(sys_sem_t*));
+  sys_sem_t *sem = (sys_sem_t*)malloc(sizeof(sys_sem_t*));
 
   if (!sem){
     ESP_LOGE(TAG, "thread_sem_init: out of memory");


### PR DESCRIPTION
Mixing lwip and libc allocation functions causes heap failures when LwIPs MEM_STATS feature is enabled. MEM_STATS uses additional bookkeeping space that is hidden from the caller. If previously allocated blocks are free'd without taking this into account the heap will assert. This commit modifies these calls to consistently use libc malloc