### PR TITLE
Use __builtin_unreachable in HAL_ASSERT no-assert mode (IDFGH-12202)

### DIFF
--- a/components/hal/platform_port/include/hal/assert.h
+++ b/components/hal/platform_port/include/hal/assert.h
@@ -38,7 +38,7 @@ extern void abort(void);
 #elif CONFIG_HAL_DEFAULT_ASSERTION_LEVEL == 2 // full assertion
 #define HAL_ASSERT(__e) (__builtin_expect(!!(__e), 1) ? (void)0 : __assert_func(__FILE__, __LINE__, __ASSERT_FUNC, #__e))
 #else // no assert
-#define HAL_ASSERT(__e) ((void)(__e))
+#define HAL_ASSERT(__e) ((void)(__e), __builtin_unreachable())
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This fixes a compile error when building with esp-clang:

```
esp-idf/components/hal/esp32/include/hal/mmu_ll.h:252:9: error: variable 'mmu_value' is used uninitialized whenever switch default is taken [-Werror,-Wsometimes-uninitialized]
        default:
        ^~~~~~~
esp-idf/components/hal/esp32/include/hal/mmu_ll.h:256:12: note: uninitialized use occurs here
    return mmu_value;
           ^~~~~~~~~
esp-idf/components/hal/esp32/include/hal/mmu_ll.h:242:23: note: initialize the variable 'mmu_value' to silence this warning
    uint32_t mmu_value;
                      ^
                       = 0
```