### PR TITLE
adc: fix adc dma interrupt stops under heavy load (IDFGH-10863)

### DIFF
--- a/components/esp_adc/adc_continuous.c
+++ b/components/esp_adc/adc_continuous.c
@@ -201,7 +201,7 @@ esp_err_t adc_continuous_new_handle(const adc_continuous_handle_cfg_t *hdl_confi
 
     gdma_strategy_config_t strategy_config = {
         .auto_update_desc = true,
-        .owner_check = true
+        .owner_check = false
     };
     gdma_apply_strategy(adc_ctx->rx_dma_channel, &strategy_config);
 

--- a/components/hal/include/hal/adc_hal.h
+++ b/components/hal/include/hal/adc_hal.h
@@ -69,7 +69,7 @@ typedef struct adc_hal_dma_ctx_t {
     dma_descriptor_t    *rx_desc;           ///< DMA descriptors
 
     /**< these will be assigned by hal layer itself */
-    dma_descriptor_t    desc_dummy_head;    ///< Dummy DMA descriptor for ``cur_desc_ptr`` to start
+    dma_descriptor_t    *desc_dummy_head;   ///< Dummy DMA descriptor for ``cur_desc_ptr`` to start
     dma_descriptor_t    *cur_desc_ptr;      ///< Pointer to the current descriptor
 
     /**< these need to be configured by `adc_hal_dma_config_t` via driver layer*/


### PR DESCRIPTION
The adc rx dma eof interrupt will stop generating after all rx eof descriptor is owered by DMA engine. This may happen under heavy load (eg. wifi initialization), and eof_desc_addr should not be used to check the current eof descriptor anymore (for there maybe long delays during adc_dma_intr_handler execution).
Fix this by disabling owner check of descriptor in the DMA engine side, and CPU determines valid eof descriptor by polling the owner bit.

closing #12053 