### PR TITLE
Bugfix: double free (IDFGH-10984)

### DIFF
--- a/examples/protocols/https_server/wss_server/main/keep_alive.c
+++ b/examples/protocols/https_server/wss_server/main/keep_alive.c
@@ -153,6 +153,7 @@ static void keep_alive_task(void* arg)
             }
     }
     vQueueDelete(keep_alive_storage->q);
+    wss_keep_alive_set_user_ctx(keep_alive_storage,NULL);
     free(keep_alive_storage);
 
     vTaskDelete(NULL);


### PR DESCRIPTION
disconnect_handler tries to free the server handle (which is pointed by user_ctx) and thus fails an assert, resulting in a crash.