### PR TITLE
Docker image Ubuntu LTS distribution upgrade from 20.04 to 22.04 (IDFGH-10840)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Like many others, we use the docker image as a base image for our ESP-IDF development in a Development Container (https://containers.dev/). We also use other facilities that require a modern C/C++ compiler version supporting C++20. That is currently impossible due to the GCC version limitations given by Ubuntu version 20.04 (GCC 9).

Further, the standard support for LTS version 20.04 will end in 2025 in comparison to version 22.04, where the standard support ends in 2027.

We have tested the upgraded version with multiple example project builds and did not encounter any issues. Most people that use Ubuntu as a daily driver are using 22.04, and we can therefore assume that the setup described in the current docker file is sufficient.
