### PR TITLE
Replace deprecated fiushregs alias with full gdb command (IDFGH-10272)

### DIFF
--- a/docs/en/api-guides/jtag-debugging/tips-and-quirks.rst
+++ b/docs/en/api-guides/jtag-debugging/tips-and-quirks.rst
@@ -112,7 +112,7 @@ On startup, debugger is issuing sequence of commands to reset the chip and halt 
 
 * ``set remote hardware-watchpoint-limit 2`` — Restrict GDB to using two hardware watchpoints supported by the chip, 2 for {IDF_TARGET_NAME}. For more information see https://sourceware.org/gdb/onlinedocs/gdb/Remote-Configuration.html.
 * ``mon reset halt`` — reset the chip and keep the CPUs halted
-* ``flushregs`` — monitor (``mon``) command can not inform GDB that the target state has changed. GDB will assume that whatever stack the target had before ``mon reset halt`` will still be valid. In fact, after reset the target state will change, and executing ``flushregs`` is a way to force GDB to get new state from the target.
+* ``maintenance flush register-cache`` — monitor (``mon``) command can not inform GDB that the target state has changed. GDB will assume that whatever stack the target had before ``mon reset halt`` will still be valid. In fact, after reset the target state will change, and executing ``maintenance flush register-cache`` is a way to force GDB to get new state from the target.
 * ``thb app_main`` — insert a temporary hardware breakpoint at ``app_main``, put here another function name if required
 * ``c`` — resume the program. It will then stop at breakpoint inserted at ``app_main``.
 

--- a/docs/en/api-guides/jtag-debugging/using-debugger.rst
+++ b/docs/en/api-guides/jtag-debugging/using-debugger.rst
@@ -63,7 +63,7 @@ Once installation is complete, configure debugging session following steps below
     ::
 
         mon reset halt
-        flushregs
+        maintenance flush register-cache
         set remote hardware-watchpoint-limit 2
 
     .. note::
@@ -129,7 +129,7 @@ Command Line
         target remote :3333
         set remote hardware-watchpoint-limit 2
         mon reset halt
-        flushregs
+        maintenance flush register-cache
         thb app_main
         c
 

--- a/docs/en/api-reference/system/heap_debug.rst
+++ b/docs/en/api-reference/system/heap_debug.rst
@@ -331,7 +331,7 @@ To gather and analyse heap trace do the following on the host:
     target remote :3333
 
     mon reset halt
-    flushregs
+    maintenance flush register-cache
 
     tb heap_trace_start
     commands

--- a/docs/zh_CN/api-guides/jtag-debugging/tips-and-quirks.rst
+++ b/docs/zh_CN/api-guides/jtag-debugging/tips-and-quirks.rst
@@ -112,7 +112,7 @@ GDB 具有 FreeRTOS 支持的 Python 扩展模块。在系统要求满足的情�
 
 * ``set remote hardware-watchpoint-limit 2`` — 限制 GDB 仅使用 {IDF_TARGET_NAME} 支持的两个硬件观察点。更多详细信息，请查阅 `GDB 配置远程目标 <https://sourceware.org/gdb/onlinedocs/gdb/Remote-Configuration.html>`_ 。
 * ``mon reset halt`` — 复位芯片并使 CPU 停止运行。
-* ``flushregs`` — monitor (``mon``) 命令无法通知 GDB 目标状态已经更改，GDB 会假设在 ``mon reset halt`` 之前所有的任务堆栈仍然有效。实际上，复位后目标状态将发生变化。执行 ``flushregs`` 是一种强制 GDB 从目标获取最新状态的方法。
+* ``maintenance flush register-cache`` — monitor (``mon``) 命令无法通知 GDB 目标状态已经更改，GDB 会假设在 ``mon reset halt`` 之前所有的任务堆栈仍然有效。实际上，复位后目标状态将发生变化。执行 ``maintenance flush register-cache`` 是一种强制 GDB 从目标获取最新状态的方法。
 * ``thb app_main`` — 在 ``app_main`` 处插入一个临时的硬件断点，如果有需要，可以将其替换为其他函数名。
 * ``c`` — 恢复程序运行，它将会在 ``app_main`` 的断点处停止运行。
 

