### PR TITLE
[Console] add setting to use PSRAM (IDFGH-10303)

### DIFF
--- a/components/console/commands.c
+++ b/components/console/commands.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/param.h>
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_console.h"
 #include "esp_system.h"
@@ -45,6 +46,9 @@ static esp_console_config_t s_config;
 /** temporary buffer used for command line parsing */
 static char *s_tmp_line_buf;
 
+/** for internal allocations */
+static uint32_t s_heap_alloc_caps = MALLOC_CAP_DEFAULT;
+
 static const cmd_item_t *find_command_by_name(const char *name);
 
 esp_err_t esp_console_init(const esp_console_config_t *config)
@@ -59,7 +63,10 @@ esp_err_t esp_console_init(const esp_console_config_t *config)
     if (s_config.hint_color == 0) {
         s_config.hint_color = ANSI_COLOR_DEFAULT;
     }
-    s_tmp_line_buf = calloc(config->max_cmdline_length, 1);
+    if (config->heap_alloc_caps != 0) {
+        s_heap_alloc_caps = config->heap_alloc_caps;
+    }
+    s_tmp_line_buf = heap_caps_calloc(config->max_cmdline_length, 1, s_heap_alloc_caps);
     if (s_tmp_line_buf == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -94,7 +101,7 @@ esp_err_t esp_console_cmd_register(const esp_console_cmd_t *cmd)
     item = (cmd_item_t *)find_command_by_name(cmd->command);
     if (!item) {
         // not registered before
-        item = calloc(1, sizeof(*item));
+        item = heap_caps_calloc(1, sizeof(*item), s_heap_alloc_caps);
         if (item == NULL) {
             return ESP_ERR_NO_MEM;
         }
@@ -187,7 +194,7 @@ esp_err_t esp_console_run(const char *cmdline, int *cmd_ret)
     if (s_tmp_line_buf == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
-    char **argv = (char **) calloc(s_config.max_cmdline_args, sizeof(char *));
+    char **argv = (char **) heap_caps_calloc(s_config.max_cmdline_args, sizeof(char *), s_heap_alloc_caps);
     if (argv == NULL) {
         return ESP_ERR_NO_MEM;
     }

--- a/components/console/esp_console.h
+++ b/components/console/esp_console.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #include <stddef.h>
 #include "sdkconfig.h"
+#include "esp_heap_caps.h"
 #include "esp_err.h"
 
 // Forward declaration. Definition in linenoise/linenoise.h.
@@ -22,6 +23,7 @@ typedef struct linenoiseCompletions linenoiseCompletions;
 typedef struct {
     size_t max_cmdline_length;  //!< length of command line buffer, in bytes
     size_t max_cmdline_args;    //!< maximum number of command line arguments to parse
+    uint32_t heap_alloc_caps;   //!< where to place internal allocations (e.g. MALLOC_CAP_SPIRAM)
     int hint_color;             //!< ASCII color code of hint text
     int hint_bold;              //!< Set to 1 to print hint text in bold
 } esp_console_config_t;
@@ -30,12 +32,13 @@ typedef struct {
  * @brief Default console configuration value
  *
  */
-#define ESP_CONSOLE_CONFIG_DEFAULT() \
-    {                                \
-        .max_cmdline_length = 256,   \
-        .max_cmdline_args = 32,      \
-        .hint_color = 39,            \
-        .hint_bold = 0               \
+#define ESP_CONSOLE_CONFIG_DEFAULT()           \
+    {                                          \
+        .max_cmdline_length = 256,             \
+        .max_cmdline_args = 32,                \
+        .heap_alloc_caps = MALLOC_CAP_DEFAULT, \
+        .hint_color = 39,                      \
+        .hint_bold = 0                         \
     }
 
 /**


### PR DESCRIPTION
Add an option to use SPIRAM for esp console allocations, otherwise fallback to default allocation scheme.

I have 215 commands, so **this was taking up nearly 20KB of internal ram**.