### PR TITLE
Fixes compilation with -save-temps flag (IDFGH-12615)

### DIFF
--- a/components/spiffs/CMakeLists.txt
+++ b/components/spiffs/CMakeLists.txt
@@ -21,9 +21,6 @@ idf_component_register(SRCS ${srcs}
                        REQUIRES esp_partition
                        PRIV_REQUIRES ${pr})
 
-if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-    set_source_files_properties(spiffs/src/spiffs_nucleus.c PROPERTIES COMPILE_FLAGS -Wno-stringop-truncation)
-endif()
-
 # Upstream SPIFFS code uses format specifiers in debug logging macros inconsistently
+list(TRANSFORM original_srcs PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 set_source_files_properties(${original_srcs} PROPERTIES COMPILE_FLAGS -Wno-format)

--- a/components/spiffs/CMakeLists.txt
+++ b/components/spiffs/CMakeLists.txt
@@ -24,3 +24,7 @@ idf_component_register(SRCS ${srcs}
 # Upstream SPIFFS code uses format specifiers in debug logging macros inconsistently
 list(TRANSFORM original_srcs PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 set_source_files_properties(${original_srcs} PROPERTIES COMPILE_FLAGS -Wno-format)
+
+get_source_file_property(nucleus_cc_flags "${CMAKE_CURRENT_LIST_DIR}/spiffs/src/spiffs_nucleus.c" COMPILE_FLAGS)
+set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/spiffs/src/spiffs_nucleus.c"
+  PROPERTIES COMPILE_FLAGS "${nucleus_cc_flags} -Wno-tautological-compare")


### PR DESCRIPTION
Project's root `CMakeLists.txt`:
```cmake
cmake_minimum_required(VERSION 3.16)

# Preserve *.i files
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -save-temps")

include($ENV{IDF_PATH}/tools/cmake/project.cmake)
project(mcu_software)
```

If try to compile with `-save-temps` and with:
```
CONFIG_COMPILER_DISABLE_GCC12_WARNINGS=y
CONFIG_COMPILER_DISABLE_GCC13_WARNINGS=y
```
it causes error:
$ idf.py build lib
[...]
components/spiffs/spiffs/src/spiffs_nucleus.c: In function 'spiffs_populate_ix_map_v':
components/spiffs/spiffs/src/spiffs_nucleus.c:682:348: error: self-comparison always evaluates to false [-Werror=tautological-compare]

This PR fixes compilation for such case

Depends from https://github.com/espressif/esp-idf/pull/13612

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only CMake flag changes for third-party SPIFFS sources; no firmware behavior or API changes.
> 
> **Overview**
> Fixes **SPIFFS** failing the build when the project adds **`-save-temps`** (and related GCC warning settings), where **`spiffs_nucleus.c`** trips **`-Werror=tautological-compare`** in `spiffs_populate_ix_map_v`.
> 
> The component **`CMakeLists.txt`** now applies **`-Wno-format`** to upstream sources using **absolute paths** (`list(TRANSFORM … PREPEND "${CMAKE_CURRENT_LIST_DIR}/"`) so per-file compile flags still attach correctly with temp files enabled. For **`spiffs_nucleus.c`**, it **appends `-Wno-tautological-compare`** to any existing **`COMPILE_FLAGS`** instead of the old GNU-only **`-Wno-stringop-truncation`** block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ed236171bbd6f5d12cbe33c27bc202bd6f5ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->