### PR TITLE
fix(driver/gpio): Fix SIG_GPIO_OUT_IDX comment for signal connect

### DIFF
--- a/components/esp_rom/include/esp_rom_gpio.h
+++ b/components/esp_rom/include/esp_rom_gpio.h
@@ -67,8 +67,8 @@ void esp_rom_gpio_connect_in_signal(uint32_t gpio_num, uint32_t signal_idx, bool
  *
  * @note There's no limitation on the number of signals that a GPIO can combine with.
  *
- * @param gpio_num GPIO number, especially, `SIG_GPIO_OUT_IDX` means disconnect GPIO and other peripherals. Only the GPIO driver can control the output level.
- * @param signal_idx Peripheral signal index (tagged as output attribute)
+ * @param gpio_num GPIO number
+ * @param signal_idx Peripheral signal index (tagged as output attribute). Particularly, `SIG_GPIO_OUT_IDX` means disconnect GPIO and other peripherals. Only the GPIO driver can control the output level.
  * @param out_inv Whether to signal to be inverted or not
  * @param oen_inv Whether the output enable control is inverted or not
  */


### PR DESCRIPTION
This PR aims to fix the comment regarding `SIG_GPIO_OUT_IDX` in `esp_rom_gpio_connect_out_signal` by commenting on the `signal_idx` parameter and not on `gpio_num`. This avoids the misunderstanding that the GPIO number needs to be set to `SIG_GPIO_OUT_IDX` rather than the signal number.