### PR TITLE
fix(bt): Fixes #12616

### DIFF
--- a/components/bt/host/bluedroid/stack/btm/btm_ble.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_ble.c
@@ -2280,15 +2280,15 @@ UINT8 btm_proc_smp_cback(tSMP_EVT event, BD_ADDR bd_addr, tSMP_EVT_DATA *p_data)
 
         }
     } else {
-        if (event == SMP_SC_LOC_OOB_DATA_UP_EVT) {
-            tBTM_LE_EVT_DATA evt_data;
-            memcpy(&evt_data.local_oob_data, &p_data->loc_oob_data, sizeof(tSMP_LOC_OOB_DATA));
-            if (btm_cb.api.p_le_callback) {
-                (*btm_cb.api.p_le_callback)(event, bd_addr, &evt_data);
-            }
-        } else {
-            BTM_TRACE_ERROR("btm_proc_smp_cback received for unknown device");
+    }
+    if (event == SMP_SC_LOC_OOB_DATA_UP_EVT) {
+        tBTM_LE_EVT_DATA evt_data;
+        memcpy(&evt_data.local_oob_data, &p_data->loc_oob_data, sizeof(tSMP_LOC_OOB_DATA));
+        if (btm_cb.api.p_le_callback) {
+            (*btm_cb.api.p_le_callback)(event, bd_addr, &evt_data);
         }
+    } else {
+        BTM_TRACE_ERROR("btm_proc_smp_cback received for unknown device");
     }
     return 0;
 }


### PR DESCRIPTION
* Ensures SM_SC_LOC_OOB_DATA_UP_EVT is processed regardless of device pointer - fixing OOB data creation issue on ESP32/PICO


Closes #12616 