### PR TITLE
change(console): print sorted help (IDFGH-11382)

### DIFF
--- a/components/console/commands.c
+++ b/components/console/commands.c
@@ -130,14 +130,17 @@ esp_err_t esp_console_cmd_register(const esp_console_cmd_t *cmd)
     }
     item->argtable = cmd->argtable;
     item->func = cmd->func;
-    cmd_item_t *last = SLIST_FIRST(&s_cmd_list);
+    cmd_item_t *last = NULL;
+    cmd_item_t *it;
+    SLIST_FOREACH(it, &s_cmd_list, next) {
+        if (strcmp(it->command, item->command) > 0) {
+            break;
+        }
+        last = it;
+    }
     if (last == NULL) {
         SLIST_INSERT_HEAD(&s_cmd_list, item, next);
     } else {
-        cmd_item_t *it;
-        while ((it = SLIST_NEXT(last, next)) != NULL) {
-            last = it;
-        }
         SLIST_INSERT_AFTER(last, item, next);
     }
     return ESP_OK;

--- a/components/console/test_apps/console/main/test_console.c
+++ b/components/console/test_apps/console/main/test_console.c
@@ -78,6 +78,21 @@ TEST_CASE("esp console help command", "[console][ignore]")
     TEST_ESP_OK(esp_console_cmd_register(&s_quit_cmd));
     TEST_ESP_OK(esp_console_register_help_command());
 
+    const esp_console_cmd_t cmd_a = {
+        .command = "aaa",
+        .help = "should appear first in help",
+        .hint = NULL,
+        .func = do_hello_cmd,
+    };
+    const esp_console_cmd_t cmd_z = {
+        .command = "zzz",
+        .help = "should appear last in help",
+        .hint = NULL,
+        .func = do_hello_cmd,
+    };
+    TEST_ESP_OK(esp_console_cmd_register(&cmd_z));
+    TEST_ESP_OK(esp_console_cmd_register(&cmd_a));
+
     TEST_ESP_OK(esp_console_start_repl(s_repl));
     vTaskDelay(pdMS_TO_TICKS(5000));
 }


### PR DESCRIPTION
console commands may be registered in random order in application, for example each module registers its own commands.

the output of help is displayed to human, best to have consistent sorted output so that the implementation ordering will not affect the output and allow the user to see a list in some logic order.