--- a/docs/zh_CN/api-guides/jtag-debugging/using-debugger.rst
+++ b/docs/zh_CN/api-guides/jtag-debugging/using-debugger.rst
@@ -63,7 +63,7 @@
     ::
 
         mon reset halt
-        flushregs
+        maintenance flush register-cache
         set remote hardware-watchpoint-limit 2
 
     .. note::
@@ -129,7 +129,7 @@
         target remote :3333
         set remote hardware-watchpoint-limit 2
         mon reset halt
-        flushregs
+        maintenance flush register-cache
         thb app_main
         c
 

--- a/examples/system/sysview_tracing/gdbinit
+++ b/examples/system/sysview_tracing/gdbinit
@@ -2,7 +2,7 @@ set pagination off
 target remote :3333
 
 mon reset halt
-flushregs
+maintenance flush register-cache
 
 b app_main
 commands

--- a/examples/system/sysview_tracing/pytest_sysview_tracing.py
+++ b/examples/system/sysview_tracing/pytest_sysview_tracing.py
@@ -22,7 +22,7 @@ def test_examples_sysview_tracing(dut: IdfDut) -> None:
         dut.expect(re.compile(rb'example: Task\[0x3[0-9A-Fa-f]+\]: received event \d+'), timeout=30)
 
     dut.gdb.write('mon reset halt')
-    dut.gdb.write('flushregs')
+    dut.gdb.write('maintenance flush register-cache')
     dut.gdb.write('b app_main')
 
     dut.gdb.write('commands', non_blocking=True)

--- a/examples/system/sysview_tracing_heap_log/gdbinit
+++ b/examples/system/sysview_tracing_heap_log/gdbinit
@@ -2,7 +2,7 @@ set pagination off
 target remote :3333
 
 mon reset halt
-flushregs
+maintenance flush register-cache
 
 tb heap_trace_start
 commands

--- a/examples/system/sysview_tracing_heap_log/pytest_sysview_tracing_heap_log.py
+++ b/examples/system/sysview_tracing_heap_log/pytest_sysview_tracing_heap_log.py
@@ -17,7 +17,7 @@ def test_examples_sysview_tracing_heap_log(idf_path: str, dut: IdfDut) -> None:
     trace_log = os.path.join(os.path.dirname(dut.gdb._logfile), 'heap_log.svdat')  # pylint: disable=protected-access
 
     dut.gdb.write('mon reset halt')
-    dut.gdb.write('flushregs')
+    dut.gdb.write('maintenance flush register-cache')
 
     dut.gdb.write('tb heap_trace_start')
     dut.gdb.write('commands', non_blocking=True)

--- a/tools/esp_app_trace/test/sysview/gdbinit
+++ b/tools/esp_app_trace/test/sysview/gdbinit
@@ -1,7 +1,7 @@
 target remote :3333
 
 mon reset halt
-flushregs
+maintenance flush register-cache
 
 b heap_trace_start
 commands

--- a/tools/idf_py_actions/debug_ext.py
+++ b/tools/idf_py_actions/debug_ext.py
@@ -54,7 +54,7 @@ GDBINIT_CONNECT = '''
 # Connect to the default openocd-esp port and break on app_main()
 target remote :3333
 monitor reset halt
-flushregs
+maintenance flush register-cache
 thbreak app_main
 continue
 '''


### PR DESCRIPTION
Usage of `flushregs` in gdb will result in the following warning:

```
Warning: 'flushregs', an alias for the command 'maintenance flush register-cache', is deprecated.
Use 'maintenance flush register-cache'.
```

This patch updates to use the recommend command.