### PR TITLE
Support SSD1306 128x32 (IDFGH-11296)

### DIFF
--- a/components/esp_lcd/include/esp_lcd_panel_vendor.h
+++ b/components/esp_lcd/include/esp_lcd_panel_vendor.h
@@ -58,6 +58,33 @@ esp_err_t esp_lcd_new_panel_st7789(const esp_lcd_panel_io_handle_t io, const esp
 esp_err_t esp_lcd_new_panel_nt35510(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel);
 
 /**
+ * @brief SSD1306 configuration structure
+ *
+ * To be used as esp_lcd_panel_dev_config_t.vendor_config.
+ * See esp_lcd_new_panel_ssd1306().
+ */
+typedef struct {
+   /**
+    * @brief Multiplex ratio: (0..63)
+    *
+    * Display's height minus one.
+    */
+   uint8_t mux_ratio;
+
+   /**
+    * @brief Enables alternative COM pin configuration.
+    *
+    * When unset then Sequential COM pin configuration is used.
+    */
+   bool com_pin_alt;
+
+   /**
+    * @brief COM Left/Right remap.
+    */
+   bool com_lr_remap;
+} esp_lcd_panel_ssd1306_config_t;
+
+/**
  * @brief Create LCD panel for model SSD1306
  *
  * @param[in] io LCD panel IO handle
@@ -67,6 +94,24 @@ esp_err_t esp_lcd_new_panel_nt35510(const esp_lcd_panel_io_handle_t io, const es
  *          - ESP_ERR_INVALID_ARG   if parameter is invalid
  *          - ESP_ERR_NO_MEM        if out of memory
  *          - ESP_OK                on success
+ *
+ * @note The default panel size is 128x64.
+ * @note Use esp_lcd_panel_ssd1306_config_t to set the correct size.
+ * Example usage:
+ * @code {c}
+ * 
+ * esp_lcd_panel_ssd1306_config_t ssd1306_config = {
+ *     .width = 128,
+ *     .height = 32
+ * };
+ * esp_lcd_panel_dev_config_t panel_config = {
+ *     <...>
+ *     .vendor_config = &ssd1306_config
+ * };
+ *
+ * esp_lcd_panel_handle_t panel_handle = NULL;
+ * esp_lcd_new_panel_ssd1306(io_handle, &panel_config, &panel_handle);
+ * @endcode
  */
 esp_err_t esp_lcd_new_panel_ssd1306(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel);
 

--- a/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
+++ b/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
@@ -34,10 +34,12 @@ static const char *TAG = "lcd_panel.ssd1306";
 #define SSD1306_CMD_MIRROR_X_ON           0xA1
 #define SSD1306_CMD_INVERT_OFF            0xA6
 #define SSD1306_CMD_INVERT_ON             0xA7
+#define SSD1306_CMD_SET_MULTIPLEX         0xA8
 #define SSD1306_CMD_DISP_OFF              0xAE
 #define SSD1306_CMD_DISP_ON               0xAF
 #define SSD1306_CMD_MIRROR_Y_OFF          0xC0
 #define SSD1306_CMD_MIRROR_Y_ON           0xC8
+#define SSD1306_CMD_SET_COMPINS           0xDA
 
 static esp_err_t panel_ssd1306_del(esp_lcd_panel_t *panel);
 static esp_err_t panel_ssd1306_reset(esp_lcd_panel_t *panel);
@@ -58,7 +60,14 @@ typedef struct {
     int y_gap;
     unsigned int bits_per_pixel;
     bool swap_axes;
+    esp_lcd_panel_ssd1306_config_t vendor;
 } ssd1306_panel_t;
+
+static esp_lcd_panel_ssd1306_config_t default_ssd1306_config = {
+    .mux_ratio = 63,
+    .com_pin_alt = true,
+    .com_lr_remap = false
+};
 
 esp_err_t esp_lcd_new_panel_ssd1306(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel)
 {
@@ -84,6 +93,10 @@ esp_err_t esp_lcd_new_panel_ssd1306(const esp_lcd_panel_io_handle_t io, const es
     ssd1306->bits_per_pixel = panel_dev_config->bits_per_pixel;
     ssd1306->reset_gpio_num = panel_dev_config->reset_gpio_num;
     ssd1306->reset_level = panel_dev_config->flags.reset_active_high;
+    ssd1306->vendor = 
+        panel_dev_config->vendor_config
+        ? *(esp_lcd_panel_ssd1306_config_t*)panel_dev_config->vendor_config
+        : default_ssd1306_config;
     ssd1306->base.del = panel_ssd1306_del;
     ssd1306->base.reset = panel_ssd1306_reset;
     ssd1306->base.init = panel_ssd1306_init;
@@ -138,6 +151,14 @@ static esp_err_t panel_ssd1306_init(esp_lcd_panel_t *panel)
 {
     ssd1306_panel_t *ssd1306 = __containerof(panel, ssd1306_panel_t, base);
     esp_lcd_panel_io_handle_t io = ssd1306->io;
+
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_SET_MULTIPLEX, (uint8_t[]) {
+        // set multiplex ratio
+        ssd1306->vendor.mux_ratio
+    }, 1), TAG, "io tx param SSD1306_CMD_SET_MULTIPLEX failed");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_SET_COMPINS, (uint8_t[1]){
+        0x2 | (ssd1306->vendor.com_pin_alt << 4) | (ssd1306->vendor.com_lr_remap << 5)
+    }, 1), TAG, "io tx param SSD1306_CMD_SET_COMPINS failed");
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_DISP_OFF, NULL, 0), TAG,
                         "io tx param SSD1306_CMD_DISP_OFF failed");
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_SET_MEMORY_ADDR_MODE, (uint8_t[]) {

--- a/examples/peripherals/lcd/i2c_oled/main/i2c_oled_example_main.c
+++ b/examples/peripherals/lcd/i2c_oled/main/i2c_oled_example_main.c
@@ -99,6 +99,14 @@ void app_main(void)
         .reset_gpio_num = EXAMPLE_PIN_NUM_RST,
     };
 #if CONFIG_EXAMPLE_LCD_CONTROLLER_SSD1306
