### PR TITLE
BT Classic: support for 32 and 128-bit custom UUIDs (IDFGH-10721)

### DIFF
--- a/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
+++ b/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
@@ -4255,7 +4255,7 @@ static void bta_dm_set_eir (char *local_name)
             for (custom_uuid_idx = 0; custom_uuid_idx < BTA_EIR_SERVER_NUM_CUSTOM_UUID; custom_uuid_idx++) {
                 if (bta_dm_cb.custom_uuid[custom_uuid_idx].len == LEN_UUID_128) {
                     if ( num_uuid < max_num_uuid ) {
-                        ARRAY16_TO_STREAM(p, bta_dm_cb.custom_uuid[custom_uuid_idx].uu.uuid128);
+                        ARRAY_TO_STREAM(p, bta_dm_cb.custom_uuid[custom_uuid_idx].uu.uuid128, LEN_UUID_128);
                         num_uuid++;
                     } else {
                         data_type = BTM_EIR_MORE_128BITS_UUID_TYPE;
@@ -4452,21 +4452,38 @@ static void bta_dm_eir_search_services( tBTM_INQ_RESULTS  *p_result,
 ** Returns          None
 **
 *******************************************************************************/
-void bta_dm_eir_update_uuid(UINT16 uuid16, BOOLEAN adding)
+void bta_dm_eir_update_uuid(tBT_UUID uuid, BOOLEAN adding)
 {
-    /* if this UUID is not advertised in EIR */
-    if ( !BTM_HasEirService( p_bta_dm_eir_cfg->uuid_mask, uuid16 )) {
-        return;
-    }
+    /* 32 and 128-bit UUIDs go to the bta_dm_cb.custom_uuid array */
+    if ((uuid.len == LEN_UUID_32) || (uuid.len == LEN_UUID_128)) {
+        if (adding) {
+            if (BTM_HasCustomEirService(bta_dm_cb.custom_uuid, uuid)) {
+                APPL_TRACE_EVENT("UUID is already added for EIR");
+                return;
+            }
+            APPL_TRACE_EVENT("Adding %d-bit UUID into EIR", uuid.len * 8);
 
-    if ( adding ) {
-        APPL_TRACE_EVENT("Adding UUID=0x%04X into EIR", uuid16);
+            BTM_AddCustomEirService(bta_dm_cb.custom_uuid, uuid);
+        } else {
+            APPL_TRACE_EVENT("Removing %d-bit UUID from EIR", uuid.len * 8);
 
-        BTM_AddEirService( bta_dm_cb.eir_uuid, uuid16 );
+            BTM_RemoveCustomEirService(bta_dm_cb.custom_uuid, uuid);
+        }
     } else {
-        APPL_TRACE_EVENT("Removing UUID=0x%04X from EIR", uuid16);
+        /* if this UUID is not advertised in EIR */
+        if (!BTM_HasEirService(p_bta_dm_eir_cfg->uuid_mask, uuid.uu.uuid16)) {
+            return;
+        }
 
-        BTM_RemoveEirService( bta_dm_cb.eir_uuid, uuid16 );
+        if (adding) {
+            APPL_TRACE_EVENT("Adding UUID=0x%04X into EIR", uuid.uu.uuid16);
+
+            BTM_AddEirService(bta_dm_cb.eir_uuid, uuid.uu.uuid16);
+        } else {
+            APPL_TRACE_EVENT("Removing UUID=0x%04X from EIR", uuid.uu.uuid16);
+
+            BTM_RemoveEirService(bta_dm_cb.eir_uuid, uuid.uu.uuid16);
+        }
     }
 #if CLASSIC_BT_INCLUDED
     bta_dm_set_eir (NULL);

--- a/components/bt/host/bluedroid/bta/dm/include/bta_dm_int.h
+++ b/components/bt/host/bluedroid/bta/dm/include/bta_dm_int.h
@@ -1808,7 +1808,7 @@ extern void bta_dm_search_cancel_notify (tBTA_DM_MSG *p_data);
 extern void bta_dm_search_cancel_transac_cmpl(tBTA_DM_MSG *p_data);
 extern void bta_dm_disc_rmt_name (tBTA_DM_MSG *p_data);
 extern tBTA_DM_PEER_DEVICE *bta_dm_find_peer_device(BD_ADDR peer_addr);
-void bta_dm_eir_update_uuid(UINT16 uuid16, BOOLEAN adding);
+void bta_dm_eir_update_uuid(tBT_UUID uuid, BOOLEAN adding);
 
 extern void bta_dm_enable_test_mode(tBTA_DM_MSG *p_data);
 extern void bta_dm_disable_test_mode(tBTA_DM_MSG *p_data);

--- a/components/bt/host/bluedroid/bta/include/bta/bta_sys.h
+++ b/components/bt/host/bluedroid/bta/include/bta/bta_sys.h
@@ -143,7 +143,7 @@ typedef void (tBTA_SYS_SSR_CFG_CBACK)(UINT8 id, UINT8 app_id, UINT16 latency, UI
 
 #if (BTA_EIR_CANNED_UUID_LIST != TRUE)
 /* eir callback for adding/removeing UUID */
-typedef void (tBTA_SYS_EIR_CBACK)(UINT16 uuid16, BOOLEAN adding);
+typedef void (tBTA_SYS_EIR_CBACK)(tBT_UUID uuid, BOOLEAN adding);
 #endif
 
 /* registration structure */
@@ -263,12 +263,20 @@ extern void bta_sys_notify_collision (BD_ADDR_PTR p_bda);
 
 #if (BTA_EIR_CANNED_UUID_LIST != TRUE)
 extern void bta_sys_eir_register(tBTA_SYS_EIR_CBACK *p_cback);
-extern void bta_sys_add_uuid(UINT16 uuid16);
+extern void bta_sys_add_uuid(UINT16 uuid);
+extern void bta_sys_add_uuid_32(UINT32 uuid32);
+extern void bta_sys_add_uuid_128(UINT8 *uuid128);
 extern void bta_sys_remove_uuid(UINT16 uuid16);
+extern void bta_sys_remove_uuid_32(UINT32 uuid32);
+extern void bta_sys_remove_uuid_128(UINT8 *uuid128);
 #else
 #define bta_sys_eir_register(ut)
 #define bta_sys_add_uuid(ut)
+#define bta_sys_add_uuid_32(ut)
+#define bta_sys_add_uuid_128(ut)
 #define bta_sys_remove_uuid(ut)
+#define bta_sys_remove_uuid_32(ut)
+#define bta_sys_remove_uuid_128(ut)
 #endif
 
 extern void bta_sys_set_policy (UINT8 id, UINT8 policy, BD_ADDR peer_addr);

--- a/components/bt/host/bluedroid/bta/sys/bta_sys_conn.c
+++ b/components/bt/host/bluedroid/bta/sys/bta_sys_conn.c
@@ -527,8 +527,55 @@ void bta_sys_eir_register(tBTA_SYS_EIR_CBACK *p_cback)
 *******************************************************************************/
 void bta_sys_add_uuid(UINT16 uuid16)
 {
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_16;
+    uuid.uu.uuid16 = uuid16;
+
     if (bta_sys_cb.eir_cb) {
-        bta_sys_cb.eir_cb(uuid16, TRUE );
+        bta_sys_cb.eir_cb(uuid, TRUE);
+    }
+}
+
+
+/*******************************************************************************
+**
+** Function         bta_sys_add_uuid_32
+**
+** Description      Called by BTA subsystems to indicate to DM that new service
+**                  class UUID is added.
+**
+** Returns          void
+**
+*******************************************************************************/
+void bta_sys_add_uuid_32(UINT32 uuid32)
+{
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_32;
+    uuid.uu.uuid32 = uuid32;
+
+    if (bta_sys_cb.eir_cb) {
+        bta_sys_cb.eir_cb(uuid, TRUE);
+    }
+}
+
+/*******************************************************************************
+**
+** Function         bta_sys_add_uuid_128
+**
+** Description      Called by BTA subsystems to indicate to DM that new service
+**                  class UUID is added.
+**
+** Returns          void
+**
+*******************************************************************************/
+void bta_sys_add_uuid_128(UINT8 *uuid128)
+{
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_128;
+    memcpy(&uuid.uu.uuid128, uuid128, LEN_UUID_128);
+
+    if (bta_sys_cb.eir_cb) {
+        bta_sys_cb.eir_cb(uuid, TRUE);
     }
 }
 
@@ -544,10 +591,57 @@ void bta_sys_add_uuid(UINT16 uuid16)
 *******************************************************************************/
 void bta_sys_remove_uuid(UINT16 uuid16)
 {
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_16;
+    uuid.uu.uuid16 = uuid16;
+
     if (bta_sys_cb.eir_cb) {
-        bta_sys_cb.eir_cb(uuid16, FALSE);
+        bta_sys_cb.eir_cb(uuid, FALSE);
     }
 }
+
+/*******************************************************************************
+**
+** Function         bta_sys_remove_uuid_32
+**
+** Description      Called by BTA subsystems to indicate to DM that the service
+**                  class UUID is removed.
+**
+** Returns          void
+**
+*******************************************************************************/
+void bta_sys_remove_uuid_32(UINT32 uuid32)
+{
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_32;
+    uuid.uu.uuid32 = uuid32;
+
+    if (bta_sys_cb.eir_cb) {
+        bta_sys_cb.eir_cb(uuid, FALSE);
+    }
+}
+
+/*******************************************************************************
+**
+** Function         bta_sys_remove_uuid_128
+**
+** Description      Called by BTA subsystems to indicate to DM that the service
+**                  class UUID is removed.
+**
+** Returns          void
+**
+*******************************************************************************/
+void bta_sys_remove_uuid_128(UINT8 *uuid128)
+{
+    tBT_UUID uuid;
+    uuid.len = LEN_UUID_128;
+    memcpy(&uuid.uu.uuid128, uuid128, LEN_UUID_128);
+
+    if (bta_sys_cb.eir_cb) {
+        bta_sys_cb.eir_cb(uuid, FALSE);
+    }
+}
+
 #endif
 
 /*******************************************************************************

--- a/components/bt/host/bluedroid/stack/btm/btm_inq.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_inq.c
@@ -2535,9 +2535,125 @@ void BTM_AddEirService( UINT32 *p_eir_uuid, UINT16 uuid16 )
     }
 }
 
+
 /*******************************************************************************
 **
-** Function         BTM_RemoveEirService
+** Function         btm_compare_uuid
+**
+** Description      Helper function for custom service managing routines.
+**
+** Parameters       uuid1 - pointer to the first tBT_UUID struct
+**                  uuid2 - pointer to the second tBT_UUID struct
+**
+** Returns          true if UUID structs are identical
+**
+*******************************************************************************/
+static bool btm_compare_uuid(tBT_UUID *uuid1, tBT_UUID *uuid2)
+{
+    if (uuid1->len != uuid2->len) {
+        return FALSE;
+    }
+
+    return (memcmp(&uuid1->uu, &uuid2->uu, uuid1->len) == 0);
+}
+
+/*******************************************************************************
+**
+** Function         btm_find_empty_custom_uuid_slot
+**
+** Description      Helper function for custom service managing routines.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          Slot number if there is empty slot,
+**                  otherwise - BTA_EIR_SERVER_NUM_CUSTOM_UUID
+**
+*******************************************************************************/
+static UINT8 btm_find_empty_custom_uuid_slot(tBT_UUID *custom_uuid, tBT_UUID uuid)
+{
+    for (UINT8 xx = 0; xx < BTA_EIR_SERVER_NUM_CUSTOM_UUID; xx++) {
+        if (custom_uuid[xx].len == 0) {
+            return xx;
+        }
+    }
+    return BTA_EIR_SERVER_NUM_CUSTOM_UUID;
+}
+
+/*******************************************************************************
+**
+** Function         btm_find_match_custom_uuid_slot
+**
+** Description      Helper function for custom service managing routines.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          Slot number if given UUID is already in slots array,
+**                  otherwise - BTA_EIR_SERVER_NUM_CUSTOM_UUID
+**
+*******************************************************************************/
+static UINT8 btm_find_match_custom_uuid_slot(tBT_UUID *custom_uuid, tBT_UUID uuid)
+{
+    for (UINT8 xx = 0; xx < BTA_EIR_SERVER_NUM_CUSTOM_UUID; xx++) {
+        if (btm_compare_uuid(&custom_uuid[xx], &uuid)) {
+            return xx;
+        }
+    }
+    return BTA_EIR_SERVER_NUM_CUSTOM_UUID;
+}
+
+/*******************************************************************************
+**
+** Function         BTM_HasCustomEirService
+**
+** Description      This function is called to know if UUID is already in custom
+**                  UUID list.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          TRUE - if found
+**                  FALSE - if not found
+**
+*******************************************************************************/
+BOOLEAN BTM_HasCustomEirService(tBT_UUID *custom_uuid, tBT_UUID uuid)
+{
+    UINT8 match_slot = btm_find_match_custom_uuid_slot(custom_uuid, uuid);
+
+    if (match_slot == BTA_EIR_SERVER_NUM_CUSTOM_UUID) {
+        return FALSE;
+    }
+    return TRUE;
+}
+
+/*******************************************************************************
+**
+** Function         BTM_AddCustomEirService
+**
+** Description      This function is called to add a custom UUID.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          None
+**
+*******************************************************************************/
+void BTM_AddCustomEirService(tBT_UUID *custom_uuid, tBT_UUID uuid)
+{
+    UINT8 empty_slot = btm_find_empty_custom_uuid_slot(custom_uuid, uuid);
+
+    if (empty_slot == BTA_EIR_SERVER_NUM_CUSTOM_UUID) {
+        BTM_TRACE_WARNING("No space to add UUID for EIR");
+    } else {
+        memcpy(&(custom_uuid[empty_slot]), &(uuid), sizeof(tBT_UUID));
+        BTM_TRACE_EVENT("UUID saved in %d slot", empty_slot);
+    }
+}
+
+/*******************************************************************************
+**
+** Function         BTM_RemoveCustomEirService
 **
 ** Description      This function is called to remove a service in bit map of UUID list.
 **
@@ -2554,6 +2670,30 @@ void BTM_RemoveEirService( UINT32 *p_eir_uuid, UINT16 uuid16 )
     service_id = btm_convert_uuid_to_eir_service(uuid16);
     if ( service_id < BTM_EIR_MAX_SERVICES ) {
         BTM_EIR_CLR_SERVICE( p_eir_uuid, service_id );
+    }
+}
+
+/*******************************************************************************
+**
+** Function         BTM_RemoveCustomEirService
+**
+** Description      This function is called to remove a a custom UUID.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          None
+**
+*******************************************************************************/
+void BTM_RemoveCustomEirService(tBT_UUID *custom_uuid, tBT_UUID uuid)
+{
+    UINT8 match_slot = btm_find_match_custom_uuid_slot(custom_uuid, uuid);
+
+    if (match_slot == BTA_EIR_SERVER_NUM_CUSTOM_UUID) {
+        BTM_TRACE_WARNING("UUID is not found for EIR");
+        return;
+    } else {
+        memset(&(custom_uuid[match_slot]), 0, sizeof(tBT_UUID));
     }
 }
 

--- a/components/bt/host/bluedroid/stack/include/stack/btm_api.h
+++ b/components/bt/host/bluedroid/stack/include/stack/btm_api.h
@@ -4082,6 +4082,22 @@ tBTM_EIR_SEARCH_RESULT BTM_HasInquiryEirService( tBTM_INQ_RESULTS *p_results,
 
 /*******************************************************************************
 **
+** Function         BTM_HasCustomEirService
+**
+** Description      This function is called to know if UUID is already in custom
+**                  UUID list.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          TRUE - if found
+**                  FALSE - if not found
+**
+*******************************************************************************/
+BOOLEAN BTM_HasCustomEirService( tBT_UUID *custom_uuid, tBT_UUID uuid );
+
+/*******************************************************************************
+**
 ** Function         BTM_AddEirService
 **
 ** Description      This function is called to add a service in bit map of UUID list.
@@ -4097,6 +4113,20 @@ void BTM_AddEirService( UINT32 *p_eir_uuid, UINT16 uuid16 );
 
 /*******************************************************************************
 **
+** Function         BTM_AddCustomEirService
+**
+** Description      This function is called to add a custom UUID.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+**                  uuid - UUID struct
+**
+** Returns          None
+**
+*******************************************************************************/
+void BTM_AddCustomEirService(tBT_UUID *custom_uuid, tBT_UUID uuid);
+
+/*******************************************************************************
+**
 ** Function         BTM_RemoveEirService
 **
 ** Description      This function is called to remove a service in bit map of UUID list.
@@ -4109,6 +4139,20 @@ void BTM_AddEirService( UINT32 *p_eir_uuid, UINT16 uuid16 );
 *******************************************************************************/
 //extern
 void BTM_RemoveEirService( UINT32 *p_eir_uuid, UINT16 uuid16 );
+
+/*******************************************************************************
+**
+** Function         BTM_RemoveCustomEirService
+**
+** Description      This function is called to remove a a custom UUID.
+**
+** Parameters       custom_uuid - pointer to custom_uuid array in tBTA_DM_CB
+                    uuid - UUID struct
+**
+** Returns          None
+**
+*******************************************************************************/
+void BTM_RemoveCustomEirService(tBT_UUID *custom_uuid, tBT_UUID uuid);
 
 /*******************************************************************************
 **


### PR DESCRIPTION
## The problem

This PR fixes issue #11529  

## What was done

I added new API functions that can add 32 and 128-bit UUID to the EIR data when these UUIDs are set in SDP.
The old functions that only work with 16-bit UUIDs have been left unchanged to avoid having to redo code that already utilizes them.

## How it was tested

`sdptool` and `wireshark` output:
for 32-bit UUID:
![image](https://github.com/espressif/esp-idf/assets/6449804/7e4bb1d5-3574-412d-ac2a-c2a7118b842a)
![image](https://github.com/espressif/esp-idf/assets/6449804/b7097b32-9108-44f7-983b-dce2efcdb4f9)

for 128-bit UUID:
![image](https://github.com/espressif/esp-idf/assets/6449804/beb1db69-3105-4d75-89de-775d2e1025b3)
![image](https://github.com/espressif/esp-idf/assets/6449804/9d7a7548-a72b-4ec9-8cdd-493e1b4b5c0c)

