### PR TITLE
fix the initialize error of dpp example (IDFGH-11656)

### DIFF
--- a/examples/wifi/wifi_easy_connect/dpp-enrollee/main/dpp_enrollee_main.c
+++ b/examples/wifi/wifi_easy_connect/dpp-enrollee/main/dpp_enrollee_main.c
@@ -155,9 +155,9 @@ void dpp_enrollee_init(void)
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_supp_dpp_init(dpp_enrollee_event_cb));
     ESP_ERROR_CHECK(dpp_enrollee_bootstrap());
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_start());
 
     /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum


### PR DESCRIPTION
fix dpp init error, set wifi mode before call esp_supp_dpp_init