### PR TITLE
This enables project(... VERSION x.y.z.a ...) and DESCRIPTION etc.. usage (IDFGH-11310)

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -361,6 +361,7 @@ The following are some project/build variables that are available as build prope
   * If :ref:`CONFIG_APP_PROJECT_VER_FROM_CONFIG` option is set, the value of :ref:`CONFIG_APP_PROJECT_VER` will be used.
   * Else, if ``PROJECT_VER`` variable is set in project CMakeLists.txt file, its value will be used.
   * Else, if the ``PROJECT_DIR/version.txt`` exists, its contents will be used as ``PROJECT_VER``.
+  * Else, if ``PROJECT_VERSION`` contains a version from ``project(... VERSION A.b.p.t ...)`` in project level CMakeLists.txt file, its contents will be used as ``PROJECT_VER``.
   * Else, if the project is located inside a Git repository, the output of git description will be used.
   * Otherwise, ``PROJECT_VER`` will be "1".
 - ``EXTRA_PARTITION_SUBTYPES``: CMake list of extra partition subtypes. Each subtype description is a comma-separated string with ``type_name, subtype_name, numeric_value`` format. Components may add new subtypes by appending them to this list.

--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -451,7 +451,7 @@ macro(project project_name)
     # LANGUAGES usually to be last topic in ARGV list, so we simply kill all the parts we also specify,
     # and append the remainder
 
-    set(ARGV_EXT "LANGUAGES;C;CXX;ASM")
+    set(extra_project_args "LANGUAGES;C;CXX;ASM")
 
     set(LANGUAGES_POS -1)
     string(FIND "${ARGV}" "LANGUAGES" LANGUAGES_POS)

--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -74,6 +74,8 @@ function(__project_get_revision var)
         if(EXISTS "${_project_path}/version.txt")
             file(STRINGS "${_project_path}/version.txt" PROJECT_VER)
             set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_project_path}/version.txt")
+        elseif (NOT "${PROJECT_VERSION}" STREQUAL "")
+            set(PROJECT_VER ${PROJECT_VERSION})
         else()
             git_describe(PROJECT_VER_GIT "${_project_path}")
             if(PROJECT_VER_GIT)
@@ -445,8 +447,50 @@ macro(project project_name)
         endif()
     endif()
 
+    # handle LANGUAGES duplicates in the definition of project ARGV coming from top CMakeFile.txt
+    # LANGUAGES usually to be last topic in ARGV list, so we simply kill all the parts we also specify,
+    # and append the remainder
+
+    set(ARGV_EXT "LANGUAGES;C;CXX;ASM")
+
+    set(LANGUAGES_POS -1)
+    string(FIND "${ARGV}" "LANGUAGES" LANGUAGES_POS)
+    if (LANGUAGES_POS GREATER 0)
+        # LANGUAGES definition from top level CMakeFile.txt exists
+        string(SUBSTRING "${ARGV}" 0 ${LANGUAGES_POS} ARGV_PREFIX)
+        string(SUBSTRING "${ARGV}" ${LANGUAGES_POS} -1 ARGV_SUB)
+        # ARGV_SUB is "LANGUAGES X Y Z and the rest", just remove what we specify
+
+        # the C definition is tricky, as it also conflicts with CSharp, CXX etc..
+        # so remove the definit option (;C; covers most, ;C at the end covers a special case.
+        # ;C theoretically could be a DESCRITION or the like too, but unlikly
+        string(REPLACE ";C;" ";" ARGV_SUB "${ARGV_SUB}")
+        string(LENGTH "${ARGV_SUB}" _C_LEN)
+        math(EXPR _C_END_POS "${_C_LEN} - 2" OUTPUT_FORMAT DECIMAL)
+        string(FIND "${ARGV_SUB}" ";C" _C_POS REVERSE) #special case ;C at the end
+        if( _C_POS GREATER_EQUAL _C_END_POS )
+            # C; present at the end
+            string(REPLACE ";C" "" ARGV_SUB "${ARGV_SUB}")
+        endif()
+
+        # ;CXX is unique enough
+        string(REPLACE ";CXX" "" ARGV_SUB "${ARGV_SUB}")
+
+        # ;ASM is unique enough
+        string(REPLACE ";ASM" "" ARGV_SUB "${ARGV_SUB}")
+
+        #last, remove the LANGUAGES keyword, which we specify ourselves, leave ; , might already be gone
+        string(REPLACE "LANGUAGES;" "" ARGV_SUB "${ARGV_SUB}")
+        string(REPLACE "LANGUAGES" "" ARGV_SUB "${ARGV_SUB}")
+
+        set(ARGV_PROJECT "${ARGV_PREFIX};${ARGV_EXT};${ARGV_SUB}")
+    else()
+        # no LANGUAGES definition from top CMakeFile.txt
+        set(ARGV_PROJECT "${ARGV};${ARGV_EXT}")
+    endif()
+
     # The actual call to project()
-    __project(${project_name} C CXX ASM)
+    __project(${ARGV_PROJECT})
 
     # Generate compile_commands.json (needs to come after project call).
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -502,7 +546,7 @@ macro(project project_name)
     #
     # PROJECT_NAME is taken from the passed name from project() call
     # PROJECT_DIR is set to the current directory
-    # PROJECT_VER is from the version text or git revision of the current repo
+    # PROJECT_VER is from the version text or the CMakeFile or git revision of the current repo
 
     # SDKCONFIG_DEFAULTS environment variable may specify a file name relative to the root of the project.
     # When building the bootloader, ignore this variable, since:


### PR DESCRIPTION
the current implementation of project.cmake
overrides the 

project() 

function with a macro which then calls the overridden function, but only provides the project name along with some predefined LANGUAGES..
in case someone wanted to specify additional LANGUAGES, DESCRIPTION etc... this is entirely ignored.
probably to keep things simple.

this fix enables the usage of all the parameters for project() including LANGUAGES

it splits the provided ARGV when there is LANGUAGES present, and eliminates the predefined languages that the project.cmake already wants to specify itself.

everything else is untouched.

this also has the benefit that the cmake own PROJECT_VERSION now is able to be specified via the project(VERSION x.y.z.a ...) and then can be used to initalize the PROJECT_VER, no need to specify the PROJECT_VER explicitly as a set(PROJECT_VER x.y.z.a)..

I admit that the solution is probly not optimal, feel free to improve on it.
