### PR TITLE
Add option to configure FATFS_USE_LABEL boolean (IDFGH-11429)

### DIFF
--- a/components/fatfs/Kconfig
+++ b/components/fatfs/Kconfig
@@ -239,4 +239,10 @@ menu "FAT Filesystem support"
             vfs_fat_pwrite(), vfs_fat_link(), vfs_fat_truncate() and vfs_fat_ftruncate() functions.
             This feature improves file-consistency and size reporting accuracy for the FatFS,
             at a price on decreased performance due to frequent disk operations
+
+    config FATFS_USE_LABEL
+        bool "Use FATFS volume label"
+        default n
+        help
+            Allows FATFS volume label to be specified using f_setlabel
 endmenu

--- a/components/fatfs/src/ffconf.h
+++ b/components/fatfs/src/ffconf.h
@@ -49,7 +49,7 @@
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 
 
-#define FF_USE_LABEL	0
+#define FF_USE_LABEL	CONFIG_FATFS_USE_LABEL
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 


### PR DESCRIPTION
By creating this option I can configure the FATFS_USE_LABEL option using my project's sdkconfig file (instead of having to edit ffconf.h)