### PR TITLE
Certificate bundle upgrade (IDFGH-12148)

### DIFF
--- a/components/mbedtls/esp_crt_bundle/esp_crt_bundle.c
+++ b/components/mbedtls/esp_crt_bundle/esp_crt_bundle.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,71 +7,226 @@
 #include <stdbool.h>
 #include "esp_crt_bundle.h"
 #include "esp_log.h"
+#include "esp_check.h"
 
-#define BUNDLE_HEADER_OFFSET 2
-#define CRT_HEADER_OFFSET 4
+#include "mbedtls/pk.h"
+
+#include "mbedtls/oid.h"
+#include "mbedtls/asn1.h"
+
+/*
+    Format of certificate bundle:
+    First, n uint32 "offset" entries, each describing the start of one certificate's data in terms of
+    bytes from the beginning of the bundle. This offset list is immediately followed by the 1st...n-th
+    certificate data. Hence, the first offset entry, i.e. the uint32 at the very start of the bundle,
+    is equal to the size of the offset list in bytes and therefore the # of certificates in the bundle
+    is [first offset]/sizeof(uint32_t)
+    [offset of 1st certificate](u32)
+    [offset of 2nd certificate](u32)
+    ...
+    [offset of n-th certificate](u32)
+    [1st certificate](variable)
+    ...
+    [n-th certificate](variable)
+
+    Structure of each certificate:
+    [length of CN](u16)
+    [length of key](u16)
+    [CN](variable)
+    [key](variable)
+
+    The offset list is used for fast random access to any certificate by index.
+    For verification, a certificate is looked up by its CN via binary search; for this reason,
+    the offset list *must* be sorted by CN (ascending) and the first certificate must be the
+    one with the least CN in the bundle, so that the first offset in the list still refers to the
+    first certificate after the list (see above).
+
+*/
+
+
+
+#define CRT_NAME_LEN_OFFSET 0 //<! offset of certificate name length value
+#define CRT_KEY_LEN_OFFSET (CRT_NAME_LEN_OFFSET + sizeof(uint16_t)) //<! offset of certificate key length value
+#define CRT_NAME_OFFSET (CRT_KEY_LEN_OFFSET + sizeof(uint16_t)) //<! certificate name data starts here
+
+#define CRT_HEADER_SIZE CRT_NAME_OFFSET //<! size of certificate header
+
+// Use a variable-length array for message digest if compiler supports it.
+#define ESP_CRT_USE_VLA ((__STDC_VERSION__ >= 199901L) && !(__STDC_NO_VLA__ == 1))
 
 static const char *TAG = "esp-x509-crt-bundle";
 
 /* a dummy certificate so that
  * cacert_ptr passes non-NULL check during handshake */
-static mbedtls_x509_crt s_dummy_crt;
+// Making this const is a bit of a hack but saves 300+ bytes of statically allocated RAM.
+// As of now, mbedtls_x509_crt_init would just zero the struct anyway, so this is actually equivalent
+// to an officially initialized x509_crt; plus, as of now, this cert's *content* is not used anywhere.
+static const mbedtls_x509_crt s_dummy_crt;
 
 
 extern const uint8_t x509_crt_imported_bundle_bin_start[] asm("_binary_x509_crt_bundle_start");
 extern const uint8_t x509_crt_imported_bundle_bin_end[]   asm("_binary_x509_crt_bundle_end");
 
+typedef const uint8_t* bundle_t;
+typedef const uint8_t* cert_t;
+
 
 typedef struct crt_bundle_t {
-    const uint8_t **crts;
-    uint16_t num_certs;
-    size_t x509_crt_bundle_len;
+    const uint8_t* bundle;
 } crt_bundle_t;
 
 static crt_bundle_t s_crt_bundle;
 
-static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_key_buf, size_t pub_key_len);
+// Read a 16-bit value stored in little-endian format from the given address
+static uint16_t get16_le(const uint8_t* const ptr) {
+    #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+        return *((const uint16_t*)ptr);
+    #else
+        return (((uint16_t)ptr[1]) << 8) | ptr[0];
+    #endif
+}
 
+static uint16_t esp_crt_get_name_len(cert_t cert) {
+    return get16_le(cert + CRT_NAME_LEN_OFFSET);
+}
 
