### PR TITLE
Less tcp packet fragmentation

### DIFF
--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -123,7 +123,7 @@ static ssize_t tcp_read(esp_tls_t *tls, char *data, size_t datalen)
 
 static ssize_t tcp_write(esp_tls_t *tls, const char *data, size_t datalen)
 {
-    return send(tls->sockfd, data, datalen, 0);
+    return send(tls->sockfd, data, datalen, MSG_MORE);
 }
 
 ssize_t esp_tls_conn_read(esp_tls_t *tls, void  *data, size_t datalen)

--- a/components/esp_http_server/src/httpd_txrx.c
+++ b/components/esp_http_server/src/httpd_txrx.c
@@ -56,7 +56,7 @@ int httpd_send(httpd_req_t *r, const char *buf, size_t buf_len)
     }
 
     struct httpd_req_aux *ra = r->aux;
-    int ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+    int ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, MSG_MORE);
     if (ret < 0) {
         ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
         return ret;
@@ -70,7 +70,7 @@ static esp_err_t httpd_send_all(httpd_req_t *r, const char *buf, size_t buf_len)
     int ret;
 
     while (buf_len > 0) {
-        ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, 0);
+        ret = ra->sd->send_fn(ra->sd->handle, ra->sd->fd, buf, buf_len, MSG_MORE);
         if (ret < 0) {
             ESP_LOGD(TAG, LOG_FMT("error in send_fn"));
             return ESP_FAIL;

--- a/components/esp_http_server/src/httpd_ws.c
+++ b/components/esp_http_server/src/httpd_ws.c
@@ -416,14 +416,14 @@ esp_err_t httpd_ws_send_frame_async(httpd_handle_t hd, int fd, httpd_ws_frame_t 
     }
 
     /* Send off header */
-    if (sess->send_fn(hd, fd, (const char *)header_buf, tx_len, 0) < 0) {
+    if (sess->send_fn(hd, fd, (const char *)header_buf, tx_len, MSG_MORE) < 0) {
         ESP_LOGW(TAG, LOG_FMT("Failed to send WS header"));
         return ESP_FAIL;
     }
 
     /* Send off payload */
     if(frame->len > 0 && frame->payload != NULL) {
-        if (sess->send_fn(hd, fd, (const char *)frame->payload, frame->len, 0) < 0) {
+        if (sess->send_fn(hd, fd, (const char *)frame->payload, frame->len, MSG_MORE) < 0) {
             ESP_LOGW(TAG, LOG_FMT("Failed to send WS payload"));
             return ESP_FAIL;
         }

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -232,7 +232,7 @@ static int tcp_write(esp_transport_handle_t t, const char *buffer, int len, int 
         ESP_LOGW(TAG, "Poll timeout or error, errno=%s, fd=%d, timeout_ms=%d", strerror(errno), ssl->sockfd, timeout_ms);
         return poll;
     }
-    int ret = send(ssl->sockfd, (const unsigned char *) buffer, len, 0);
+    int ret = send(ssl->sockfd, (const unsigned char *) buffer, len, MSG_MORE);
     if (ret < 0) {
         ESP_LOGE(TAG, "tcp_write error, errno=%s", strerror(errno));
         esp_transport_capture_errno(t, errno);


### PR DESCRIPTION
I noticed that our products waste about 40% of their tcp traffic, because we send every second a very short status update through a websocket client to our cloud and esp_websocket_client keeps sending two tcp packets, one for the websocket header, and one for the websocket payload.

I tried merging those two buffers into a single one by providing additional websocket methods that expect a unused 16 byte prefix buffer to put the websocket header into, meaning the user code has to preallocate these bytes already.

websocket_client from esp-protocols also has a patch available, which uses those new optimized websocket sending mechanisms and my wireshark recording shows great success! all websocket headers are now merged together with the websocket payload.

I expect lots of review comments and change requests, I just want to start the discussion how to integrate this properly in the esp-idf