### PR TITLE
docs: fix typo in gatt_client example readme

### DIFF
--- a/examples/bluetooth/bluedroid/ble/gatt_client/README.md
+++ b/examples/bluetooth/bluedroid/ble/gatt_client/README.md
@@ -38,7 +38,7 @@ See the [Getting Started Guide](https://idf.espressif.com/) for full steps to co
 
 This example works with UUID16 as default. To change to UUID128, follow this steps:
 
-1. Change the UIID16 to UUID128. You can change the UUID according to your needs.
+1. Change the UUID16 to UUID128. You can change the UUID according to your needs.
 
 ```c
 // Create a new UUID128 (using random values for this example)


### PR DESCRIPTION
Fix typo of 'UIID16' found in gatt_client example documentation README.