### PR TITLE
fix (esp-tls): make the wolfSSL backend send entire client certificat…

### DIFF
--- a/components/esp-tls/esp_tls_wolfssl.c
+++ b/components/esp-tls/esp_tls_wolfssl.c
@@ -97,7 +97,7 @@ static esp_err_t esp_load_wolfssl_verify_buffer(esp_tls_t *tls, const unsigned c
             wolf_fileformat = WOLFSSL_FILETYPE_ASN1;
         }
         if (type == FILE_TYPE_SELF_CERT) {
-            if ((*err_ret = wolfSSL_CTX_use_certificate_buffer( (WOLFSSL_CTX *)tls->priv_ctx, cert_buf, cert_len, wolf_fileformat)) == WOLFSSL_SUCCESS) {
+            if ((*err_ret = wolfSSL_CTX_use_certificate_chain_buffer_format( (WOLFSSL_CTX *)tls->priv_ctx, cert_buf, cert_len, wolf_fileformat)) == WOLFSSL_SUCCESS) {
                 return ESP_OK;
             }
             return ESP_FAIL;


### PR DESCRIPTION
…e chains

This change makes the wolfSSL backend sent the complete TLS client certificate chain. This align the wolfSSL backend with the behavior of the mbedTLS backend. Some servers need the intermediate certificates to verify a client certificate. If the provided PEM file contains only a single certificate this change has no effect.

This impacts higher level APIs to function as someone would expect. E.g.: esp_websocket_client_config_t.client_cert: when passing here a pem file containing 2 certificates (the CA's and the client's) it would be expected that both are transmitted during TLS handshake.