### PR TITLE
Provide ulp_adc_deinit() API to fix ADC1 handle leakage (IDFGH-11673)

### DIFF
--- a/components/ulp/ulp_common/include/ulp_adc.h
+++ b/components/ulp/ulp_common/include/ulp_adc.h
@@ -29,6 +29,13 @@ typedef struct {
  */
 esp_err_t ulp_adc_init(const ulp_adc_cfg_t *cfg);
 
+/**
+ * @brief Deinitialize ADC after use with ULP, allowing it to be reclaimed
+ *
+ * @return esp_err_t    ESP_OK for successful.
+*/
+esp_err_t ulp_adc_deinit();
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/ulp/ulp_common/ulp_adc.c
+++ b/components/ulp/ulp_common/ulp_adc.c
@@ -15,17 +15,16 @@
 #include "esp_private/adc_share_hw_ctrl.h"
 
 static const char *TAG = "ulp_adc";
+static adc_oneshot_unit_handle_t s_adc1_handle = NULL;
 
 esp_err_t ulp_adc_init(const ulp_adc_cfg_t *cfg)
 {
     esp_err_t ret = ESP_OK;
 
-    ESP_GOTO_ON_FALSE(cfg, ESP_ERR_INVALID_ARG, err, TAG, "cfg == NULL");
-    ESP_GOTO_ON_FALSE(cfg->adc_n == ADC_UNIT_1, ESP_ERR_INVALID_ARG, err, TAG, "Only ADC_UNIT_1 is supported for now");
+    ESP_RETURN_ON_FALSE(cfg, ESP_ERR_INVALID_ARG, TAG, "cfg == NULL");
+    ESP_RETURN_ON_FALSE(cfg->adc_n == ADC_UNIT_1, ESP_ERR_INVALID_ARG, TAG, "Only ADC_UNIT_1 is supported for now");
 
     //-------------ADC1 Init---------------//
-    adc_oneshot_unit_handle_t adc1_handle;
-
     adc_oneshot_unit_init_cfg_t init_config1 = {
         .unit_id = cfg->adc_n,
         .ulp_mode = cfg->ulp_mode,
@@ -37,21 +36,27 @@ esp_err_t ulp_adc_init(const ulp_adc_cfg_t *cfg)
         init_config1.ulp_mode = ADC_ULP_MODE_RISCV;
     }
 
-
-    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init_config1, &adc1_handle));
+    ret = adc_oneshot_new_unit(&init_config1, &s_adc1_handle);
+    if (ret != ESP_OK) return ret;
 
     //-------------ADC1 Config---------------//
     adc_oneshot_chan_cfg_t config = {
         .bitwidth = cfg->width,
         .atten = cfg->atten,
     };
-    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_handle, cfg->channel, &config));
+    ret = adc_oneshot_config_channel(s_adc1_handle, cfg->channel, &config);
+    if (ret != ESP_OK) return ret;
 
     //Calibrate the ADC
 #if SOC_ADC_CALIBRATION_V1_SUPPORTED
     adc_set_hw_calibration_code(cfg->adc_n, cfg->atten);
 #endif
 
-err:
     return ret;
+}
+
+esp_err_t ulp_adc_deinit()
+{
+    // No need to check for null-pointer and stuff, oneshot driver already does that
+    return adc_oneshot_del_unit(s_adc1_handle);
 }


### PR DESCRIPTION
Fix for #12766. Also restructured error handling in `ulp_adc_init(...)` so that it returns an error code instead of calling `abort()` from `ESP_ERROR_CHECK(...)`. 
Tested against `ulp_riscv_adc` example (deep sleep case) as well as our own custom app (light sleep case).

P.S. Right now `ulp_adc` driver is remarkably similar to `oneshot` driver itself, it mostly duplicates configuration API, introducing little new functionality. While I think this PR should be merged and backported to v5.1 branch ASAP to enable customers (like us) to use ULP ADC with Light Sleep, it's probably worth integrating ULP-related initialization code into `oneshot` driver itself in future releases. After all, `adc_oneshot_unit_init_cfg_t::ulp_mode` is already there.