### PR TITLE
Fix `rx_buffer` type in TCP example (IDFGH-10780)

### DIFF
--- a/examples/protocols/sockets/tcp_client/main/tcp_client_v4.c
+++ b/examples/protocols/sockets/tcp_client/main/tcp_client_v4.c
@@ -30,7 +30,7 @@ static const char *payload = "Message from ESP32 ";
 
 void tcp_client(void)
 {
-    char rx_buffer[128];
+    uint8_t rx_buffer[128];
     char host_ip[] = HOST_IP_ADDR;
     int addr_family = 0;
     int ip_protocol = 0;
@@ -79,7 +79,7 @@ void tcp_client(void)
             else {
                 rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
                 ESP_LOGI(TAG, "Received %d bytes from %s:", len, host_ip);
-                ESP_LOGI(TAG, "%s", rx_buffer);
+                ESP_LOGI(TAG, "%s", (char*) rx_buffer);
             }
         }
 

--- a/examples/protocols/sockets/tcp_client/main/tcp_client_v6.c
+++ b/examples/protocols/sockets/tcp_client/main/tcp_client_v6.c
@@ -161,7 +161,7 @@ static int get_src_iface(char *interface)
 
 void tcp_client(void)
 {
-    char rx_buffer[128];
+    uint8_t rx_buffer[128];
     char host_ip[] = HOST_IP_ADDR;
     int addr_family = 0;
     int ip_protocol = 0;
@@ -242,7 +242,7 @@ void tcp_client(void)
             else {
                 rx_buffer[len] = 0; // Null-terminate whatever we received and treat like a string
                 ESP_LOGI(TAG, "Received %d bytes from %s:", len, host_ip);
-                ESP_LOGI(TAG, "%s", rx_buffer);
+                ESP_LOGI(TAG, "%s", (char*) rx_buffer);
             }
         }
 


### PR DESCRIPTION
In the example projects for protocol/socket/TCP..., the `rx_buffer` was of type `char*`. I changed it to `uint8_t*`.  

Semantically, TCP transmits a byte stream, not a char stream. Using `char*` in the example can potentially confuse beginners.  

Let me know if there are further considerations. 