### PR TITLE
fix: memalign: respect `malloc_alwaysinternal_limit` (IDFGH-11209)

### DIFF
--- a/components/heap/heap_private.h
+++ b/components/heap/heap_private.h
@@ -62,6 +62,7 @@ inline static uint32_t get_all_caps(const heap_t *heap)
 */
 void *heap_caps_realloc_default(void *p, size_t size);
 void *heap_caps_malloc_default(size_t size);
+void *heap_caps_aligned_alloc_default(size_t alignment, size_t size);
 
 
 #ifdef __cplusplus

--- a/components/newlib/heap.c
+++ b/components/newlib/heap.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,7 @@
 */
 extern void *heap_caps_malloc_default( size_t size );
 extern void *heap_caps_realloc_default( void *ptr, size_t size );
+extern void *heap_caps_aligned_alloc_default( size_t alignment, size_t size );
 
 void* malloc(size_t size)
 {
@@ -71,7 +72,7 @@ void* _calloc_r(struct _reent *r, size_t nmemb, size_t size)
 
 void* memalign(size_t alignment, size_t n)
 {
-    return heap_caps_aligned_alloc(alignment, n, MALLOC_CAP_DEFAULT);
+    return heap_caps_aligned_alloc_default(alignment, n);
 }
 
 int posix_memalign(void **out_ptr, size_t alignment, size_t size)
@@ -81,7 +82,7 @@ int posix_memalign(void **out_ptr, size_t alignment, size_t size)
         *out_ptr = NULL;
         return 0;
     }
-    void *result = heap_caps_aligned_alloc(alignment, size, MALLOC_CAP_DEFAULT);
+    void *result = heap_caps_aligned_alloc_default(alignment, size);
     if (result != NULL) {
         /* Modify output pointer only on success */
         *out_ptr = result;

--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -22,9 +22,7 @@ components/esp_rom/include/esp32s2/rom/rsa_pss.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
 
 ## Header produced non-zero object:
 components/esp_phy/esp32/include/phy_init_data.h
@@ -68,13 +66,9 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
-components/unity/unity/extras/
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/


### PR DESCRIPTION
This changes `memalign` (and `posix_memalign`) so that it uses an allocation method with the same selection criteria (checking `malloc_alwaysinternal_limit` and picking one of:

 - always MALLOC_CAP_INTERNAL
 - MALLOC_CAP_INTERNAL first with fallback
 - MALLOC_CAP_SPIRAM first with fallback

`malloc_alwaysinternal_limit` is in turn set by the options `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL` and
`CONFIG_SPRIAM_USE_CAPS_ALLOC`.

This notably affects folks using esp-rs to build rust code for the esp-idf, as all allocations from rust use `memalign`.