### PR TITLE
[ESP32-C3] add missing define REG_SPI_BASE(i)

### DIFF
--- a/components/soc/esp32c3/include/soc/spi_reg.h
+++ b/components/soc/esp32c3/include/soc/spi_reg.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 #include "soc.h"
-#define REG_SPI_BASE(i)     ((i==2) ? (DR_REG_SPI2_BASE : (DR_REG_SPI0_BASE - (i * 0x1000))))
+#define REG_SPI_BASE(i)     (((i)==2) ? (DR_REG_SPI2_BASE) : (DR_REG_SPI0_BASE - ((i) * 0x1000)))
 
 #define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
 /* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */

--- a/components/soc/esp32c3/include/soc/spi_reg.h
+++ b/components/soc/esp32c3/include/soc/spi_reg.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 #include "soc.h"
+#define REG_SPI_BASE(i)     ((i==2) ? (DR_REG_SPI2_BASE : (DR_REG_SPI0_BASE - (i * 0x1000))))
 
 #define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
 /* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */


### PR DESCRIPTION
similar to #12559 but for the C3 it is completely missing.