### PR TITLE
feat(fatfs): add Kconfig settings for FF_USE_STRFUNC (IDFGH-12317)

### DIFF
--- a/components/fatfs/Kconfig
+++ b/components/fatfs/Kconfig
@@ -205,6 +205,63 @@ menu "FAT Filesystem support"
             file is opened in write-mode, the seek mechanism will automatically fallback
             to the default implementation.
 
+    choice FATFS_USE_STRFUNC_CHOICE
+        prompt "Enable string functions, f_gets(), f_putc(), f_puts() and f_printf()"
+        default FATFS_USE_STRFUNC_NONE
+        help
+            These are specialized alternatives to stdio functions for working
+            directly with FATFS without VFS.  Legacy code may need functions,
+            but for new development, it is advised to use stdio under VFS.
+
+            0: Disable. FF_PRINT_LLI, FF_PRINT_FLOAT and FF_STRF_ENCODE have no effect.
+            1: Enable without LF-CRLF conversion.
+            2: Enable with LF-CRLF conversion.
+
+        config FATFS_USE_STRFUNC_NONE
+            bool "0:Disable"
+
+        config FATFS_USE_STRFUNC_WITHOUT_CRLF_CONV
+            bool "1:Enable without LF-CRLF conversion"
+
+        config FATFS_USE_STRFUNC_WITH_CRLF_CONV
+            bool "2:Enable with LF-CRLF conversion"
+    endchoice
+
+    config FATFS_PRINT_LLI
+        depends on !FATFS_USE_STRFUNC_NONE
+        bool "Make fatfs f_printf() support long long argument"
+        default 0
+
+    config FATFS_PRINT_FLOAT
+        depends on !FATFS_USE_STRFUNC_NONE
+        bool "Make fatfs f_printf() support floating point argument"
+        default 0
+
+    choice FATFS_STRF_ENCODE_CHOICE
+        prompt "FatFS string functions: convert character encoding"
+        depends on !FATFS_LFN_NONE && !FATFS_USE_STRFUNC_NONE
+        default FATFS_STRF_ENCODE_UTF8
+        help
+            When FF_LFN_UNICODE >= 1 with LFN enabled, string functions convert the character
+            encoding in it. FF_STRF_ENCODE selects assumption of character encoding ON THE FILE
+            to be read/written via those functions.
+             0: ANSI/OEM in current CP
+             1: Unicode in UTF-16LE
+             2: Unicode in UTF-16BE
+             3: Unicode in UTF-8
+
+        config FATFS_STRF_ENCODE_ANSI
+            bool "0:ANSI/OEM in current CP"
+
+        config FATFS_STRF_ENCODE_UTF16LE
+            bool "1:Unicode in UTF-16LE"
+
+        config FATFS_STRF_ENCODE_UTF16BE
+            bool "2:Unicode in UTF-16BE"
+
+        config FATFS_STRF_ENCODE_UTF8
+            bool "3:Unicode in UTF-8"
+    endchoice
 
     config FATFS_FAST_SEEK_BUFFER_SIZE
         int "Fast seek CLMT buffer size"

--- a/components/fatfs/src/ffconf.h
+++ b/components/fatfs/src/ffconf.h
@@ -57,11 +57,36 @@
 #define FF_USE_FORWARD	0
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
+#if defined(CONFIG_FATFS_USE_STRFUNC_WITHOUT_CRLF_CONV)
+#define FF_USE_STRFUNC 1
+#elif defined(CONFIG_FATFS_USE_STRFUNC_WITH_CRLF_CONV)
+#define FF_USE_STRFUNC 2
+#else /* CONFIG_FATFS_USE_STRFUNC_NONE */
+#define FF_USE_STRFUNC 0
+#endif
 
-#define FF_USE_STRFUNC	0
+#ifdef CONFIG_FATFS_PRINT_LLI
+#define FF_PRINT_LLI	1
+#else
 #define FF_PRINT_LLI	0
+#endif
+
+#ifdef CONFIG_FATFS_PRINT_FLOAT
+#define FF_PRINT_FLOAT	1
+#else
 #define FF_PRINT_FLOAT	0
+#endif
+
+#if defined(CONFIG_FATFS_STRF_ENCODE_ANSI)
+#define FF_STRF_ENCODE	0
+#elif defined(CONFIG_FATFS_STRF_ENCODE_UTF16LE)
+#define FF_STRF_ENCODE	1
+#elif defined(CONFIG_FATFS_STRF_ENCODE_UTF16BE)
+#define FF_STRF_ENCODE	2
+#else /* CONFIG_FATFS_STRF_ENCODE_UTF8 */
 #define FF_STRF_ENCODE	3
+#endif
+
 /* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /


### PR DESCRIPTION
Legacy fatfs code being ported to ESP-IDF may use `f_gets()`, `f_puts()`, `f_putc()`, and `f_printf()` calls, but the define `FF_USE_STRFUNC` is set to 0 without Kconfig options to enable it.

This commit retains the existing default behavior of `FF_USE_STRFUNC=0` and adds Kconfig settings so users can configure `FF_USE_STRFUNC` and the related `FF_PRINT_LLI`, `FF_PRINT_FLOAT`, and `FF_STRF_ENCODE` if needed.

Closes: https://github.com/espressif/esp-idf/issues/13350

(This PR replaces #13351 which had an invalid branch name due to capital letters.)