### PR TITLE
Fix phy_bbpll_en_usb compile error for ESP32-S2 (IDFGH-11554)

### DIFF
--- a/components/esp_phy/include/esp_private/phy.h
+++ b/components/esp_phy/include/esp_private/phy.h
@@ -114,9 +114,9 @@ uint8_t phy_dig_reg_backup(bool backup_en, uint32_t *mem_addr);
 void phy_freq_mem_backup(bool backup_en, uint32_t *mem);
 #endif
 
-#if CONFIG_ESP_PHY_ENABLE_USB
+#if CONFIG_ESP_PHY_ENABLE_USB && (CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3)
 /**
- * @brief Enable or disable USB when phy init.
+ * @brief Work-around for phy init on ESP32S3 and ESP32C3
  */
 void phy_bbpll_en_usb(bool en);
 #endif

--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -816,7 +816,8 @@ void esp_phy_load_cal_and_init(void)
     }
 #endif
 
-#if CONFIG_ESP_PHY_ENABLE_USB
+// Work-around only defined for ESP32-C3 and ESP32-S3
+#if CONFIG_ESP_PHY_ENABLE_USB && (CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3)
     phy_bbpll_en_usb(true);
 #endif
 


### PR DESCRIPTION
Closes https://github.com/espressif/esp-idf/issues/12185

Tested in VSCodium:
```
Version: 1.84.2
Release: 23314
```

Verified: compilation with esp32s2 target before commit fails with expected error and succeeds with this commit.

Verified: affected blocks still effective when target is esp32s3 or esp32c3