### PR TITLE
feat(esp_netif): Allow traffic reporting (IDFGH-12314)

### DIFF
--- a/components/esp_netif/Kconfig
+++ b/components/esp_netif/Kconfig
@@ -36,6 +36,13 @@ menu "ESP NETIF Adapter"
     config ESP_NETIF_USES_TCPIP_WITH_BSD_API
         bool # Set to true if the chosen TCP/IP stack provides BSD socket API
 
+    config ESP_NETIF_REPORT_DATA_TRAFFIC
+        bool "Report data traffic via events"
+        default n
+        help
+            Enable if esp_netif_transmit() and esp_netif_receive() should generate events. This can be useful
+            to blink data traffic indication lights.
+
     config ESP_NETIF_RECEIVE_REPORT_ERRORS
         bool "Use esp_err_t to report errors from esp_netif_receive"
         default n

--- a/components/esp_netif/include/esp_netif_types.h
+++ b/components/esp_netif/include/esp_netif_types.h
@@ -101,6 +101,10 @@ typedef enum {
     IP_EVENT_ETH_LOST_IP,              /*!< ethernet lost IP and the IP is reset to 0 */
     IP_EVENT_PPP_GOT_IP,               /*!< PPP interface got IP */
     IP_EVENT_PPP_LOST_IP,              /*!< PPP interface lost IP */
+#ifdef CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC
+    IP_EVENT_TRANSMIT,                 /*!< transmitting data */
+    IP_EVENT_RECEIVE,                  /*!< receiving data */
+#endif
 } ip_event_t;
 
 /** @brief IP event base declaration */
@@ -151,6 +155,13 @@ typedef struct {
     uint8_t mac[6];    /*!< MAC address of the connected client */
 } ip_event_ap_staipassigned_t;
 
+#ifdef CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC
+/** Event structure for IP_EVENT_TRANSMIT and IP_EVENT_RECEIVE */
+typedef struct {
+    esp_netif_t *esp_netif; /*!< Pointer to the associated netif handle */
+    size_t len; /*!< Length of the data */
+} ip_event_transmit_receive_t;
+#endif
 
 typedef enum esp_netif_flags {
     ESP_NETIF_DHCP_CLIENT = 1 << 0,

--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -1242,6 +1242,13 @@ void esp_netif_free_rx_buffer(void *h, void* buffer)
 
 esp_err_t esp_netif_transmit(esp_netif_t *esp_netif, void* data, size_t len)
 {
+#ifdef CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC
+    ip_event_transmit_receive_t evt = {
+        .esp_netif = esp_netif,
+        .len = len,
+    };
+    esp_event_post(IP_EVENT, IP_EVENT_TRANSMIT, &evt, sizeof(evt), 0);
+#endif
     return (esp_netif->driver_transmit)(esp_netif->driver_handle, data, len);
 }
 
@@ -1252,6 +1259,13 @@ esp_err_t esp_netif_transmit_wrap(esp_netif_t *esp_netif, void *data, size_t len
 
 esp_err_t esp_netif_receive(esp_netif_t *esp_netif, void *buffer, size_t len, void *eb)
 {
+#ifdef CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC
+    ip_event_transmit_receive_t evt = {
+        .esp_netif = esp_netif,
+        .len = len,
+    };
+    esp_event_post(IP_EVENT, IP_EVENT_RECEIVE, &evt, sizeof(evt), 0);
+#endif
 #ifdef CONFIG_ESP_NETIF_RECEIVE_REPORT_ERRORS
     return esp_netif->lwip_input_fn(esp_netif->netif_handle, buffer, len, eb);
 #else


### PR DESCRIPTION
This enables traffic indicators or data traffic statistics.

It is a fairly small feature hidden behind the new configuration `CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC`.
It does not have any effect, if you choose not to configure it.