### PR TITLE
enabling a partition in front of partition table (IDFGH-11338)

### DIFF
--- a/components/esp_partition/partition_target.c
+++ b/components/esp_partition/partition_target.c
@@ -221,7 +221,7 @@ bool esp_partition_is_flash_region_writable(size_t addr, size_t size)
 
 bool esp_partition_main_flash_region_safe(size_t addr, size_t size)
 {
-    if (addr <= ESP_PARTITION_TABLE_OFFSET + ESP_PARTITION_TABLE_MAX_LEN) {
+    if ((addr < ESP_PARTITION_TABLE_OFFSET + ESP_PARTITION_TABLE_MAX_LEN) && ((addr + size) > ESP_PARTITION_TABLE_OFFSET)) {
         return false;
     }
     const esp_partition_t *p = esp_ota_get_running_partition();

--- a/components/partition_table/gen_esp32part.py
+++ b/components/partition_table/gen_esp32part.py
@@ -191,7 +191,8 @@ class PartitionTable(list):
         # fix up missing offsets & negative sizes
         last_end = offset_part_table + PARTITION_TABLE_SIZE  # first offset after partition table
         for e in res:
-            if e.offset is not None and e.offset < last_end:
+            if e.offset is not None and e.offset < last_end and e.offset + e.size > offset_part_table:
+
                 if e == res[0]:
                     raise InputError('CSV Error at line %d: Partitions overlap. Partition sets offset 0x%x. '
                                      'But partition table occupies the whole sector 0x%x. '
@@ -260,7 +261,7 @@ class PartitionTable(list):
         # check for overlaps
         last = None
         for p in sorted(self, key=lambda x:x.offset):
-            if p.offset < offset_part_table + PARTITION_TABLE_SIZE:
+            if p.offset < offset_part_table + PARTITION_TABLE_SIZE and p.offset + p.size > offset_part_table:
                 raise InputError('Partition offset 0x%x is below 0x%x' % (p.offset, offset_part_table + PARTITION_TABLE_SIZE))
             if last is not None and p.offset < last.offset + last.size:
                 raise InputError('Partition at 0x%x overlaps 0x%x-0x%x' % (p.offset, last.offset, last.offset + last.size - 1))


### PR DESCRIPTION
In real world project one finds himself with the need to place partitions before the partition table..
Reasons for that could be:

* Enlarged Bootloader demands for moving the partition table anyway, a good fix adress is probably far away from 0, 
* 0x10000 (64k) as offset for the partition table for the lifetime of the application is probably a good idea..
* according to https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/bootloader.html
for Secure Boot V2 capailities (if desired to be used later), the max size for the bootloader is 0xC000 anyway
* this leaves significant space, that cant be used due to various checks in the code base and the idf py domain, preventing any partition being declared north of the partition table..
* the remaining hole of 0x4000 bye (16k) is just enough for the bare minimum nvs, which, should the bootloader indeed need to grow for some reason, can move back south of the partition table.
* the provided changes enable a real world partition table like this one..

bootloader, 0xB0, 0x0B,   0x01000,   0xc000,
nvs,      data, nvs,      0x0d000,   0x3000,
#part_table, data, 0xEE,  0x10000,   0x1000,
phy_init, data, phy,      0x11000,   0x1000,
otadata,  data, ota,      0x12000,   0x2000,

emul_efuse, data, efuse,  0x14000,   0x2000,
nvs_keys, data, nvs_keys, 0x16000,   0x1000,
nvs_sys,  data, nvs,      0x17000,   0x9000,

ota_0,    app,  ota_0,    0x20000, 0x140000,
ota_1,    app,  ota_1,   0x160000, 0x140000,
usr,      data, nvs,     0x2a0000,  0x20000,
www,      data, spiffs,  0x2c0000, 0x140000,

rfc