### PR TITLE
Fix for issue #12779 (IDFGH-11667)

### DIFF
--- a/tools/idf_py_actions/tools.py
+++ b/tools/idf_py_actions/tools.py
@@ -626,7 +626,7 @@ def ensure_build_directory(args: 'PropertyDict', prog_name: str, always_run_cmak
 
     try:
         python = cache['PYTHON']
-        if python != sys.executable:
+        if os.path.normcase(python) != os.path.normcase(sys.executable):
             raise FatalError(
                 "'{}' is currently active in the environment while the project was configured with '{}'. "
                 "Run '{} fullclean' to start again.".format(sys.executable, python, prog_name))


### PR DESCRIPTION
fix(esp32): This should fix python path issue on Windows
This fixes idf.py error

c:\work\esp32\.espressif\python_env\idf5.3_py3.11_env\Scripts\python.exe' is currently active in the environment while the project was configured with 'C:\work\esp32\.espressif\python_env\idf5.3_py3.11_env\Scripts\python.exe'. Run 'idf.py fullclean' to start again

on Windows