+#if EXAMPLE_LCD_V_RES != 64
+    esp_lcd_panel_ssd1306_config_t ssd1306_config = {
+        .mux_ratio = EXAMPLE_LCD_V_RES-1,
+        .com_pin_alt = false
+    };
+    panel_config.vendor_config = &ssd1306_config;
+#endif
+
     ESP_ERROR_CHECK(esp_lcd_new_panel_ssd1306(io_handle, &panel_config, &panel_handle));
 #elif CONFIG_EXAMPLE_LCD_CONTROLLER_SH1107
     ESP_ERROR_CHECK(esp_lcd_new_panel_sh1107(io_handle, &panel_config, &panel_handle));


### PR DESCRIPTION
SSD1306 may have different sizes and resolutions: 128x32, 128x64, 96x16
and others.

`SSD1306_CMD_SET_MULTIPLEX` (0xA8) initialization command effectively
sets the height of the display's resolution. The value for this command
is the height in pixels minus one.

```
Set MUX ratio to N+1 MUX
N=A[5:0] : from 16MUX to 64MUX, RESET= 111111b (i.e. 63d, 64MUX)
A[5:0] from 0 to 14 are invalid entry.
```

`SSD1306_CMD_SET_COMPINS` (0xDA) configures the communication pins.
According to the datasheet it should be `0x2` with other optional bits
set.

```
A[4]=0b, Sequential COM pin configuration
A[4]=1b(RESET), Alternative COM pin configuration

A[5]=0b(RESET), Disable COM Left/Right remap
A[5]=1b, Enable COM Left/Right remap
```

* https://github.com/adafruit/Adafruit_SSD1306;
* https://www.digikey.com/htmldatasheets/production/2047793/0/0/1/ssd1306.html