### PR TITLE
Fix APB_CLK_FREQ value for C6 (IDFGH-11886)

### DIFF
--- a/components/soc/esp32c6/include/soc/soc.h
+++ b/components/soc/esp32c6/include/soc/soc.h
@@ -139,7 +139,7 @@
 #define  APB_CLK_FREQ_ROM                            ( 40*1000000 )
 #define  CPU_CLK_FREQ_ROM                            APB_CLK_FREQ_ROM
 #define  CPU_CLK_FREQ_MHZ_BTLD                       (80)               // The cpu clock frequency (in MHz) to set at 2nd stage bootloader system clock configuration
-#define  APB_CLK_FREQ                                ( 40*1000000 )
+#define  APB_CLK_FREQ                                ( 80*1000000 )
 #define  MODEM_REQUIRED_MIN_APB_CLK_FREQ             ( 80*1000000 )
 #define  REF_CLK_FREQ                                ( 1000000 )
 #define  XTAL_CLK_FREQ                               (40*1000000)


### PR DESCRIPTION
This PR changes previously wrong value of `APB_CLK_FREQ`.  It solves the issue with RMT LED driver where pulse with where incorrectly calculated using 40 MHz instead of 80 MHz clock base.