### PR TITLE
fix(rtc_time): ext 32khz xtal tolerance changed from 0.5% to 5%

### DIFF
--- a/components/esp_hw_support/port/esp32c3/rtc_time.c
+++ b/components/esp_hw_support/port/esp32c3/rtc_time.c
@@ -138,7 +138,7 @@ uint32_t rtc_clk_cal_ratio(rtc_cal_sel_t cal_clk, uint32_t slowclk_cycles)
 static bool rtc_clk_cal_32k_valid(rtc_xtal_freq_t xtal_freq, uint32_t slowclk_cycles, uint64_t actual_xtal_cycles)
 {
     uint64_t expected_xtal_cycles = (xtal_freq * 1000000ULL * slowclk_cycles) >> 15; // xtal_freq(hz) * slowclk_cycles / 32768
-    uint64_t delta = expected_xtal_cycles / 2000;                                    // 5/10000
+    uint64_t delta = expected_xtal_cycles / 200;                                    // 5/10000
     return (actual_xtal_cycles >= (expected_xtal_cycles - delta)) && (actual_xtal_cycles <= (expected_xtal_cycles + delta));
 }
 


### PR DESCRIPTION
Hello, I have described the issue I'm facing here: #11755

Some ESP units in my production have been showing poor RTC performance, even with the external 32 kHz correctly soldered to the board. 

I found out that some xtal units were slightly out of the 0.5% tolerance that is hard coded, so the esp-idf changed the RTC input to the RC oscillator that has 5% tolerance.

I'm not sure what is the point of this. It would make sense to maintain any external xtal that has an error lower than 5%.

I've changed the tolerance to 5%, just for the ESP32C3 port, which is the only one I'm able to test at the moment.