### PR TITLE
i2c_master handle NACK (IDFGH-12083)

### DIFF
--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -974,7 +974,7 @@ esp_err_t i2c_master_transmit(i2c_master_dev_handle_t i2c_dev, const uint8_t *wr
 
     i2c_operation_t i2c_ops[] = {
         {.hw_cmd = I2C_TRANS_START_COMMAND},
-        {.hw_cmd = I2C_TRANS_WRITE_COMMAND(false), .data = (uint8_t *)write_buffer, .total_bytes = write_size},
+        {.hw_cmd = I2C_TRANS_WRITE_COMMAND, .data = (uint8_t *)write_buffer, .total_bytes = write_size},
         {.hw_cmd = I2C_TRANS_STOP_COMMAND},
     };
 
@@ -994,7 +994,7 @@ esp_err_t i2c_master_transmit_receive(i2c_master_dev_handle_t i2c_dev, const uin
 
     i2c_operation_t i2c_ops[] = {
         {.hw_cmd = I2C_TRANS_START_COMMAND},
-        {.hw_cmd = I2C_TRANS_WRITE_COMMAND(false), .data = (uint8_t *)write_buffer, .total_bytes = write_size},
+        {.hw_cmd = I2C_TRANS_WRITE_COMMAND, .data = (uint8_t *)write_buffer, .total_bytes = write_size},
         {.hw_cmd = I2C_TRANS_START_COMMAND},
         {.hw_cmd = I2C_TRANS_READ_COMMAND(ACK_VAL), .data = read_buffer, .total_bytes = read_size - 1},
         {.hw_cmd = I2C_TRANS_READ_COMMAND(NACK_VAL), .data = (read_buffer + read_size - 1), .total_bytes = 1},

--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -776,6 +776,7 @@ static esp_err_t s_i2c_asynchronous_transaction(i2c_master_dev_handle_t i2c_dev,
 
 static esp_err_t s_i2c_synchronous_transaction(i2c_master_dev_handle_t i2c_dev, i2c_operation_t *i2c_ops, size_t ops_dim, int timeout_ms)
 {
+    esp_err_t ret = ESP_OK;
     i2c_dev->master_bus->trans_done = false;
     TickType_t ticks_to_wait = (timeout_ms == -1) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
     if (xSemaphoreTake(i2c_dev->master_bus->bus_lock_mux, ticks_to_wait) != pdTRUE) {
@@ -792,9 +793,14 @@ static esp_err_t s_i2c_synchronous_transaction(i2c_master_dev_handle_t i2c_dev, 
     i2c_dev->master_bus->sent_all = false;
     i2c_dev->master_bus->trans_finish = false;
     i2c_dev->master_bus->queue_trans = false;
-    ESP_RETURN_ON_ERROR(s_i2c_transaction_start(i2c_dev, timeout_ms), TAG, "I2C transaction failed");
+
+    ESP_GOTO_ON_ERROR(s_i2c_transaction_start(i2c_dev, timeout_ms), err, TAG, "I2C transaction failed");
     xSemaphoreGive(i2c_dev->master_bus->bus_lock_mux);
     return ESP_OK;
+
+err:
+    xSemaphoreGive(i2c_dev->master_bus->bus_lock_mux);
+    return ret;
 }
 
 esp_err_t i2c_new_master_bus(const i2c_master_bus_config_t *bus_config, i2c_master_bus_handle_t *ret_bus_handle)

--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -325,7 +325,7 @@ static void s_i2c_start_end_command(i2c_master_bus_handle_t i2c_master, i2c_oper
 #if SOC_I2C_SUPPORT_10BIT_ADDR
             if (i2c_master->addr_10bits_bus == I2C_ADDR_BIT_LEN_10) {
                 i2c_ll_hw_cmd_t hw_write_cmd = {
-                    .ack_en = false,
+                    .ack_en = true,
                     .op_code = I2C_LL_CMD_WRITE,
                     .byte_num = 2,
                 };
@@ -345,7 +345,7 @@ static void s_i2c_start_end_command(i2c_master_bus_handle_t i2c_master, i2c_oper
             }
 #endif
             i2c_ll_hw_cmd_t hw_write_cmd = {
-                .ack_en = false,
+                .ack_en = true,
                 .op_code = I2C_LL_CMD_WRITE,
                 .byte_num = 1,
             };

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -58,7 +58,7 @@ extern "C" {
 #define NACK_VAL 1
 
 #define I2C_TRANS_READ_COMMAND(ack_value)    {.ack_val = (ack_value), .op_code = I2C_LL_CMD_READ}
-#define I2C_TRANS_WRITE_COMMAND(ack_check)   {.ack_en = (ack_check), .op_code = I2C_LL_CMD_WRITE}
+#define I2C_TRANS_WRITE_COMMAND              {.ack_en = true, .op_code = I2C_LL_CMD_WRITE}
 #define I2C_TRANS_STOP_COMMAND               {.op_code = I2C_LL_CMD_STOP}
 #define I2C_TRANS_START_COMMAND              {.op_code = I2C_LL_CMD_RESTART}
 


### PR DESCRIPTION
Closes #13134 

In summary, this PR:
- Resolves a deadlock on `s_i2c_synchronous_transaction` failure
- Handles NACK received on the slave address when using `i2c_master_receive`
- Handles NACK received on the slave address and write bytes when using `i2c_master_transmit` and `i2c_master_transmit_receive`

### TODO

#### `i2c_master_probe` reports incorrect _NOT FOUND_ if previous transaction failed
I noticed that after dealing with an unexpected NACK (on slave address or write byte) on `i2c_master_transmit`, the `i2c_master_probe` function will report NOT_FOUND on an existing address. This is seems to be due to some missing cleanup or resetting of initial state when starting `i2c_master_probe`. 

I was planning on continuing to develop this PR until the probe issue was resolved and was looking into writing tests. Since then, @mythbuster5 has voiced that they would add NACK checking in https://github.com/espressif/esp-idf/issues/13136#issuecomment-1933340595. Wanting to prevent duplication of effort, I'm not sure if I should continue further development on this PR. 

I look forward to feedback, both on the current approach and if/how to continue.
