### PR TITLE
[ESP32-C2] Correct REG_SPI_BASE(i) (IDFGH-11421)

### DIFF
--- a/components/soc/esp32c2/include/soc/spi_reg.h
+++ b/components/soc/esp32c2/include/soc/spi_reg.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 #include "soc/soc.h"
-#define REG_SPI_BASE(i)     (DR_REG_SPI2_BASE + (i - 2) * 0x1000)
+#define REG_SPI_BASE(i)     ((i==2) ? (DR_REG_SPI2_BASE : (DR_REG_SPI0_BASE - (i * 0x1000))))
 
 #define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
 /* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */

--- a/components/soc/esp32c2/include/soc/spi_reg.h
+++ b/components/soc/esp32c2/include/soc/spi_reg.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 #include "soc/soc.h"
-#define REG_SPI_BASE(i)     ((i==2) ? (DR_REG_SPI2_BASE : (DR_REG_SPI0_BASE - (i * 0x1000))))
+#define REG_SPI_BASE(i)     (((i)==2) ? (DR_REG_SPI2_BASE) : (DR_REG_SPI0_BASE - ((i) * 0x1000)))
 
 #define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
 /* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */


### PR DESCRIPTION
Given these defines (verified against the technical reference guide):
```c++
#define DR_REG_SPI1_BASE                        0x60002000
#define DR_REG_SPI0_BASE                        0x60003000
#define DR_REG_SPI2_BASE                        0x60024000
```

The existing formula can never match these registers.