### PR TITLE
fixing OTA write up to SPI_FLASH_SEC_SIZE margins (IDFGH-11311)

### DIFF
--- a/components/app_update/esp_ota_ops.c
+++ b/components/app_update/esp_ota_ops.c
@@ -197,13 +197,20 @@ esp_err_t esp_ota_write(esp_ota_handle_t handle, const void *data, size_t size)
         return ESP_ERR_INVALID_ARG;
     }
 
+    if(size == 0)
+    {
+        ESP_LOGD(TAG, "write data size is 0");
+        return ESP_OK;
+    }
+
     // find ota handle in linked list
     for (it = LIST_FIRST(&s_ota_ops_entries_head); it != NULL; it = LIST_NEXT(it, entries)) {
         if (it->handle == handle) {
             if (it->need_erase) {
                 // must erase the partition before writing to it
-                uint32_t first_sector = it->wrote_size / SPI_FLASH_SEC_SIZE;
-                uint32_t last_sector = (it->wrote_size + size) / SPI_FLASH_SEC_SIZE;
+                uint32_t first_sector = it->wrote_size / SPI_FLASH_SEC_SIZE; //first affected sector
+                uint32_t last_sector = (it->wrote_size + size - 1) / SPI_FLASH_SEC_SIZE; //last affected sector
+
 
                 ret = ESP_OK;
                 if ((it->wrote_size % SPI_FLASH_SEC_SIZE) == 0) {

--- a/components/app_update/include/esp_ota_ops.h
+++ b/components/app_update/include/esp_ota_ops.h
@@ -111,7 +111,7 @@ esp_err_t esp_ota_begin(const esp_partition_t* partition, size_t image_size, esp
  * @param size    Size of data buffer in bytes.
  *
  * @return
- *    - ESP_OK: Data was written to flash successfully.
+ *    - ESP_OK: Data was written to flash successfully, or size = 0
  *    - ESP_ERR_INVALID_ARG: handle is invalid.
  *    - ESP_ERR_OTA_VALIDATE_FAILED: First byte of image contains invalid app image magic byte.
  *    - ESP_ERR_FLASH_OP_TIMEOUT or ESP_ERR_FLASH_OP_FAIL: Flash write failed.


### PR DESCRIPTION
when OTA update is performed on a partition that extends to the very last byte of the flash,  then ...
esp_partition_erase_range, called by esp_ota_write(),  will get to erase the sector past flash size which it will decline with an error.

example:

120 sectors to write, (0 to 119), sector 120 is just outside the flash
writing the last bytes <= SPI_FLASH_SEC_SIZE will produce this:

first_sector will be 119 (already erased in previous write operations, has a ramainder to write)
last_sector will be 120 (just outside flash)

the fix determines this situation (condition could probably even better be 
if((it->wrote_size + size) >= it->part->size)

and repositions the last_sector to really be the last, so when it is compared to be == first_sector, it will be ignored..

I also believe, that esp_partition_erase_range has a latent issue

...
esp_err_t esp_partition_erase_range(const esp_partition_t *partition,
                                    size_t offset, size_t size)
{
    assert(partition != NULL);
    if (offset > partition->size) {   //<<----------- should be >=
        return ESP_ERR_INVALID_ARG;
    }
    if (offset + size > partition->size) {   //<<----------- should be >=
        return ESP_ERR_INVALID_SIZE;
    }
...

but I probably didnt get all the internal info right...
