### PR TITLE
Update temp_sensor.rst documentation to match example (IDFGH-12025)

### DIFF
--- a/docs/en/api-reference/peripherals/temp_sensor.rst
+++ b/docs/en/api-reference/peripherals/temp_sensor.rst
@@ -74,11 +74,8 @@ Creating a Temperature Sensor Handle
 .. code:: c
 
     temperature_sensor_handle_t temp_handle = NULL;
-    temperature_sensor_config_t temp_sensor = {
-        .range_min = 20,
-        .range_max = 50,
-    };
-    ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor, &temp_handle));
+    temperature_sensor_config_t temp_sensor_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(20, 50);
+    ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor_config, &temp_handle));
 
 .. _temp-enable-and-disable-temperature-sensor:
 


### PR DESCRIPTION
Update temp_sensor.rst documentation to match example

https://github.com/espressif/esp-idf/blob/a5b261f699808efdacd287adbded5b718dffd14e/examples/peripherals/temperature_sensor/temp_sensor/main/temp_sensor_main.c#L14-L32

When using documentation the ESP will assert on invalid clock selection.