### PR TITLE
feat(esp_common): Add ESP_EXIT_ON_ERROR and ESP_EXIT_ON_FALSE macros (IDFGH-12532)

### DIFF
--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -28,7 +28,7 @@ extern "C" {
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
-#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                       \
+#define ESP_EXIT_ON_ERROR(x, log_tag, format, ...) do {                                       \
         (void)log_tag;                                                                          \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
@@ -87,7 +87,7 @@ extern "C" {
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
-#define ESP_RETURN_VOID_ON_FALSE(a, log_tag, format, ...) do {                                  \
+#define ESP_EXIT_ON_FALSE(a, log_tag, format, ...) do {                                  \
         (void)log_tag;                                                                          \
         if (unlikely(!(a))) {                                                                   \
             return;                                                                             \
@@ -153,7 +153,7 @@ extern "C" {
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
-#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                             \
+#define ESP_EXIT_ON_ERROR(x, log_tag, format, ...) do {                                             \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
@@ -212,7 +212,7 @@ extern "C" {
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
-#define ESP_RETURN_VOID_ON_FALSE(a, err_code, log_tag, format, ...) do {                                   \
+#define ESP_EXIT_ON_FALSE(a, err_code, log_tag, format, ...) do {                                   \
         if (unlikely(!(a))) {                                                                              \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return;                                                                                        \
@@ -269,7 +269,7 @@ extern "C" {
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
-#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                  \
+#define ESP_EXIT_ON_ERROR(x, log_tag, format, ...) do {                                  \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
@@ -328,7 +328,7 @@ extern "C" {
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
-#define ESP_RETURN_VOID_ON_FALSE(a, log_tag, format, ...) do {                                  \
+#define ESP_EXIT_ON_FALSE(a, log_tag, format, ...) do {                                  \
         if (unlikely(!(a))) {                                                                   \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             return;                                                                             \

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -25,10 +25,21 @@ extern "C" {
     } while(0)
 
 /**
+ * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ */
+#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
+        (void)log_tag;                                                                          \
+        esp_err_t err_rc_ = (x);                                                                \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            return err_rc_;                                                                     \
+        }                                                                                       \
+    } while(0)
+
+/**
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
-#define ESP_EXIT_ON_ERROR(x, log_tag, format, ...) do {                                       \
+#define ESP_EXIT_ON_ERROR(x, log_tag, format, ...) do {                                         \
         (void)log_tag;                                                                          \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
@@ -37,13 +48,13 @@ extern "C" {
     } while(0)
 
 /**
- * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */
-#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
+#define ESP_EXIT_ON_ERROR_ISR(x, log_tag, format, ...) do {                                     \
         (void)log_tag;                                                                          \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            return err_rc_;                                                                     \
+            return;                                                                             \
         }                                                                                       \
     } while(0)
 
@@ -159,7 +170,7 @@ extern "C" {
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
-    
+
 /**
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -376,7 +376,7 @@ extern "C" {
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
-    
+
 /**
  * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
  */

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -82,7 +82,6 @@ extern "C" {
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
-    
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
@@ -148,7 +147,6 @@ extern "C" {
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
-    
 /**
  * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
  */
@@ -171,7 +169,6 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
-    
 /**
  * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */
@@ -228,7 +225,6 @@ extern "C" {
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
-    
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
@@ -239,7 +235,6 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
-    
 /**
  * A version of ESP_EXIT_ON_FALSE() macro that can be called from ISR.
  */
@@ -307,7 +302,6 @@ extern "C" {
             return;                                                                             \
         }                                                                                       \
     } while(0)
-    
 /**
  * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -25,6 +25,18 @@ extern "C" {
     } while(0)
 
 /**
+ * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
+ * This macro is used when the function returns void.
+ */
+#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                       \
+        (void)log_tag;                                                                          \
+        esp_err_t err_rc_ = (x);                                                                \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            return;                                                                             \
+        }                                                                                       \
+    } while(0)
+
+/**
  * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
  */
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
@@ -68,6 +80,17 @@ extern "C" {
         (void)log_tag;                                                                          \
         if (unlikely(!(a))) {                                                                   \
             return err_code;                                                                    \
+        }                                                                                       \
+    } while(0)
+    
+/**
+ * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
+ * and returns without a value.
+ */
+#define ESP_RETURN_VOID_ON_FALSE(a, log_tag, format, ...) do {                                  \
+        (void)log_tag;                                                                          \
+        if (unlikely(!(a))) {                                                                   \
+            return;                                                                             \
         }                                                                                       \
     } while(0)
 
@@ -125,6 +148,18 @@ extern "C" {
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
+    
+/**
+ * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
+ * This macro is used when the function returns void.
+ */
+#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                             \
+        esp_err_t err_rc_ = (x);                                                                           \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            return;                                                                                        \
+        }                                                                                                  \
+    } while(0)
 
 /**
  * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
@@ -170,6 +205,17 @@ extern "C" {
         if (unlikely(!(a))) {                                                                              \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return err_code;                                                                               \
+        }                                                                                                  \
+    } while(0)
+
+/**
+ * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
+ * and returns without a value.
+ */
+#define ESP_RETURN_VOID_ON_FALSE(a, err_code, log_tag, format, ...) do {                                   \
+        if (unlikely(!(a))) {                                                                              \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            return;                                                                                        \
         }                                                                                                  \
     } while(0)
 
@@ -220,6 +266,18 @@ extern "C" {
     } while(0)
 
 /**
+ * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
+ * This macro is used when the function returns void.
+ */
+#define ESP_RETURN_VOID_ON_ERROR(x, log_tag, format, ...) do {                                  \
+        esp_err_t err_rc_ = (x);                                                                \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            return;                                                                             \
+        }                                                                                       \
+    } while(0)
+
+/**
  * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
  */
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
@@ -265,6 +323,17 @@ extern "C" {
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
+    
+/**
+ * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
+ * and returns without a value.
+ */
+#define ESP_RETURN_VOID_ON_FALSE(a, log_tag, format, ...) do {                                  \
+        if (unlikely(!(a))) {                                                                   \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            return;                                                                             \
+        }                                                                                       \
+    } while(0)
 
 /**
  * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
@@ -302,6 +371,7 @@ extern "C" {
 #endif // !(defined(__cplusplus) && (__cplusplus >  201703L))
 
 #endif // !CONFIG_COMPILER_OPTIMIZATION_CHECKS_SILENT
+
 
 #ifdef __cplusplus
 }

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -82,6 +82,7 @@ extern "C" {
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
+
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
@@ -147,6 +148,7 @@ extern "C" {
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
+
 /**
  * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
  */
@@ -169,6 +171,7 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
+
 /**
  * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */
@@ -225,6 +228,7 @@ extern "C" {
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
+
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
@@ -235,6 +239,7 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
+
 /**
  * A version of ESP_EXIT_ON_FALSE() macro that can be called from ISR.
  */
@@ -244,6 +249,7 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
+
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message,
  * sets the local variable 'ret' to the supplied 'err_code', and then exits by jumping to 'goto_tag'.
@@ -302,6 +308,7 @@ extern "C" {
             return;                                                                             \
         }                                                                                       \
     } while(0)
+
 /**
  * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -372,7 +372,6 @@ extern "C" {
 
 #endif // !CONFIG_COMPILER_OPTIMIZATION_CHECKS_SILENT
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -108,6 +108,16 @@ extern "C" {
 /**
  * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
  */
+#define ESP_EXIT_ON_FALSE_ISR(a, log_tag, format, ...) do {                                  \
+        (void)log_tag;                                                                          \
+        if (unlikely(!(a))) {                                                                   \
+            return;                                                                             \
+        }                                                                                       \
+    } while(0)
+
+/**
+ * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
+ */
 #define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                         \
         (void)log_tag;                                                                          \
         if (unlikely(!(a))) {                                                                   \

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -150,6 +150,17 @@ extern "C" {
     } while(0)
     
 /**
+ * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ */
+#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                              \
+        esp_err_t err_rc_ = (x);                                                                           \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
+            return err_rc_;                                                                                \
+        }                                                                                                  \
+    } while(0)
+    
+/**
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
@@ -160,15 +171,15 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
-
+    
 /**
- * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */
-#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                              \
+#define ESP_EXIT_ON_ERROR_ISR(x, log_tag, format, ...) do {                                         \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
             ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
