### PR TITLE
fix receicing of DHCP vendor info (IDFGH-10591)

### DIFF
--- a/components/lwip/port/hooks/lwip_default_hooks.c
+++ b/components/lwip/port/hooks/lwip_default_hooks.c
@@ -124,11 +124,11 @@ ip4_route_src_hook(const ip4_addr_t *src,const ip4_addr_t *dest)
 #if LWIP_DHCP_ENABLE_VENDOR_SPEC_IDS
 #define DHCP_OPTION_VSI             43
 #define DHCP_OPTION_VCI             60
-#define DHCP_OPTION_VSI_MAX         16
+#define DHCP_OPTION_VSI_MAX         64
 
 static u8_t vendor_class_len = 0;
 static char *vendor_class_buf = NULL;
-static u32_t dhcp_option_vsi[DHCP_OPTION_VSI_MAX] = {0};
+static u8_t dhcp_option_vsi[DHCP_OPTION_VSI_MAX];
 
 void dhcp_free_vendor_class_identifier(void)
 {
@@ -209,16 +209,10 @@ void dhcp_parse_extra_opts(struct dhcp *dhcp, uint8_t state, uint8_t option, uin
     if ((option == DHCP_OPTION_VSI) &&
              (state == DHCP_STATE_REBOOTING || state == DHCP_STATE_REBINDING ||
               state == DHCP_STATE_RENEWING  || state == DHCP_STATE_REQUESTING || state == DHCP_STATE_SELECTING)) {
-      u8_t n;
-      u32_t value;
       u16_t copy_len;
-      for (n = 0; n < DHCP_OPTION_VSI_MAX && len > 0; n++) {
-        copy_len = LWIP_MIN(len, 4);
-        LWIP_ERROR("dhcp_parse_extra_opts(): extracting VSI option failed",
-           pbuf_copy_partial(p, &value, copy_len, offset) == copy_len, return;);
-        dhcp_option_vsi[n] = lwip_htonl(value);
-        len -= copy_len;
-      }
+      copy_len = LWIP_MIN(len, sizeof(dhcp_option_vsi));
+      LWIP_ERROR("dhcp_parse_extra_opts(): extracting VSI option failed",
+         pbuf_copy_partial(p, &dhcp_option_vsi, copy_len, offset) == copy_len, return;);
     } /* DHCP_OPTION_VSI */
 #endif /* LWIP_DHCP_ENABLE_VENDOR_SPEC_IDS */
 }


### PR DESCRIPTION
**Test Setup**

DHCP-Server sends forced vendor option

```
host devbrd-dhcptest    { 
 hardware ethernet cc:db:a7:1d:XX:XX; fixed-address 10.X.X.X;
 option dhcp-parameter-request-list 1,3,28,6,43; # default + vendor
 option vendor-encapsulated-options "hallo test 1234";
}

```
**with current master**

this source

```
 char vendor_buf[128];
 bzero(&vendor_buf[0], sizeof(vendor_buf));
 esp_netif_dhcpc_option(wifi_device, ESP_NETIF_OP_GET, ESP_NETIF_VENDOR_SPECIFIC_INFO, &vendor_buf[0], sizeof(vendor_buf)-1);
 ESP_LOGI(TAG, "vendor string:%s:", &vendor_buf[0]);

```

logs

`vendor string:llahllahllahllah:`

what is obviously wrong

**Bugs in lwip_default_hooks.c**

- the vendor option of the DHCP response is treated as multiple of 32-bit (what is an invalid assumption, see RFC 2132)
- the response is converted from network to host byte order (for no reason)
- the loop will always duplicate the first 4 bytes because offset is not adjusted
- not checked: the 32-bit handling will produce garbage when the last read is shorter than 4 bytes

**Hints for everyone who would like to use vendor stuff in DHCP**

- query for vendor response in DHCP request: CMakeLists.txt ->  `add_definitions(-DLWIP_HOOK_DHCP_EXTRA_REQUEST_OPTIONS=,43)`

- send custom vendor with request: after WIFI_EVENT_STA_START -> `esp_netif_dhcpc_option(wifi_device, ESP_NETIF_OP_SET, ESP_NETIF_VENDOR_CLASS_IDENTIFIER, vendor_string, strlen(vendor_string))`
