### PR TITLE
fix(freertos): fix broken critical section macros (IDFGH-11943)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/portable/riscv/include/freertos/portmacro.h
+++ b/components/freertos/FreeRTOS-Kernel/portable/riscv/include/freertos/portmacro.h
@@ -332,6 +332,8 @@ FORCE_INLINE_ATTR BaseType_t xPortGetCoreID(void)
     } else {                                \
         portENTER_CRITICAL(mux);            \
     }                                       \
+    BaseType_t ret = pdPASS;                \
+    ret;                                    \
 })
 #define portEXIT_CRITICAL_SAFE(mux)     ({  \
     if (xPortInIsrContext()) {              \
@@ -340,7 +342,7 @@ FORCE_INLINE_ATTR BaseType_t xPortGetCoreID(void)
         portEXIT_CRITICAL(mux);             \
     }                                       \
 })
-#define portTRY_ENTER_CRITICAL_SAFE(mux, timeout)   portENTER_CRITICAL_SAFE(mux, timeout)
+#define portTRY_ENTER_CRITICAL_SAFE(mux, timeout)   portENTER_CRITICAL_SAFE(mux)
 
 // ---------------------- Yielding -------------------------
 

--- a/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos/portmacro.h
+++ b/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos/portmacro.h
@@ -464,7 +464,7 @@ FORCE_INLINE_ATTR BaseType_t xPortGetCoreID(void);
 #define portENTER_CRITICAL_ISR(mux)                 vPortEnterCritical(mux)
 #define portEXIT_CRITICAL_ISR(mux)                  vPortExitCritical(mux)
 
-#define portTRY_ENTER_CRITICAL_SAFE(mux, timeout)   xPortEnterCriticalTimeoutSafe(mux)
+#define portTRY_ENTER_CRITICAL_SAFE(mux, timeout)   xPortEnterCriticalTimeoutSafe(mux, timeout)
 #define portENTER_CRITICAL_SAFE(mux)                vPortEnterCriticalSafe(mux)
 #define portEXIT_CRITICAL_SAFE(mux)                 vPortExitCriticalSafe(mux)
 


### PR DESCRIPTION
Fix some rarely used portable macros related to critical section.

1. Add the missing `timeout` parameter to xtensa port of `portTRY_ENTER_CRITICAL_SAFE`.
2. Add the missing return value to RISC-V port of `portEXIT_CRITICAL_SAFE` and remove extra `timeout` parameter.