### PR TITLE
manager: fixing unwinding protocom endpoints, on prov_stop. (IDFGH-11307)

### DIFF
--- a/components/wifi_provisioning/src/manager.c
+++ b/components/wifi_provisioning/src/manager.c
@@ -558,6 +558,16 @@ static void prov_stop_and_notify(bool is_async)
         vTaskDelay(cleanup_delay / portTICK_PERIOD_MS);
     }
 
+    protocomm_remove_endpoint(prov_ctx->pc, "prov-ctrl");
+
+    protocomm_remove_endpoint(prov_ctx->pc, "prov-scan");
+
+    protocomm_remove_endpoint(prov_ctx->pc, "prov-config");
+
+    protocomm_unset_security(prov_ctx->pc, "prov-session");
+
+    protocomm_unset_version(prov_ctx->pc, "proto-ver");
+
     /* All the extra application added endpoints are also
      * removed automatically when prov_stop is called */
     prov_ctx->mgr_config.scheme.prov_stop(prov_ctx->pc);


### PR DESCRIPTION
protocom endpoints added during wifi_prov_mgr_start_service arent currently removed during prov_stop_and_notify.
this is probably no problem, if protocom uses the httpd server itself, starting and stopping it on demand (not sure if it is designed for restart) and probaly the handlers will get removed in the process..

But: if protocom is provided with the handle of an external httpd server, it add the endpoints to it. they remain attached even if protocom is finished --> the endpoints need to be removed too.

This enables starting and stopping provisioning on a pre-started http server that is specified via wifi_prov_scheme_softap_set_httpd_handle
this effectively enables to start and stop provisioning at any time without turning off the http server

I very likely didn't cover everything involved, but as far, it works for me..

appreciate a short feedback on that