### PR TITLE
Updated Dockerfile for devcontainer usage (IDFGH-12213)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -91,6 +91,9 @@ RUN : \
   && rm -rf $IDF_TOOLS_PATH/dist \
   && :
 
+# Add get_idf as alias
+RUN echo 'alias get_idf=". /opt/esp/idf/export.sh"' >> /root/.bashrc
+
 # The constraint file has been downloaded and the right Python package versions installed. No need to check and
 # download this at every invocation of the container.
 ENV IDF_PYTHON_CHECK_CONSTRAINTS=no


### PR DESCRIPTION
## Info
Added pip and `get_idf` alias to .bashrc to use the docker container in a development container (e.g. github devcontainer).

Without pip, the docker image is not easily usable inside a vscode environment.

Without the alias, it is harder to get `idf.py` working (e.g. manually call export.sh) if not using entrypoint.sh or spawning additional terminals in a dev container environment.