-            return err_rc_;                                                                                \
+            return;                                                                                        \
         }                                                                                                  \
     } while(0)
 
@@ -209,6 +220,16 @@ extern "C" {
     } while(0)
 
 /**
+ * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
+ */
+#define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                                    \
+        if (unlikely(!(a))) {                                                                              \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
+            return err_code;                                                                               \
+        }                                                                                                  \
+    } while(0)
+    
+/**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
@@ -218,17 +239,16 @@ extern "C" {
             return;                                                                                        \
         }                                                                                                  \
     } while(0)
-
+    
 /**
- * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
+ * A version of ESP_EXIT_ON_FALSE() macro that can be called from ISR.
  */
-#define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                                    \
+#define ESP_EXIT_ON_FALSE_ISR(a, log_tag, format, ...) do {                                        \
         if (unlikely(!(a))) {                                                                              \
             ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
-            return err_code;                                                                               \
+            return;                                                                                        \
         }                                                                                                  \
     } while(0)
-
 /**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message,
  * sets the local variable 'ret' to the supplied 'err_code', and then exits by jumping to 'goto_tag'.
@@ -266,6 +286,17 @@ extern "C" {
     } while(0)
 
 /**
+ * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ */
+#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
+        esp_err_t err_rc_ = (x);                                                                \
+        if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
+            return err_rc_;                                                                     \
+        }                                                                                       \
+    } while(0)
+    
+/**
  * Macro which can be used to check the error code. If the code is not ESP_OK, it prints the message and returns.
  * This macro is used when the function returns void.
  */
