### PR TITLE
Update iperf example documentation with console interface details. (IDFGH-10832)

### DIFF
--- a/examples/wifi/iperf/README.md
+++ b/examples/wifi/iperf/README.md
@@ -16,16 +16,17 @@ This example implements the protocol used by the common performance measurement 
 Performance can be measured between two ESP32s running this example, or between a single ESP32 and a computer running the iPerf tool
 
 Demo steps to test station TCP Tx performance:
+1. Configure in `menuconfig` which serial output you are using. Execute `idf.py menuconfig` and go to `Component config/ESP System Settings/Channel for console output`, then select the appropiate interface. By default the UART0 interface is used, this means that for example in the ESP32-S3-DevKitC-1 you should connect to the micro-usb connector labeled as UART and not to the one labeled as USB. To use the one labeled as USB you should change the aforementioned setting to `USB Serial/JTAG Controller`.
 
-1. Build the iperf example with sdkconfig.defaults, which contains performance test specific configurations
+2. Build the iperf example with sdkconfig.defaults, which contains performance test specific configurations
 
-2. Run the demo as station mode and join the target AP
+3. Run the demo as station mode and join the target AP
    sta ssid password
 
-3. Run iperf as server on AP side
+4. Run iperf as server on AP side
    iperf -s -i 3
 
-4. Run iperf as client on ESP32 side
+5. Run iperf as client on ESP32 side
    iperf -c 192.168.10.42 -i 3 -t 60
 
 The console output, which is printed by station TCP RX throughput test, looks like:


### PR DESCRIPTION
I wanted to try `iperf` on a custom project but the serial seemed stuck after booting. I am using USB to power the board, flash and see the monitor traces. I deployed the example on a `ESP32-S3-DevKitC-1` with the same results since I was connected to the micro-usb labeled as USB. After taking a brief look to the code I noticed that the console configuration is dependent of `menuconfig` values. 

I updated the `iperf` documentation with some details about the `menuconfig` configuration to warn users about which micro-usb interface is being used by default and how to change this configuration in case they want to use the other connector like me. 