### PR TITLE
Update .gitignore (Sublime + Clangd) (IDFGH-10554)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@ test_multi_heap_host
 *.swp
 *.swo
 
+# Sublime Text files
+*.sublime-project
+*.sublime-workspace
+
 # Clion IDE CMake build & config
 .idea/
 cmake-build-*/
@@ -99,3 +103,6 @@ managed_components
 pytest_embedded_log/
 list_job_*.txt
 size_info.txt
+
+# clang config (for LSP)
+.clangd


### PR DESCRIPTION
- Adds Sublime Text
- Adds clang config, useful for custom local LSP server

For me to get a LSP server running I needed to add a local `.clangd` file as seen here: https://github.com/espressif/esp-idf/issues/6721#issuecomment-997150632