### PR TITLE
feat(idf.py): Allow adding arguments from file via @filename.txt (#11783) (IDFGH-10584)

### DIFF
--- a/tools/test_idf_py/args_a
+++ b/tools/test_idf_py/args_a
@@ -1,0 +1,1 @@
+-DAAA -DBBB

--- a/tools/test_idf_py/args_b
+++ b/tools/test_idf_py/args_b
@@ -1,0 +1,1 @@
+-DCCC -DDDD

--- a/tools/test_idf_py/args_circular_a
+++ b/tools/test_idf_py/args_circular_a
@@ -1,0 +1,1 @@
+-DAAA @args_circular_b

--- a/tools/test_idf_py/args_circular_b
+++ b/tools/test_idf_py/args_circular_b
@@ -1,0 +1,1 @@
+-DBBB @args_circular_a

--- a/tools/test_idf_py/args_recursive
+++ b/tools/test_idf_py/args_recursive
@@ -1,0 +1,1 @@
+@args_a -DEEE -DFFF


### PR DESCRIPTION
See discussion in #11783.

Replicates functionality from `esptool.py` allowing arguments to be loaded from a file, simplifying multiple build profiles.

See espressif/esptool@d9b82fa7d2e727b0f8d989e29b06a49b2c22a871