### PR TITLE
fix(esp_event): esp_event_loop_create_default()=ESP_OK when existing (IDFGH-12482)

### DIFF
--- a/components/esp_event/default_event_loop.c
+++ b/components/esp_event/default_event_loop.c
@@ -92,7 +92,7 @@ esp_err_t esp_event_isr_post(esp_event_base_t event_base, int32_t event_id,
 esp_err_t esp_event_loop_create_default(void)
 {
     if (s_default_loop) {
-        return ESP_ERR_INVALID_STATE;
+        return ESP_OK;
     }
 
     esp_event_loop_args_t loop_args = {

--- a/components/esp_event/include/esp_event.h
+++ b/components/esp_event/include/esp_event.h
@@ -61,9 +61,8 @@ esp_err_t esp_event_loop_delete(esp_event_loop_handle_t event_loop);
  * @brief Create default event loop
  *
  * @return
- *  - ESP_OK: Success
+ *  - ESP_OK: Success, or default event loop has already been created
  *  - ESP_ERR_NO_MEM: Cannot allocate memory for event loops list
- *  - ESP_ERR_INVALID_STATE: Default event loop has already been created
  *  - ESP_FAIL: Failed to create task loop
  *  - Others: Fail
  */


### PR DESCRIPTION
Change the return value from `esp_event_loop_create_default()` to be `ESP_OK` instead of `ESP_ERR_INVALID_STATE` when the event loop already exists. This helps setups where there are multiple call sites with checks like this:

```c
ESP_ERROR_CHECK(esp_event_loop_create_default());
```

Which otherwise can result in a reboot loop.