### PR TITLE
fix: create-project & create_component with proper file permission (IDFGH-10599)

### DIFF
--- a/tools/idf_py_actions/create_ext.py
+++ b/tools/idf_py_actions/create_ext.py
@@ -40,7 +40,11 @@ def is_empty_and_create(path: str, action: str) -> None:
 
 
 def create_project(target_path: str, name: str) -> None:
-    copy_tree(os.path.join(os.environ['IDF_PATH'], 'examples', 'get-started', 'sample_project'), target_path)
+    copy_tree(
+        os.path.join(os.environ['IDF_PATH'], 'examples', 'get-started', 'sample_project'),
+        target_path,
+        preserve_mode=0,
+    )
     main_folder = os.path.join(target_path, 'main')
     os.rename(os.path.join(main_folder, 'main.c'), os.path.join(main_folder, '.'.join((name, 'c'))))
     replace_in_file(os.path.join(main_folder, 'CMakeLists.txt'), 'main', name)
@@ -49,7 +53,11 @@ def create_project(target_path: str, name: str) -> None:
 
 
 def create_component(target_path: str, name: str) -> None:
-    copy_tree(os.path.join(os.environ['IDF_PATH'], 'tools', 'templates', 'sample_component'), target_path)
+    copy_tree(
+        os.path.join(os.environ['IDF_PATH'], 'tools', 'templates', 'sample_component'),
+        target_path,
+        preserve_mode=0,
+    )
     os.rename(os.path.join(target_path, 'main.c'), os.path.join(target_path, '.'.join((name, 'c'))))
     os.rename(os.path.join(target_path, 'include', 'main.h'),
               os.path.join(target_path, 'include', '.'.join((name, 'h'))))

--- a/tools/test_build_system/test_common.py
+++ b/tools/test_build_system/test_common.py
@@ -237,6 +237,20 @@ def test_create_project(idf_py: IdfPyFunc, idf_copy: Path) -> None:
     assert ret.returncode == 4, 'Command create-project exit value is wrong.'
 
 
+def test_create_project_with_idf_readonly(idf_copy: Path) -> None:
+    def change_to_readonly(src: Path) -> None:
+        for root, dirs, files in os.walk(src):
+            for name in dirs:
+                os.chmod(os.path.join(root, name), 0o555) # read & execute
+            for name in files:
+                path = os.path.join(root, name)
+                if '/bin/' in path: continue  # skip excutables
+                os.chmod(os.path.join(root, name), 0o444) # readonly
+    logging.info('Check that command for creating new project will success if the IDF itself is readonly.')
+    change_to_readonly(idf_copy)
+    run_idf_py('create-project', '--path', str(idf_copy / 'example_proj'), 'temp_test_project')
+
+
 @pytest.mark.usefixtures('test_app_copy')
 def test_docs_command(idf_py: IdfPyFunc) -> None:
     logging.info('Check docs command')


### PR DESCRIPTION
On Linux distributions such as [NixOS](https://nixos.org/) that emphasize immutability and reproducibility, the file permissions of all software packages are forced to be set to **read-only** to ensure that they will not be tampered with. 
As a result, the following permission error occurs when using `idf.py create-project` on such systems, and this PR fix the problem:

```shell
› idf.py create-project ws2812_led_1
Executing action: create-project
Traceback (most recent call last):
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf.py", line 767, in <module>
    main()
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf.py", line 702, in main
    cli(sys.argv[1:], prog_name=PROG, complete_var=SHELL_COMPLETE_VAR)
  File "/nix/store/3rhkgqrzf4mza4c7h6ljh2iwnwgv77ca-python3-3.10.12-env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/3rhkgqrzf4mza4c7h6ljh2iwnwgv77ca-python3-3.10.12-env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/nix/store/3rhkgqrzf4mza4c7h6ljh2iwnwgv77ca-python3-3.10.12-env/lib/python3.10/site-packages/click/core.py", line 1689, in invoke
    return _process_result(rv)
  File "/nix/store/3rhkgqrzf4mza4c7h6ljh2iwnwgv77ca-python3-3.10.12-env/lib/python3.10/site-packages/click/core.py", line 1626, in _process_result
    value = ctx.invoke(self._result_callback, value, **ctx.params)
  File "/nix/store/3rhkgqrzf4mza4c7h6ljh2iwnwgv77ca-python3-3.10.12-env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf.py", line 605, in execute_tasks
    task(ctx, global_args, task.action_args)
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf.py", line 187, in __call__
    self.callback(self.name, context, global_args, **action_args)
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf_py_actions/create_ext.py", line 68, in create_new
    func_action_map[action](target_path, action_args['name'])
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf_py_actions/create_ext.py", line 46, in create_project
    replace_in_file(os.path.join(main_folder, 'CMakeLists.txt'), 'main', name)
  File "/nix/store/jc0qzi0322w9w1nsssbw1vbkhlkgm6p8-esp-idf-v5.1/tools/idf_py_actions/create_ext.py", line 20, in replace_in_file
    with open(filename, 'r+') as f:
PermissionError: [Errno 13] Permission denied: '/home/ryan/codes/esp/ws2812_led_1/main/CMakeLists.txt'

› ls -al $IDF_PATH/examples/get-started
total 8
dr-xr-xr-x 1 root root 120  1月  1  1970 .
dr-xr-xr-x 1 root root 346  1月  1  1970 ..
dr-xr-xr-x 1 root root  84  1月  1  1970 blink
-r--r--r-- 5 root root 158  1月  1  1970 .build-test-rules.yml
dr-xr-xr-x 1 root root 120  1月  1  1970 hello_world
-r--r--r-- 7 root root 197  1月  1  1970 README.md
dr-xr-xr-x 1 root root  54  1月  1  1970 sample_project
```