### PR TITLE
Add user pointers to avoid using global variables in callbacks (IDFGH-12601)

### DIFF
--- a/components/bt/common/btc/core/btc_manage.c
+++ b/components/bt/common/btc/core/btc_manage.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,8 +10,10 @@
 
 #if BTC_DYNAMIC_MEMORY == FALSE
 void *btc_profile_cb_tab[BTC_PID_NUM] = {};
+void *btc_profile_ptr_tab[BTC_PID_NUM] = {};
 #else
 void **btc_profile_cb_tab;
+void **btc_profile_ptr_tab;
 #endif
 
 void esp_profile_cb_reset(void)
@@ -20,6 +22,7 @@ void esp_profile_cb_reset(void)
 
     for (i = 0; i < BTC_PID_NUM; i++) {
         btc_profile_cb_tab[i] = NULL;
+        btc_profile_ptr_tab[i] = NULL;
     }
 }
 
@@ -41,4 +44,24 @@ void *btc_profile_cb_get(btc_pid_t profile_id)
     }
 
     return btc_profile_cb_tab[profile_id];
+}
+
+int btc_profile_ptr_set(btc_pid_t profile_id, void *ptr)
+{
+    if (profile_id < 0 || profile_id >= BTC_PID_NUM) {
+        return -1;
+    }
+
+    btc_profile_ptr_tab[profile_id] = ptr;
+
+    return 0;
+}
+
+void *btc_profile_ptr_get(btc_pid_t profile_id)
+{
+    if (profile_id < 0 || profile_id >= BTC_PID_NUM) {
+        return NULL;
+    }
+
+    return btc_profile_ptr_tab[profile_id];
 }

--- a/components/bt/common/btc/core/btc_task.c
+++ b/components/bt/common/btc/core/btc_task.c
@@ -295,8 +295,8 @@ static bt_status_t btc_task_post(btc_msg_t *msg, uint32_t timeout)
 /**
  * transfer an message to another module in the different task.
  * @param  msg       message
- * @param  arg       paramter
- * @param  arg_len   length of paramter
+ * @param  arg       parameter
+ * @param  arg_len   length of parameter
  * @param  copy_func deep copy function
  * @param  free_func deep free function
  * @return           BT_STATUS_SUCCESS: success
@@ -342,7 +342,7 @@ bt_status_t btc_transfer_context(btc_msg_t *msg, void *arg, int arg_len, btc_arg
 }
 
 /**
- * transfer an message to another module in tha same task.
+ * transfer an message to another module in the same task.
  * @param  msg       message
  * @return           BT_STATUS_SUCCESS: success
  *                   others: fail
@@ -378,6 +378,11 @@ static void btc_deinit_mem(void) {
     if (btc_profile_cb_tab) {
         osi_free(btc_profile_cb_tab);
         btc_profile_cb_tab = NULL;
+    }
+
+    if (btc_profile_ptr_tab) {
+        osi_free(btc_profile_ptr_tab);
+        btc_profile_ptr_tab = NULL;
     }
 
 #if (BLE_INCLUDED == TRUE)
@@ -441,6 +446,11 @@ static bt_status_t btc_init_mem(void) {
         goto error_exit;
     }
     memset((void *)btc_profile_cb_tab, 0, sizeof(void *) * BTC_PID_NUM);
+
+    if ((btc_profile_ptr_tab = (void **)osi_malloc(sizeof(void *) * BTC_PID_NUM)) == NULL) {
+        goto error_exit;
+    }
+    memset((void *)btc_profile_ptr_tab, 0, sizeof(void *) * BTC_PID_NUM);
 
 #if (BLE_INCLUDED == TRUE)
     if ((gl_bta_adv_data_ptr = (tBTA_BLE_ADV_DATA *)osi_malloc(sizeof(tBTA_BLE_ADV_DATA))) == NULL) {

--- a/components/bt/common/btc/include/btc/btc_manage.h
+++ b/components/bt/common/btc/include/btc/btc_manage.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,13 +11,18 @@
 
 #if BTC_DYNAMIC_MEMORY == FALSE
 extern void *btc_profile_cb_tab[BTC_PID_NUM];
+extern void *btc_profile_ptr_tab[BTC_PID_NUM];
 #else
 extern void **btc_profile_cb_tab;
+extern void **btc_profile_ptr_tab;
 #endif
 /* reset gatt callback table */
 void esp_profile_cb_reset(void);
 
 int btc_profile_cb_set(btc_pid_t profile_id, void *cb);
 void *btc_profile_cb_get(btc_pid_t profile_id);
