### PR TITLE
allows provisioner node to use esp_ble_mesh_server_model_send_msg

### DIFF
--- a/components/bt/esp_ble_mesh/mesh_common/mesh_common.c
+++ b/components/bt/esp_ble_mesh/mesh_common/mesh_common.c
@@ -77,6 +77,10 @@ uint8_t bt_mesh_get_device_role(struct bt_mesh_model *model, bool srv_send)
     bt_mesh_client_user_data_t *client = NULL;
 
     if (srv_send) {
+        if (IS_ENABLED(CONFIG_BLE_MESH_PROVISIONER) && bt_mesh_is_provisioner_en()) {
+            BT_DBG("Message is sent by a provisioner(server) model");
+            return PROVISIONER;
+        }
         BT_DBG("Message is sent by a server model");
         return NODE;
     }


### PR DESCRIPTION
I was trying to alter ble_mesh_vendor_model example to be able to send ESP_BLE_MESH_VND_MODEL_OP_SEND from both devices, but it turned out provisioner node can't act as server. 

This patch allows ble mesh provisioner node to also act as ble mesh server otherwise esp_ble_mesh_server_model_send_msg fails with error.