### PR TITLE
Fix: Remove a sign-compare build warning (IDFGH-11602)

### DIFF
--- a/components/soc/include/soc/soc_memory_types.h
+++ b/components/soc/include/soc/soc_memory_types.h
@@ -127,7 +127,7 @@ inline static bool IRAM_ATTR esp_ptr_in_iram(const void *p) {
 }
 
 inline static bool IRAM_ATTR esp_ptr_in_drom(const void *p) {
-    uint32_t drom_start_addr = SOC_DROM_LOW;
+    int32_t drom_start_addr = SOC_DROM_LOW;
 #if CONFIG_ESP32S3_DATA_CACHE_16KB
     /* For ESP32-S3, when the DCACHE size is set to 16 kB, the unused 48 kB is
      * added to the heap in 2 blocks of 32 kB (from 0x3FCF0000) and 16 kB


### PR DESCRIPTION
Otherwise the compare in the return line of the function causes the following warning: `comparison of integer expressions of different signedness: 'int' and 'uint32_t' {aka 'unsigned int'}`

or even a build fail if Werror=sign-compare is configured. This behavior was introduced by https://github.com/espressif/esp-idf/commit/a2580b3f361a6531e3d4cc2ea89ccb1e3c9945ff and the tags 4.4.5 and 4.4.6 are affected.

Changing the uint32_t to int32_t matches the code from IDF 5.x (without any judgement if addresses should be signed or unsigned): https://github.com/espressif/esp-idf/blob/master/components/esp_hw_support/include/esp_memory_utils.h#L305C5-L305C12