### PR TITLE
feat(esp_netfi): Add DHCPS option for captive portal identification (IDFGH-11885)

### DIFF
--- a/components/esp_netif/include/esp_netif_types.h
+++ b/components/esp_netif/include/esp_netif_types.h
@@ -37,7 +37,7 @@ extern "C" {
 
 
 /**
- * @brief Definition of ESP-NETIF bridge controll
+ * @brief Definition of ESP-NETIF bridge control
  */
 #define ESP_NETIF_BR_FLOOD      -1
 #define ESP_NETIF_BR_DROP        0
@@ -89,6 +89,7 @@ typedef enum{
     ESP_NETIF_IP_REQUEST_RETRY_TIME         = 52,   /**< Request IP address retry counter */
     ESP_NETIF_VENDOR_CLASS_IDENTIFIER       = 60,   /**< Vendor Class Identifier of a DHCP client */
     ESP_NETIF_VENDOR_SPECIFIC_INFO          = 43,   /**< Vendor Specific Information of a DHCP server */
+    ESP_NETIF_CAPTIVEPORTAL_URI             = 114,  /**< Captive Portal Identification */
 } esp_netif_dhcp_option_id_t;
 
 /** IP event declarations */
@@ -127,7 +128,7 @@ typedef struct {
  */
 typedef struct {
     esp_netif_t *esp_netif;          /*!< Pointer to corresponding esp-netif object */
-    esp_netif_ip_info_t ip_info;     /*!< IP address, netmask, gatway IP address */
+    esp_netif_ip_info_t ip_info;     /*!< IP address, netmask, gateway IP address */
     bool ip_changed;                 /*!< Whether the assigned IP has changed or not */
 } ip_event_got_ip_t;
 

--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -2334,6 +2334,10 @@ esp_err_t esp_netif_dhcps_option_api(esp_netif_api_msg_t *msg)
                 }
                 break;
             }
+            case ESP_NETIF_CAPTIVEPORTAL_URI: {
+                opt_info = (char *)opt->val;
+                break;
+            }
 
             default:
                 break;

--- a/components/lwip/include/apps/dhcpserver/dhcpserver_options.h
+++ b/components/lwip/include/apps/dhcpserver/dhcpserver_options.h
@@ -1,16 +1,8 @@
-// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2017-2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #pragma once
 
 #ifdef __cplusplus
@@ -129,6 +121,7 @@ typedef enum
     CLIENT_LAST_TRANSACTION_TIME = 91,
     ASSOCIATED_IP = 92,
     USER_AUTHENTICATION_PROTOCOL = 98,
+    CAPTIVEPORTAL_URI = 114,
     AUTO_CONFIGURE = 116,
     NAME_SERVICE_SEARCH = 117,
     SUBNET_SELECTION = 118,

--- a/examples/protocols/http_server/captive_portal/README.md
+++ b/examples/protocols/http_server/captive_portal/README.md
@@ -5,7 +5,11 @@
 
 (See the README.md file in the upper level 'examples' directory for more information about examples.)
 
-This example demonstrates a simple captive portal that will redirect all DNS IP questions to point to the softAP and redirect all HTTP requests to the captive portal root page. Triggers captive portal (sign in) pop up on Android, iOS and Windows. Note that the example will not redirect HTTPS requests.
+This example demonstrates two methods of a captive portal, used to direct users to an authentication page or other necessary starting point before browsing.
+
+One approach response to all DNS queries with the address of the softAP, and redirects all HTTP requests to the captive portal root page. This "funnelling" of DNS and traffic triggers the captive portal (sign in) to appear on Android, iOS, and Windows. Note that the example will not redirect HTTPS requests.
+
+The other approach is a more modern method which includes a field in the DHCP offer (AKA DHCP Option 114), provided when the client is assigned an IP address, which specifies to the client where the captive portal is. This is advantageous because it doesn't require the overhead of DNS redirects and can work more reliably around HTTPS, HTST, and other security systems, as well as being more standards compliant. This feature is toggleable in the `Example Configuration`, but does not conflict with the DNS methodology -- these two methods work towards the same goal and can complement each other.
 
 ## How to Use Example
 
