### PR TITLE
fix(mqtt/tcp):  mqtt_cfg must be of const type (IDFGH-12203)

### DIFF
--- a/examples/protocols/mqtt/tcp/main/app_main.c
+++ b/examples/protocols/mqtt/tcp/main/app_main.c
@@ -109,7 +109,7 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
 static void mqtt_app_start(void)
 {
-    esp_mqtt_client_config_t mqtt_cfg = {
+    const esp_mqtt_client_config_t mqtt_cfg = {
         .broker.address.uri = CONFIG_BROKER_URL,
     };
 #if CONFIG_BROKER_URL_FROM_STDIN


### PR DESCRIPTION
例程examples/protocol/mqtt/tcp

mqtt_app_start函数中
esp_mqtt_client_config_t mqtt_cfg 应该被声明为const,与其他mqtt例程保持一致

在函数中，变量mqtt_cfg如果不用const修饰，其他变量是随机值，很可能导致例程运行出错
    esp_mqtt_client_config_t mqtt_cfg = {
        .broker.address.uri = CONFIG_BROKER_URL,
    };