### PR TITLE
[GDBStub] kconfig gdbstub runtime should be separate bool (IDFGH-10309)

### DIFF
--- a/components/esp_system/Kconfig
+++ b/components/esp_system/Kconfig
@@ -39,13 +39,6 @@ menu "ESP System Settings"
             help
                 Invoke gdbstub on the serial port, allowing for gdb to attach to it to do a postmortem
                 of the crash.
-
-        config ESP_SYSTEM_GDBSTUB_RUNTIME
-            bool "GDBStub at runtime"
-            select ESP_GDBSTUB_ENABLED
-            depends on !IDF_TARGET_ESP32C2
-            help
-                Invoke gdbstub on the serial port, allowing for gdb to attach to it and to do a debug on runtime.
     endchoice
 
     config ESP_SYSTEM_PANIC_REBOOT_DELAY_SECONDS
@@ -56,6 +49,17 @@ menu "ESP System Settings"
         help
             After the panic handler executes, you can specify a number of seconds to
             wait before the device reboots.
+
+    config ESP_SYSTEM_GDBSTUB_RUNTIME
+        bool "GDBStub at runtime"
+        select ESP_GDBSTUB_ENABLED
+        default n
+        help
+            Enable GDBStub inclusion into firmware.
+            This allows to debug the target device using serial port:
+            - Run 'idf.py monitor'.
+            - Wait for the device to initialize.
+            - Press Ctrl+C to interrupt the execution and enter GDB attached to your device for debugging.
 
     config ESP_SYSTEM_SINGLE_CORE_MODE
         bool


### PR DESCRIPTION
See: https://github.com/espressif/esp-idf/issues/11568#issuecomment-1571565125

This is a runtime feature, not a panic feature. 