### PR TITLE
Update uart_ll.h - Fixing division by zero (IDFGH-10990)

### DIFF
--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -131,9 +131,9 @@ FORCE_INLINE_ATTR void uart_ll_get_sclk(uart_dev_t *hw, soc_module_clk_t *source
  */
 FORCE_INLINE_ATTR void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t sclk_freq)
 {
-#define DIV_UP(a, b)    ((float)((a) + (b) - 1) / (b))
+#define DIV_UP(a, b)    ((uint64_t)((a) + (b) - 1) / (b))
     const uint32_t max_div = BIT(12) - 1;   // UART divider integer part only has 12 bits
-    int sclk_div = DIV_UP(sclk_freq, max_div * baud) + 0.5;
+    uint32_t sclk_div = DIV_UP(sclk_freq, max_div * baud);
 
     if (sclk_div == 0)
         sclk_div = 1;

--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -131,9 +131,12 @@ FORCE_INLINE_ATTR void uart_ll_get_sclk(uart_dev_t *hw, soc_module_clk_t *source
  */
 FORCE_INLINE_ATTR void uart_ll_set_baudrate(uart_dev_t *hw, uint32_t baud, uint32_t sclk_freq)
 {
-#define DIV_UP(a, b)    (((a) + (b) - 1) / (b))
+#define DIV_UP(a, b)    ((float)((a) + (b) - 1) / (b))
     const uint32_t max_div = BIT(12) - 1;   // UART divider integer part only has 12 bits
-    int sclk_div = DIV_UP(sclk_freq, max_div * baud);
+    int sclk_div = DIV_UP(sclk_freq, max_div * baud) + 0.5;
+
+    if (sclk_div == 0)
+        sclk_div = 1;
 
     uint32_t clk_div = ((sclk_freq) << 4) / (baud * sclk_div);
     // The baud rate configuration register is divided into


### PR DESCRIPTION
I have faced the division by zero when the baud rate is higher than 1Mbits/s.    It happens because the integer division returns zero for sclk_div while slightly below 1.0.

I also added 0.5 to improve the roundup process of converting float to integer.

With that fix, I can reach 3.125Mbits/s.