### PR TITLE
Make RS485 mode switching functions consistent across all chips (IDFGH-11432)

### DIFF
--- a/components/hal/esp32c2/include/hal/uart_ll.h
+++ b/components/hal/esp32c2/include/hal/uart_ll.h
@@ -717,8 +717,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_app_ctrl(uart_dev_t *hw)
     hw->conf0.irda_en = 0;
     hw->conf0.sw_rts = 0;
     hw->conf0.irda_en = 0;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->rs485_conf.en = 1;
 }
 
@@ -735,12 +733,9 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
     hw->conf0.sw_rts = 1;
     // Half duplex mode
     hw->rs485_conf.tx_rx_en = 0;
-    // Setting this bit will allow data to be transmitted while receiving data(full-duplex mode).
-    // But note that this full-duplex mode has no conflict detection function
-    hw->rs485_conf.rx_busy_tx_en = 0;
+    // This is to void collision
+    hw->rs485_conf.rx_busy_tx_en = 1;
     hw->conf0.irda_en = 0;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->rs485_conf.en = 1;
 }
 
@@ -758,8 +753,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_collision_detect(uart_dev_t *hw)
     hw->rs485_conf.tx_rx_en = 1;
     // Transmitter should send data when the receiver is busy,
     hw->rs485_conf.rx_busy_tx_en = 1;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->conf0.sw_rts = 0;
     hw->rs485_conf.en = 1;
 }

--- a/components/hal/esp32c3/include/hal/uart_ll.h
+++ b/components/hal/esp32c3/include/hal/uart_ll.h
@@ -715,8 +715,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_app_ctrl(uart_dev_t *hw)
     hw->conf0.irda_en = 0;
     hw->conf0.sw_rts = 0;
     hw->conf0.irda_en = 0;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->rs485_conf.en = 1;
 }
 
@@ -731,14 +729,11 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
 {
     // Enable receiver, sw_rts = 1  generates low level on RTS pin
     hw->conf0.sw_rts = 1;
-    // Half duplex mode
+    // Must be set to 0 to automatically remove echo
     hw->rs485_conf.tx_rx_en = 0;
-    // Setting this bit will allow data to be transmitted while receiving data(full-duplex mode).
-    // But note that this full-duplex mode has no conflict detection function
-    hw->rs485_conf.rx_busy_tx_en = 0;
+    // This is to void collision
+    hw->rs485_conf.rx_busy_tx_en = 1;
     hw->conf0.irda_en = 0;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->rs485_conf.en = 1;
 }
 
@@ -756,8 +751,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_collision_detect(uart_dev_t *hw)
     hw->rs485_conf.tx_rx_en = 1;
     // Transmitter should send data when the receiver is busy,
     hw->rs485_conf.rx_busy_tx_en = 1;
-    hw->rs485_conf.dl0_en = 1;
-    hw->rs485_conf.dl1_en = 1;
     hw->conf0.sw_rts = 0;
     hw->rs485_conf.en = 1;
 }

--- a/components/hal/esp32c6/include/hal/uart_ll.h
+++ b/components/hal/esp32c6/include/hal/uart_ll.h
@@ -921,8 +921,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_app_ctrl(uart_dev_t *hw)
     hw->conf0_sync.irda_en = 0;
     hw->conf0_sync.sw_rts = 0;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -944,12 +942,9 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
     hw->conf0_sync.sw_rts = 1;
     // Half duplex mode
     hw->rs485_conf_sync.rs485tx_rx_en = 0;
-    // Setting this bit will allow data to be transmitted while receiving data(full-duplex mode).
-    // But note that this full-duplex mode has no conflict detection function
-    hw->rs485_conf_sync.rs485rxby_tx_en = 0;
+    // This is to void collision
+    hw->rs485_conf_sync.rs485rxby_tx_en = 1;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -972,8 +967,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_collision_detect(uart_dev_t *hw)
     hw->rs485_conf_sync.rs485tx_rx_en = 1;
     // Transmitter should send data when the receiver is busy,
     hw->rs485_conf_sync.rs485rxby_tx_en = 1;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->conf0_sync.sw_rts = 0;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);

--- a/components/hal/esp32h2/include/hal/uart_ll.h
+++ b/components/hal/esp32h2/include/hal/uart_ll.h
@@ -760,8 +760,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_app_ctrl(uart_dev_t *hw)
     hw->conf0_sync.irda_en = 0;
     hw->conf0_sync.sw_rts = 0;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -779,12 +777,9 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
     hw->conf0_sync.sw_rts = 1;
     // Half duplex mode
     hw->rs485_conf_sync.rs485tx_rx_en = 0;
-    // Setting this bit will allow data to be transmitted while receiving data(full-duplex mode).
-    // But note that this full-duplex mode has no conflict detection function
-    hw->rs485_conf_sync.rs485rxby_tx_en = 0;
+    // This is to void collision
+    hw->rs485_conf_sync.rs485rxby_tx_en = 1;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -803,8 +798,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_collision_detect(uart_dev_t *hw)
     hw->rs485_conf_sync.rs485tx_rx_en = 1;
     // Transmitter should send data when the receiver is busy,
     hw->rs485_conf_sync.rs485rxby_tx_en = 1;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->conf0_sync.sw_rts = 0;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);

--- a/components/hal/esp32p4/include/hal/uart_ll.h
+++ b/components/hal/esp32p4/include/hal/uart_ll.h
@@ -1040,8 +1040,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_app_ctrl(uart_dev_t *hw)
     hw->conf0_sync.irda_en = 0;
     hw->conf0_sync.sw_rts = 0;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -1063,12 +1061,9 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
     hw->conf0_sync.sw_rts = 1;
     // Half duplex mode
     hw->rs485_conf_sync.rs485tx_rx_en = 0;
-    // Setting this bit will allow data to be transmitted while receiving data(full-duplex mode).
-    // But note that this full-duplex mode has no conflict detection function
-    hw->rs485_conf_sync.rs485rxby_tx_en = 0;
+	// This is to void collision
+    hw->rs485_conf_sync.rs485rxby_tx_en = 1;
     hw->conf0_sync.irda_en = 0;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);
 }
@@ -1091,8 +1086,6 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_collision_detect(uart_dev_t *hw)
     hw->rs485_conf_sync.rs485tx_rx_en = 1;
     // Transmitter should send data when the receiver is busy,
     hw->rs485_conf_sync.rs485rxby_tx_en = 1;
-    hw->rs485_conf_sync.dl0_en = 1;
-    hw->rs485_conf_sync.dl1_en = 1;
     hw->conf0_sync.sw_rts = 0;
     hw->rs485_conf_sync.rs485_en = 1;
     uart_ll_update(hw);


### PR DESCRIPTION
This PR addresses the issue when due to enabled `dl0_en` and `dl1_en` bits, the UART driver is unable to receive data properly when the remote side transmits right after reception without delay. This issue affects the ESP32-C2, ESP32-C3, ESP32-C6, ESP32-H2 and ESP32-P4.

Fixes https://github.com/espressif/esp-idf/issues/12568