### PR TITLE
Fix #13293: Flush rgb lcd PSRAM framebuffers after allocation (IDFGH-12244)

### DIFF
--- a/components/esp_lcd/rgb/esp_lcd_panel_rgb.c
+++ b/components/esp_lcd/rgb/esp_lcd_panel_rgb.c
@@ -153,10 +153,14 @@ static esp_err_t lcd_rgb_panel_alloc_frame_buffers(const esp_lcd_rgb_panel_confi
             if (fb_in_psram) {
                 // the low level malloc function will help check the validation of alignment
                 rgb_panel->fbs[i] = heap_caps_aligned_calloc(psram_trans_align, 1, rgb_panel->fb_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                ESP_RETURN_ON_FALSE(rgb_panel->fbs[i], ESP_ERR_NO_MEM, TAG, "no mem for frame buffer");
+                // calloc not only allocates but also zero's the buffer. We have to make sure this is
+                // properly committed to the PSRAM, otherwise all sorts of visual corruption will happen.
+                ESP_RETURN_ON_ERROR(esp_cache_msync(rgb_panel->fbs[i], rgb_panel->fb_size, 0), TAG, "flush cache buffer failed");
             } else {
                 rgb_panel->fbs[i] = heap_caps_aligned_calloc(sram_trans_align, 1, rgb_panel->fb_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
+                ESP_RETURN_ON_FALSE(rgb_panel->fbs[i], ESP_ERR_NO_MEM, TAG, "no mem for frame buffer");
             }
-            ESP_RETURN_ON_FALSE(rgb_panel->fbs[i], ESP_ERR_NO_MEM, TAG, "no mem for frame buffer");
         }
     }
 


### PR DESCRIPTION
Framebuffers are allocated using calloc, which also zero's the buffer. This zeroing is done by the CPU and thus uses the CPU's writeback cache for the PSRAM. If the framebuffer is not flushed after allocation, the DMA hardware is going to read stale data and push that to the display hardware.

This fixes: https://github.com/espressif/esp-idf/issues/13293