@@ -276,15 +307,15 @@ extern "C" {
             return;                                                                             \
         }                                                                                       \
     } while(0)
-
+    
 /**
- * A version of ESP_RETURN_ON_ERROR() macro that can be called from ISR.
+ * A version of ESP_EXIT_ON_ERROR() macro that can be called from ISR.
  */
-#define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
+#define ESP_EXIT_ON_ERROR_ISR(x, log_tag, format, ...) do {                              \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
             ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
-            return err_rc_;                                                                     \
+            return;                                                                             \
         }                                                                                       \
     } while(0)
 

--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -378,6 +378,16 @@ extern "C" {
     } while(0)
     
 /**
+ * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
+ */
+#define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                         \
+        if (unlikely(!(a))) {                                                                   \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
+            return err_code;                                                                    \
+        }                                                                                       \
+    } while(0)
+
+/**
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
@@ -389,12 +399,12 @@ extern "C" {
     } while(0)
 
 /**
- * A version of ESP_RETURN_ON_FALSE() macro that can be called from ISR.
+ * A version of ESP_EXIT_ON_FALSE() macro that can be called from ISR.
  */
-#define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                         \
+#define ESP_EXIT_ON_FALSE_ISR(a, log_tag, format, ...) do {                              \
         if (unlikely(!(a))) {                                                                   \
             ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
-            return err_code;                                                                    \
+            return;                                                                             \
         }                                                                                       \
     } while(0)
 


### PR DESCRIPTION
In our projects, we often use the `ESP_RETURN_ON_*` macros quite often. However, when the function itself returns void, we encounter limitations in using these macros.

While testing a variant of `ESP_EXIT_ON_ERROR`, I came across [this commit](https://github.com/espressif/esp-idf/commit/6792024add7caef100a88a2c23d7b0b8933360e1), which suggests that this method was planned. I'm unsure why it didn't make it into the actual code.

Feel free to consider this as a suggestion. If, for some reason, it's not accepted, I'm happy to just use a custom header for our projects.