-static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_key_buf, size_t pub_key_len)
+static const uint8_t* esp_crt_get_name(cert_t cert) {
+    return cert + CRT_NAME_OFFSET;
+}
+
+static uint16_t esp_crt_get_key_len(cert_t cert) {
+    return get16_le(cert + CRT_KEY_LEN_OFFSET);
+}
+
+static const uint8_t* esp_crt_get_key(cert_t cert) {
+    return esp_crt_get_name(cert) + esp_crt_get_name_len(cert);
+}
+
+static uint16_t esp_crt_get_len(cert_t cert) {
+    return CRT_HEADER_SIZE + esp_crt_get_name_len(cert) + esp_crt_get_key_len(cert);
+}
+
+static uint32_t esp_crt_get_cert_offset(bundle_t bundle, const uint32_t index) {
+    return ((const uint32_t*)bundle)[index];
+}
+
+static uint32_t esp_crt_get_certcount(bundle_t bundle) {
+    // Offset of 1st certificate == end of offset list == size of offset list == # of certs * sizeof(uint32_t)
+    return esp_crt_get_cert_offset(bundle,0) / sizeof(uint32_t);
+}
+
+/**
+ * @brief Get the certificate at the given index within a bundle.
+ *
+ * @param bundle pointer to the \c bundle_t
+ * @param index of the certificate; must be less than \c esp_crt_get_certcount(...) !
+ * @return pointer to the certificate
+ */
+static cert_t esp_crt_get_cert(bundle_t bundle, const uint32_t index) {
+    return bundle + esp_crt_get_cert_offset(bundle,index);
+}
+
+static int esp_crt_check_signature(const mbedtls_x509_crt* const child, const uint8_t* const pub_key_buf, const size_t pub_key_len)
 {
     int ret = 0;
-    mbedtls_x509_crt parent;
+    mbedtls_pk_context pubkey;
     const mbedtls_md_info_t *md_info;
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
-    mbedtls_x509_crt_init(&parent);
+    mbedtls_pk_init(&pubkey);
 
-    if ( (ret = mbedtls_pk_parse_public_key(&parent.pk, pub_key_buf, pub_key_len) ) != 0) {
+    if ( unlikely( (ret = mbedtls_pk_parse_public_key(&pubkey, pub_key_buf, pub_key_len)) != 0 ) ) {
         ESP_LOGE(TAG, "PK parse failed with error %X", ret);
         goto cleanup;
     }
 
-
     // Fast check to avoid expensive computations when not necessary
-    if (!mbedtls_pk_can_do(&parent.pk, child->MBEDTLS_PRIVATE(sig_pk))) {
-        ESP_LOGE(TAG, "Simple compare failed");
-        ret = -1;
+    if ( unlikely( !mbedtls_pk_can_do( &pubkey, child->MBEDTLS_PRIVATE(sig_pk)) ) ) {
+        ESP_LOGE(TAG, "Unsuitable public key");
+        ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
         goto cleanup;
     }
 
     md_info = mbedtls_md_info_from_type(child->MBEDTLS_PRIVATE(sig_md));
-    if ( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash )) != 0 ) {
-        ESP_LOGE(TAG, "Internal mbedTLS error %X", ret);
+
+    if( unlikely( md_info == NULL) ) {
+        ESP_LOGE(TAG, "Unknown message digest");
+        ret = MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE;
         goto cleanup;
     }
 
-    if ( (ret = mbedtls_pk_verify_ext( child->MBEDTLS_PRIVATE(sig_pk), child->MBEDTLS_PRIVATE(sig_opts), &parent.pk,
-                                       child->MBEDTLS_PRIVATE(sig_md), hash, mbedtls_md_get_size( md_info ),
-                                       child->MBEDTLS_PRIVATE(sig).p, child->MBEDTLS_PRIVATE(sig).len )) != 0 ) {
+    {
 
-        ESP_LOGE(TAG, "PK verify failed with error %X", ret);
-        goto cleanup;
+        const unsigned char md_size = mbedtls_md_get_size(md_info);
+#if ESP_CRT_USE_VLA
+        unsigned char hash[md_size];
+#else
+        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
+#endif
+
+        if ( unlikely( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash)) != 0) ) {
+            ESP_LOGE(TAG, "MD failed with error %X", ret);
+            goto cleanup;
+        }
+
+        if ( unlikely( (ret = mbedtls_pk_verify_ext( child->MBEDTLS_PRIVATE(sig_pk), child->MBEDTLS_PRIVATE(sig_opts), &pubkey,
+                                                     child->MBEDTLS_PRIVATE(sig_md), hash, md_size,
+                                                     child->MBEDTLS_PRIVATE(sig).p, child->MBEDTLS_PRIVATE(sig).len )) != 0) ) {
+
+            ESP_LOGE(TAG, "PK verify failed with error %X", ret);
+            goto cleanup;
+        }
     }
 cleanup:
-    mbedtls_x509_crt_free(&parent);
+    mbedtls_pk_free(&pubkey);
 
     return ret;
+}
+
+static size_t min(const size_t s1, const size_t s2) {
+    return s1 < s2 ? s1 : s2;
+}
+
+static cert_t esp_crt_find_cert(const unsigned char* const issuer, const size_t issuer_len)
+{
+    if (unlikely( issuer == NULL || issuer_len == 0 )) {
+        return NULL;
+    }
+
+    int start = 0;
+    int end = esp_crt_get_certcount(s_crt_bundle.bundle)-1;
+
+    /* Look for the certificate using binary search on subject name */
+    while (start <= end) {
+
+        const int middle = (start + end) / 2;
+
+        cert_t cert = esp_crt_get_cert(s_crt_bundle.bundle, middle);
+
+        const size_t cert_name_len = esp_crt_get_name_len(cert);
+
+        // Issuers are in DER encoding, with lengths encoded in the content; if valid DER, differing lengths
+        // are reflected in differing content.
+        // Still, we won't try to memcmp beyond the given length:
+        int cmp_res = memcmp(issuer, esp_crt_get_name(cert), min(issuer_len, cert_name_len) );
+
+        if ( unlikely( cmp_res == 0 ) ) {
+            cmp_res = (int)issuer_len - cert_name_len;
+            if( likely( cmp_res >= 0 ) ) {
+                // Names match and we actually did compare against the CA's full name
+                return cert;
+            }
+        }
+
+        if (cmp_res < 0) {
+            end = middle - 1;
+        } else {
+            start = middle + 1;
+        }
+
+    }
+
+    return NULL;
+
 }
 
 