+
+int btc_profile_ptr_set(btc_pid_t profile_id, void *ptr);
+void *btc_profile_ptr_get(btc_pid_t profile_id);
 
 #endif /* __BTC_MANAGE_H__ */

--- a/components/bt/host/bluedroid/api/esp_gap_ble_api.c
+++ b/components/bt/host/bluedroid/api/esp_gap_ble_api.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,18 @@ esp_err_t esp_ble_gap_register_callback(esp_gap_ble_cb_t callback)
 esp_gap_ble_cb_t esp_ble_gap_get_callback(void)
 {
     return (esp_gap_ble_cb_t) btc_profile_cb_get(BTC_PID_GAP_BLE);
+}
+
+esp_err_t esp_ble_gap_register_ptr(void *ptr)
+{
+    ESP_BLUEDROID_STATUS_CHECK(ESP_BLUEDROID_STATUS_ENABLED);
+
+    return (btc_profile_ptr_set(BTC_PID_GAP_BLE, ptr) == 0 ? ESP_OK : ESP_FAIL);
+}
+
+void *esp_ble_gap_get_ptr(void)
+{
+    return btc_profile_ptr_get(BTC_PID_GAP_BLE);
 }
 
 #if (BLE_42_FEATURE_SUPPORT == TRUE)

--- a/components/bt/host/bluedroid/api/esp_gatts_api.c
+++ b/components/bt/host/bluedroid/api/esp_gatts_api.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,6 +32,18 @@ esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback)
 esp_gatts_cb_t esp_ble_gatts_get_callback(void)
 {
     return (esp_gatts_cb_t) btc_profile_cb_get(BTC_PID_GATTS);
+}
+
+esp_err_t esp_ble_gatts_register_ptr(void *ptr)
+{
+    ESP_BLUEDROID_STATUS_CHECK(ESP_BLUEDROID_STATUS_ENABLED);
+
+    return (btc_profile_ptr_set(BTC_PID_GATTS, ptr) == 0 ? ESP_OK : ESP_FAIL);
+}
+
+void *esp_ble_gatts_get_ptr(void)
+{
+    return btc_profile_ptr_get(BTC_PID_GATTS);
 }
 
 esp_err_t esp_ble_gatts_app_register(uint16_t app_id)
@@ -272,7 +284,7 @@ esp_err_t esp_ble_gatts_send_indicate(esp_gatt_if_t gatts_if, uint16_t conn_id, 
     }
 
     if (L2CA_CheckIsCongest(L2CAP_ATT_CID, p_tcb->peer_bda)) {
-        LOG_DEBUG("%s, the l2cap chanel is congest.", __func__);
+        LOG_DEBUG("%s, the l2cap channel is congest.", __func__);
         return ESP_FAIL;
     }
 

