### PR TITLE
Factory Reset: Bootloader with a little Wait Time to enable Usage of GPIO 0 (BOOT) button  (IDFGH-11320)

### DIFF
--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -172,7 +172,7 @@ menu "Bootloader config"
     config BOOTLOADER_WAIT_AFTER_EN_TIME_MS
         int "Time to wait before the Factory Reset GPIO probe (ms)"
         depends on BOOTLOADER_WAIT_AFTER_EN
-        default 3000
+        default 1000
         range 0 10000
         help
             The specified waiting time after booting the bootloader and prior to probing the Factory Reset GPIO

--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -151,6 +151,32 @@ menu "Bootloader config"
             bool "Reset on GPIO high"
     endchoice
 
+    config BOOTLOADER_WAIT_AFTER_EN
+        bool "Enable Waiting time before Factory Reset GPIO probe (especially usefull for GPIO 0 as factory reset)"
+        default y
+        depends on BOOTLOADER_FACTORY_RESET
+        help
+            Enable Wait Time in bootloader prior to probing for Factory Reset condition.
+            This is especially usefull if GPIO 0 (BOOT button on most Dev Boards) is set as Factory Reset GPIO.
+            Without the wait time, the GPIO 0 / BOOT, if held down, during boot, is already probed by the ROM loader
+            which would be selecting UART boot mode.
+
+            The intended use case is as follows:
+               * set GPIO 0 (BOOT) as Factory Reset, which is already a pre-installed button on almost every ESP32 board
+               * for the GPIO 0 (BOOT): set 'Reset on GPIO Low'
+               * enable the Waiting Time after EN
+               * press RESET (EN) --> ROM Loader determines normal flash boot
+               * shortly after, press and hold GPIO 0 (BOOT) button until the Factory reset condition is recognized
+               * boot continues, Factory reset is applied
+
+    config BOOTLOADER_WAIT_AFTER_EN_TIME_MS
+        int "Time to wait before the Factory Reset GPIO probe (ms)"
+        depends on BOOTLOADER_WAIT_AFTER_EN
+        default 3000
+        range 0 10000
+        help
+            The specified waiting time after booting the bootloader and prior to probing the Factory Reset GPIO
+
     config BOOTLOADER_OTA_DATA_ERASE
         bool "Clear OTA data on factory reset (select factory partition)"
         depends on BOOTLOADER_FACTORY_RESET

--- a/components/bootloader/subproject/main/bootloader_start.c
+++ b/components/bootloader/subproject/main/bootloader_start.c
@@ -96,14 +96,13 @@ static int selected_boot_partition(const bootloader_state_t *bs)
 #endif
 
 #ifdef CONFIG_BOOTLOADER_WAIT_AFTER_EN
-        ESP_LOGW(TAG, "Use GPIO %d for more than %d s to perform factory reset!",
+        ESP_LOGW(TAG, "Use GPIO %d for more than %d s to perform Factory Feset!",
             (int)CONFIG_BOOTLOADER_NUM_PIN_FACTORY_RESET,
             (int)(CONFIG_BOOTLOADER_HOLD_TIME_GPIO + BL_HOLDOFF_TIME_MS/1000)
         );
 
         //give the user a chance to react after a power up to hold BOOT button
-        uint32_t tm_start = esp_log_early_timestamp();
-        do { } while (BL_HOLDOFF_TIME_MS > ((esp_log_early_timestamp() - tm_start) ));
+        esp_rom_delay_us(BL_HOLDOFF_TIME_MS * 1000u);
 #endif
 
         if (bootloader_common_check_long_hold_gpio_level(CONFIG_BOOTLOADER_NUM_PIN_FACTORY_RESET, CONFIG_BOOTLOADER_HOLD_TIME_GPIO, reset_level) == GPIO_LONG_HOLD) {


### PR DESCRIPTION
Using GPIO 0 (BOOT) button to perform Factory Reset is pretty handy, as this GPIO comes already as a button on most ESP32 based Dev Kits of any sort. No need to solder / connect an extra button for that purpose..

The only problem: 

GPIO 0 (BOOT) has a double use already, if held down during reset, the ROM Loader uses it to determine UART BOOT condition, so the esp bootloader wont even start. On the other hand, the bootloader boots so quickly that it passes the         

..
if (bootloader_common_check_long_hold_gpio_level(CONFIG_BOOTLOADER_NUM_PIN_FACTORY_RESET, CONFIG_BOOTLOADER_HOLD_TIME_GPIO, reset_level) == GPIO_LONG_HOLD) 
..
and wont ever see a GPIO 0 (BOOT) pressed and held "right after reset"

Solution:

introducing a Kconfig configurable wait time in the bootloader, right before this very if condition.  It enables to comfortly reset the ESP and apply the factory reset condition just after it (pressing and holding as usual)..

typical USE CASE:

+               * set GPIO 0 (BOOT) as Factory Reset, which is already a pre-installed button on almost every ESP32 board
+               * for the GPIO 0 (BOOT): set 'Reset on GPIO Low'
+               * enable the Waiting Time after EN
+               * press RESET (EN) --> ROM Loader determines normal flash boot
+               * shortly after, press and hold GPIO 0 (BOOT) button until the Factory reset condition is recognized
+               * boot continues, Factory reset is applied, if no factory image present: Reset is performed and a UART BOOT is recognized (BOOT still asserted) --> release BOOT, perform reset





Regarding the change:

* it is a configurable busy wait (what else is there to do in mean time?) prior to checking the factory reset condition
* the code adds around 0x40 byte, so there is like 0x10 byte left :) I put 2 LOGI outputs together to make some space. the LOGs really add to the bin size.


