### PR TITLE
Make FreeRTOS configUSE_TIMERS optional in KConfig (IDFGH-12576)

### DIFF
--- a/components/freertos/Kconfig
+++ b/components/freertos/Kconfig
@@ -161,6 +161,13 @@ menu "FreeRTOS"
                 Enable backward compatibility with APIs prior to FreeRTOS v8.0.0. (see
                 configENABLE_BACKWARD_COMPATIBILITY documentation for more details).
 
+        config FREERTOS_USE_TIMERS
+            bool "configUSE_TIMERS"
+            default y
+            depends on !IDF_TARGET_LINUX
+            help
+                Enable FreeRTOS Software Timers.
+
         config FREERTOS_TIMER_SERVICE_TASK_NAME
             string "configTIMER_SERVICE_TASK_NAME"
             default "Tmr Svc"

--- a/components/freertos/config/include/freertos/FreeRTOSConfig.h
+++ b/components/freertos/config/include/freertos/FreeRTOSConfig.h
@@ -183,7 +183,11 @@
 
 /* ------------------- Software Timer ---------------------- */
 
-#define configUSE_TIMERS                          1
+#if CONFIG_FREERTOS_USE_TIMERS
+    #define configUSE_TIMERS                      1
+#else
+    #define configUSE_TIMERS                      0
+#endif
 #define configTIMER_TASK_PRIORITY                 CONFIG_FREERTOS_TIMER_TASK_PRIORITY
 #define configTIMER_QUEUE_LENGTH                  CONFIG_FREERTOS_TIMER_QUEUE_LENGTH
 #define configTIMER_TASK_STACK_DEPTH              CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH
@@ -214,7 +218,11 @@
 #define INCLUDE_uxTaskGetStackHighWaterMark        1
 #define INCLUDE_eTaskGetState                      1
 #define INCLUDE_xTaskResumeFromISR                 1
-#define INCLUDE_xTimerPendFunctionCall             1
+#if CONFIG_FREERTOS_USE_TIMERS
+  #define INCLUDE_xTimerPendFunctionCall           1
+#else
+  #define INCLUDE_xTimerPendFunctionCall           0
+#endif
 #define INCLUDE_xTaskGetSchedulerState             1
 #define INCLUDE_xTaskGetCurrentTaskHandle          1
 


### PR DESCRIPTION
The FreeRTOS Software Timers may not be required in some user applications, as the esp_timer provides much of the same functionality.

This PR adds a KConfig option to allow the user to disable the FreeRTOS Software timers using the configUSE_TIMERS option. This allows saving the stack space that would have been used by the inactive FreeRTOS timer service task.