### PR TITLE
Fix ULP FSM register macros with addr[9:0] > 0xFF (IDFGH-10397)

### DIFF
--- a/components/ulp/ulp_fsm/include/esp32/ulp.h
+++ b/components/ulp/ulp_fsm/include/esp32/ulp.h
@@ -331,7 +331,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg) {
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_WR_REG(reg, low_bit, high_bit, val) {.wr_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .data = val, \
     .low = low_bit, \
@@ -345,7 +345,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg) {
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_RD_REG(reg, low_bit, high_bit) {.rd_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .unused = 0, \
     .low = low_bit, \

--- a/components/ulp/ulp_fsm/include/esp32s2/ulp.h
+++ b/components/ulp/ulp_fsm/include/esp32s2/ulp.h
@@ -319,7 +319,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg)
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_WR_REG(reg, low_bit, high_bit, val) {.wr_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .data = val, \
     .low = low_bit, \
@@ -333,7 +333,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg)
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_RD_REG(reg, low_bit, high_bit) {.rd_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .unused = 0, \
     .low = low_bit, \

--- a/components/ulp/ulp_fsm/include/esp32s3/ulp.h
+++ b/components/ulp/ulp_fsm/include/esp32s3/ulp.h
@@ -319,7 +319,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg)
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_WR_REG(reg, low_bit, high_bit, val) {.wr_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .data = val, \
     .low = low_bit, \
@@ -333,7 +333,7 @@ static inline uint32_t SOC_REG_TO_ULP_PERIPH_SEL(uint32_t reg)
  * This instruction can access RTC_CNTL_, RTC_IO_, SENS_, and RTC_I2C peripheral registers.
  */
 #define I_RD_REG(reg, low_bit, high_bit) {.rd_reg = {\
-    .addr = (reg & 0xff) / sizeof(uint32_t), \
+    .addr = ((reg) / sizeof(uint32_t)) & 0xff, \
     .periph_sel = SOC_REG_TO_ULP_PERIPH_SEL(reg), \
     .unused = 0, \
     .low = low_bit, \


### PR DESCRIPTION
The following was prematurely constraining reg to 8 bits, effectively masking off addr[7:6]:
`.addr = (reg & 0xff) / sizeof(uint32_t),`
This was an issue when reading from or writing to registers with bits[9:8] != 0.

For example, on S3 operations with the following register:
`#define RTC_CNTL_TOUCH_DAC1_REG          (DR_REG_RTCCNTL_BASE + 0x150)`
MIstakenly interact with the following register instead (as 0x150 & 0xFF == 0x50):
`#define RTC_CNTL_STORE0_REG          (DR_REG_RTCCNTL_BASE + 0x50)`

Fixed by applying the bitmask after the division, instead of before.