### PR TITLE
BLE GATTS and GAP callback getter methods (IDFGH-11703)

### DIFF
--- a/components/bt/host/bluedroid/api/esp_gap_ble_api.c
+++ b/components/bt/host/bluedroid/api/esp_gap_ble_api.c
@@ -22,6 +22,11 @@ esp_err_t esp_ble_gap_register_callback(esp_gap_ble_cb_t callback)
     return (btc_profile_cb_set(BTC_PID_GAP_BLE, callback) == 0 ? ESP_OK : ESP_FAIL);
 }
 
+esp_gap_ble_cb_t esp_ble_gap_get_callback(void)
+{
+    return (esp_gap_ble_cb_t) btc_profile_cb_get(BTC_PID_GAP_BLE);
+}
+
 #if (BLE_42_FEATURE_SUPPORT == TRUE)
 esp_err_t esp_ble_gap_config_adv_data(esp_ble_adv_data_t *adv_data)
 {

--- a/components/bt/host/bluedroid/api/esp_gatts_api.c
+++ b/components/bt/host/bluedroid/api/esp_gatts_api.c
@@ -29,6 +29,11 @@ esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback)
     return (btc_profile_cb_set(BTC_PID_GATTS, callback) == 0 ? ESP_OK : ESP_FAIL);
 }
 
+esp_gatts_cb_t esp_ble_gatts_get_callback(void)
+{
+    return (esp_gatts_cb_t) btc_profile_cb_get(BTC_PID_GATTS);
+}
+
 esp_err_t esp_ble_gatts_app_register(uint16_t app_id)
 {
     btc_msg_t msg = {0};

--- a/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
@@ -1315,6 +1315,15 @@ typedef void (* esp_gap_ble_cb_t)(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_p
  */
 esp_err_t esp_ble_gap_register_callback(esp_gap_ble_cb_t callback);
 
+/**
+ * @brief           This function is called to get the current gap callback
+ *
+ * @return
+ *                  - esp_gap_ble_cb_t : callback function
+ *
+ */
+esp_gap_ble_cb_t esp_ble_gap_get_callback(void);
+
 #if (BLE_42_FEATURE_SUPPORT == TRUE)
 /**
  * @brief           This function is called to override the BTA default ADV parameters.

--- a/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
@@ -304,6 +304,16 @@ typedef void (* esp_gatts_cb_t)(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
 esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback);
 
 /**
+ * @brief           This function is called to get the current application callbacks
+ *                  with BTA GATTS module.
+ *
+ * @return
+ *                  - esp_gatts_cb_t : current callback
+ *
+ */
+esp_gatts_cb_t esp_ble_gatts_get_callback(void);
+
+/**
  * @brief           This function is called to register application identifier
  *
  * @return


### PR DESCRIPTION
Allows user methods to access the BLE GATTS and GAP callbacks, if set. This allows multiple callback to be used, for instance, when there are multiple services and profiles.