### PR TITLE
feat(esp_eth): add support for ch395(SPI and UART dual stack) (IDFGH-12405)

### DIFF
--- a/components/esp_eth/CMakeLists.txt
+++ b/components/esp_eth/CMakeLists.txt
@@ -52,6 +52,11 @@ if(CONFIG_ETH_ENABLED)
                          "src/esp_eth_phy_ksz8851snl.c")
     endif()
 
+    if(CONFIG_ETH_SPI_ETHERNET_CH395 OR CONFIG_ETH_UART_ETHERNET_CH395)
+        list(APPEND srcs "src/esp_eth_mac_ch395.c"
+                         "src/esp_eth_phy_ch395.c")
+    endif()
+
     if(CONFIG_ETH_USE_OPENETH)
         list(APPEND srcs "src/esp_eth_mac_openeth.c"
                          "src/esp_eth_phy_dp83848.c")

--- a/components/esp_eth/Kconfig
+++ b/components/esp_eth/Kconfig
@@ -156,7 +156,35 @@ menu "Ethernet"
                 The KSZ8851SNL is a single-chip Fast Ethernet controller consisting of
                 a 10/100 physical layer transceiver (PHY), a MAC, and a Serial Peripheral Interface (SPI).
                 Select this to enable KSZ8851SNL driver.
+
+        config ETH_SPI_ETHERNET_CH395
+            bool "Use CH395"
+            help
+                CH395 is an Ethernet protocol stack management IC which provides Ethernet communication
+                ability for MCU system. CH395 has built-in 10 / 100M Ethernet MAC and PHY and fully compatible
+                with IEEE 802.3 protocol, it also has built-in protocol stack firmware such as PPPOE, IP, DHCP,
+                ARP, ICMP, IGMP, UDP, TCP and etc.
+                Select this to enable CH395 driver.
     endif # ETH_USE_SPI_ETHERNET
+
+    menuconfig ETH_USE_UART_ETHERNET
+        bool "Support UART to Ethernet Module"
+        default n
+        select ETH_ENABLED
+        help
+            ESP-IDF can also support some UART-Ethernet modules.
+
+    if ETH_USE_UART_ETHERNET
+        config ETH_UART_ETHERNET_CH395
+            bool "Use CH395"
+            help
+                CH395 is an Ethernet protocol stack management IC which provides Ethernet communication
+                ability for MCU system. CH395 has built-in 10 / 100M Ethernet MAC and PHY and fully compatible
+                with IEEE 802.3 protocol, it also has built-in protocol stack firmware such as PPPOE, IP, DHCP,
+                ARP, ICMP, IGMP, UDP, TCP and etc.
+                Select this to enable CH395 driver.
+
+    endif # ETH_USE_UART_ETHERNET
 
     menuconfig ETH_USE_OPENETH
         bool "Support OpenCores Ethernet MAC (for use with QEMU)"

--- a/components/esp_eth/include/esp_eth_mac.h
+++ b/components/esp_eth/include/esp_eth_mac.h
@@ -468,6 +468,7 @@ typedef struct {
     eth_data_interface_t interface;                 /*!< EMAC Data interface to PHY (MII/RMII) */
     eth_mac_clock_config_t clock_config;            /*!< EMAC Interface clock configuration */
     eth_mac_dma_burst_len_t dma_burst_len;          /*!< EMAC DMA burst length for both Tx and Rx */
+    int intr_priority;                              /*!< EMAC interrupt priority, if set to 0 or a negative value, the driver will try to allocate an interrupt with a default priority */
 #if SOC_EMAC_USE_IO_MUX
     eth_mac_dataif_gpio_config_t emac_dataif_gpio;  /*!< EMAC MII/RMII data plane GPIO configuration */
 #endif // SOC_EMAC_USE_IO_MUX
@@ -495,6 +496,7 @@ typedef struct {
             }                                         \
         },                                            \
         .dma_burst_len = ETH_DMA_BURST_LEN_32,        \
+        .intr_priority = 0,                           \
     }
 #elif CONFIG_IDF_TARGET_ESP32P4
 #define ETH_ESP32_EMAC_DEFAULT_CONFIG()               \
@@ -519,6 +521,7 @@ typedef struct {
             }                                         \
         },                                            \
         .dma_burst_len = ETH_DMA_BURST_LEN_32,        \
