### PR TITLE
fix(esp32): Removed rogue semicolon in #define in esp_smartconfig.h (IDFGH-11769)

### DIFF
--- a/components/esp_wifi/include/esp_smartconfig.h
+++ b/components/esp_wifi/include/esp_smartconfig.h
@@ -56,7 +56,7 @@ typedef struct {
     .enable_log = false, \
     .esp_touch_v2_enable_crypt = false,\
     .esp_touch_v2_key = NULL \
-};
+}
 
 /**
   * @brief  Get the version of SmartConfig.


### PR DESCRIPTION
Removed rogue semicolon in the `#define` for default Smartconfig config.

This semicolon is not congruent with the Wifi default config.

Mainly, it does not play nice with C++ brace initialisation, for example:

```
struct S
{
    std::unique_ptr<smartconfig_start_config_t> cfg;

    x() : cfg(new smartconfig_start_config_t(SMARTCONFIG_START_CONFIG_DEFAULT()))
    {}
};
```

Produces a compiler error due to the semicolon placed in by the preprocessor text substitution.

However, similar useful code for Wifi works fine since there is no semicolon in the define [here](https://github.com/espressif/esp-idf/blob/341a8f2d65dc36b4e869feadc6cc0a21c96b0378/components/esp_wifi/include/esp_wifi.h#L277), for example:

```
struct S
{
    std::unique_ptr<wifi_init_config_t> cfg;

    x() : cfg(new wifi_init_config_t(WIFI_INIT_CONFIG_DEFAULT()))
    {}
};
```

Is fine.