### PR TITLE
bugfix: avoid warning in espcoredump when log disabled (IDFGH-10636)

### DIFF
--- a/components/espcoredump/src/port/xtensa/core_dump_port.c
+++ b/components/espcoredump/src/port/xtensa/core_dump_port.c
@@ -413,7 +413,7 @@ bool esp_core_dump_check_task(core_dump_task_header_t *task)
                                         sol_frame->a1);
         } else {
     // to avoid warning that 'exc_frame' is unused when ESP_COREDUMP_LOG_PROCESS does nothing
-    #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_LOGS
             XtExcFrame *exc_frame = (XtExcFrame *)task->stack_start;
             ESP_COREDUMP_LOG_PROCESS("Task (TCB:%x) EXIT/PC/PS/A0/SP %x %x %x %x %x",
                                         task->tcb_addr,


### PR DESCRIPTION
With commit 08be8ff5ecbaeb076b6bc4836170b17a91400529 an option to disable the logs in `espcoredump` was introduced. When using this option together with `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH`, I observe the following warning: 

```
[53/1513] Building C object esp-idf/espcoredump/CMakeFiles/__idf_espcoredump.dir/src/port/xtensa/core_dump_port.c.obj
C:/repos/v3/esp-idf/components/espcoredump/src/port/xtensa/core_dump_port.c: In function 'esp_core_dump_check_task':
C:/repos/v3/esp-idf/components/espcoredump/src/port/xtensa/core_dump_port.c:404:25: warning: unused variable 'exc_frame' [-Wunused-variable]
             XtExcFrame *exc_frame = (XtExcFrame *)task->stack_start;
                         ^~~~~~~~~
```

This PR adds a fix to avoid this warning. 

FYI @KonssnoK 