### PR TITLE
fix(esp32s3): Add config value for RTC_XTAL_CAL_RETRY for S3 hardware variant

### DIFF
--- a/components/esp_hw_support/port/esp32s3/Kconfig.rtc
+++ b/components/esp_hw_support/port/esp32s3/Kconfig.rtc
@@ -37,3 +37,13 @@ config RTC_CLK_CAL_CYCLES
         - 32768 Hz if the 32k crystal oscillator is used. For this use value 3000 or more.
             In case more value will help improve the definition of the launch of the crystal.
             If the crystal could not start, it will be switched to internal RC.
+
+config RTC_XTAL_CAL_RETRY
+    int "Number of attempts to repeat 32k XTAL calibration"
+    default 3
+    depends on RTC_CLK_SRC_EXT_CRYS
+    help
+        Number of attempts to repeat 32k XTAL calibration
+        before giving up and switching to the internal RC.
+        Increase this option if the 32k crystal oscillator
+        does not start and switches to internal RC.

--- a/components/esp_system/port/soc/esp32s3/clk.c
+++ b/components/esp_system/port/soc/esp32s3/clk.c
@@ -34,7 +34,11 @@ static const char *TAG = "clk";
  */
 #define SLOW_CLK_CAL_CYCLES     CONFIG_RTC_CLK_CAL_CYCLES
 
+#ifdef CONFIG_RTC_XTAL_CAL_RETRY
+#define RTC_XTAL_CAL_RETRY CONFIG_RTC_XTAL_CAL_RETRY
+#else
 #define RTC_XTAL_CAL_RETRY 1
+#endif
 
 /* Indicates that this 32k oscillator gets input from external oscillator, rather
  * than a crystal.


### PR DESCRIPTION
Adding support for the RTC_XTAL_CAL_RETRY config setting to the ESP32S3.

This config setting is already supported on other chip variants. We have run into an issue recently with some production hardware where an additional retry was needed for the external crystal to be detected during a cold boot. Copying this behaviour from other chip variants has resolved the issue for us.

This change is such that it will not impact existing behaviour for users of the S3 variant, unless they specifically enable the config value