### PR TITLE
feat(mcpwm): Allow for pull up/down to be configurable on generators (IDFGH-10647)

### DIFF
--- a/components/driver/mcpwm/include/driver/mcpwm_gen.h
+++ b/components/driver/mcpwm/include/driver/mcpwm_gen.h
@@ -24,6 +24,8 @@ typedef struct {
     struct {
         uint32_t invert_pwm: 1;   /*!< Whether to invert the PWM signal (done by GPIO matrix) */
         uint32_t io_loop_back: 1; /*!< For debug/test, the signal output from the GPIO will be fed to the input path as well */
+        uint32_t pull_up: 1;      /*!< Whether to pull up internally */
+        uint32_t pull_down: 1;    /*!< Whether to pull down internally */
     } flags;                      /*!< Extra configuration flags for generator */
 } mcpwm_generator_config_t;
 

--- a/components/driver/mcpwm/mcpwm_gen.c
+++ b/components/driver/mcpwm/mcpwm_gen.c
@@ -88,8 +88,8 @@ esp_err_t mcpwm_new_generator(mcpwm_oper_handle_t oper, const mcpwm_generator_co
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_OUTPUT | (config->flags.io_loop_back ? GPIO_MODE_INPUT : 0), // also enable the input path if `io_loop_back` is enabled
         .pin_bit_mask = (1ULL << config->gen_gpio_num),
-        .pull_down_en = false,
-        .pull_up_en = true,
+        .pull_down_en = config->flags.pull_down,
+        .pull_up_en = config->flags.pull_up,
     };
     ESP_GOTO_ON_ERROR(gpio_config(&gpio_conf), err, TAG, "config gen GPIO failed");
     esp_rom_gpio_connect_out_signal(config->gen_gpio_num,


### PR DESCRIPTION
Implements feature requested in https://github.com/espressif/esp-idf/issues/11877.

Copies config fields from other gpio config types out of the MCPWM component.