### PR TITLE
Fixed type of `drom_start_addr` due to following compiler complain: (IDFGH-10673)

### DIFF
--- a/components/esp_hw_support/include/esp_memory_utils.h
+++ b/components/esp_hw_support/include/esp_memory_utils.h
@@ -273,7 +273,7 @@ bool esp_ptr_external_ram(const void *p);
  */
 __attribute__((always_inline))
 inline static bool esp_ptr_in_drom(const void *p) {
-    uint32_t drom_start_addr = SOC_DROM_LOW;
+    int32_t drom_start_addr = SOC_DROM_LOW;
 #if CONFIG_ESP32S3_DATA_CACHE_16KB
     /* For ESP32-S3, when the DCACHE size is set to 16 kB, the unused 48 kB is
      * added to the heap in 2 blocks of 32 kB (from 0x3FCF0000) and 16 kB


### PR DESCRIPTION
```
error: comparison of integer expressions of different signedness: 'intptr_t' {aka 'int'} and 'uint32_t' {aka 'long unsigned int'} [-Werror=sign-compare]
  286 |     return ((intptr_t)p >= drom_start_addr && (intptr_t)p < SOC_DROM_HIGH);
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```