### PR TITLE
Fix "error code" Typo (IDFGH-11162)

### DIFF
--- a/components/esp_wifi/include/esp_wifi.h
+++ b/components/esp_wifi/include/esp_wifi.h
@@ -829,7 +829,7 @@ esp_err_t esp_wifi_get_promiscuous_ctrl_filter(wifi_promiscuous_filter_t *filter
   *    - ESP_ERR_WIFI_MODE: invalid mode
   *    - ESP_ERR_WIFI_PASSWORD: invalid password
   *    - ESP_ERR_WIFI_NVS: WiFi internal NVS error
-  *    - others: refer to the erro code in esp_err.h
+  *    - others: refer to the error code in esp_err.h
   */
 esp_err_t esp_wifi_set_config(wifi_interface_t interface, wifi_config_t *conf);
 

--- a/components/protocomm/test_apps/main/test_protocomm.c
+++ b/components/protocomm/test_apps/main/test_protocomm.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -234,7 +234,7 @@ static esp_err_t prepare_command1(session_t *session, SessionData *req)
     ret = mbedtls_aes_setkey_enc(&session->ctx_aes, session->sym_key,
                                  sizeof(session->sym_key)*8);
     if (ret != 0) {
-        ESP_LOGE(TAG, "Failed at mbedtls_aes_setkey_enc with erro code : %d", ret);
+        ESP_LOGE(TAG, "Failed at mbedtls_aes_setkey_enc with error code : %d", ret);
         free(outbuf);
         return ESP_FAIL;
     }
@@ -243,7 +243,7 @@ static esp_err_t prepare_command1(session_t *session, SessionData *req)
                                 &session->nc_off, session->rand,
                                 session->stb, session->device_pubkey, outbuf);
     if (ret != 0) {
-        ESP_LOGE(TAG, "Failed at mbedtls_aes_crypt_ctr with erro code : %d", ret);
+        ESP_LOGE(TAG, "Failed at mbedtls_aes_crypt_ctr with error code : %d", ret);
         free(outbuf);
         return ESP_FAIL;
     }
@@ -308,7 +308,7 @@ static esp_err_t verify_response1(session_t *session, SessionData *resp)
                                     &session->nc_off, session->rand, session->stb,
                                     in->sr1->device_verify_data.data, check_buf);
     if (ret != 0) {
-        ESP_LOGE(TAG, "Failed at mbedtls_aes_crypt_ctr with erro code : %d", ret);
+        ESP_LOGE(TAG, "Failed at mbedtls_aes_crypt_ctr with error code : %d", ret);
         return ESP_FAIL;
     }
     hexdump("Dec Device verifier", check_buf, sizeof(check_buf));


### PR DESCRIPTION
Fixed typo: "erro code" -> "error code"