### PR TITLE
feat(lwip): TCPIP_THREAD_NAME "tcpip"

### DIFF
--- a/components/lwip/port/include/lwipopts.h
+++ b/components/lwip/port/include/lwipopts.h
@@ -820,7 +820,7 @@ static inline uint32_t timeout_from_offered(uint32_t lease, uint32_t min)
 /**
  * TCPIP_THREAD_NAME: The name assigned to the main tcpip thread.
  */
-#define TCPIP_THREAD_NAME              "tiT"
+#define TCPIP_THREAD_NAME              "tcpip"
 
 /**
  * TCPIP_THREAD_STACKSIZE: The stack size used by the main tcpip thread.


### PR DESCRIPTION
"tiT" has been used since the original public version bd6ea4393c7d2f059fc4decc70f1ec3eb3597268, "tcpip" is less confusing.