### PR TITLE
ESP32 Add lcd sleep command (IDFGH-11203)

### DIFF
--- a/components/esp_lcd/include/esp_lcd_panel_ops.h
+++ b/components/esp_lcd/include/esp_lcd_panel_ops.h
@@ -133,6 +133,17 @@ esp_err_t esp_lcd_panel_disp_on_off(esp_lcd_panel_handle_t panel, bool on_off);
 esp_err_t esp_lcd_panel_disp_off(esp_lcd_panel_handle_t panel, bool off)
 __attribute__((deprecated("use esp_lcd_panel_disp_on_off instead")));
 
+/**
+ * @brief Turn display in sleep mode
+ *
+ * @param[in] panel LCD panel handle, which is created by other factory API like `esp_lcd_new_panel_st7789()`
+ * @param[in] sleep True turn display on sleep mode, False wake up
+ * @return
+ *          - ESP_OK on success
+ *          - ESP_ERR_NOT_SUPPORTED if this function is not supported by the panel
+ */
+esp_err_t esp_lcd_panel_disp_sleep(esp_lcd_panel_handle_t panel, bool sleep);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_lcd/interface/esp_lcd_panel_interface.h
+++ b/components/esp_lcd/interface/esp_lcd_panel_interface.h
@@ -120,6 +120,17 @@ struct esp_lcd_panel_t {
      */
     esp_err_t (*disp_on_off)(esp_lcd_panel_t *panel, bool on_off);
 
+    /**
+    * @brief Turn display in sleep mode
+    *
+    * @param[in] panel LCD panel handle, which is created by other factory API like `esp_lcd_new_panel_st7789()`
+    * @param[in] sleep True turn display on sleep mode, False wake up
+    * @return
+    *          - ESP_OK on success
+    *          - ESP_ERR_NOT_SUPPORTED if this function is not supported by the panel
+    */
+    esp_err_t (*disp_sleep)(esp_lcd_panel_t *panel, bool sleep);
+
     void *user_data;    /*!< User data, used to store externally customized data */
 };
 

--- a/components/esp_lcd/src/esp_lcd_panel_ops.c
+++ b/components/esp_lcd/src/esp_lcd_panel_ops.c
@@ -68,3 +68,13 @@ esp_err_t esp_lcd_panel_disp_off(esp_lcd_panel_handle_t panel, bool off)
 {
     return esp_lcd_panel_disp_on_off(panel, !off);
 }
+
+esp_err_t esp_lcd_panel_disp_sleep(esp_lcd_panel_handle_t panel, bool sleep)
+{
+    ESP_RETURN_ON_FALSE(panel, ESP_ERR_INVALID_ARG, TAG, "invalid panel handle");
+    if (panel->disp_sleep) {
+        return panel->disp_sleep(panel, sleep);
+    } else {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+}


### PR DESCRIPTION
Add code to set display in sleep mode.

### Abstract
Some driver (ST7789) support sleep mode that reduce a lots power consumption.
In my case with [2inc-display](https://www.waveshare.com/wiki/2inch_LCD_Module) Power consumption from 5mA to 0.3mA