### PR TITLE
Add Padding for Odd-Length Packets in UDP Checksum (IDFGH-12490)

### DIFF
--- a/examples/network/sta2eth/main/ethernet_iface.c
+++ b/examples/network/sta2eth/main/ethernet_iface.c
@@ -118,6 +118,10 @@ static void update_udp_checksum(uint16_t *udp_header, uint16_t* ip_header)
     for (int i = 0; i < payload_len/2; i++) {
         sum += htons(*ptr++);
     }
+    // add the padding if the packet length is odd
+    if (payload_len & 1) {
+        sum += (*((uint8_t *)ptr) << 8);
+    }
     // add some IP header data
     ptr = ip_header + 6;
     for (int i = 0; i < 4; i++) {       // IP addresses


### PR DESCRIPTION
This PR adds padding to the checksum calculation process for odd-length packets. By shifting bytes left by 8 bits, it ensures accurate checksums. This enhancement improves program reliability.