### PR TITLE
Keep export.sh Bourne Shell compatible (IDFGH-11073)

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -19,7 +19,7 @@ __verbose() {
 
 __script_dir(){
     # shellcheck disable=SC2169,SC2169,SC2039,SC3010,SC3028  # unreachable with 'dash'
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [ `uname -s` = "Darwin" ]; then
         # convert possibly relative path to absolute
         script_dir="$(__realpath "${self_path}")"
         # resolve any ../ references to make the path shorter


### PR DESCRIPTION
The '[[' operator is not supported by /bin/sh
Use '[' instead to keep it compatible.