### PR TITLE
Handle object files with `.*.o` patterns when running Linker Script Generator (IDFGH-11962)

### DIFF
--- a/tools/ldgen/ldgen/entity.py
+++ b/tools/ldgen/ldgen/entity.py
@@ -181,7 +181,8 @@ class EntityDB:
 
     def _match_obj(self, archive, obj):
         objs = self.get_objects(archive)
-        match_objs = (fnmatch.filter(objs, obj + '.o')
+        match_objs = (fnmatch.filter(objs, obj + '.*.o')
+                      + fnmatch.filter(objs, obj + '.o')
                       + fnmatch.filter(objs, obj + '.*.obj')
                       + fnmatch.filter(objs, obj + '.obj'))
 


### PR DESCRIPTION
Currently, only `.o`, `.*.obj` and `.obj` patterns are taken into account. It would be great to have object files with the `.*.o` extension pattern (e.g. `file.cpp.o`) also processed as they're quite widespread in third-party integrations.