### PR TITLE
Missing include for rom/uart.h (IDFGH-11947)

### DIFF
--- a/components/esp_rom/include/esp32/rom/uart.h
+++ b/components/esp_rom/include/esp32/rom/uart.h
@@ -10,6 +10,7 @@
 #include "ets_sys.h"
 #include "soc/soc.h"
 #include "soc/uart_periph.h"
+#include "soc/uart_reg.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Without this include it fails to compile with this error:

```
esp/esp-idf-v5.2/components/esp_rom/include/esp32/rom/uart.h:262:32: error: implicit declaration of function 'UART_STATUS_REG' [-Werror=implicit-function-declaration]
  262 |         status = READ_PERI_REG(UART_STATUS_REG(uart_no));
```