### PR TITLE
Fix: esptool_py incorrectly assumed target name equals binary name (IDFGH-11420)

### DIFF
--- a/components/esptool_py/project_include.cmake
+++ b/components/esptool_py/project_include.cmake
@@ -122,7 +122,6 @@ idf_build_get_property(build_dir BUILD_DIR)
 
 idf_build_get_property(elf_name EXECUTABLE_NAME GENERATOR_EXPRESSION)
 idf_build_get_property(elf EXECUTABLE GENERATOR_EXPRESSION)
-idf_build_get_property(elf_dir EXECUTABLE_DIR GENERATOR_EXPRESSION)
 
 if(CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES AND NOT BOOTLOADER_BUILD)
     set(unsigned_project_binary "${elf_name}-unsigned.bin")
@@ -138,10 +137,10 @@ set(PROJECT_BIN "${elf_name}.bin")
 if(CONFIG_APP_BUILD_GENERATE_BINARIES)
     add_custom_command(OUTPUT "${build_dir}/.bin_timestamp"
         COMMAND ${ESPTOOLPY} elf2image ${esptool_elf2image_args}
-            -o "${build_dir}/${unsigned_project_binary}" "${elf_dir}/${elf}"
+            -o "${build_dir}/${unsigned_project_binary}" "$<TARGET_FILE:$<GENEX_EVAL:${elf}>>"
         COMMAND ${CMAKE_COMMAND} -E echo "Generated ${build_dir}/${unsigned_project_binary}"
         COMMAND ${CMAKE_COMMAND} -E md5sum "${build_dir}/${unsigned_project_binary}" > "${build_dir}/.bin_timestamp"
-        DEPENDS ${elf}
+        DEPENDS "$<TARGET_FILE:$<GENEX_EVAL:${elf}>>"
         VERBATIM
         WORKING_DIRECTORY ${build_dir}
         COMMENT "Generating binary image from built executable"
@@ -237,7 +236,7 @@ add_custom_target(monitor
     COMMAND ${CMAKE_COMMAND}
     -D "IDF_PATH=${idf_path}"
     -D "SERIAL_TOOL=${ESPMONITOR}"
-    -D "SERIAL_TOOL_ARGS=--target;${target};${monitor_rev_args};${elf_dir}/${elf}"
+    -D "SERIAL_TOOL_ARGS=--target;${target};${monitor_rev_args};$<TARGET_FILE:$<GENEX_EVAL:${elf}>>"
     -D "WORKING_DIRECTORY=${build_dir}"
     -P run_serial_tool.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
While integrating the ESP-IDF into our existing CMake structure, I've come across quite some hurdles.
Most I've been able to fix in our CMake files, however this one I could not.

Most of the targets created by the esptool_py component assume that the `EXECUTABLE` IDF build property (which contains the name of the CMake executable target) always equals the name of the created binary.

This is however not always  true. For instance, in our setup we use `CMAKE_EXECUTABLE_SUFFIX_C` and `CMAKE_EXECUTABLE_SUFFIX_CXX` in our toolchain file (both set to `.elf`).
If we do `add_executable(my_app)`, the target binary file would actually be `my_app.elf`.

In order to fix this, I've updated it to use the `TARGET_FILE` generated expression. That way we also no longer need the `EXECUTABLE_DIR` IDF build property here.

I've fixed this on v5.0.1 (as that's the ESP-IDF version I'm currently trying to integrate), but I assume it should be easy to apply the same fix to newer versions and the master branch as well.

Note that this problem might exist in multiple places where `EXECUTABLE` is being used.
While going through the ESP-IDF code base, I even noticed that a few places actually already seem to use the `TARGET_FILE` expression.
To be honest the property name might be somewhat confusing as well, as it is actually the **executable _target_**.