### PR TITLE
docs(get-started): Add which as deps (IDFGH-12546)

### DIFF
--- a/docs/en/get-started/linux-macos-setup.rst
+++ b/docs/en/get-started/linux-macos-setup.rst
@@ -44,7 +44,7 @@ CentOS 7 is still supported but CentOS version 8 is recommended for a better use
 
 - Arch::
 
-    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb
+    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb which
 
 .. note::
     - CMake version 3.16 or newer is required for use with ESP-IDF. Run "tools/idf_tools.py install cmake" to install a suitable version if your OS versions does not have one.

--- a/docs/zh_CN/get-started/linux-macos-setup.rst
+++ b/docs/zh_CN/get-started/linux-macos-setup.rst
@@ -1,4 +1,4 @@
-﻿*********************************************
+*********************************************
 Linux 和 macOS 平台工具链的标准设置
 *********************************************
 
@@ -44,7 +44,7 @@ Linux 用户
 
 - Arch::
 
-    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb
+    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb which
 
 .. note::
     - 使用 ESP-IDF 需要 CMake 3.16 或以上版本。较早的 Linux 发行版可能需要升级自身的软件源仓库，或开启 backports 套件库，或安装 "cmake3" 软件包（不是安装 "cmake"）。


### PR DESCRIPTION
In some cases, Arch Linux does not install 'which' in the system. 
It may cause problems like this:
```
{"message":"Command failed: which -a python; which -a python3\n/bin/sh: line 1: which: command not found\n/bin/sh: line 1: which: command not found\n","stack":"Error: Command failed: which -a python; which -a python3\n/bin/sh: line 1: which: command not found\n/bin/sh: line 1: which: command not found\n\n\tat ChildProcess.exithandler (node:child_process:420:12)\n\tat ChildProcess.emit (node:events:514:28)\n\tat maybeClose (node:internal/child_process:1091:16)\n\tat ChildProcess._handle.onexit (node:internal/child_process:302:5)","level":"error","timestamp":"2024-04-06T12:50:36.294Z"}
{"user":true,"message":"Error looking for python in system","stack":"Error: Command failed: which -a python; which -a python3\n/bin/sh: line 1: which: command not found\n/bin/sh: line 1: which: command not found\n\n\tat ChildProcess.exithandler (node:child_process:420:12)\n\tat ChildProcess.emit (node:events:514:28)\n\tat maybeClose (node:internal/child_process:1091:16)\n\tat ChildProcess._handle.onexit (node:internal/child_process:302:5)","level":"error","timestamp":"2024-04-06T12:50:36.296Z"}

{"message":"Cannot access filePath: cmake","stack":"Error: spawn which ENOENT\n\tat ChildProcess._handle.onexit (node:internal/child_process:283:19)\n\tat onErrorNT (node:internal/child_process:476:16)\n\tat process.processTicksAndRejections (node:internal/process/task_queues:82:21)","level":"error","timestamp":"2024-04-06T12:59:55.984Z"}
{"message":"Cannot access filePath: ninja","stack":"Error: spawn which ENOENT\n\tat ChildProcess._handle.onexit (node:internal/child_process:283:19)\n\tat onErrorNT (node:internal/child_process:476:16)\n\tat process.processTicksAndRejections (node:internal/process/task_queues:82:21)","level":"error","timestamp":"2024-04-06T12:59:56.058Z"}
{"user":true,"message":"Something went wrong while trying to build the project","stack":"Error: CMake or Ninja executables not found\n\tat uo.build (/dist/extension.js:2:1522778)\n\tat async Xs (/dist/extension.js:2:1623409)\n\tat async /dist/extension.js:2:1764720","level":"error","timestamp":"2024-04-06T12:59:56.061Z"}
```