### PR TITLE
W5500: Add possibility to drive without IRQ line (IDFGH-11571)

### DIFF
--- a/components/esp_eth/Kconfig
+++ b/components/esp_eth/Kconfig
@@ -144,6 +144,14 @@ menu "Ethernet"
                 making it compatible with the software TCP/IP stack.
                 Say yes to enable W5500 driver.
 
+        if ETH_SPI_ETHERNET_W5500
+            config ETH_SPI_ETHERNET_W5500_POLLING
+                bool "Use W5500 in polling mode (without interrupt)"
+                help
+                    Running W5500 in polling mode is not ideal, but it allows this driver to be used on
+                    hardware where the interrupt line of the W5500 chip is not connected.
+        endif # ETH_SPI_ETHERNET_W5500
+
         config ETH_SPI_ETHERNET_KSZ8851SNL
             bool "Use KSZ8851SNL"
             help


### PR DESCRIPTION
For some available hardware where the the interrupt line of the W5500 is not connected to a GPIO it is necessary to use polling. While I think this is bad hardware design, this change makes it possible to use the driver in such situations by selecting CONFIG_ETH_SPI_ETHERNET_W5500_POLLING