### PR TITLE
fix: corrected typo from disbale to disable in numerous places (IDFGH-11298)

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
@@ -54,7 +54,7 @@ typedef uint8_t   esp_ble_auth_req_t;         /*!< combination of the above bit 
 #define ESP_BLE_ONLY_ACCEPT_SPECIFIED_AUTH_DISABLE 0    /*!< authentication disable*/
 #define ESP_BLE_ONLY_ACCEPT_SPECIFIED_AUTH_ENABLE  1    /*!< authentication enable*/
 
-#define ESP_BLE_OOB_DISABLE 0    /*!< disbale the out of bond*/
+#define ESP_BLE_OOB_DISABLE 0    /*!< disable the out of bond*/
 #define ESP_BLE_OOB_ENABLE  1    /*!< enable the out of bond*/
 
 /// relate to BTM_IO_CAP_xxx in stack/btm_api.h

--- a/components/bt/host/bluedroid/stack/btm/btm_ble_gap.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_ble_gap.c
@@ -4352,7 +4352,7 @@ void btm_ble_read_remote_features_complete(UINT8 *p)
 *******************************************************************************/
 void btm_ble_write_adv_enable_complete(UINT8 *p)
 {
-    /* if write adv enable/disbale not succeed */
+    /* if write adv enable/disable not succeed */
     if (*p != HCI_SUCCESS) {
         BTM_TRACE_ERROR("%s failed", __func__);
     }

--- a/components/hal/esp32c3/include/hal/clk_tree_ll.h
+++ b/components/hal/esp32c3/include/hal/clk_tree_ll.h
@@ -120,7 +120,7 @@ static inline __attribute__((always_inline)) bool clk_ll_xtal32k_is_enabled(void
     bool xtal_xpd_sw = (xtal_conf & RTC_CNTL_XTAL32K_XPD_FORCE) >> RTC_CNTL_XTAL32K_XPD_FORCE_S;
     /* If xtal xpd software control is on */
     bool xtal_xpd_st = (xtal_conf & RTC_CNTL_XPD_XTAL_32K) >> RTC_CNTL_XPD_XTAL_32K_S;
-    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disbaled
+    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disabled
     bool enabled = !xtal_xpd_sw || xtal_xpd_st;
     return enabled;
 }

--- a/components/hal/esp32s2/include/hal/clk_tree_ll.h
+++ b/components/hal/esp32s2/include/hal/clk_tree_ll.h
@@ -216,7 +216,7 @@ static inline __attribute__((always_inline)) bool clk_ll_xtal32k_is_enabled(void
     bool xtal_xpd_sw = (xtal_conf & RTC_CNTL_XTAL32K_XPD_FORCE) >> RTC_CNTL_XTAL32K_XPD_FORCE_S;
     /* If xtal xpd software control is on */
     bool xtal_xpd_st = (xtal_conf & RTC_CNTL_XPD_XTAL_32K) >> RTC_CNTL_XPD_XTAL_32K_S;
-    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disbaled
+    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disabled
     bool enabled = !xtal_xpd_sw || xtal_xpd_st;
     return enabled;
 }

--- a/components/hal/esp32s3/include/hal/clk_tree_ll.h
+++ b/components/hal/esp32s3/include/hal/clk_tree_ll.h
@@ -122,7 +122,7 @@ static inline __attribute__((always_inline)) bool clk_ll_xtal32k_is_enabled(void
     bool xtal_xpd_sw = (xtal_conf & RTC_CNTL_XTAL32K_XPD_FORCE) >> RTC_CNTL_XTAL32K_XPD_FORCE_S;
     /* If xtal xpd software control is on */
     bool xtal_xpd_st = (xtal_conf & RTC_CNTL_XPD_XTAL_32K) >> RTC_CNTL_XPD_XTAL_32K_S;
-    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disbaled
+    // disabled = xtal_xpd_sw && !xtal_xpd_st; enabled = !disabled
     bool enabled = !xtal_xpd_sw || xtal_xpd_st;
     return enabled;
 }


### PR DESCRIPTION
Just a few corrections of the typo `disbale` to `disable`

Thanks for your consideration