+        .intr_priority = 0,                           \
         .emac_dataif_gpio =                           \
         {                                             \
             .rmii =                                   \

--- a/components/esp_eth/include/esp_eth_phy.h
+++ b/components/esp_eth/include/esp_eth_phy.h
@@ -390,6 +390,19 @@ esp_eth_phy_t *esp_eth_phy_new_w5500(const eth_phy_config_t *config);
 */
 esp_eth_phy_t *esp_eth_phy_new_ksz8851snl(const eth_phy_config_t *config);
 #endif
+
+#if CONFIG_ETH_SPI_ETHERNET_CH395 || CONFIG_ETH_UART_ETHERNET_CH395
+/**
+* @brief Create a PHY instance of CH395
+*
+* @param[in] config: configuration of PHY
+*
+* @return
+*      - instance: create PHY instance successfully
+*      - NULL: create PHY instance failed because some error occurred
+*/
+esp_eth_phy_t *esp_eth_phy_new_ch395(const eth_phy_config_t *config);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_eth/src/ch395.h
+++ b/components/esp_eth/src/ch395.h
@@ -1,0 +1,788 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Sergey Kharenko
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-FileContributor: 2023-2024 NanjingQinhengMicroelectronics CO LTD
+ * SPDX-FileContributor: 2024 Sergey Kharenko
+ * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup Command Code
+ * @note A command operation sequence includes:
+ * A command code (for serial port mode, two synchronization codes are required before the command code),
+ * Several input data (can be 0),
+ * Several output data (can be 0)
+ * @note Command code naming rules: CMDxy_NAME
+ * Where x and y are both numbers, x indicates the minimum number of input data (number of bytes), y indicates
+ * the minimum number of output data (number of bytes), and if y is W, it means that you need to wait for the
+ * command to be executed successfully. Some commands can read and write data blocks of 0 to multiple bytes.
+ * The number of bytes of the data block itself is not included in the above x or y
+ * @{
+*/
+
+/**
+ * @brief Get the chip and firmware version number
+ * @return version number (bit 7 is 0, bit 6 is 1, bit 5~bit 0 are version
+ * numbers)
+ * @example The value of the version number returned by CH395 is 0x41, that is
+ * the version number is 01H
+ */
+#define CMD01_GET_IC_VER                    0x01
+
+
+
+/**
+ * @brief Set the serial port communication baud rate ( the default baud rate after power on or reset is 9600bps)
+ * @param baudrate(LSB) 3 bytes
+ * @return
+ *   - CMD_RET_SUCCESS - on success
+ *   - others - indicate that the operation is not completed
+ */
+#define CMD31_SET_BAUDRATE                  0x02
+
+
+
+/**
+ * @brief Enter sleep state
+*/
+#define CMD00_ENTER_SLEEP                   0x03
+
+
+
+/**
+ * @brief Perform hardware reset
+*/
+#define CMD00_RESET_ALL                     0x05
+
+
+
+/**
+ * @brief Test communication interface and working status
+ * @param Any
+ * @return - bitwise inversion of input data
+*/
+#define CMD11_CHECK_EXIST                   0x06
+
+/**
+ * @brief Get the global interrupt status. Programs after version 0x44 need to
+ * use this command to get all interrupts due to the increased number of
+ * sockets
+ * @return - global interrupt status
+ */
+#define CMD02_GET_GLOB_INT_STATUS_ALL       0x19
+
+
+/**
+ * @brief Set PHY, default is Auto-negotiate
+ * @param param PHY parameter
+ */
+#define CMD10_SET_PHY                       0x20
+
+
+
+/**
+ * @brief Set MAC address
+ * @warning Must be set before @ref CMD0W_INIT_CH395
+ * @param address 6-byte MAC address
+ */
+#define CMD60_SET_MAC_ADDR                  0x21
+
+
+
+/**
+ * @brief Set IP address
+ * @warning Must be set before @ref CMD0W_INIT_CH395
+ * @param address 4-byte IP address
+ */
+#define CMD40_SET_IP_ADDR                   0x22
+
+
+
+/**
+ * @brief Set gateway IP address
+ * @warning Must be set before @ref CMD0W_INIT_CH395
+ * @param address 4-byte gateway IP address
+ */
+#define CMD40_SET_GWIP_ADDR                 0x23
+
+
+/**
+ * @brief Set subnet mask
+ * @warning Must be set before @ref CMD0W_INIT_CH395
+ * @param address 4-byte subnet mask
+ */
+#define CMD40_SET_MASK_ADDR                 0x24
+
+
+
+/**
+ * @brief Set MAC filtering to filter broadcast, multicast, etc.
+ * @param filter_type
+ * @param HASH0 4-byte hash table
+ * @param HASH1 4-byte hash table
+ */
+#define CMD90_SET_MAC_FILT                  0x25
+
+
+
+/**
+ * @brief Get the current status of PHY, such as disconnected, 10/100M FULL/HALF
+ * @return status Current PHY status
+ */
+#define CMD01_GET_PHY_STATUS                0x26
+
+
+
+/**
+ * @brief Initialize CH395
+ * @warning The execution time of this command is about 200MS. You need to wait
+ * for the successful execution of this command before you can send the next
+ * command
+ */
+#define CMD0W_INIT_CH395                    0x27
+
+
+
+/**
+ * @brief Get unreachable information
+ * @return type unreachable type
+ * @return code unreachable protocol code
+ * @return ip 4-byte unreachable IP
+ */
+#define CMD08_GET_UNREACH_IPPORT            0x28
+
+
+
+/**
+ * @brief Get the global interrupt status
+ * @return status global interrupt status
+ */
+#define CMD01_GET_GLOB_INT_STATUS           0x29
+
+
+
+/**
+ * @brief Number of retries
+ * @note Only valid in TCP mode
+ * @param retries number of retries
+ */
+#define CMD10_SET_RETRAN_COUNT              0x2A
+
+
+
+/**
+ * @brief Retry period
+ * @note Only valid in TCP mode. The maximum value is 20, cannot be set to 0
+ * @param retries number of retries
+ */
+#define CMD20_SET_RETRAN_PERIOD             0x2B
+
+
+
+/**
+ * @brief Get command execution status
+ * @return status command execution status
+ */
+#define CMD01_GET_CMD_STATUS                0x2C
+
+
+
+/**
+ * @brief Get the remote port and IP address.
+ * @note Used in TCP server mode
+ * @return address 4-byte remote IP address
+ * @return port 2-byte remote port number
+ */
+#define CMD06_GET_REMOT_IPP_SN              0x2D
+
+
+
+/**
+ * @brief Clear the receive buffer
+ * @param socknum index value of the socket
+ */
+#define CMD10_CLEAR_RECV_BUF_SN             0x2E
+
+
+
+/**
+ * @brief Get socket n status
+ * @param socknum index value of the socket
+ * @return status opened or closed
+ * @return tcp_status TCP status, only valid in TCP mode and the status is open
+ */
+#define CMD12_GET_SOCKET_STATUS_SN          0x2F
+
+
+
+/**
+ * @brief Get the interrupt status of socket n
+ * @param socknum index value of the socket
+ * @return status socket interrupt status
+ */
+#define CMD11_GET_INT_STATUS_SN             0x30
+
+
+
+/**
+ * @brief Set the destination IP address of socket n
+ * @param socknum index value of the socket
+ * @param address 4-byte IP address
+ */
+#define CMD50_SET_IP_ADDR_SN                0x31
+
+
+
+/**
+ * @brief Set the destination port of socket n
+ * @param socknum index value of the socket
+ * @param port 2-byte destination port
+ */
+#define CMD30_SET_DES_PORT_SN               0x32
+
+
+
+/**
+ * @brief Set the source port of socket n
+ * @param socknum index value of the socket
+ * @param port 2-byte source port
+ */
+#define CMD30_SET_SOUR_PORT_SN              0x33
+
+
+
+/**
+ * @brief Set the protocol type of socket n
+ * @param socknum index value of the socket
+ * @param type protocol type
+ */
+#define CMD20_SET_PROTO_TYPE_SN             0x34
+
+
+
+/**
+ * @brief Open socket n
+ * @note This command needs to wait for the command to be executed successfully
+ * @param socknum index value of the socket
+ */
+#define CMD1W_OPEN_SOCKET_SN                0x35
+
+
+
+
+/**
+ * @brief Socket n listens
+ * @note After receiving this command, socket n enters server mode, which is
+ * only valid for TCP mode
+ * @note This command needs to wait for the command to be executed successfully
+ * @param socknum index value of the socket
+ */
+#define CMD1W_TCP_LISTEN_SN                 0x36
+
+
+
+/**
+ * @brief Socket n connection
+ * @note After receiving this command, socket n enters client mode, which is
+ * only valid for TCP mode
+ * @note This command needs to wait for the command to be executed successfully
+ * @param socknum index value of the socket
+ */
+#define CMD1W_TCP_CONNECT_SN                0x37
+
+
+
+
+/**
+ * @brief Socket n disconnects
+ * @note After receiving this command, socket n disconnects the existing
+ * connection, which is only valid for TCP mode
+ * @note This command needs to wait for the command to be executed successfully
+ * @param socknum index value of the socket
+ */
+#define CMD1W_TCP_DISNCONNECT_SN            0x38
+
+
+
+/**
+ * @brief Write data to socket n buffer
+ * @param socknum index value of the socket
+ * @param len 2-byte length
+ */
+#define CMD30_WRITE_SEND_BUF_SN             0x39
+
+
+
+/**
+ * @brief Get the length of data received by socket n
+ * @param socknum index value of the socket
+ * @return len 2-byte receiving length
+ */
+#define CMD12_GET_RECV_LEN_SN               0x3B
+
+
+
+/**
+ * @brief Read socket n receive buffer data
+ * @param socknum index value of the socket
+ * @param len(LSB) 2-byte read length
+ * @return data
+ */
+#define CMD30_READ_RECV_BUF_SN              0x3C
+
+
+
+/**
+ * @brief Close socket n
+ * @param socknum index value of the socket
+ * @note This command needs to wait for the command to be executed successfully
+ */
+#define CMD1W_CLOSE_SOCKET_SN               0x3D
+
+
+
+/**
+ * @brief Set the IP packet protocol type of socket n
+ * @note this command is only valid when the socket is in IP RAW mode
+ * @param socknum index value of the socket
+ * @param type IP RAW protocol type
+ */
+#define CMD20_SET_IPRAW_PRO_SN              0x3E
+
+
+
+/**
+ * @brief Turn on/off PING
+ * @note it is turned on by default
+ * @param enable 0 means to turn off PING, 1 means to turn on PING
+ */
+#define CMD10_PING_ENABLE                   0x3F
+
+
+
+/**
+ * @brief Get MAC address
+ * @return address 6-byte MAC address
+ */
+#define CMD06_GET_MAC_ADDR                  0x40
+
+
+
+/**
+ * @brief Set DHCP enable
+ * @param enable 1 starts DHCP, 0 turns off DHCP
+ */
+#define CMD10_DHCP_ENABLE                   0x41
+
+
+
+/**
+ * @brief Get DHCP status
+ * @return
+ *   - 0 success
+ *   - others fail
+ */
+#define CMD01_GET_DHCP_STATUS               0x42
+
+
+
+/**
+ * @brief Get IP, subnet mask, gateway info
+ * @return IP 4 bytes
+ * @return gateway 4 bytes
+ * @return mask 4 bytes
+ * @return DNS1 4 bytes
+ * @return DNS2 4 bytes
+ */
+#define CMD014_GET_IP_INF                   0x43
+
+
+
+
+/**
+ * @brief Set PPPOE user name
+ * @param name using 0 to end
+ */
+#define CMD00_PPPOE_SET_USER_NAME           0x44
+
+
+
+/**
+ * @brief Set PPPOE password
+ * @param password using 0 to end
+ */
+#define CMD00_PPPOE_SET_PASSWORD            0x45
+
+
+
+/**
+ * @brief Set PPPOE enable
+ * @param enable 1 starts, 0 turns off
+ */
+#define CMD10_PPPOE_ENABLE                  0x46
+
+
+
+/**
+ * @brief Get PPPOE status
+ * @return
+ *   - 0 success
+ *   - others fail
+ */
+#define CMD01_GET_PPPOE_STATUS              0x47
+
+
+
+/**
+ * @brief Set TCP MSS
+ * @param MSS(LSB) 2 bytes TCP MSS
+ */
+#define CMD20_SET_TCP_MSS                   0x50
+
+
+
+/**
+ * @brief Set TTL
+ * @param socknum index value of the socket
+ * @param ttl TTL value, the maximum is 128
+ */
+#define CMD20_SET_TTL                       0x51
+
+
+
+/**
+ * @brief Set SOCKET receive buffer
+ * @param socknum index value of the socket
+ * @param blkidx starting block index
+ * @param blknum block number
+ */
+#define CMD30_SET_RECV_BUF                  0x52
+
+
+
+/**
+ * @brief Set SOCKET send buffer
+ * @param socknum index value of the socket
+ * @param blkidx starting block index
+ * @param blknum block number
+ */
+#define CMD30_SET_SEND_BUF                  0x53
+
+
+
+/**
+ * @brief Set MAC receive buffer
+ * @param size size of the MAC receive buffer in 1 byte, in units of 16
+ */
+#define CMD10_SET_MAC_RECV_BUF              0x54
+
+
+
+/**
+ * @brief Set function parameters
+ * @param params 4-byte startup parameters
+ */
+#define CMD40_SET_FUN_PARA                  0x55
+
+
+
+/**
+ * @brief Set KEEPLIVE idle time
+ * @param time(LSB) 4-byte keep-alive timer idle time
+ */
+#define CMD40_SET_KEEP_LIVE_IDLE            0x56
+
+
+
+/**
+ * @brief Set KEEPLIVE interval time
+ * @param time(LSB) 4-byte keep-alive timer interval time
+ */
+#define CMD40_SET_KEEP_LIVE_INTVL           0x57
+
+
+
+/**
+ * @brief Set KEEPLIVE retries
+ * @param times retry times
+ */
+#define CMD10_SET_KEEP_LIVE_CNT             0x58
+
+
+
+/**
+ * @brief Set socket n KEEPLIVE
+ * @param socknum index value of the socket
+ * @param enable 1 starts, 0 turns off
+ */
+#define CMD20_SET_KEEP_LIVE_SN              0X59
+
+
+
+/**
+ * @brief Erase EEPROM
+ */
+#define CMD00_EEPROM_ERASE                  0xE9
+
+
+
+/**
+ * @brief Write EEPROM
+ * @param address 2-byte address
+ * @param length length must be less than 64
+ */
+#define CMD30_EEPROM_WRITE                  0xEA
+
+
+
+/**
+ * @brief Read EEPROM
+ * @param address 2-byte address
+ * @param length length must be less than 64
+ */
+#define CMD30_EEPROM_READ                   0xEB
+
+
+
+/**
+ * @brief Read GPIO register
+ * @param address REG address
+ */
+#define CMD10_READ_GPIO_REG                 0xEC
+
+
+
+/**
+ * @brief Write GPIO register
+ * @param address REG address
+ * @param data
+ */
+#define CMD20_WRITE_GPIO_REG                0xED
+
+/**
+ * @}
+*/
+
+
+
+/**
+ * @defgroup Socket Protocal
+ * @{
+ */
+#define PROTO_TYPE_IP_RAW           0 /* IP layer raw data*/
+#define PROTO_TYPE_MAC_RAW          1 /* MAC layer raw data*/
+#define PROTO_TYPE_UDP              2 /* UDP protocol type*/
+#define PROTO_TYPE_TCP              3 /* TCP protocol type*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup PHY Command Parameters/Status
+ * @{
+ */
+#define PHY_DISCONN                 (1<<0) /* PHY disconnect*/
+#define PHY_10M_FLL                 (1<<1) /* 10M full duplex*/
+#define PHY_10M_HALF                (1<<2) /* 10M half-duplex*/
+#define PHY_100M_FLL                (1<<3) /* 100M full duplex*/
+#define PHY_100M_HALF               (1<<4) /* 100M half-duplex*/
+#define PHY_AUTO                    (1<<5) /* PHY automatic mode*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup MAC Filter
+ * @{
+ */
+#define MAC_FILT_RECV_BORADPKT      (1<<0) /* Enable receiving broadcast packets*/
+#define MAC_FILT_RECV_ALL           (1<<1) /* Enable receiving all data packets*/
+#define MAC_FILT_RECV_MULTIPKT      (1<<2) /* Enable receiving multicast packets*/
+#define MAC_FILT_RECV_ENABLE        (1<<3) /* Enable reception*/
+#define MAC_FILT_SEND_ENABLE        (1<<4) /* Enable sending*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup Global Interrupt Status
+ * @{
+ */
+#define GINT_STAT_UNREACH           (1<<0) /* Unreachable interrupt*/
+#define GINT_STAT_IP_CONFLI         (1<<1) /* IP conflict*/
+#define GINT_STAT_PHY_CHANGE        (1<<2) /* PHY status change*/
+#define GINT_STAT_DHCP              (1<<3) /* PHY status change*/
+#define GINT_STAT_SOCK0             (1<<4) /* socket0 generates an interrupt*/
+#define GINT_STAT_SOCK1             (1<<5) /* socket1 generates an interrupt*/
+#define GINT_STAT_SOCK2             (1<<6) /* socket2 generates an interrupt*/
+#define GINT_STAT_SOCK3             (1<<7) /* socket3 generates an interrupt*/
+#define GINT_STAT_SOCK4             (1<<8) /* Scoket4 generates an interrupt*/
+#define GINT_STAT_SOCK5             (1<<9) /* Scoket5 generates an interrupt*/
+#define GINT_STAT_SOCK6             (1<<10) /* Scoket6 generates an interrupt*/
+#define GINT_STAT_SOCK7             (1<<11) /* Scoket7 generates an interrupt*/
+/**
+ * @}
+ */
+
+
+
+
+/**
+ * @defgroup Socket Interrupt Status
+ * @{
+ */
+#define SINT_STAT_SENBUF_FREE       (1<<0) /* Send buffer is free*/
+#define SINT_STAT_SEND_OK           (1<<1) /* Sent successfully*/
+#define SINT_STAT_RECV              (1<<2) /* The socket port receives data or the receive buffer is not empty*/
+#define SINT_STAT_CONNECT           (1<<3) /* The connection is successful, this interrupt is generated in TCP mode*/
+#define SINT_STAT_DISCONNECT        (1<<4) /* The connection is disconnected, this interrupt occurs in TCP mode*/
+#define SINT_STAT_TIM_OUT           (1<<6) /* This interrupt occurs in ARP and TCP modes*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup Command Status
+ * @{
+ */
+#define CH395_ERR_SUCCESS           0x00 /* Command operation successful*/
+#define CH395_RET_ABORT             0x5F /* Command operation failed*/
+#define CH395_ERR_BUSY              0x10 /* Busy status, indicating that the command is currently being executed*/
+#define CH395_ERR_MEM               0x11 /* Memory error*/
+#define CH395_ERR_BUF               0x12 /* Buffer error*/
+#define CH395_ERR_TIMEOUT           0x13 /* timeout*/
+#define CH395_ERR_RTE               0x14 /* Routing error*/
+#define CH395_ERR_ABRT              0x15 /* Connection stopped*/
+#define CH395_ERR_RST               0x16 /* Connection reset*/
+#define CH395_ERR_CLSD              0x17 /* connection closed/socket in closed state*/
+#define CH395_ERR_CONN              0x18 /* No connection*/
+#define CH395_ERR_VAL               0x19 /* Wrong value*/
+#define CH395_ERR_ARG               0x1A /* Wrong parameter*/
+#define CH395_ERR_USE               0x1B /* Already used*/
+#define CH395_ERR_IF                0x1C /* MAC error*/
+#define CH395_ERR_ISCONN            0x1D /* Connected*/
+#define CH395_ERR_OPEN              0X20 /* Already opened*/
+#define CH395_ERR_UNKNOW            0xFA /* Unknown error*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup PPP Status
+ * @{
+ */
+#define CH395_PPP_SUCCESS           0 /* Success*/
+#define CH395_PPPERR_PARM           1 /* Invalid parameter*/
+#define CH395_PPPERR_OPEN           2 /* Unable to open PPP session*/
+#define CH395_PPPERR_DEVICE         3 /* Invalid PPP device*/
+#define CH395_PPPERR_ALLOC          4 /* Resource allocation failed*/
+#define CH395_PPPERR_USER           5 /* User interrupt*/
+#define CH395_PPPERR_CONNECT        6 /* Disconnected*/
+#define CH395_PPPERR_AUTHFAIL       7 /* Challenge identification failed*/
+#define CH395_PPPERR_PROTOCOL       8 /* Handshake protocol failed*/
+#define CH395_PPPERR_TIME_OUT       9 /* Timeout failure*/
+#define CH395_PPPERR_CLOSE          10 /* Close failed*/
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup Unreachable Code
+ * @note Please refer to the RFC792 document for other values
+ * @{
+ */
+#define UNREACH_CODE_HOST           0 /* The host is unreachable*/
+#define UNREACH_CODE_NET            1 /* The network is unreachable*/
+#define UNREACH_CODE_PROTOCOL       2 /* The protocol is unreachable*/
+#define UNREACH_CODE_PROT           3 /* Port unreachable*/
+/**
+ * @}
+ */
+
+
+
+
+/**
+ * @defgroup Command Header
+ * @{
+ */
+#define SER_SYNC_CODE1              0x57 /* Serial port command synchronization code 1 */
+#define SER_SYNC_CODE2              0xAB /* Serial port command synchronization code 2 */
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup TCP Status
+ * @{
+ */
+# define TCP_CLOSED                 0
+# define TCP_LISTEN                 1
+# define TCP_SYN_SENT               2
+# define TCP_SYN_RCVD               3
+# define TCP_ESTABLISHED            4
+# define TCP_FIN_WAIT_1             5
+# define TCP_FIN_WAIT_2             6
+# define TCP_CLOSE_WAIT             7
+# define TCP_CLOSING                8
+# define TCP_LAST_ACK               9
+# define TCP_TIME_WAIT              10
+/**
+ * @}
+ */
+
+
+
+/**
+ * @defgroup GPIO Register Address
+ * @{
+ */
+#define GPIO_DIR_REG                0x80 /* Register direction register, 1: output; 0: input*/
+#define GPIO_IN_REG                 0x81 /* GPIO input register*/
+#define GPIO_OUT_REG                0x82 /* GPIO output register*/
+#define GPIO_CLR_REG                0x83 /* GPIO output clear: 0=keep, 1=clear */
+#define GPIO_PU_REG                 0x84 /* GPIO pull-up enable register*/
+#define GPIO_PD_REG                 0x85 /* GPIO pull-down enable register*/
+/**
+ * @}
+ */
+
+
+
+
+/**
+ * @defgroup Function Parameter
+ * @{
+ */
+#define FUN_PARA_FLAG_TCP_SERVER    (1<<1) /* tcp server multi-connection mode flag, supported by version 0X44 and later*/
+#define FUN_PARA_FLAG_LOW_PWR       (1<<2) /* Low energy consumption mode */
+#define SOCK_CTRL_FLAG_SOCKET_CLOSE (1<<3) /* CH395 does not actively close the Socket */
+#define SOCK_DISABLE_SEND_OK_INT    (1<<4) /* send ok interrupt control bit, 1 means turning off send ok interrupt*/
+/**
+ * @}
+ */
+
+# ifdef __cplusplus
+}
+# endif

--- a/components/esp_eth/src/esp_eth_mac_ch395.c
+++ b/components/esp_eth/src/esp_eth_mac_ch395.c
@@ -1,0 +1,1694 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-FileContributor: 2024 Sergey Kharenko
+ * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+
+#include "driver/gpio.h"
+#include "esp_attr.h"
+#include "esp_check.h"
+#include "esp_cpu.h"
+#include "esp_err.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_spec.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_rom_gpio.h"
+#include "esp_timer.h"
+#include "freertos/idf_additions.h"
+#include "freertos/projdefs.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#include "ch395.h"
+#include "portmacro.h"
+
+static const char *TAG = "ch395.mac";
+
+#define CH395_UART_DEFAULT_BAUDRATE         (9600)
+#define CH395_MAC_TX_WAIT_TIMEOUT_MS        (50)
+#define CH395_LOCK_TIMEOUT_MS               (50)
+#define CH395_MIN_TX_PACKSZ                 (60)
+#define CH395_POWER_ON_DELAY_MS             (200)
+#define CH395_RX_WAIT_TIMEOUT_MS            (40)
+
+const static uint8_t CH395_CMD_TXBUFFER = CMD30_WRITE_SEND_BUF_SN;
+const static uint8_t CH395_CMD_RXBUFFER = CMD30_READ_RECV_BUF_SN;
+const static uint8_t CH395_CMD_GETPHY = CMD01_GET_PHY_STATUS;
+const static uint8_t CH395_CMD_SETPHY = CMD10_SET_PHY;
+const static uint8_t CH395_CMD_GETRXSZ = CMD12_GET_RECV_LEN_SN;
+const static uint8_t CH395_PARAM_SOCKID = 0;
+
+const static uint8_t CH395_PADDING_BUFF[CH395_MIN_TX_PACKSZ] = {0x00};
+const static uint8_t CH395_UART_HEAD_BUFF[] = {SER_SYNC_CODE1, SER_SYNC_CODE2};
+
+
+typedef struct {
+    int cs_pin;
+    spi_device_handle_t hdl;
+    spi_transaction_t trans;
+    uint8_t cache[2];
+    SemaphoreHandle_t lock;
+} eth_spi_ctx_t;
+
+typedef struct {
+    uart_port_t port;
+    uint8_t cache[2];
+    SemaphoreHandle_t lock;
+} eth_uart_ctx_t;
+
+typedef struct {
+    void *ctx;
+    void *(*init)(const void *config);
+    esp_err_t (*deinit)(void *ctx);
+    esp_err_t (*io)(void *ctx, uint8_t cmd, uint8_t *tx_data,
+                    uint32_t tx_len, uint8_t *rx_data, uint32_t rx_len);
+
+    esp_err_t (*tx_buffer)(void *ctx, uint8_t *data, uint32_t len);
+    esp_err_t (*rx_buffer)(void *ctx, uint8_t *data, uint32_t len);
+    esp_err_t (*get_rx_size)(void *ctx, uint32_t *len);
+
+    esp_err_t (*set_phy)(void *ctx, uint8_t mode);
+    esp_err_t (*get_phy)(void *ctx, uint8_t *sta);
+} eth_generic_driver_t;
+
+typedef struct {
+    esp_eth_mac_t parent;
+    esp_eth_mediator_t *eth;
+
+    eth_generic_driver_t drv;
+
+    int int_gpio_num;
+
+    TaskHandle_t rx_task_hdl;
+    SemaphoreHandle_t tx_busy_lock;
+
+    esp_timer_handle_t poll_timer;
+    uint32_t poll_period_ms;
+
+    uint8_t version;
+    uint8_t addr[6];
+    uint8_t *rx_buffer;
+    uint32_t rx_len;
+} emac_ch395_t;
+
+
+static void *ch395_spi_init(const void *config)
+{
+    void *ret = NULL;
+    eth_ch395_config_t *ch395_config = (eth_ch395_config_t *)config;
+    eth_spi_ctx_t *spi = calloc(1, sizeof(eth_spi_ctx_t));
+    ESP_GOTO_ON_FALSE(spi, NULL, err, TAG, "no memory for SPI context data");
+
+    /* SPI device init */
+    spi_device_interface_config_t *spi_devcfg;
+    spi_devcfg = ch395_config->spi.spi_devcfg;
+
+    /* Cancel autocontrol of CS pin*/
+    ESP_GOTO_ON_FALSE(
+        spi_devcfg->spics_io_num >= 0, NULL, err, TAG, "invalid CS pin number");
+
+    spi->cs_pin = spi_devcfg->spics_io_num;
+    spi_devcfg->spics_io_num = -1;
+
+    gpio_config_t gpio_cfg = {.pin_bit_mask =
+                                  1ull << (spi->cs_pin),
+                              .mode = GPIO_MODE_OUTPUT,
+                              .intr_type = GPIO_INTR_DISABLE
+                             };
+    gpio_config(&gpio_cfg);
+    ESP_GOTO_ON_FALSE(gpio_set_level(spi->cs_pin, 1)
+                      == ESP_OK,
+                      NULL, err, TAG, "cannot init CS pin");
+
+    ESP_GOTO_ON_FALSE(
+        spi_devcfg->command_bits == 0 && spi_devcfg->address_bits == 0, NULL,
+        err, TAG, "incorrect SPI frame format (command_bits/address_bits)");
+    ESP_GOTO_ON_FALSE(
+        spi_bus_add_device(ch395_config->spi.spi_host_id, spi_devcfg, &spi->hdl)
+        == ESP_OK,
+        NULL, err, TAG, "adding device to SPI host #%d failed",
+        ch395_config->spi.spi_host_id + 1);
+    /* create mutex */
+    spi->lock = xSemaphoreCreateMutex();
+    ESP_GOTO_ON_FALSE(spi->lock, NULL, err, TAG, "create lock failed");
+
+    spi->trans.flags = 0;
+    spi->trans.length = 8;
+
+    ret = spi;
+    return ret;
+err:
+    if (spi) {
+        if (spi->lock) {
+            vSemaphoreDelete(spi->lock);
+        }
+        free(spi);
+    }
+    return ret;
+}
+
+static esp_err_t ch395_spi_deinit(void *spi_ctx)
+{
+    esp_err_t ret = ESP_OK;
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+
+    gpio_reset_pin(spi->cs_pin);
+    spi_bus_remove_device(spi->hdl);
+    vSemaphoreDelete(spi->lock);
+
+    free(spi);
+    return ret;
+}
+
+
+static inline bool ch395_spi_lock(eth_spi_ctx_t *spi)
+{
+    return xSemaphoreTake(spi->lock, pdMS_TO_TICKS(CH395_LOCK_TIMEOUT_MS))
+           == pdTRUE;
+}
+
+static inline bool ch395_spi_unlock(eth_spi_ctx_t *spi)
+{
+    return xSemaphoreGive(spi->lock) == pdTRUE;
+}
+
+static inline void ch395_spi_start(eth_spi_ctx_t *spi)
+{
+    gpio_set_level(spi->cs_pin, 0);
+}
+
+static inline void ch395_spi_stop(eth_spi_ctx_t *spi)
+{
+    gpio_set_level(spi->cs_pin, 1);
+}
+
+static esp_err_t ch395_spi_io(void *spi_ctx, uint8_t cmd, uint8_t *tx_data,
+                              uint32_t tx_len, uint8_t *rx_data,
+                              uint32_t rx_len)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &cmd;
+    spi->trans.rx_buffer = NULL;
+
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    if (tx_len > 0) {
+        for (uint32_t i = 0; i < tx_len; i++) {
+            spi->trans.tx_buffer = tx_data + i;
+            if (spi_device_polling_transmit(spi->hdl, &(spi->trans))
+                    != ESP_OK) {
+                ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                         __LINE__);
+                ch395_spi_stop(spi);
+                ch395_spi_unlock(spi);
+                return ESP_FAIL;
+            }
+        }
+    }
+
+    if (rx_len > 0) {
+        spi->trans.tx_buffer = NULL;
+        for (uint32_t i = 0; i < rx_len; i++) {
+            spi->trans.rx_buffer = rx_data + i;
+            if (spi_device_polling_transmit(spi->hdl, &(spi->trans))
+                    != ESP_OK) {
+                ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                         __LINE__);
+                ch395_spi_stop(spi);
+                ch395_spi_unlock(spi);
+                return ESP_FAIL;
+            }
+        }
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    return ESP_OK;
+}
+
+static esp_err_t ch395_spi_tx_buffer(void *spi_ctx, uint8_t *data,
+                                 uint32_t len)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &CH395_CMD_TXBUFFER;
+    spi->trans.rx_buffer = NULL;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.tx_buffer = &CH395_PARAM_SOCKID;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    if (len < CH395_MIN_TX_PACKSZ) {
+        spi->cache[0] = (uint8_t)CH395_MIN_TX_PACKSZ;
+        spi->cache[1] = (uint8_t)(CH395_MIN_TX_PACKSZ >> 8);
+    } else {
+        spi->cache[0] = (uint8_t)len;
+        spi->cache[1] = (uint8_t)(len >> 8);
+    }
+
+    spi->trans.length = 8 * 2;
+    spi->trans.tx_buffer = spi->cache;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                    __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.length = 8 * len;
+    spi->trans.tx_buffer = data;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                    __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    if (len < CH395_MIN_TX_PACKSZ) {
+        spi->trans.length = 8 * (CH395_MIN_TX_PACKSZ - len);
+        spi->trans.tx_buffer = CH395_PADDING_BUFF;
+        if (spi_device_polling_transmit(spi->hdl, &(spi->trans))
+                != ESP_OK) {
+            ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                        __LINE__);
+            ch395_spi_stop(spi);
+            ch395_spi_unlock(spi);
+            return ESP_FAIL;
+        }
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    return ESP_OK;
+}
+
+
+static esp_err_t ch395_spi_rx_buffer(void *spi_ctx, uint8_t *data,
+                                 uint32_t len)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &CH395_CMD_RXBUFFER;
+    spi->trans.rx_buffer = NULL;
+
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.tx_buffer = &CH395_PARAM_SOCKID;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->cache[0] = (uint8_t)len;
+    spi->cache[1] = (uint8_t)(len >> 8);
+
+    spi->trans.length = 8 * 2;
+    spi->trans.tx_buffer = spi->cache;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                    __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.length = 8 * 4;
+    spi->trans.tx_buffer = NULL;
+    while(len>4){
+        spi->trans.rx_buffer = data;
+        if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+            ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                        __LINE__);
+            ch395_spi_stop(spi);
+            ch395_spi_unlock(spi);
+            return ESP_FAIL;
+        }
+        data += 4;
+        len -= 4;
+    }
+
+    spi->trans.length = 8 * len;
+    spi->trans.rx_buffer = data;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__,
+                    __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    return ESP_OK;
+}
+
+static esp_err_t ch395_spi_get_rx_size(void *spi_ctx, uint32_t *len)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &CH395_CMD_GETRXSZ;
+    spi->trans.rx_buffer = NULL;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.tx_buffer = &CH395_PARAM_SOCKID;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.length = 8 * 2;
+    spi->trans.tx_buffer = NULL;
+    spi->trans.rx_buffer = spi->cache;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    *len = spi->cache[0] + ((spi->cache[1]) << 8);
+
+    return ESP_OK;
+}
+
+static esp_err_t ch395_spi_get_phy_status(void *spi_ctx, uint8_t *sta)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &CH395_CMD_GETPHY;
+    spi->trans.rx_buffer = NULL;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.tx_buffer = NULL;
+    spi->trans.rx_buffer = sta;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    return ESP_OK;
+}
+
+static esp_err_t ch395_spi_set_phy_mode(void *spi_ctx, uint8_t mode)
+{
+    eth_spi_ctx_t *spi = (eth_spi_ctx_t *)spi_ctx;
+    if (!ch395_spi_lock(spi)) {
+        return ESP_ERR_TIMEOUT;
+    }
+    ch395_spi_start(spi);
+
+    spi->trans.length = 8;
+    spi->trans.tx_buffer = &CH395_CMD_SETPHY;
+    spi->trans.rx_buffer = NULL;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    spi->trans.tx_buffer = &mode;
+    if (spi_device_polling_transmit(spi->hdl, &(spi->trans)) != ESP_OK) {
+        ESP_LOGE(TAG, "%s(%d): spi transmit failed", __FUNCTION__, __LINE__);
+        ch395_spi_stop(spi);
+        ch395_spi_unlock(spi);
+        return ESP_FAIL;
+    }
+
+    ch395_spi_stop(spi);
+    ch395_spi_unlock(spi);
+
+    return ESP_OK;
+}
+
+
+
+static void *ch395_uart_init(const void *config)
+{
+    void *ret = NULL;
+    eth_ch395_config_t *ch395_config = (eth_ch395_config_t *)config;
+    eth_uart_ctx_t *uart = calloc(1, sizeof(eth_uart_ctx_t));
+    ESP_GOTO_ON_FALSE(uart, NULL, err, TAG, "no memory for UART context data");
+
+    /* UART device init */
+    uart_config_t uart_devcfg;
+    uart_devcfg = *(ch395_config->uart.uart_devcfg);
+
+    ESP_GOTO_ON_FALSE(uart_driver_install(ch395_config->uart.uart_port_id, 2048,
+                                          0, 0, NULL, 0)
+                          == ESP_OK,
+                      NULL, err, TAG, "uart port init failed");
+    ESP_GOTO_ON_FALSE(uart_devcfg.data_bits == UART_DATA_8_BITS
+                          && uart_devcfg.flow_ctrl == UART_HW_FLOWCTRL_DISABLE
+                          && uart_devcfg.parity == UART_PARITY_DISABLE
+                          && uart_devcfg.stop_bits == UART_STOP_BITS_1,
+                      NULL, err, TAG, "incorrect UART configuration");
+    ESP_GOTO_ON_FALSE(
+        uart_param_config(ch395_config->uart.uart_port_id, &uart_devcfg)
+            == ESP_OK,
+        NULL, err, TAG, "uart param init failed");
+    ESP_GOTO_ON_FALSE(uart_set_pin(ch395_config->uart.uart_port_id,
+                                   ch395_config->uart.uart_tx_gpio_num,
+                                   ch395_config->uart.uart_rx_gpio_num, -1, -1)
+                          == ESP_OK,
+                      NULL, err, TAG, "uart pin set failed");
+
+    uart->port = ch395_config->uart.uart_port_id;
+
+    /* create mutex */
+    uart->lock = xSemaphoreCreateMutex();
+    ESP_GOTO_ON_FALSE(uart->lock, NULL, err, TAG, "create lock failed");
+
+    ret = (void *)uart;
+    return ret;
+
+err:
+    if (uart) {
+        if (uart->lock) { vSemaphoreDelete(uart->lock); }
+        free(uart);
+    }
+    return ret;
+}
+
+static esp_err_t ch395_uart_deinit(void *uart_ctx)
+{
+    esp_err_t ret = ESP_OK;
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    uart_driver_delete(uart->port);
+    vSemaphoreDelete(uart->lock);
+
+    free(uart);
+    return ret;
+}
+
+
+static inline bool ch395_uart_lock(eth_uart_ctx_t *uart)
+{
+    return xSemaphoreTake(uart->lock, pdMS_TO_TICKS(CH395_LOCK_TIMEOUT_MS))
+           == pdTRUE;
+}
+
+static inline bool ch395_uart_unlock(eth_uart_ctx_t *uart)
+{
+    return xSemaphoreGive(uart->lock) == pdTRUE;
+}
+
+static esp_err_t ch395_uart_io(void *uart_ctx, uint8_t cmd, uint8_t *tx_data,
+                               uint32_t tx_len, uint8_t *rx_data,
+                               uint32_t rx_len)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uart_flush(uart->port);
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &cmd, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (tx_len > 0) {
+        if (uart_write_bytes(uart->port, tx_data, tx_len) < 0) {
+            ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__,
+                     __LINE__);
+            ch395_uart_unlock(uart);
+            return ESP_FAIL;
+        }
+    }
+
+    if (rx_len > 0) {
+        if (uart_read_bytes(uart->port, rx_data, rx_len,
+                            pdMS_TO_TICKS(CH395_RX_WAIT_TIMEOUT_MS))
+                < 0) {
+            ESP_LOGE(TAG, "%s(%d): uart receive failed", __FUNCTION__,
+                     __LINE__);
+            ch395_uart_unlock(uart);
+            return ESP_FAIL;
+        }
+    }
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+static esp_err_t ch395_uart_tx_buffer(void *uart_ctx, uint8_t *data,
+                                 uint32_t len)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_CMD_TXBUFFER, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_PARAM_SOCKID, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (len < CH395_MIN_TX_PACKSZ) {
+        uart->cache[0] = (uint8_t)CH395_MIN_TX_PACKSZ;
+        uart->cache[1] = (uint8_t)(CH395_MIN_TX_PACKSZ >> 8);
+    } else {
+        uart->cache[0] = (uint8_t)len;
+        uart->cache[1] = (uint8_t)(len >> 8);
+    }
+
+    if (uart_write_bytes(uart->port, uart->cache, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__,
+                 __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, data, len) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (len < 60) {
+        if (uart_write_bytes(uart->port, CH395_PADDING_BUFF, 60 - len) < 0) {
+            ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__,
+                     __LINE__);
+            ch395_uart_unlock(uart);
+            return ESP_FAIL;
+        }
+    }
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+
+static esp_err_t ch395_uart_rx_buffer(void *uart_ctx, uint8_t *data,
+                                 uint32_t len)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uart_flush(uart->port);
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_CMD_RXBUFFER, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_PARAM_SOCKID, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    uart->cache[0] = (uint8_t)len;
+    uart->cache[1] = (uint8_t)(len >> 8);
+
+    if (uart_write_bytes(uart->port, uart->cache, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__,
+                 __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_read_bytes(uart->port, data, len,
+                        pdMS_TO_TICKS(CH395_RX_WAIT_TIMEOUT_MS))
+            < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart receive failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+
+
+static esp_err_t ch395_uart_get_rx_size(void *uart_ctx, uint32_t *len)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uart_flush(uart->port);
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_CMD_GETRXSZ, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_PARAM_SOCKID, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_read_bytes(uart->port, uart->cache, 2,
+                        pdMS_TO_TICKS(CH395_RX_WAIT_TIMEOUT_MS))
+            < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart receive failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    *len = uart->cache[0] + ((uart->cache[1]) << 8);
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+static esp_err_t ch395_uart_get_phy_status(void *uart_ctx, uint8_t *sta)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uart_flush(uart->port);
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_CMD_GETPHY, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_read_bytes(uart->port, sta, 1,
+                        pdMS_TO_TICKS(CH395_RX_WAIT_TIMEOUT_MS))
+            < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart receive failed", __FUNCTION__,
+                 __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+static esp_err_t ch395_uart_set_phy_mode(void *uart_ctx, uint8_t mode)
+{
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)uart_ctx;
+
+    if (!ch395_uart_lock(uart)) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uart_flush(uart->port);
+    if (uart_write_bytes(uart->port, CH395_UART_HEAD_BUFF, 2) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &CH395_CMD_SETPHY, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    if (uart_write_bytes(uart->port, &mode, 1) < 0) {
+        ESP_LOGE(TAG, "%s(%d): uart transmit failed", __FUNCTION__, __LINE__);
+        ch395_uart_unlock(uart);
+        return ESP_FAIL;
+    }
+
+    ch395_uart_unlock(uart);
+    return ESP_OK;
+}
+
+
+
+static esp_err_t ch395_cmd_pending_finish(emac_ch395_t *emac)
+{
+    uint8_t wait_cnt = 10;
+    uint8_t status;
+
+    while (wait_cnt--) {
+        if (emac->drv.io(emac->drv.ctx, CMD01_GET_CMD_STATUS, NULL, 0, &status, 1)
+                != ESP_OK) {
+            return ESP_FAIL;
+        }
+
+        switch (status) {
+        case CH395_ERR_SUCCESS: return ESP_OK;
+
+        case CH395_ERR_BUSY: continue;
+
+        default: return ESP_ERR_INVALID_STATE;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+
+    if (wait_cnt == 0) {
+        return ESP_ERR_TIMEOUT;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t ch395_set_baudrate(emac_ch395_t *emac, uint32_t baudrate)
+{
+    esp_err_t ret = ESP_OK;
+    uint8_t params[3];
+
+    params[0] = (uint8_t)baudrate;
+    params[1] = (uint8_t)(baudrate >> 8);
+    params[2] = (uint8_t)(baudrate >> 16);
+
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD31_SET_BAUDRATE, params, 3, NULL, 0), err,
+        TAG, "self check failed");
+    vTaskDelay(pdMS_TO_TICKS(100));
+err:
+    return ret;
+}
+
+static esp_err_t ch395_set_host_baudrate(emac_ch395_t *emac, uint32_t baudrate)
+{
+    esp_err_t ret = ESP_OK;
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)emac->drv.ctx;
+
+    ESP_GOTO_ON_ERROR(uart_set_baudrate(uart->port, baudrate), err, TAG,
+                      "uart set baudrate failed");
+err:
+    return ret;
+}
+
+static esp_err_t ch395_get_host_baudrate(emac_ch395_t *emac, uint32_t *baudrate)
+{
+    esp_err_t ret = ESP_OK;
+    eth_uart_ctx_t *uart = (eth_uart_ctx_t *)emac->drv.ctx;
+
+    ESP_GOTO_ON_ERROR(uart_get_baudrate(uart->port, baudrate), err, TAG,
+                      "uart get baudrate failed");
+err:
+    return ret;
+}
+
+static esp_err_t ch395_self_check(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+
+    uint8_t idata = 0xA5;
+    uint8_t odata;
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD11_CHECK_EXIST, &idata, 1, &odata, 1), err,
+        TAG, "self check failed");
+
+    if (odata == 0x5A) {
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+
+err:
+    return ret;
+}
+
+
+static esp_err_t ch395_strict_self_check(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+    uint8_t idata = 0;
+    uint8_t odata;
+
+    ESP_LOGI(TAG, "communication self check started. this will take some time...");
+
+    for (; idata < 0xFF; idata++) {
+        ESP_GOTO_ON_ERROR(
+            emac->drv.io(emac->drv.ctx, CMD11_CHECK_EXIST, &idata, 1, &odata, 1),
+            err, TAG, "self check failed");
+        ESP_GOTO_ON_FALSE(odata == (uint8_t)(~idata), ESP_ERR_NOT_FOUND, err,
+                          TAG, "self check failed");
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+
+    ESP_LOGI(TAG, "Communication self check passed!");
+err:
+    return ret;
+}
+
+static esp_err_t ch395_set_mac_addr(emac_ch395_t *emac)
+{
+    ESP_LOGE(TAG,
+             "%s(%d): You are trying to setting the MAC address. Once it is "
+             "overwritten, it can NOT be recovered FOREVER!!!"
+             "Therefore, this operation is FORBIDDEN in the driver. If you "
+             "really want to do that, please manually exec related"
+             " code or using DEBUG395.exe(Provided in "
+             "https://www.wch.cn/downloads/CH395EVT_ZIP.html ) instead",
+             __FUNCTION__, __LINE__);
+    return ESP_FAIL;
+}
+
+static esp_err_t ch395_get_mac_addr(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD06_GET_MAC_ADDR, NULL, 0, emac->addr, 6),
+        err, TAG, "read MAC failed");
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_reset(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+    /* software reset */
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD00_RESET_ALL, NULL, 0, NULL, 0), err, TAG,
+        "reset all failed");
+    vTaskDelay(pdMS_TO_TICKS(60));
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_verify_id(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+    uint8_t version = 0;
+
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD01_GET_IC_VER, NULL, 0, &version, 1), err,
+        TAG, "read chip version failed");
+    if (version >> 6 == 0x01) {
+        emac->version = version;
+        ESP_LOGI(TAG, "ch395 version: %02X", version);
+        return ESP_OK;
+    } else {
+        ESP_LOGE(TAG,
+                 "ch395 version mismatched, got %02X, bit 7, 6 should be 0, 1!",
+                 version);
+        return ESP_ERR_INVALID_VERSION;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_setup_default(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+    uint8_t param = 0;
+
+    /* Disable PING*/
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD10_PING_ENABLE, &param, 1, NULL, 0), err,
+        TAG, "disable PING failed");
+
+    /* Disable PPPOE*/
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD10_PPPOE_ENABLE, &param, 1, NULL, 0), err,
+        TAG, "disable PPPOE failed");
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    /* Disable DHCP*/
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD10_DHCP_ENABLE, &param, 1, NULL, 0), err,
+        TAG, "disable DHCP failed");
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    /* Disable SEND_OK_INT(only valid for 0x46 and later version)*/
+    if (emac->version >= 0x46) {
+        uint8_t fun_params[4] = {SOCK_DISABLE_SEND_OK_INT, 0x00};
+        ESP_GOTO_ON_ERROR(emac->drv.io(emac->drv.ctx, CMD40_SET_FUN_PARA,
+                                              fun_params, 4, NULL, 0),
+                          err, TAG, "disable Send OK INT failed");
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD0W_INIT_CH395, NULL, 0, NULL, 0), err, TAG,
+        "init CH395 failed");
+    vTaskDelay(pdMS_TO_TICKS(400));
+    ESP_GOTO_ON_ERROR(ch395_cmd_pending_finish(emac), err, TAG,
+                      "init CH395 timeout");
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_start(esp_eth_mac_t *mac)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    uint8_t sock_num = 0;
+
+    /* Enable MAC RAW mode for SOCK0*/
+    uint8_t sock_params[2];
+    sock_params[0] = 0;
+    sock_params[1] = PROTO_TYPE_MAC_RAW;
+    ESP_GOTO_ON_ERROR(emac->drv.io(emac->drv.ctx, CMD20_SET_PROTO_TYPE_SN,
+                                          sock_params, 2, NULL, 0),
+                      err, TAG, "setting MAC Raw mode failed");
+
+    /* Enable MAC filter, no blocking broadcast and multicast */
+    uint8_t macfil_params[9];
+    memset(macfil_params, 0, 0);
+    macfil_params[0] = MAC_FILT_SEND_ENABLE | MAC_FILT_RECV_ENABLE
+                       | MAC_FILT_RECV_BORADPKT | MAC_FILT_RECV_MULTIPKT;
+    ESP_GOTO_ON_ERROR(emac->drv.io(emac->drv.ctx, CMD90_SET_MAC_FILT,
+                                          macfil_params, 9, NULL, 0),
+                      err, TAG, "setting MAC Filter failed");
+    /* open SOCK0 */
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD1W_OPEN_SOCKET_SN, &sock_num, 1, NULL, 0),
+        err, TAG, "issue OPEN command failed");
+    vTaskDelay(pdMS_TO_TICKS(100));
+    ESP_GOTO_ON_ERROR(ch395_cmd_pending_finish(emac), err, TAG,
+                      "open SOCK 0 failed");
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_stop(esp_eth_mac_t *mac)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    uint8_t sock_num = 0;
+
+    /* close SOCK0 */
+    ESP_GOTO_ON_ERROR(
+        emac->drv.io(emac->drv.ctx, CMD1W_CLOSE_SOCKET_SN, &sock_num, 1, NULL, 0),
+        err, TAG, "issue CLOSE command failed");
+    ESP_GOTO_ON_ERROR(ch395_cmd_pending_finish(emac), err, TAG,
+                      "close SOCK 0 failed");
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_mediator(esp_eth_mac_t *mac,
+        esp_eth_mediator_t *eth)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(eth, ESP_ERR_INVALID_ARG, err, TAG,
+                      "can't set mac's mediator to null");
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    emac->eth = eth;
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_write_phy_reg(esp_eth_mac_t *mac, uint32_t phy_addr,
+        uint32_t phy_reg,
+        uint32_t reg_value)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+
+    ESP_GOTO_ON_FALSE(phy_reg == CMD10_SET_PHY, ESP_ERR_INVALID_ARG, err, TAG,
+                      "wrong PHY CMD");
+
+    ESP_GOTO_ON_ERROR(emac->drv.set_phy(emac->drv.ctx, (uint8_t)reg_value), err, TAG,
+                      "setting up PHY status failed");
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_read_phy_reg(esp_eth_mac_t *mac, uint32_t phy_addr,
+        uint32_t phy_reg,
+        uint32_t *reg_value)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(reg_value, ESP_ERR_INVALID_ARG, err, TAG,
+                      "can't set reg_value to null");
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+
+    ESP_GOTO_ON_FALSE(phy_reg == CMD01_GET_PHY_STATUS, ESP_ERR_INVALID_ARG, err,
+                      TAG, "wrong PHY CMD");
+
+    ESP_GOTO_ON_ERROR(emac->drv.get_phy(emac->drv.ctx, (uint8_t *)reg_value), err,
+                      TAG, "read PHY status failed");
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_addr(esp_eth_mac_t *mac, uint8_t *addr)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(addr, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    memcpy(emac->addr, addr, 6);
+    ESP_GOTO_ON_ERROR(ch395_set_mac_addr(emac), err, TAG,
+                      "set mac address failed");
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_get_addr(esp_eth_mac_t *mac, uint8_t *addr)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(addr, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    memcpy(addr, emac->addr, 6);
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_link(esp_eth_mac_t *mac, eth_link_t link)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+
+    switch (link) {
+    case ETH_LINK_UP:
+        ESP_LOGD(TAG, "link is up");
+        ESP_GOTO_ON_ERROR(mac->start(mac), err, TAG, "ch395 start failed");
+        if (emac->poll_timer) {
+            ESP_GOTO_ON_ERROR(
+                esp_timer_start_periodic(emac->poll_timer,
+                                         emac->poll_period_ms * 1000),
+                err, TAG, "start poll timer failed");
+        }
+        break;
+    case ETH_LINK_DOWN:
+        ESP_LOGD(TAG, "link is down");
+        ESP_GOTO_ON_ERROR(mac->stop(mac), err, TAG, "ch395 stop failed");
+        if (emac->poll_timer) {
+            ESP_GOTO_ON_ERROR(esp_timer_stop(emac->poll_timer), err, TAG,
+                              "stop poll timer failed");
+        }
+        break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_ARG, err, TAG,
+                          "unknown link status");
+        break;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_speed(esp_eth_mac_t *mac, eth_speed_t speed)
+{
+    esp_err_t ret = ESP_OK;
+
+    switch (speed) {
+    case ETH_SPEED_10M: ESP_LOGD(TAG, "working in 10Mbps"); break;
+    case ETH_SPEED_100M: ESP_LOGD(TAG, "working in 100Mbps"); break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_ARG, err, TAG,
+                          "unknown speed");
+        break;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_duplex(esp_eth_mac_t *mac,
+                                       eth_duplex_t duplex)
+{
+    esp_err_t ret = ESP_OK;
+
+    switch (duplex) {
+    case ETH_DUPLEX_HALF: ESP_LOGD(TAG, "working in half duplex"); break;
+    case ETH_DUPLEX_FULL: ESP_LOGD(TAG, "working in full duplex"); break;
+    default:
+        ESP_GOTO_ON_FALSE(false, ESP_ERR_INVALID_ARG, err, TAG,
+                          "unknown duplex");
+        break;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_set_promiscuous(esp_eth_mac_t *mac, bool enable)
+{
+    /* ch395 doesn't support promiscuous function, so accept any value */
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static esp_err_t emac_ch395_enable_flow_ctrl(esp_eth_mac_t *mac, bool enable)
+{
+    /* ch395 doesn't support flow control function, so accept any value */
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static esp_err_t emac_ch395_set_peer_pause_ability(esp_eth_mac_t *mac,
+        uint32_t ability)
+{
+    /* ch395 doesn't suppport PAUSE function, so accept any value */
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static esp_err_t emac_ch395_flush_recv_frame(emac_ch395_t *emac)
+{
+    esp_err_t ret = ESP_OK;
+
+    uint8_t sock_num = 0;
+    ESP_GOTO_ON_ERROR(emac->drv.io(emac->drv.ctx, CMD10_CLEAR_RECV_BUF_SN,
+                                          &sock_num, 1, NULL, 1),
+                      err, TAG, "flush receive buffer failed");
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_transmit(esp_eth_mac_t *mac, uint8_t *buf,
+                                     uint32_t length)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+
+    ESP_GOTO_ON_FALSE(length <= ETH_MAX_PACKET_SIZE, ESP_ERR_INVALID_ARG, err,
+                      TAG, "frame size is too big (actual %lu, maximum %lu)",
+                      length, (uint32_t)ETH_MAX_PACKET_SIZE);
+
+    ESP_GOTO_ON_FALSE(
+        xSemaphoreTake(emac->tx_busy_lock,
+                       pdMS_TO_TICKS(CH395_MAC_TX_WAIT_TIMEOUT_MS))
+        == pdTRUE,
+        ESP_ERR_TIMEOUT, err, TAG, "waiting last transmit time out");
+
+    ESP_GOTO_ON_ERROR(emac->drv.tx_buffer(emac->drv.ctx, buf, length), err, TAG,
+                      "write frame failed");
+
+err:
+    return ret;
+}
+
+static esp_err_t emac_ch395_receive(esp_eth_mac_t *mac, uint8_t *buf,
+                                    uint32_t *length)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+
+    ESP_GOTO_ON_ERROR(emac->drv.get_rx_size(emac->drv.ctx, length), err, TAG,
+                      "read receive length failed");
+
+    ESP_GOTO_ON_FALSE(*length <= ETH_MAX_PACKET_SIZE - ETH_CRC_LEN
+                      && *length >= ETH_MIN_PACKET_SIZE - ETH_CRC_LEN,
+                      ESP_ERR_INVALID_SIZE, err, TAG,
+                      "received invalid frame, length(%lu)", *length);
+
+    ESP_GOTO_ON_ERROR(emac->drv.rx_buffer(emac->drv.ctx, buf, *length), err, TAG,
+                      "receive frame failed");
+    return ret;
+
+err:
+    *length = 0;
+    emac_ch395_flush_recv_frame(emac);
+    return ret;
+}
+
+IRAM_ATTR static void ch395_isr_handler(void *arg)
+{
+    emac_ch395_t *emac = (emac_ch395_t *)arg;
+    BaseType_t high_task_wakeup = pdFALSE;
+
+    /* notify ch395 task */
+    vTaskNotifyGiveFromISR(emac->rx_task_hdl, &high_task_wakeup);
+    if (high_task_wakeup != pdFALSE) {
+        portYIELD_FROM_ISR();
+    }
+}
+
+static void ch395_poll_timer(void *arg)
+{
+    emac_ch395_t *emac = (emac_ch395_t *)arg;
+    xTaskNotifyGive(emac->rx_task_hdl);
+}
+
+static void emac_ch395_task(void *arg)
+{
+    emac_ch395_t *emac = (emac_ch395_t *)arg;
+    uint8_t sock_num = 0;
+    uint8_t g_intr = 0;
+    uint8_t s_intr = 0;
+
+    uint8_t *cache = NULL;
+
+    while (1) {
+        /* check if the task receives any notification */
+        if (emac->int_gpio_num >= 0) { // if in interrupt mode
+            if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000)) == 0
+                    && // if no notification ...
+                    gpio_get_level(emac->int_gpio_num)
+                    != 0) { // ...and no interrupt asserted
+                continue;   // -> just continue to check again
+            }
+        } else {
+            ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        }
+
+        /* read interrupt status */
+        emac->drv.io(emac->drv.ctx, CMD01_GET_GLOB_INT_STATUS, NULL, 0, &g_intr, 1);
+        if (!(g_intr & GINT_STAT_SOCK0)) {
+            continue;
+        }
+
+        emac->drv.io(emac->drv.ctx, CMD11_GET_INT_STATUS_SN, &sock_num, 1, &s_intr, 1);
+        if (s_intr & (SINT_STAT_SENBUF_FREE)) {
+            xSemaphoreGive(emac->tx_busy_lock);
+        }
+
+        if (s_intr & SINT_STAT_RECV) {
+            if (emac->parent.receive(&emac->parent, emac->rx_buffer,
+                                     &emac->rx_len) == ESP_OK) {
+                ESP_LOGD(TAG, "receive len=%lu", emac->rx_len);
+
+                /* allocate memory and check whether it failed */
+                cache = malloc(emac->rx_len);
+                if(cache == NULL){
+                    ESP_LOGE(TAG, "no memory for receive buffer");
+                    continue;
+                }
+                memcpy(cache, emac->rx_buffer, emac->rx_len);
+
+                emac->eth->stack_input(emac->eth, cache, emac->rx_len);
+            } else {
+                ESP_LOGE(TAG, "frame read from module failed");
+            }
+        }
+    }
+    vTaskDelete(NULL);
+}
+
+static esp_err_t emac_ch395_spi_init(esp_eth_mac_t *mac)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    esp_eth_mediator_t *eth = emac->eth;
+
+    if (emac->int_gpio_num >= 0) {
+        esp_rom_gpio_pad_select_gpio(emac->int_gpio_num);
+        gpio_set_direction(emac->int_gpio_num, GPIO_MODE_INPUT);
+        gpio_set_pull_mode(emac->int_gpio_num, GPIO_PULLUP_ONLY);
+        gpio_set_intr_type(emac->int_gpio_num, GPIO_INTR_NEGEDGE); // active low
+        gpio_intr_enable(emac->int_gpio_num);
+        gpio_isr_handler_add(emac->int_gpio_num, ch395_isr_handler, emac);
+    }
+    ESP_GOTO_ON_ERROR(eth->on_state_changed(eth, ETH_STATE_LLINIT, NULL), err,
+                      TAG, "lowlevel init failed");
+
+    vTaskDelay(pdMS_TO_TICKS(CH395_POWER_ON_DELAY_MS));
+
+    ESP_GOTO_ON_ERROR(ch395_strict_self_check(emac), err, TAG,
+                    "cannot pass self check");
+    /* reset ch395 */
+    ESP_GOTO_ON_ERROR(ch395_reset(emac), err, TAG, "reset ch395 failed");
+
+    /* verify chip id */
+    ESP_GOTO_ON_ERROR(ch395_verify_id(emac), err, TAG, "vefiry chip ID failed");
+    /* get emac address */
+    ESP_GOTO_ON_ERROR(ch395_get_mac_addr(emac), err, TAG,
+                      "fetch ethernet mac address failed");
+    /* default setup of internal registers */
+    ESP_GOTO_ON_ERROR(ch395_setup_default(emac), err, TAG,
+                      "ch395 default setup failed");
+
+    return ESP_OK;
+err:
+    if (emac->int_gpio_num >= 0) {
+        gpio_isr_handler_remove(emac->int_gpio_num);
+        gpio_reset_pin(emac->int_gpio_num);
+    }
+    eth->on_state_changed(eth, ETH_STATE_DEINIT, NULL);
+    return ret;
+
+}
+
+static esp_err_t emac_ch395_uart_init(esp_eth_mac_t *mac)
+{
+    esp_err_t ret = ESP_OK;
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    esp_eth_mediator_t *eth = emac->eth;
+
+    if (emac->int_gpio_num >= 0) {
+        esp_rom_gpio_pad_select_gpio(emac->int_gpio_num);
+        gpio_set_direction(emac->int_gpio_num, GPIO_MODE_INPUT);
+        gpio_set_pull_mode(emac->int_gpio_num, GPIO_PULLUP_ONLY);
+        gpio_set_intr_type(emac->int_gpio_num, GPIO_INTR_NEGEDGE); // active low
+        gpio_intr_enable(emac->int_gpio_num);
+        gpio_isr_handler_add(emac->int_gpio_num, ch395_isr_handler, emac);
+    }
+    ESP_GOTO_ON_ERROR(eth->on_state_changed(eth, ETH_STATE_LLINIT, NULL), err,
+                      TAG, "lowlevel init failed");
+
+    vTaskDelay(pdMS_TO_TICKS(CH395_POWER_ON_DELAY_MS));
+
+    if (ch395_self_check(emac) != ESP_OK) {
+        uint32_t baudrate;
+        ch395_get_host_baudrate(emac, &baudrate);
+
+        ESP_LOGW(
+            TAG,
+            "cannot communicate using current baudrate(%lu bps). this may happen when the chip cold boots. "
+            "trying initial baudrate(9600 bps)...",
+            baudrate);
+        vTaskDelay(pdMS_TO_TICKS(50));
+
+        ch395_set_host_baudrate(emac, CH395_UART_DEFAULT_BAUDRATE);
+        ESP_GOTO_ON_ERROR(ch395_self_check(emac), err, TAG,
+                          "cannot communicate with CH395");
+        ESP_LOGI(
+            TAG,
+            "successfully communicate with CH395, now changing baudrate to the setting...");
+
+        ch395_set_baudrate(emac, baudrate);
+        ch395_set_host_baudrate(emac, baudrate);
+        ESP_GOTO_ON_ERROR(
+            ch395_self_check(emac), err, TAG,
+            "cannot communicate with CH395 using setting baudrate(%lu bps)",
+            baudrate);
+    }
+
+    /* reset ch395 */
+    ESP_GOTO_ON_ERROR(ch395_reset(emac), err, TAG, "reset ch395 failed");
+
+    uint32_t baudrate;
+    ch395_get_host_baudrate(emac, &baudrate);
+    ch395_set_host_baudrate(emac, CH395_UART_DEFAULT_BAUDRATE);
+    ESP_GOTO_ON_ERROR(ch395_self_check(emac), err, TAG,
+                      "cannot communicate with CH395");
+    ch395_set_baudrate(emac, baudrate);
+    ch395_set_host_baudrate(emac, baudrate);
+    ESP_GOTO_ON_ERROR(
+        ch395_strict_self_check(emac), err, TAG,
+        "cannot communicate with CH395 using setting baudrate(%lu bps)",
+        baudrate);
+
+    /* verify chip id */
+    ESP_GOTO_ON_ERROR(ch395_verify_id(emac), err, TAG, "vefiry chip ID failed");
+    /* get emac address */
+    ESP_GOTO_ON_ERROR(ch395_get_mac_addr(emac), err, TAG,
+                      "fetch ethernet mac address failed");
+    /* default setup of internal registers */
+    ESP_GOTO_ON_ERROR(ch395_setup_default(emac), err, TAG,
+                      "ch395 default setup failed");
+
+    return ESP_OK;
+err:
+    if (emac->int_gpio_num >= 0) {
+        gpio_isr_handler_remove(emac->int_gpio_num);
+        gpio_reset_pin(emac->int_gpio_num);
+    }
+    eth->on_state_changed(eth, ETH_STATE_DEINIT, NULL);
+    return ret;
+}
+
+static esp_err_t emac_ch395_deinit(esp_eth_mac_t *mac)
+{
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    esp_eth_mediator_t *eth = emac->eth;
+    mac->stop(mac);
+    if (emac->int_gpio_num >= 0) {
+        gpio_isr_handler_remove(emac->int_gpio_num);
+        gpio_reset_pin(emac->int_gpio_num);
+    }
+    if (emac->poll_timer && esp_timer_is_active(emac->poll_timer)) {
+        esp_timer_stop(emac->poll_timer);
+    }
+    eth->on_state_changed(eth, ETH_STATE_DEINIT, NULL);
+    return ESP_OK;
+}
+
+static esp_err_t emac_ch395_spi_del(esp_eth_mac_t *mac)
+{
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    if (emac->poll_timer) {
+        esp_timer_delete(emac->poll_timer);
+    }
+    vTaskDelete(emac->rx_task_hdl);
+    ch395_spi_deinit(emac->drv.ctx);
+    heap_caps_free(emac->rx_buffer);
+    free(emac);
+    return ESP_OK;
+}
+
+static esp_err_t emac_ch395_uart_del(esp_eth_mac_t *mac)
+{
+    emac_ch395_t *emac = __containerof(mac, emac_ch395_t, parent);
+    if (emac->poll_timer) {
+        esp_timer_delete(emac->poll_timer);
+    }
+    vTaskDelete(emac->rx_task_hdl);
+    ch395_uart_deinit(emac->drv.ctx);
+    heap_caps_free(emac->rx_buffer);
+    free(emac);
+    return ESP_OK;
+}
+
+esp_eth_mac_t *esp_eth_mac_new_ch395(const eth_ch395_config_t *ch395_config,
+                                     const eth_mac_config_t *mac_config)
+{
+    esp_eth_mac_t *ret = NULL;
+    emac_ch395_t *emac = NULL;
+    ESP_GOTO_ON_FALSE(ch395_config && mac_config, NULL, err, TAG,
+                      "invalid argument");
+    emac = calloc(1, sizeof(emac_ch395_t));
+    ESP_GOTO_ON_FALSE(emac, NULL, err, TAG, "no mem for MAC instance");
+
+    ESP_GOTO_ON_FALSE((ch395_config->mode == ETH_CH395_MODE_SPI)
+                          || (ch395_config->mode == ETH_CH395_MODE_UART),
+                      NULL, err, TAG, "invalid mode");
+
+    /* bind methods and attributes */
+    emac->int_gpio_num = ch395_config->int_gpio_num;
+    emac->poll_period_ms = ch395_config->poll_period_ms;
+    emac->parent.set_mediator = emac_ch395_set_mediator;
+    emac->parent.deinit = emac_ch395_deinit;
+    emac->parent.start = emac_ch395_start;
+    emac->parent.stop = emac_ch395_stop;
+    emac->parent.write_phy_reg = emac_ch395_write_phy_reg;
+    emac->parent.read_phy_reg = emac_ch395_read_phy_reg;
+    emac->parent.set_addr = emac_ch395_set_addr;
+    emac->parent.get_addr = emac_ch395_get_addr;
+    emac->parent.set_speed = emac_ch395_set_speed;
+    emac->parent.set_duplex = emac_ch395_set_duplex;
+    emac->parent.set_link = emac_ch395_set_link;
+    emac->parent.set_promiscuous = emac_ch395_set_promiscuous;
+    emac->parent.set_peer_pause_ability = emac_ch395_set_peer_pause_ability;
+    emac->parent.enable_flow_ctrl = emac_ch395_enable_flow_ctrl;
+    emac->parent.transmit = emac_ch395_transmit;
+    emac->parent.receive = emac_ch395_receive;
+
+    if(ch395_config->mode == ETH_CH395_MODE_SPI){
+        ESP_LOGD(TAG, "Using SPI Driver");
+        emac->parent.init = emac_ch395_spi_init;
+        emac->parent.del = emac_ch395_spi_del;
+
+        emac->drv.init = ch395_spi_init;
+        emac->drv.deinit = ch395_spi_deinit;
+        emac->drv.io = ch395_spi_io;
+        emac->drv.tx_buffer = ch395_spi_tx_buffer;
+        emac->drv.rx_buffer = ch395_spi_rx_buffer;
+        emac->drv.get_rx_size = ch395_spi_get_rx_size;
+        emac->drv.set_phy = ch395_spi_set_phy_mode;
+        emac->drv.get_phy = ch395_spi_get_phy_status;
+
+        /* SPI device init */
+        ESP_GOTO_ON_FALSE((emac->drv.ctx = emac->drv.init(ch395_config)) != NULL,
+                        NULL, err, TAG, "SPI initialization failed");
+    }
+    else{
+        ESP_LOGD(TAG, "Using UART Driver");
+        emac->parent.init = emac_ch395_uart_init;
+        emac->parent.del = emac_ch395_uart_del;
+
+        emac->drv.init = ch395_uart_init;
+        emac->drv.deinit = ch395_uart_deinit;
+        emac->drv.io = ch395_uart_io;
+        emac->drv.tx_buffer = ch395_uart_tx_buffer;
+        emac->drv.rx_buffer = ch395_uart_rx_buffer;
+        emac->drv.get_rx_size = ch395_uart_get_rx_size;
+        emac->drv.set_phy = ch395_uart_set_phy_mode;
+        emac->drv.get_phy = ch395_uart_get_phy_status;
+
+        /* UART device init */
+        ESP_GOTO_ON_FALSE((emac->drv.ctx = emac->drv.init(ch395_config)) != NULL,
+                        NULL, err, TAG, "UART initialization failed");
+    }
+
+    /* create tx mutex */
+    emac->tx_busy_lock = xSemaphoreCreateBinary();
+    ESP_GOTO_ON_FALSE(emac->tx_busy_lock, NULL, err, TAG,
+                      "create ch395 tx mutex failed");
+    xSemaphoreGive(emac->tx_busy_lock);
+
+    /* create ch395 task */
+    BaseType_t core_num = tskNO_AFFINITY;
+    if (mac_config->flags & ETH_MAC_FLAG_PIN_TO_CORE) {
+        core_num = esp_cpu_get_core_id();
+    }
+    BaseType_t xReturned = xTaskCreatePinnedToCore(
+                               emac_ch395_task, "ch395_tsk", mac_config->rx_task_stack_size, emac,
+                               mac_config->rx_task_prio, &emac->rx_task_hdl, core_num);
+    ESP_GOTO_ON_FALSE(xReturned == pdPASS, NULL, err, TAG,
+                      "create ch395 task failed");
+
+    emac->rx_buffer = heap_caps_malloc(ETH_MAX_PACKET_SIZE, MALLOC_CAP_DMA);
+    ESP_GOTO_ON_FALSE(emac->rx_buffer, NULL, err, TAG,
+                      "RX buffer allocation failed");
+
+    if (emac->int_gpio_num < 0) {
+        const esp_timer_create_args_t poll_timer_args = {
+            .callback = ch395_poll_timer,
+            .name = "emac_spi_poll_timer",
+            .arg = emac,
+            .skip_unhandled_events = true
+        };
+        ESP_GOTO_ON_FALSE(esp_timer_create(&poll_timer_args, &emac->poll_timer)
+                          == ESP_OK,
+                          NULL, err, TAG, "create poll timer failed");
+    }
+
+    return &(emac->parent);
+
+err:
+    if (emac) {
+        if (emac->poll_timer) {
+            esp_timer_delete(emac->poll_timer);
+        }
+
+        if (emac->rx_task_hdl) {
+            vTaskDelete(emac->rx_task_hdl);
+        }
+
+        if (emac->drv.ctx) {
+            emac->drv.deinit(emac->drv.ctx);
+        }
+
+        heap_caps_free(emac->rx_buffer);
+        free(emac);
+    }
+    return ret;
+}

--- a/components/esp_eth/src/esp_eth_phy_ch395.c
+++ b/components/esp_eth/src/esp_eth_phy_ch395.c
@@ -1,0 +1,423 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-FileContributor: 2024 Sergey Kharenko
+ * SPDX-FileContributor: 2024 Espressif Systems (Shanghai) CO LTD
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/cdefs.h>
+#include "driver/gpio.h"
+#include "esp_err.h"
+#include "esp_eth_phy.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_eth_phy_802_3.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/projdefs.h"
+#include "freertos/task.h"
+
+#include "ch395.h"
+#include "hal/eth_types.h"
+
+#define CH395_WAIT_FOR_RESET_MS (50) // wait for CH395 hardware reset
+#define CH395_WAIT_FOR_PHY_SET_MS (350)
+
+static const char *TAG = "ch395.phy";
+
+typedef struct {
+    esp_eth_phy_t parent;
+    esp_eth_mediator_t *eth;
+    int addr;
+    uint32_t reset_timeout_ms;
+    uint32_t autonego_timeout_ms;
+    eth_link_t link_status;
+    int reset_gpio_num;
+} phy_ch395_t;
+
+static esp_err_t ch395_update_link_duplex_speed(phy_ch395_t *ch395)
+{
+    esp_err_t ret = ESP_OK;
+    esp_eth_mediator_t *eth = ch395->eth;
+    eth_speed_t speed = ETH_SPEED_10M;
+    eth_duplex_t duplex = ETH_DUPLEX_HALF;
+
+    uint8_t status;
+    eth_link_t link;
+
+    ESP_GOTO_ON_ERROR(eth->phy_reg_read(eth, ch395->addr, CMD01_GET_PHY_STATUS,
+                                        (uint32_t *)(&status)),
+                      err, TAG, "read PHY status failed");
+
+    switch (status) {
+    case PHY_DISCONN: link = ETH_LINK_DOWN; break;
+
+    case PHY_10M_HALF:
+    case PHY_10M_FLL:
+    case PHY_100M_HALF:
+    case PHY_100M_FLL: link = ETH_LINK_UP; break;
+
+    default:
+        ESP_LOGE(TAG, "PHY in unknow state!");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* check if link status changed */
+    if (ch395->link_status != link) {
+        /* when link up, read negotiation result */
+        if (link == ETH_LINK_UP) {
+            switch (status) {
+            case PHY_10M_HALF:
+                speed = ETH_SPEED_10M;
+                duplex = ETH_DUPLEX_HALF;
+                break;
+
+            case PHY_10M_FLL:
+                speed = ETH_SPEED_10M;
+                duplex = ETH_DUPLEX_FULL;
+                break;
+
+            case PHY_100M_HALF:
+                speed = ETH_SPEED_100M;
+                duplex = ETH_DUPLEX_HALF;
+                break;
+
+            case PHY_100M_FLL:
+                speed = ETH_SPEED_100M;
+                duplex = ETH_DUPLEX_FULL;
+                break;
+
+            default:
+                ESP_LOGE(TAG, "PHY in unknow state!");
+                return ESP_ERR_INVALID_STATE;
+            }
+
+            ESP_GOTO_ON_ERROR(
+                eth->on_state_changed(eth, ETH_STATE_SPEED, (void *)speed), err,
+                TAG, "change speed failed");
+            ESP_GOTO_ON_ERROR(
+                eth->on_state_changed(eth, ETH_STATE_DUPLEX, (void *)duplex),
+                err, TAG, "change duplex failed");
+        }
+        ESP_GOTO_ON_ERROR(
+            eth->on_state_changed(eth, ETH_STATE_LINK, (void *)link), err, TAG,
+            "change link failed");
+        ch395->link_status = link;
+    }
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t ch395_set_mediator(esp_eth_phy_t *phy,
+                                    esp_eth_mediator_t *eth)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(eth, ESP_ERR_INVALID_ARG, err, TAG,
+                      "mediator can't be null");
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    ch395->eth = eth;
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t ch395_get_link(esp_eth_phy_t *phy)
+{
+    esp_err_t ret = ESP_OK;
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    /* Updata information about link, speed, duplex */
+    ESP_GOTO_ON_ERROR(ch395_update_link_duplex_speed(ch395), err, TAG,
+                      "update link duplex speed failed");
+    return ESP_OK;
+err:
+    return ret;
+}
+
+// static esp_err_t ch395_set_link(esp_eth_phy_t *phy, eth_link_t link)
+// {
+//     esp_err_t ret = ESP_OK;
+//     phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+//     esp_eth_mediator_t *eth   = ch395->eth;
+
+//     if (ch395->link_status != link) {
+//         ch395->link_status = link;
+//         // link status changed, inmiedately report to upper layers
+//         ESP_GOTO_ON_ERROR(eth->on_state_changed(eth, ETH_STATE_LINK, (void
+//         *)ch395->link_status), err, TAG, "change link failed");
+//     }
+
+// err:
+//     return ret;
+// }
+
+static esp_err_t ch395_reset(esp_eth_phy_t *phy)
+{
+    esp_err_t ret = ESP_OK;
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    ch395->link_status = ETH_LINK_DOWN;
+    esp_eth_mediator_t *eth = ch395->eth;
+    uint8_t mode = PHY_AUTO;
+
+    ESP_GOTO_ON_ERROR(eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode),
+                      err, TAG, "send RESET cmd failed");
+    vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_reset_hw(esp_eth_phy_t *phy)
+{
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    // set reset_gpio_num to a negative value can skip hardware reset phy chip
+    if (ch395->reset_gpio_num >= 0) {
+        esp_rom_gpio_pad_select_gpio(ch395->reset_gpio_num);
+        gpio_set_direction(ch395->reset_gpio_num, GPIO_MODE_OUTPUT);
+        gpio_set_level(ch395->reset_gpio_num, 0);
+        esp_rom_delay_us(100); // insert min input assert time
+        gpio_set_level(ch395->reset_gpio_num, 1);
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_RESET_MS));
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t ch395_autonego_ctrl(esp_eth_phy_t *phy,
+                                     eth_phy_autoneg_cmd_t cmd,
+                                     bool *autonego_en_stat)
+{
+    esp_err_t ret = ESP_OK;
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    esp_eth_mediator_t *eth = ch395->eth;
+
+    uint8_t status;
+    uint8_t mode;
+
+    ESP_GOTO_ON_ERROR(eth->phy_reg_read(eth, ch395->addr, CMD01_GET_PHY_STATUS,
+                                        (uint32_t *) & (status)),
+                      err, TAG, "read PHY status failed");
+
+    switch (cmd) {
+    case ESP_ETH_PHY_AUTONEGO_RESTART:
+    case ESP_ETH_PHY_AUTONEGO_EN:
+        mode = PHY_AUTO;
+        ESP_GOTO_ON_ERROR(
+            eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode), err, TAG,
+            "set auto negotiate failed");
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+        break;
+
+    case ESP_ETH_PHY_AUTONEGO_DIS:
+        ESP_LOGW(
+            TAG,
+            "autonego cannot be turned off individually, manually set up speed and link instead");
+        break;
+
+    case ESP_ETH_PHY_AUTONEGO_G_STAT: *autonego_en_stat = true; break;
+
+    default: return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t ch395_pwrctl(esp_eth_phy_t *phy, bool enable)
+{
+    // power control is not supported for CH395 internal PHY
+    return ESP_OK;
+}
+
+static esp_err_t ch395_set_addr(esp_eth_phy_t *phy, uint32_t addr)
+{
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    ch395->addr = addr;
+    return ESP_OK;
+}
+
+static esp_err_t ch395_get_addr(esp_eth_phy_t *phy, uint32_t *addr)
+{
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(addr, ESP_ERR_INVALID_ARG, err, TAG,
+                      "addr can't be null");
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    *addr = ch395->addr;
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t ch395_del(esp_eth_phy_t *phy)
+{
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    free(ch395);
+    return ESP_OK;
+}
+
+static esp_err_t ch395_advertise_pause_ability(esp_eth_phy_t *phy,
+        uint32_t ability)
+{
+    // pause ability advertisement is not supported for CH395 internal PHY
+    return ESP_OK;
+}
+
+static esp_err_t ch395_loopback(esp_eth_phy_t *phy, bool enable)
+{
+    // Loopback is not supported for CH395 internal PHY
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static esp_err_t ch395_set_speed(esp_eth_phy_t *phy, eth_speed_t speed)
+{
+    esp_err_t ret = ESP_OK;
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    esp_eth_mediator_t *eth = ch395->eth;
+
+    /* Since the link is going to be reconfigured, consider it down to be status
+     * updated once the driver re-started */
+    ch395->link_status = ETH_LINK_DOWN;
+
+    uint8_t status;
+    uint8_t mode;
+
+    ESP_GOTO_ON_ERROR(eth->phy_reg_read(eth, ch395->addr, CMD01_GET_PHY_STATUS,
+                                        (uint32_t *) & (status)),
+                      err, TAG, "read PHY status failed");
+
+    if (status == PHY_100M_FLL || status == PHY_10M_FLL) {
+        if (speed == ETH_SPEED_100M) {
+            mode = PHY_100M_FLL;
+        } else {
+            mode = PHY_10M_FLL;
+        }
+        ESP_GOTO_ON_ERROR(
+            eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode), err, TAG,
+            "set speed failed");
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+    } else if (status == PHY_100M_HALF || status == PHY_10M_HALF) {
+        if (speed == ETH_SPEED_100M) {
+            mode = PHY_100M_HALF;
+        } else {
+            mode = PHY_10M_HALF;
+        }
+        ESP_GOTO_ON_ERROR(
+            eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode), err, TAG,
+            "set speed failed");
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+    } else {
+        ESP_LOGE(TAG, "cannot set speed");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_set_duplex(esp_eth_phy_t *phy, eth_duplex_t duplex)
+{
+    esp_err_t ret = ESP_OK;
+    phy_ch395_t *ch395 = __containerof(phy, phy_ch395_t, parent);
+    esp_eth_mediator_t *eth = ch395->eth;
+
+    /* Since the link is going to be reconfigured, consider it down to be status
+     * updated once the driver re-started */
+    ch395->link_status = ETH_LINK_DOWN;
+
+    uint8_t status;
+    uint8_t mode;
+
+    ESP_GOTO_ON_ERROR(eth->phy_reg_read(eth, ch395->addr, CMD01_GET_PHY_STATUS,
+                                        (uint32_t *) & (status)),
+                      err, TAG, "read PHY status failed");
+
+    if (status == PHY_100M_FLL || status == PHY_100M_HALF) {
+        if (duplex == ETH_DUPLEX_FULL) {
+            mode = PHY_100M_FLL;
+        } else {
+            mode = PHY_100M_HALF;
+        }
+        ESP_GOTO_ON_ERROR(
+            eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode), err, TAG,
+            "set duplex failed");
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+    } else if (status == PHY_10M_FLL || status == PHY_10M_HALF) {
+        if (duplex == ETH_DUPLEX_FULL) {
+            mode = PHY_10M_FLL;
+        } else {
+            mode = PHY_10M_HALF;
+        }
+        ESP_GOTO_ON_ERROR(
+            eth->phy_reg_write(eth, ch395->addr, CMD10_SET_PHY, mode), err, TAG,
+            "set duplex failed");
+        vTaskDelay(pdMS_TO_TICKS(CH395_WAIT_FOR_PHY_SET_MS));
+    } else {
+        ESP_LOGE(TAG, "cannot set duplex");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+err:
+    return ret;
+}
+
+static esp_err_t ch395_init(esp_eth_phy_t *phy)
+{
+    esp_err_t ret = ESP_OK;
+    /* Power on Ethernet PHY */
+    ESP_GOTO_ON_ERROR(ch395_pwrctl(phy, true), err, TAG,
+                      "power control failed");
+    /* Reset Ethernet PHY */
+    ESP_GOTO_ON_ERROR(ch395_reset(phy), err, TAG, "reset failed");
+    return ESP_OK;
+err:
+    return ret;
+}
+
+static esp_err_t ch395_deinit(esp_eth_phy_t *phy)
+{
+    esp_err_t ret = ESP_OK;
+    /* Power off Ethernet PHY */
+    ESP_GOTO_ON_ERROR(ch395_pwrctl(phy, false), err, TAG,
+                      "power control failed");
+    return ESP_OK;
+err:
+    return ret;
+}
+
+esp_eth_phy_t *esp_eth_phy_new_ch395(const eth_phy_config_t *config)
+{
+    esp_eth_phy_t *ret = NULL;
+    ESP_GOTO_ON_FALSE(config, NULL, err, TAG, "invalid arguments");
+    phy_ch395_t *ch395 = calloc(1, sizeof(phy_ch395_t));
+    ESP_GOTO_ON_FALSE(ch395, NULL, err, TAG, "no mem for PHY instance");
+    ch395->addr = config->phy_addr;
+    ch395->reset_timeout_ms = config->reset_timeout_ms;
+    ch395->reset_gpio_num = config->reset_gpio_num;
+    ch395->link_status = ETH_LINK_DOWN;
+    ch395->autonego_timeout_ms = config->autonego_timeout_ms;
+    ch395->parent.reset = ch395_reset;
+    ch395->parent.reset_hw = ch395_reset_hw;
+    ch395->parent.init = ch395_init;
+    ch395->parent.deinit = ch395_deinit;
+    ch395->parent.set_mediator = ch395_set_mediator;
+    ch395->parent.autonego_ctrl = ch395_autonego_ctrl;
+    ch395->parent.get_link = ch395_get_link;
+    // ch395->parent.set_link = ch395_set_link;
+    ch395->parent.pwrctl = ch395_pwrctl;
+    ch395->parent.get_addr = ch395_get_addr;
+    ch395->parent.set_addr = ch395_set_addr;
+    ch395->parent.advertise_pause_ability = ch395_advertise_pause_ability;
+    ch395->parent.loopback = ch395_loopback;
+    ch395->parent.set_speed = ch395_set_speed;
+    ch395->parent.set_duplex = ch395_set_duplex;
+    ch395->parent.del = ch395_del;
+    return &(ch395->parent);
+err:
+    return ret;
+}

--- a/examples/ethernet/basic/components/ethernet_init/Kconfig.projbuild
+++ b/examples/ethernet/basic/components/ethernet_init/Kconfig.projbuild
@@ -131,6 +131,13 @@ menu "Example Ethernet Configuration"
                 select ETH_SPI_ETHERNET_W5500
                 help
                     Select external SPI-Ethernet module (W5500).
+
+            config EXAMPLE_USE_CH395_SPI
+                bool "CH395 Module"
+                select ETH_SPI_ETHERNET_CH395
+                select EXAMPLE_ETH_SPI_USE_CHIP_MAC
+                help
+                    Select external SPI-Ethernet module (CH395).
         endchoice
 
         config EXAMPLE_ETH_SPI_HOST
@@ -289,5 +296,91 @@ menu "Example Ethernet Configuration"
             default 1
             help
                 Set the second SPI Ethernet module PHY address according your board schematic.
+
+        config EXAMPLE_ETH_SPI_USE_CHIP_MAC
+            bool "Use the MAC address built into the chip"
+            default false
     endif # EXAMPLE_USE_SPI_ETHERNET
+
+    config EXAMPLE_USE_UART_ETHERNET
+        bool "UART Ethernet"
+        default n
+        select ETH_USE_UART_ETHERNET
+        help
+            Use external UART-Ethernet module(s).
+
+    if EXAMPLE_USE_UART_ETHERNET
+        choice EXAMPLE_ETHERNET_TYPE_UART
+            prompt "Ethernet UART"
+            default EXAMPLE_USE_CH395_UART
+            help
+                Select which kind of Ethernet will be used in the example.
+
+            config EXAMPLE_USE_CH395_UART
+                bool "CH395 Module"
+                select ETH_UART_ETHERNET_CH395
+                select EXAMPLE_ETH_UART_USE_CHIP_MAC
+                help
+                    Select external UART-Ethernet module (CH395).
+        endchoice
+
+        config EXAMPLE_ETH_UART_PORT
+            int "UART Port Number"
+            range 0 2
+            default 1
+            help
+                Set the UART port used to communicate with the UART Ethernet Controller.
+
+        config EXAMPLE_ETH_UART_BAUDRATE_BPS
+            int "UART Baudrate (bps)"
+            range 9600 3000000
+            default 3000000
+            help
+                Set the baudrate (bps) of UART interface.
+
+        config EXAMPLE_ETH_UART_TX_GPIO
+            int "TX GPIO number UART Ethernet module"
+            range 0 ENV_GPIO_IN_RANGE_MAX
+            default 2
+
+        config EXAMPLE_ETH_UART_RX_GPIO
+            int "RX GPIO number UART Ethernet module"
+            range 0 ENV_GPIO_IN_RANGE_MAX
+            default 3
+
+        config EXAMPLE_ETH_UART_INT_GPIO
+            int "Interrupt GPIO number UART Ethernet module"
+            range -1 ENV_GPIO_IN_RANGE_MAX
+            default 4 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3
+            default 4 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C6
+            default 10 if IDF_TARGET_ESP32H2
+            default 48 if IDF_TARGET_ESP32P4
+            help
+                Set the GPIO number used by the first UART Ethernet module interrupt line.
+                Set -1 to use UART Ethernet module in polling mode.
+
+        config EXAMPLE_ETH_UART_POLLING_MS
+            int "Polling period in msec of UART Ethernet Module"
+            default 10
+
+        config EXAMPLE_ETH_UART_PHY_RST_GPIO
+            int "PHY Reset GPIO number of UART Ethernet Module"
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            default -1
+            help
+                Set the GPIO number used to reset PHY chip on the first UART Ethernet module.
+                Set to -1 to disable PHY chip hardware reset.
+
+        config EXAMPLE_ETH_UART_PHY_ADDR
+            int "PHY Address of UART Ethernet Module"
+            range 0 31
+            default 1
+            help
+                Set the first UART Ethernet module PHY address according your board schematic.
+
+        config EXAMPLE_ETH_UART_USE_CHIP_MAC
+            bool "Use the MAC address built into the chip"
+            default false
+
+    endif # EXAMPLE_USE_UART_ETHERNET
 endmenu


### PR DESCRIPTION
### Brief Introduction
CH395 is the first domestic Ethernet controller that supports 10M/100M and has a built-in TCP/IP protocol stack. It was designed by NanjingQinhengMicroelectronics CO LTD (abbreviated as WCH) and officially launched on March 1, 2013. In terms of functionality, ch395 is comparable to Wiznet W5500. In addition, this chip can also use UART to communicate, which has fewer lines than SPI.

However, WCH only provides sample code on 80C51. What's worse, sample code is more focus on hardware TCP/IP stack of the chip. Introductions about MAC Raw mode are pretty brief. This seriously hinders its compatibility with the lwip. 

My work is to explore the functionality of the chip in MAC RAW mode and port it into the `esp-eth-drivers`. As far as I know, no one has ever done that.

### High Lights

1. SPI and UART dual stack support
2. UART automatic baudrate configuration(refer to [README](https://github.com/SergeyKharenko/esp-eth-drivers/blob/patch_ch395/ch395/README.md) in detail)
3. Static cache to store fragmented data generated during transmission and reception
4. Optimization of frequently used function
5. Passed **5 hours** iperf stability test with no error

### Issue & Solution
1. Cannot send pack less than 60 bytes in MAC RAW mode. Just padding 0 to these packs before transferring to CH395
2. ~~Cannot accept continuous R/W in SPI Mode. R/W one byte per transaction.~~
3. Send `CMD01_GET_CMD_STATUS` before the CH395 init, the status is keeping `CH395_ERR_BUSY`. Leave enough waiting time for some operations that require query to avoid queries.
4. Fail to init CH395 after sending `CMD40_SET_FUN_PARA` to disable `SEND_OK` interrupt. Add additional delay(20 ms)
5. After sending `CMD10_SET_PHY` to setup mode of PHY, within a short period of time, user would get unknow status of PHY(using `CMD01_GET_PHY_STATUS`). Add additional delay(350 ms)

### Performance Report
#### UART Mode
|Baudrate(bps)|TCP Receive(Mbps)|UDP Send(Mbps)|
|:-------------------:|:--------------------------:|:-----------------------:|
|3000000|1.8|1.94|
|1500000|0.92|0.99|
|921600|0.54|0.61|
|460800|0.28|0.30|
|250000|0.15|0.16|

Both transmit and receive increase LINEARLY as the baudrate increases. That fully demonstrates that the system bottleneck is not in the driver layer, but in baudrate instead.


#### SPI Mode
|Frequency(MHz)|TCP Receive(Mbps)|UDP Send(Mbps)|
|:-------------------:|:--------------------------:|:-----------------------:|
|40(OC)|0.54|0.58|
|30|0.53|0.57|
|20|0.53|0.57|
|16|0.50|0.53|
|10|0.51|0.55|
|4|0.46|0.49|
|1|0.30|0.32|

The sending and receiving speed gradually becomes saturated after the SPI frequency is higher than 10MHz. This is mainly because the chip cannot support SPI continuous reading and writing, and a certain delay must be added between bytes, which makes DMA useless. I have already sent my questions to WCH engineers and hope to get a reply soon. On the other hand, someone could provide me with some valuable advice on SPI transmission if possible?

**After Optimization**
|Frequency(MHz)|TCP Receive(Mbps)|UDP Send(Mbps)|
|:-------------------:|:--------------------------:|:-----------------------:|
|20|1.63|13.58|
|16|1.55|11.47|
|10|0.95|7.82|

Optimization is based on the following "features":
1. At frequency below 20MHz, 4 bytes of continuous reading of SRAM is correct. Thus, in `ch395_rx_buffer`, packet reads are performed in 4-byte increments to improve efficiency. I guess this may be due to the SRAM's synchronization mechanism.
2. Continuous writing of SRAM has no issue. Thus, in `ch395_tx_buffer`, packet writings are performed in one transmission. That's why TX Performance has been greatly improved.
3. However, register reading cannot be continuous. I tried frequency below 10MHz to read MAC addresses continuously. Only the first byte is correct. Therefore,  `ch395_spi_io` operations are as legacy. 


PS:
Here is the introduction to this ethernet controller in detail:
_CH395 is an Ethernet protocol stack management IC which provides Ethernet communication ability for MCU system. CH395 has built-in 10 / 100M Ethernet MAC and PHY and fully compatible with IEEE 802.3 protocol, it also has built-in protocol stack firmware such as PPPOE, IP, DHCP, ARP, ICMP, IGMP, UDP, TCP and etc. A MCU system can easily connect to Ethernet through CH395. CH395 supports 3 types of communication interfaces: 8-bit parallel port, SPI or USART. A MCU/DSP/MPU can use any of the above communication interfaces to operate CH395 for Ethernet communication._
![image](https://github.com/espressif/esp-eth-drivers/assets/47017076/bd6f681e-b589-428e-bdd8-b1dbe24e4e3e)