### PR TITLE
[linenoise] fix bug where backspace erases the prompt in dumb mode (IDFGH-12508)

### DIFF
--- a/components/console/linenoise/linenoise.c
+++ b/components/console/linenoise/linenoise.c
@@ -1135,10 +1135,15 @@ static int linenoiseDumb(char* buf, size_t buflen, const char* prompt) {
         } else if (c == BACKSPACE || c == 0x8) {
             if (count > 0) {
                 buf[count - 1] = 0;
-                count --;
-            }
+                count--;
+            // Only erase symbol echoed from stdin.
             fputs("\x08 ", stdout); /* Windows CMD: erase symbol under cursor */
             flushWrite();
+            } else {
+                // Consume backspace so that the cursor does not go to the prompt
+                continue;
+            }
+            
         } else {
             buf[count] = c;
             ++count;


### PR DESCRIPTION
Backspace erases the prompt when dumb mode is enabled.