@@ -81,9 +236,9 @@ cleanup:
  * only verify the first untrusted link in the chain is signed by the
  * root certificate in the trusted bundle
 */
-int esp_crt_verify_callback(void *buf, mbedtls_x509_crt *crt, int depth, uint32_t *flags)
+int esp_crt_verify_callback(void *buf, mbedtls_x509_crt* const crt, const int depth, uint32_t* const flags)
 {
-    mbedtls_x509_crt *child = crt;
+    const mbedtls_x509_crt* const child = crt;
 
     /* It's OK for a trusted cert to have a weak signature hash alg.
        as we already trust this certificate */
@@ -94,120 +249,116 @@ int esp_crt_verify_callback(void *buf, mbedtls_x509_crt *crt, int depth, uint32_
     }
 
 
-    if (s_crt_bundle.crts == NULL) {
+    if( unlikely( s_crt_bundle.bundle == NULL ) ) {
         ESP_LOGE(TAG, "No certificates in bundle");
         return MBEDTLS_ERR_X509_FATAL_ERROR;
     }
 
-    ESP_LOGD(TAG, "%d certificates in bundle", s_crt_bundle.num_certs);
+    ESP_LOGD(TAG, "%" PRIu16 " certificates in bundle", (uint16_t)esp_crt_get_certcount(s_crt_bundle.bundle));
 
-    size_t name_len = 0;
-    const uint8_t *crt_name;
+    cert_t cert = esp_crt_find_cert(child->issuer_raw.p, child->issuer_raw.len);
 
-    bool crt_found = false;
-    int start = 0;
-    int end = s_crt_bundle.num_certs - 1;
-    int middle = (end - start) / 2;
+    if ( likely( cert != NULL ) ) {
 
-    /* Look for the certificate using binary search on subject name */
-    while (start <= end) {
-        name_len = s_crt_bundle.crts[middle][0] << 8 | s_crt_bundle.crts[middle][1];
-        crt_name = s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET;
+        const int ret = esp_crt_check_signature(child, esp_crt_get_key(cert), esp_crt_get_key_len(cert));
 
-        int cmp_res = memcmp(child->issuer_raw.p, crt_name, name_len );
-        if (cmp_res == 0) {
-            crt_found = true;
-            break;
-        } else if (cmp_res < 0) {
-            end = middle - 1;
+        if ( likely( ret == 0 ) ) {
+            ESP_LOGD(TAG, "Certificate validated");
+            *flags = 0;
+            return 0;
         } else {
-            start = middle + 1;
+            ESP_LOGI(TAG, "Certificate signature failed to verify");
         }
-        middle = (start + end) / 2;
-    }
 
-    int ret = MBEDTLS_ERR_X509_FATAL_ERROR;
-    if (crt_found) {
-        size_t key_len = s_crt_bundle.crts[middle][2] << 8 | s_crt_bundle.crts[middle][3];
-        ret = esp_crt_check_signature(child, s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET + name_len, key_len);
-    }
-
-    if (ret == 0) {
-        ESP_LOGI(TAG, "Certificate validated");
-        *flags = 0;
-        return 0;
+    } else {
+        ESP_LOGI(TAG, "No matching trusted root certificate found");
     }
 
     ESP_LOGE(TAG, "Failed to verify certificate");
-    return MBEDTLS_ERR_X509_FATAL_ERROR;
+    return MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
 }
 
+/**
+ * @brief Perform some consistency checks on the user-provided bundle data to try and make sure
+ * it actually is a certificate bundle.
+ *
+ * @param x509_bundle pointer to the bundle data
+ * @param bundle_size size of bundle data
+ * @return true the given bundle data is consistent
+ * @return false the given bundle data is invalid
+ */
+static bool esp_crt_check_bundle(const uint8_t* const x509_bundle, const size_t bundle_size)
+{
+    if (unlikely( x509_bundle == NULL || bundle_size <= (sizeof(uint32_t) + CRT_HEADER_SIZE)) ) {
+        // Bundle is too small for even one offset and one certificate
+        return false;
+    }
 
-/* Initialize the bundle into an array so we can do binary search for certs,
+    // Pointer to the first offset entry
+    const uint32_t* offsets = (const uint32_t*)x509_bundle;
+
+    if(unlikely( offsets[0] == 0 || (offsets[0] % sizeof(uint32_t)) != 0) ) {
+        // First offset is invalid.
+        // The first certificate must start after N uint32_t offset values.
+        return false;
+    }
+
+    if(unlikely( offsets[0] >= bundle_size )) {
+        // First cert starts beyond end of bundle
+        return false;
+    }
+
+    const uint32_t num_certs = esp_crt_get_certcount(x509_bundle);
+
+    if(unlikely( num_certs > CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS )) {
+        ESP_LOGE(TAG, "No. of certs in the certificate bundle = %" PRIu32 " exceeds\n"
+                    "Max allowed certificates in the certificate bundle = %d\n"
+                    "Please update the menuconfig option with appropriate value",
+                    num_certs, CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS);
+        return false;
+    }
+
+
+    // Check all offsets for consistency with certificate data
+
+    for (uint32_t i = 0; i < num_certs-1; ++i ) {
+        const uint32_t off = offsets[i];
+        cert_t cert = x509_bundle + off;
+        // The next offset in the list must point to right after the current cert
+        const uint32_t expected_next_offset = off + esp_crt_get_len(cert);
+
+        if( unlikely( offsets[i+1] != expected_next_offset || expected_next_offset >= bundle_size ) ) {
+            return false;
+        }
+    }
+
+    // All checks passed.
+    return true;
+
+}
+
+/*
    the bundle generated by the python utility is already presorted by subject name
  */
-static esp_err_t esp_crt_bundle_init(const uint8_t *x509_bundle, size_t bundle_size)
+static esp_err_t esp_crt_bundle_init(const uint8_t* const x509_bundle, const size_t bundle_size)
 {
-    if (bundle_size < BUNDLE_HEADER_OFFSET + CRT_HEADER_OFFSET) {
-        ESP_LOGE(TAG, "Invalid certificate bundle");
+    if ( likely( esp_crt_check_bundle(x509_bundle, bundle_size) ) ) {
+        s_crt_bundle.bundle = x509_bundle;
+        return ESP_OK;
+    } else {
         return ESP_ERR_INVALID_ARG;
     }
-
-    uint16_t num_certs = (x509_bundle[0] << 8) | x509_bundle[1];
-    if (num_certs > CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS) {
-        ESP_LOGE(TAG, "No. of certs in the certificate bundle = %d exceeds\n"
-                      "Max allowed certificates in the certificate bundle = %d\n"
-                      "Please update the menuconfig option with appropriate value", num_certs, CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS);
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    const uint8_t **crts = calloc(num_certs, sizeof(x509_bundle));
-    if (crts == NULL) {
-        ESP_LOGE(TAG, "Unable to allocate memory for bundle");
-        return ESP_ERR_NO_MEM;
-    }
-
-    const uint8_t *cur_crt;
-    /* This is the maximum region that is allowed to access */
-    const uint8_t *bundle_end = x509_bundle + bundle_size;
-    cur_crt = x509_bundle + BUNDLE_HEADER_OFFSET;
-
-    for (int i = 0; i < num_certs; i++) {
-        crts[i] = cur_crt;
-        if (cur_crt + CRT_HEADER_OFFSET > bundle_end) {
-            ESP_LOGE(TAG, "Invalid certificate bundle");
-            free(crts);
-            return ESP_ERR_INVALID_ARG;
-        }
-        size_t name_len = cur_crt[0] << 8 | cur_crt[1];
-        size_t key_len = cur_crt[2] << 8 | cur_crt[3];
-        cur_crt = cur_crt + CRT_HEADER_OFFSET + name_len + key_len;
-    }
-
-    if (cur_crt > bundle_end) {
-        ESP_LOGE(TAG, "Invalid certificate bundle");
-        free(crts);
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    /* The previous crt bundle is only updated when initialization of the
-     * current crt_bundle is successful */
-    /* Free previous crt_bundle */
-    free(s_crt_bundle.crts);
-    s_crt_bundle.num_certs = num_certs;
-    s_crt_bundle.crts = crts;
-    return ESP_OK;
 }
 
 esp_err_t esp_crt_bundle_attach(void *conf)
 {
     esp_err_t ret = ESP_OK;
     // If no bundle has been set by the user then use the bundle embedded in the binary
-    if (s_crt_bundle.crts == NULL) {
+    if (s_crt_bundle.bundle == NULL) {
         ret = esp_crt_bundle_init(x509_crt_imported_bundle_bin_start, x509_crt_imported_bundle_bin_end - x509_crt_imported_bundle_bin_start);
     }
 
-    if (ret != ESP_OK) {
+    if ( unlikely(ret != ESP_OK) ) {
         ESP_LOGE(TAG, "Failed to attach bundle");
         return ret;
     }
@@ -218,8 +369,7 @@ esp_err_t esp_crt_bundle_attach(void *conf)
          * cacert_ptr passes non-NULL check during handshake
          */
         mbedtls_ssl_config *ssl_conf = (mbedtls_ssl_config *)conf;
-        mbedtls_x509_crt_init(&s_dummy_crt);
-        mbedtls_ssl_conf_ca_chain(ssl_conf, &s_dummy_crt, NULL);
+        mbedtls_ssl_conf_ca_chain(ssl_conf, (mbedtls_x509_crt*)&s_dummy_crt, NULL);
         mbedtls_ssl_conf_verify(ssl_conf, esp_crt_verify_callback, NULL);
     }
 
@@ -228,8 +378,7 @@ esp_err_t esp_crt_bundle_attach(void *conf)
 
 void esp_crt_bundle_detach(mbedtls_ssl_config *conf)
 {
-    free(s_crt_bundle.crts);
-    s_crt_bundle.crts = NULL;
+    s_crt_bundle.bundle = NULL;
     if (conf) {
         mbedtls_ssl_conf_verify(conf, NULL, NULL);
     }

--- a/components/mbedtls/esp_crt_bundle/gen_crt_bundle.py
+++ b/components/mbedtls/esp_crt_bundle/gen_crt_bundle.py
@@ -8,7 +8,7 @@
 # The bundle will have the format: number of certificates; crt 1 subject name length; crt 1 public key length;
 # crt 1 subject name; crt 1 public key; crt 2...
 #
-# SPDX-FileCopyrightText: 2018-2022 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2018-2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import with_statement
@@ -53,9 +53,6 @@ class CertificateBundle:
     def __init__(self):
         self.certificates = []
         self.compressed_crts = []
-
-        if os.path.isfile(ca_bundle_bin_file):
-            os.remove(ca_bundle_bin_file)
 
     def add_from_path(self, crts_path):
 
@@ -120,7 +117,11 @@ class CertificateBundle:
         # Sort certificates in order to do binary search when looking up certificates
         self.certificates = sorted(self.certificates, key=lambda cert: cert.subject.public_bytes(default_backend()))
 
-        bundle = struct.pack('>H', len(self.certificates))
+        # List of offsets in bytes from the start of the bundle to each certificate inside
+        offsets = []
+        len_offsets = 4 * len(self.certificates)  # final size of the offsets list
+
+        bundle = b''
 
         for crt in self.certificates:
             """ Read the public key as DER format """
@@ -132,11 +133,17 @@ class CertificateBundle:
 
             name_len = len(sub_name_der)
             key_len = len(pub_key_der)
-            len_data = struct.pack('>HH', name_len, key_len)
+            len_data = struct.pack('<HH', name_len, key_len)
+
+            # Certificate starts at this position in the bundle
+            offsets.append(len_offsets + len(bundle))
 
             bundle += len_data
             bundle += sub_name_der
             bundle += pub_key_der
+
+        # Output all offsets before the first certificate
+        bundle = struct.pack('<{0:d}L'.format(len(offsets)), *offsets) + bundle
 
         return bundle
 
@@ -180,6 +187,10 @@ def main():
     parser.add_argument('--quiet', '-q', help="Don't print non-critical status messages to stderr", action='store_true')
     parser.add_argument('--input', '-i', nargs='+', required=True,
                         help='Paths to the custom certificate folders or files to parse, parses all .pem or .der files')
+    parser.add_argument('--output', '-o', default=ca_bundle_bin_file,
+                        help='Name of the output file (default: %s), or - for stdout' % ca_bundle_bin_file)
+    parser.add_argument('--arr', '-a', help='Output result as comma-separated list of byte values suitable for array initialization', action='store_true')
+    parser.add_argument('--dec', '-d', help='Output byte values in decimal instead of hex; only valid if used with -a', action='store_true')
     parser.add_argument('--filter', '-f', help='Path to CSV-file where the second columns contains the name of the certificates \
                         that should be included from cacrt_all.pem')
 
@@ -204,8 +215,35 @@ def main():
 
     crt_bundle = bundle.create_bundle()
 
-    with open(ca_bundle_bin_file, 'wb') as f:
-        f.write(crt_bundle)
+    # By default, the output is the crt_bundle's binary data
+    result = crt_bundle
+
+    # Transform binary to array initialization if requested
+    if args.arr:
+        # Default: hex
+        fmt = '0x{0:02x}, '
+        if args.dec:
+            fmt = '{0:d}, '
+        cnt = 0
+        result = ''
+        for b in crt_bundle:
+            result += fmt.format(b)
+            cnt += 1
+            if (cnt % 16) == 0:
+                result += '\n'
+        # Remove trailing comma
+        if result.endswith(', '):
+            result = result[:len(result) - 2]
+        result = bytes(result, 'utf-8')
+
+    # Output to file or stdout as needed
+    if args.output == '-':
+        sys.stdout.buffer.write(result)
+    else:
+        # if os.path.isfile(args.output):
+        #     os.remove(args.output)
+        with open(args.output, 'wb') as f:
+            f.write(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Modified gen_crt_bundle.py and esp_crt_bundle.c to build/use a static 'index' of the certificates in a bundle and include this index data in the bundle data.
This obviates the need for esp_crt_bundle.c to allocate heap memory and build the index at runtime, saving ~120x4 bytes of heap for the full/'unfiltered' bundle.
Changed "mbedtls_x509_crt parent" in esp_crt_check_signature() to "mbedtls_pk_context pubkey" to save some 200 bytes of stack requirement.