### PR TITLE
docs: Correct coap IPV6 support requirement comments (IDFGH-11821)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -458,7 +458,7 @@ menu "LWIP"
         default y
         help
             Enable IPv6 function. If not use IPv6 function, set this option to n.
-            If disabling LWIP_IPV6 then some other components (coap and asio) will
+            If disabling LWIP_IPV6 then some other components (asio) will
             no longer be available.
 
     config LWIP_IPV6_AUTOCONFIG

--- a/docs/en/api-guides/performance/size.rst
+++ b/docs/en/api-guides/performance/size.rst
@@ -441,7 +441,7 @@ lwIP IPv6
 
   .. note::
 
-      IPv6 is required by some components such as ``coap`` and :doc:`/api-reference/protocols/asio`. These components will not be available if IPV6 is disabled.
+      IPv6 is required by some components such as :doc:`/api-reference/protocols/asio`. These components will not be available if IPV6 is disabled.
 
 lwIP IPv4
 @@@@@@@@@


### PR DESCRIPTION
coap (libcoap) can now be built with or without IPV6.