--- a/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h
@@ -156,7 +156,7 @@ typedef enum {
     ESP_GAP_BLE_PASSKEY_REQ_EVT,                            /*!< passkey request event */
     ESP_GAP_BLE_OOB_REQ_EVT,                                /*!< OOB request event */
     ESP_GAP_BLE_LOCAL_IR_EVT,                               /*!< BLE local IR (identity Root 128-bit random static value used to generate Long Term Key) event */
-    ESP_GAP_BLE_LOCAL_ER_EVT,                               /*!< BLE local ER (Encryption Root vakue used to genrate identity resolving key) event */
+    ESP_GAP_BLE_LOCAL_ER_EVT,                               /*!< BLE local ER (Encryption Root value used to generate identity resolving key) event */
     ESP_GAP_BLE_NC_REQ_EVT,                                 /*!< Numeric Comparison request event */
     //BLE_42_FEATURE_SUPPORT
     ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT,                      /*!< When stop adv complete, the event comes */
@@ -786,9 +786,9 @@ typedef uint8_t esp_ble_gap_all_phys_t;
 #define ESP_BLE_GAP_PRI_PHY_CODED  ESP_BLE_GAP_PHY_CODED  /*!< Primary Phy is LE CODED */
 typedef uint8_t esp_ble_gap_pri_phy_t; // primary phy
 
-#define ESP_BLE_GAP_PHY_1M_PREF_MASK                   (1 << 0) /*!< The Host prefers use the LE1M transmitter or reciever PHY */
-#define ESP_BLE_GAP_PHY_2M_PREF_MASK                   (1 << 1) /*!< The Host prefers use the LE2M transmitter or reciever PHY */
-#define ESP_BLE_GAP_PHY_CODED_PREF_MASK                (1 << 2) /*!< The Host prefers use the LE CODED transmitter or reciever PHY */
+#define ESP_BLE_GAP_PHY_1M_PREF_MASK                   (1 << 0) /*!< The Host prefers use the LE1M transmitter or receiver PHY */
+#define ESP_BLE_GAP_PHY_2M_PREF_MASK                   (1 << 1) /*!< The Host prefers use the LE2M transmitter or receiver PHY */
+#define ESP_BLE_GAP_PHY_CODED_PREF_MASK                (1 << 2) /*!< The Host prefers use the LE CODED transmitter or receiver PHY */
 typedef uint8_t esp_ble_gap_phy_mask_t;
 
 #define ESP_BLE_GAP_PHY_OPTIONS_NO_PREF                  0 /*!< The Host has no preferred coding when transmitting on the LE Coded PHY */
@@ -1500,6 +1500,27 @@ esp_err_t esp_ble_gap_register_callback(esp_gap_ble_cb_t callback);
  *
  */
 esp_gap_ble_cb_t esp_ble_gap_get_callback(void);
+
+/**
+ * @brief           This function is called to register user pointer
+ *
+ * @param[in]       ptr: user pointer to set
+ *
+ * @return
+ *                  - ESP_OK : success
+ *                  - other  : failed
+ *
+ */
+esp_err_t esp_ble_gap_register_ptr(void *ptr);
+
+/**
+ * @brief           This function is called to get the current gap user pointer
+ *
+ * @return
+ *                  - current user pointer (may be NULL if not set)
+ *
+ */
+void *esp_ble_gap_get_ptr(void);
 
 #if (BLE_42_FEATURE_SUPPORT == TRUE)
 /**

--- a/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -304,6 +304,27 @@ esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback);
  *
  */
 esp_gatts_cb_t esp_ble_gatts_get_callback(void);
+
+/**
+ * @brief           This function is called to register application user pointer
+ *                  with BTA GATTS module.
+ *
+ * @return
+ *                  - ESP_OK : success
+ *                  - other  : failed
+ *
+ */
+esp_err_t esp_ble_gatts_register_ptr(void *ptr);
+
+/**
+ * @brief           This function is called to get the current application user pointer
+ *                  with BTA GATTS module.
+ *
+ * @return
+ *                  - current user pointer (may be NULL if not set)
+ *
+ */
+void *esp_ble_gatts_get_ptr(void);
 
 /**
  * @brief           This function is called to register application identifier

--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -21,10 +21,7 @@ components/esp_rom/include/esp32s2/rom/rsa_pss.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
-components/lwip/lwip/src/include/netif/ppp/
 
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
@@ -60,13 +57,9 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
-components/unity/unity/extras/
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/


### PR DESCRIPTION
The motivation to propose this change is based on the callbacks used both by:

GAP:  (esp_ble_gap_register_callback, esp_ble_gap_get_callback)
GATTS: (esp_ble_gatts_register_callback, esp_ble_gatts_get_callback)

The proposed solution is to add 2 new more entry points for each of the profiles:

GAP: (esp_ble_gap_register_ptr, esp_ble_gap_get_ptr)
GATTS: (esp_ble_gatts_register_ptr, esp_ble_gatts_get_ptr)

With these new entry points, the registered callbacks now have to ability to retrieve a pre-set user pointer, avoiding, in this way, the use of global variables, which is consolidated as a bad practice and should be avoided when possible. This problem yet has another weight in multi-core environments.