### PR TITLE
improve: add ethernet deinit to example (IDFGH-11704)

### DIFF
--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -21,9 +21,7 @@ components/esp_rom/include/esp32s2/rom/rsa_pss.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
 
 ## Header produced non-zero object:
 components/esp_phy/esp32/include/phy_init_data.h
@@ -67,13 +65,9 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
-components/unity/unity/extras/
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/


### PR DESCRIPTION
On the idf 5.1, the Ethernet driver has an internal counter that will be initialized at __esp_eth_driver_install__ and will be incremented at __esp_eth_new_netif_glue__.

To perform a successful ethernet deinit the counter must be cleared and it is done by __esp_eth_del_netif_glue__ which decrements the counter dealing to successful __esp_eth_driver_uninstall__.

This procedure was unclear in the previous code sample.