### PR TITLE
cmake: correct the parameter annotation of idf_build_set_property (IDFGH-11752)

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -23,7 +23,7 @@ endfunction()
 #        also added to the internal list of build properties if it isn't there already.
 #
 # @param[in] property the property to set the value of
-# @param[out] value value of the property
+# @param[in] value value of the property
 #
 # @param[in, optional] APPEND (option) append the value to the current value of the
 #                     property instead of replacing it


### PR DESCRIPTION
The value parameter should be marked as [in] instead of [out], as it is used to set the property value, not to get it.