### PR TITLE
Fix Dockerfile to create Images with no git safe directory restrictions

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -38,6 +38,9 @@ RUN : \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
   && :
 
+# Configure git to allow access to all git repositories in the Filesystem
+RUN git config --global --add safe.directory '*'
+
 # To build the image for a branch or a tag of IDF, pass --build-arg IDF_CLONE_BRANCH_OR_TAG=name.
 # To build the image with a specific commit ID of IDF, pass --build-arg IDF_CHECKOUT_REF=commit-id.
 # It is possibe to combine both, e.g.:


### PR DESCRIPTION
## Problem
If a folder which is a repository is mounted on the docker container and then a child folder is build, the docker container is not able to see the git repo in the parent folder.

## Fix
Just set every folder as safe for git, as this implies no security risk in a docker container, solving the issue to not be able to access certain git repositories.
