### PR TITLE
feat: Add support for ESP-IDF versions below 5.2 (IDFGH-11800)

### DIFF
--- a/examples/storage/littlefs/CMakeLists.txt
+++ b/examples/storage/littlefs/CMakeLists.txt
@@ -1,6 +1,17 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+idf_build_get_property(IDF_MAJOR IDF_VERSION_MAJOR)
+idf_build_get_property(IDF_MINOR IDF_VERSION_MINOR)
+idf_build_get_property(IDF_PATCH IDF_VERSION_PATCH)
+set(IDF_RELEASE_VERSION "${IDF_MAJOR}.${IDF_MINOR}.${IDF_PATCH}")
+
+if (IDF_RELEASE_VERSION VERSION_LESS "5.2")
+  # "Add partition sub-type `littlefs` (0x83) for ESP-IDF versions below 5.2"
+  idf_build_set_property(EXTRA_PARTITION_SUBTYPES "data, littlefs, 0x83" APPEND)
+endif ()
+
 project(littlefs_example)

--- a/examples/storage/littlefs/main/idf_component.yml
+++ b/examples/storage/littlefs/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  joltwallet/littlefs: "==1.5.5"
+  joltwallet/littlefs: "==1.12.1"
   ## Required IDF version
   idf:
-    version: ">=5.2.0"
+    version: ">=5.0.0"


### PR DESCRIPTION
In ESP-IDF 5.2, **littlefs** became a valid [sub-type](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#subtype
) for the partition table, with the value of 0x83, and this example uses it. However, before that, this sub-type was not recognized by default. Therefore, I updated the `CMakeLists.txt` file to set it as a custom sub-type for ESP-IDF versions lower than 5.2, in order to make this example compatible with older ESP-IDF versions.