### PR TITLE
mbedtls: define MBEDTLS_SSL_CID_TLS1_3_PAD_GRANULARITY for CID padding

### DIFF
--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -280,13 +280,13 @@ menu "mbedTLS"
                     Maximum length of CIDs used for outgoing DTLS messages
 
             config MBEDTLS_SSL_CID_PADDING_GRANULARITY
-                int "Record plaintext padding (for DTLS 1.2)"
+                int "Record plaintext padding"
                 default 16
                 range 0 32
                 depends on MBEDTLS_SSL_DTLS_CONNECTION_ID
                 help
-                    Controls the use of record plaintext padding when
-                    using the Connection ID extension in DTLS 1.2.
+                    Controls the use of record plaintext padding in TLS 1.3 and
+                    when using the Connection ID extension in DTLS 1.2.
 
                     The padding will always be chosen so that the length of the
                     padded plaintext is a multiple of the value of this option.

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -2859,7 +2859,7 @@
 /** \def MBEDTLS_SSL_CID_PADDING_GRANULARITY
  *
  * This option controls the use of record plaintext padding
- * when using the Connection ID extension in DTLS 1.2.
+ * in TLS 1.3 and when using the Connection ID extension in DTLS 1.2.
  *
  * The padding will always be chosen so that the length of the
  * padded plaintext is a multiple of the value of this option.
@@ -2872,9 +2872,9 @@
  *
  */
 #ifdef CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID
-#define MBEDTLS_SSL_CID_PADDING_GRANULARITY    CONFIG_MBEDTLS_SSL_CID_PADDING_GRANULARITY
+#define MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY    CONFIG_MBEDTLS_SSL_CID_PADDING_GRANULARITY
 #else
-#undef MBEDTLS_SSL_CID_PADDING_GRANULARITY
+#undef MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY
 #endif
 
 


### PR DESCRIPTION
Updates config to define the new MBEDTLS_SSL_CID_TLS1_3_PAD_GRANULARITY
option, which replaced the previously used
MBEDTLS_SSL_CID_PADDING_GRANULARITY. The old option is continuing to be
used as the new one exceeds the maximum length for an option name in
esp-idf.

See https://github.com/Mbed-TLS/mbedtls/pull/4490 for more information.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

> Note: enabling `MBEDTLS_SSL_CID_PADDING_GRANULARITY` without this fix currently breaks builds.