### PR TITLE
Fix Dockerfile to create Images with no git safe directory restrictions [v5.1 backport] (IDFGH-11514)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -34,6 +34,9 @@ RUN : \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
   && :
 
+# Configure git to allow access to all git repositories in the Filesystem
+RUN git config --global --add safe.directory '*'
+
 # To build the image for a branch or a tag of IDF, pass --build-arg IDF_CLONE_BRANCH_OR_TAG=name.
 # To build the image with a specific commit ID of IDF, pass --build-arg IDF_CHECKOUT_REF=commit-id.
 # It is possibe to combine both, e.g.:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN : \
   && :
 
 # Configure git to allow access to all git repositories in the Filesystem
-RUN git config --global --add safe.directory '*'
+RUN git config --system --add safe.directory '*'
 
 # To build the image for a branch or a tag of IDF, pass --build-arg IDF_CLONE_BRANCH_OR_TAG=name.
 # To build the image with a specific commit ID of IDF, pass --build-arg IDF_CHECKOUT_REF=commit-id.


### PR DESCRIPTION
## Problem
If a folder is mounted to the docker container that is not owned by the running user, git disallows the direct access without explicit set of a safe directory. This can happen for example if using wsl on Windows while using a repository on the Windows Filesystem.

## Fix
Just set every folder as safe for git, as this implies no security risk in a docker container, solving the issue to not be able to access certain git repositories.

## Reference
The github action for ESP-IDF Builds solved this by adding the command before running the actual action command (See espressif/esp-idf-ci-action#27)

## Info
This is a backport of #12636 