### PR TITLE
fix: assert failed in example uart_async_rxtxtasks (IDFGH-11380)

### DIFF
--- a/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
+++ b/examples/peripherals/uart/uart_async_rxtxtasks/main/uart_async_rxtxtasks_main.c
@@ -72,6 +72,6 @@ static void rx_task(void *arg)
 void app_main(void)
 {
     init();
-    xTaskCreate(rx_task, "uart_rx_task", 1024 * 2, NULL, configMAX_PRIORITIES, NULL);
-    xTaskCreate(tx_task, "uart_tx_task", 1024 * 2, NULL, configMAX_PRIORITIES - 1, NULL);
+    xTaskCreate(rx_task, "uart_rx_task", 1024 * 2, NULL, configMAX_PRIORITIES - 1, NULL);
+    xTaskCreate(tx_task, "uart_tx_task", 1024 * 2, NULL, configMAX_PRIORITIES - 2, NULL);
 }


### PR DESCRIPTION
In `esp-idf/components/freertos/FreeRTOS-Kernel/tasks.c:1127`, verify `uxPriority` must be less than `configMAX_PRIORITIES`.
```c
    /* This is used as an array index so must ensure it's not too large. */
    configASSERT( uxPriority < configMAX_PRIORITIES );
```

In the example, `uxPriority` equals `configMAX_PRIORITIES`, resulting in a failed assert.
```c
xTaskCreate(rx_task, "uart_rx_task", 1024 * 2, NULL, configMAX_PRIORITIES, NULL);
```