### PR TITLE
jtag serial drive write function loses characters when rx ring buffer… (IDFGH-10925)

### DIFF
--- a/components/driver/usb_serial_jtag/usb_serial_jtag.c
+++ b/components/driver/usb_serial_jtag/usb_serial_jtag.c
@@ -168,8 +168,8 @@ int usb_serial_jtag_write_bytes(const void* src, size_t size, TickType_t ticks_t
     // Now trigger the ISR to read data from the ring buffer.
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
        
-    // Return -1 on failure, 0 on success.
-    return (result == pdFALSE) ? -1 : 0;
+    // Return 0 on failure, size on success.
+    return (result == pdFALSE) ? 0 : size;
 }
 
 esp_err_t usb_serial_jtag_driver_uninstall(void)

--- a/components/driver/usb_serial_jtag/usb_serial_jtag.c
+++ b/components/driver/usb_serial_jtag/usb_serial_jtag.c
@@ -163,10 +163,13 @@ int usb_serial_jtag_write_bytes(const void* src, size_t size, TickType_t ticks_t
 
     const uint8_t *buff = (const uint8_t *)src;
     // Blocking method, Sending data to ringbuffer, and handle the data in ISR.
-    xRingbufferSend(p_usb_serial_jtag_obj->tx_ring_buf, (void*) (buff), size, ticks_to_wait);
+    BaseType_t result = xRingbufferSend(p_usb_serial_jtag_obj->tx_ring_buf, (void*) (buff), size, ticks_to_wait);
+
     // Now trigger the ISR to read data from the ring buffer.
-   usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
-   return size;
+    usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
+       
+    // Return -1 on failure, 0 on success.
+    return (result == pdFALSE) ? -1 : 0;
 }
 
 esp_err_t usb_serial_jtag_driver_uninstall(void)

--- a/components/vfs/vfs_usb_serial_jtag.c
+++ b/components/vfs/vfs_usb_serial_jtag.c
@@ -407,11 +407,14 @@ static void usbjtag_tx_char_via_driver(int fd, int c)
 {
     char ch = (char) c;
     TickType_t ticks = (TX_FLUSH_TIMEOUT_US / 1000) / portTICK_PERIOD_MS;
+    // Attempt to send the character immediately without blocking.
     if (usb_serial_jtag_write_bytes(&ch, 1, 0) != 0) {
         s_ctx.tx_tried_blocking = false;
+    } else {
         return;
     }
 
+    // If immediate send fails, try blocking with a timeout.
     if (s_ctx.tx_tried_blocking == false) {
         if (usb_serial_jtag_write_bytes(&ch, 1, ticks) != 0) {
             return;

--- a/components/vfs/vfs_usb_serial_jtag.c
+++ b/components/vfs/vfs_usb_serial_jtag.c
@@ -410,7 +410,6 @@ static void usbjtag_tx_char_via_driver(int fd, int c)
     // Attempt to send the character immediately without blocking.
     if (usb_serial_jtag_write_bytes(&ch, 1, 0) != 0) {
         s_ctx.tx_tried_blocking = false;
-    } else {
         return;
     }
 


### PR DESCRIPTION
upon examining the code, I noticed that the [usbjtag_tx_char_via_driver](https://github.com/espressif/esp-idf/blob/32472536715d674c160a2565795895e0273f8cde/components/vfs/vfs_usb_serial_jtag.c#L406) function contains a comparison that checks whether an immediate send operation succeeds. However, the return value from [usb_serial_jtag_write_bytes](https://github.com/espressif/esp-idf/blob/32472536715d674c160a2565795895e0273f8cde/components/driver/usb_serial_jtag/usb_serial_jtag.c#L158) is always 1, which prevents the intended logic to try blocking for 50 mS, but also a return that always skyp the bloking try.