### PR TITLE
[SECURITY] [docs] Add warning about integrity of pre_encrypted_ota (IDFGH-12071)

### DIFF
--- a/examples/system/ota/pre_encrypted_ota/README.md
+++ b/examples/system/ota/pre_encrypted_ota/README.md
@@ -9,6 +9,9 @@ Pre-encrypted firmware binary must be hosted on OTA update server.
 This firmware will be fetched and then decrypted on device before being flashed.
 This allows firmware to remain `confidential` on the OTA update channel irrespective of underlying transport (e.g., non-TLS).
 
+> [!CAUTION]
+> Using the Pre-encrypted Binary OTA provides confidentiality of the firmware, but it does not ensure authenticity of the firmware. For ensuring that the firmware is coming from trusted source, please consider enabling secure boot feature along with the Pre-encrypted binary OTA. Please refer to security guide in the ESP-IDF docs for more details.
+
 ## ESP Encrypted Image Abstraction Layer
 
 This example uses `esp_encrypted_img` component hosted at [idf-extra-components/esp_encrypted_img](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img) and available though the [IDF component manager](https://components.espressif.com/component/espressif/esp_encrypted_img).


### PR DESCRIPTION
Using the Encrypted Binary OTA provides confidentiality of the firmware, but does not provide integrity of the firmware: if an attacker is able to read out the firmware of one device (for example, via a fault-injection attack), they can also construct arbitrary valid encrypted OTA updates, that can then be installed on other devices that share the same private key.

This was not immediately obvious to me when I read what the pre_encrypted_ota functionality does, but became clear when I reviewed the cryptography used.