### PR TITLE
ledc.c: Fix frequency calculation. (IDFGH-10569)

### DIFF
--- a/components/driver/include/driver/ledc.h
+++ b/components/driver/include/driver/ledc.h
@@ -104,7 +104,7 @@ typedef struct {
 
 /**
  * @brief LEDC channel configuration
- *        Configure LEDC channel with the given channel/output gpio_num/interrupt/source timer/frequency(Hz)/LEDC duty resolution
+ *        Configure LEDC channel with the given channel/output gpio_num/interrupt/source timer/frequency(Hz)/LEDC duty
  *
  * @param ledc_conf Pointer of LEDC channel configure struct
  *
@@ -113,6 +113,18 @@ typedef struct {
  *     - ESP_ERR_INVALID_ARG Parameter error
  */
 esp_err_t ledc_channel_config(const ledc_channel_config_t *ledc_conf);
+
+/**
+ * @brief Helper function to calculate the maximum possible LEDC duty resolution in bits for ledc_timer_config()
+ *
+ * @param src_clk_freq LEDC Source clock frequency (Hz), i.e. APB_CLK_FREQ, REF_CLK_FREQ etc
+ * @param freq_hz LEDC timer frequency (Hz)
+ *
+ * @return
+ *     - 0  error
+ *     - Others LEDC channel duty resolution
+ */
+uint32_t ledc_calc_duty_resolution(uint32_t src_clk_freq, uint32_t freq_hz);
 
 /**
  * @brief LEDC timer configuration

--- a/components/driver/ledc.c
+++ b/components/driver/ledc.c
@@ -840,7 +840,7 @@ uint32_t ledc_get_freq(ledc_mode_t speed_mode, ledc_timer_t timer_num)
         ESP_LOGW(LEDC_TAG, "LEDC timer not configured, call ledc_timer_config to set timer frequency");
         return 0;
     }
-    return ((uint64_t) src_clk_freq << 8) / precision / clock_divider;
+    return (((uint64_t) src_clk_freq << LEDC_LL_FRACTIONAL_BITS) + (uint64_t) precision * clock_divider / 2) / precision / clock_divider;
 }
 
 static inline void ledc_calc_fade_end_channel(uint32_t *fade_end_status, uint32_t *channel)


### PR DESCRIPTION
Round int instead of truncate.
ledc_get_freq() returns value 2Hz when the actual 3Hz was setted (Tested with oscilloscope).

Add ledc_calc_duty_resolution() -
Helper function to calculate the maximum possible LEDC duty resolution in bits for ledc_timer_config()
