### PR TITLE
Fixing gdbinit file generation for windows (IDFGH-11562)

### DIFF
--- a/tools/idf_py_actions/debug_ext.py
+++ b/tools/idf_py_actions/debug_ext.py
@@ -308,7 +308,7 @@ def action_extensions(base_actions: Dict, project_path: str) -> Dict:
             raise FatalError('ELF file not found. You need to build & flash the project before running debug targets')
 
         # Recreate empty 'gdbinit' directory
-        gdbinit_dir = os.path.join(project_desc['build_dir'], 'gdbinit')
+        gdbinit_dir = '/'.join([project_desc['build_dir'], 'gdbinit'])
         if os.path.isfile(gdbinit_dir):
             os.remove(gdbinit_dir)
         elif os.path.isdir(gdbinit_dir):
@@ -316,7 +316,7 @@ def action_extensions(base_actions: Dict, project_path: str) -> Dict:
         os.mkdir(gdbinit_dir)
 
         # Prepare gdbinit for Python GDB extensions import
-        py_extensions = os.path.join(gdbinit_dir, 'py_extensions')
+        py_extensions = '/'.join([gdbinit_dir, 'py_extensions'])
         with open(py_extensions, 'w') as f:
             if is_gdb_with_python(gdb):
                 f.write(GDBINIT_PYTHON_TEMPLATE.format(sys_path=sys.path))
@@ -324,7 +324,7 @@ def action_extensions(base_actions: Dict, project_path: str) -> Dict:
                 f.write(GDBINIT_PYTHON_NOT_SUPPORTED)
 
         # Prepare gdbinit for related ELFs symbols load
-        symbols = os.path.join(gdbinit_dir, 'symbols')
+        symbols = '/'.join([gdbinit_dir, 'symbols'])
         with open(symbols, 'w') as f:
             boot_elf = get_normalized_path(project_desc['bootloader_elf']) if 'bootloader_elf' in project_desc else None
             if boot_elf and os.path.exists(boot_elf):
@@ -336,7 +336,7 @@ def action_extensions(base_actions: Dict, project_path: str) -> Dict:
 
         # Generate the gdbinit for target connect if no custom gdbinit is present
         if not gdbinit:
-            gdbinit = os.path.join(gdbinit_dir, 'connect')
+            gdbinit = '/'.join([gdbinit_dir, 'connect'])
             with open(gdbinit, 'w') as f:
                 f.write(GDBINIT_CONNECT)
 


### PR DESCRIPTION
Running gdb on windows fails using the following steps:

```pwsh
# launch openocd server (the project is already build & flash)
# 1 & 2 mean different terminal prompts
1> $Env:ESPPORT = "COM3"
1> idf.py -C C:\myproject\ -B $Env:TMP/myproject `
         openocd --openocd-commands "-f interface/ftdi/olimex-arm-usb-ocd-h.cfg -f target/esp32.cfg -c 'adapter speed 5000'"
2> idf.py -B $Env:TMP/myproject gdb -C C:\myproject
```
gdb fails with the following message:

```bash
C:\ProgramData\Espressif\frameworks\esp-idf-v5.1\tools\check_python_dependencies.py:12: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
Executing action: gdb
GNU gdb (esp-gdb) 12.1_20221002
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-w64-mingw32 --target=xtensa-esp-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
add symbol table from file "C:\Users\migue\AppData\Local\Temp\mqtt\bootloader\bootloader.elf"
C:/Users/me/AppData/Local/Temp/myproject\gdbinit\gdbinit:3: Error in sourced command file:
C:/Users/me/AppData/Local/Temp/myproject\gdbinit\symbols:6: Error in sourced command file:
Undefined command: "".  Try "help".
(gdb)
```
By reviewing the framework generated files two issues were identified:
+ Fixing newline characters of the symbol file. The problem is in the method
```python
    def generate_gdbinit_rom_add_symbols(target: str) -> str:
````
  which generates an array of strings `r` which joins using:
```python
            return os.linesep.join(r)
```
  this is wrong  it should use:
```python
            return '\n'.join(r)
```
+ gdbinit path separators must be fixed because gdb cannot understand win32 backslash.
```python
        gdbinit_dir = '/'.join([project_desc['build_dir'], 'gdbinit'])
        py_extensions = '/'.join([gdbinit_dir, 'py_extensions'])
        symbols = '/'.join([gdbinit_dir, 'symbols'])
        gdbinit = '/'.join([gdbinit_dir, 'connect'])
```
Then the original:
```bash
    source C:/Users/me/AppData/Local/Temp/myproject\gdbinit\py_extensions
    source C:/Users/me/AppData/Local/Temp/myproject\gdbinit\symbols
    source C:/Users/me/AppData/Local/Temp/myprojectgdbinit\connect
```
will turn into:
```bash
    source C:/Users/me/AppData/Local/Temp/myproject/gdbinit/py_extensions
    source C:/Users/me/AppData/Local/Temp/myproject/gdbinit/symbols
    source C:/Users/me/AppData/Local/Temp/myproject/gdbinit/connect
```