@@ -27,6 +31,7 @@ In the `Example Configuration` menu:
     * Set `SoftAP SSID`
     * Set `SoftAP Password`
     * Set `Maximal STA connections`
+    * Set `DHCP Captive portal` to enable or disable DHCP Option 114
 
 ### Build and Flash
 
@@ -41,6 +46,9 @@ idf.py -p PORT flash monitor
 See the Getting Started Guide for full steps to configure and use ESP-IDF to build projects.
 
 ## Example Output
+
+
+### ESP32 Output for DNS Redirect
 
 ```
 I (733) example: Set up softAP with IP: 192.168.4.1
@@ -94,4 +102,28 @@ I (23453) example_dns_redirect_server: Waiting for data
 I (23473) example: Serve root
 I (23503) example_dns_redirect_server: Received 48 bytes from 192.168.4.2 | DNS reply with len: 64
 I (23513) example_dns_redirect_server: Waiting for data
+```
+
+### `tcpdump` Output for DHCP Option 114
+
+Note `URL (114)` with the AP address.
+
+```
+19:14:20.522698 c8:yy:yy:yy:yy:yy > 74:xx:xx:xx:xx:xx, ethertype IPv4 (0x0800), length 590: (tos 0x0, ttl 64, id 243, offset 0, flags [none], proto UDP (17), length 576)
+    192.168.4.1.67 > 192.168.4.2.68: [udp sum ok] BOOTP/DHCP, Reply, length 548, xid 0x76a26648, Flags [none] (0x0000)
+	  Your-IP 192.168.4.2
+	  Client-Ethernet-Address 74:xx:xx:xx:xx:xx
+	  Vendor-rfc1048 Extensions
+	    Magic Cookie 0x63825363
+	    DHCP-Message (53), length 1: Offer
+	    Subnet-Mask (1), length 4: 255.255.255.0
+	    Lease-Time (51), length 4: 7200
+	    Server-ID (54), length 4: 192.168.4.1
+	    Default-Gateway (3), length 4: 192.168.4.1
+	    Domain-Name-Server (6), length 4: 192.168.4.1
+	    BR (28), length 4: 192.168.4.255
+	    MTU (26), length 2: 1500
+	    URL (114), length 18: "http://192.168.4.1"
+	    Router-Discovery (31), length 1: N
+	    Vendor-Option (43), length 6: 1.4.0.0.0.2
 ```

--- a/examples/protocols/http_server/captive_portal/main/Kconfig.projbuild
+++ b/examples/protocols/http_server/captive_portal/main/Kconfig.projbuild
@@ -17,4 +17,10 @@ menu "Example Configuration"
         default 4
         help
             Max number of the STA connects to AP.
+
+    config ESP_ENABLE_DHCP_CAPTIVEPORTAL
+        bool "DHCP Captive portal"
+        default y
+        help
+            Enables more modern DHCP-based Option 114 to provide clients with the captive portal URI
 endmenu

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -498,7 +498,6 @@ components/hal/spi_slave_hal_iram.c
 components/idf_test/include/idf_performance.h
 components/log/host_test/log_test/main/log_test.cpp
 components/lwip/apps/ping/ping.c
-components/lwip/include/apps/dhcpserver/dhcpserver_options.h
 components/lwip/include/apps/esp_ping.h
 components/lwip/include/apps/ping/ping.h
 components/mbedtls/esp_crt_bundle/test_gen_crt_bundle/test_gen_crt_bundle.py


### PR DESCRIPTION
[RFC 8910](https://www.rfc-editor.org/rfc/rfc8910.html) provides a DHCP option to notify clients of a captive portal to be visited prior to using the network.

This is supported by vendors (see [Apple since iOS 14 and macOS Big Sur](https://developer.apple.com/news/?id=q78sq5rv), [Android since Android 11](https://developer.android.com/about/versions/11/features/captive-portal)), and provides a more standards-compliant mechanism than DNS-based redirection.

This is a simple addition and will be useful in scenarios where the ESP32 broadcasts a network and needs to direct clients to a portal or served content in a modern, standards-compliant way.

This would also address #2723.