### PR TITLE
docs(jtag-debugging): add links to gdbstub for convenience (IDFGH-10898)

### DIFF
--- a/docs/en/api-guides/jtag-debugging/index.rst
+++ b/docs/en/api-guides/jtag-debugging/index.rst
@@ -2,7 +2,15 @@ JTAG Debugging
 ==============
 :link_to_translation:`zh_CN:[中文]`
 
-This document provides a guide to installing OpenOCD for {IDF_TARGET_NAME} and debugging using GDB. The document is structured as follows:
+This document provides a guide to installing OpenOCD for {IDF_TARGET_NAME} and debugging using GDB. 
+
+.. note::
+
+    You can also debug your ESP32 without needing to setup JTAG or OpenOCD by using ``idf.py monitor``. See: :doc:`IDF Monitor <../../api-guides/tools/idf-monitor.html>` and :ref:CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME
+
+.. highlight:: none
+
+The document is structured as follows:
 
 :ref:`jtag-debugging-introduction`
     Introduction to the purpose of this guide.


### PR DESCRIPTION
gdbstubs are kind of a hidden feature.

If you google "esp32 debugging", you'll find nothing about GDB Stubs. 

They need to be linked more. They should probably even have their own article. 

---

**suggestion**: There should be a separate **ESP32 debugging** article, that links to
-  JTAG debugging
- GDB Stubs debugging 