### PR TITLE
feat(i2c): Add API to support sending register or command bytes separately from the data (IDFGH-12639)

### DIFF
--- a/components/esp_driver_i2c/include/driver/i2c_master.h
+++ b/components/esp_driver_i2c/include/driver/i2c_master.h
@@ -124,6 +124,27 @@ esp_err_t i2c_master_bus_rm_device(i2c_master_dev_handle_t handle);
 esp_err_t i2c_master_transmit(i2c_master_dev_handle_t i2c_dev, const uint8_t *write_buffer, size_t write_size, int xfer_timeout_ms);
 
 /**
+ * @brief Perform a write transaction with prefixed register/command bytes on the I2C bus.
+ *        The transaction will be undergoing until it finishes or it reaches
+ *        the timeout provided.
+ *
+ * @note If a callback was registered with `i2c_master_register_event_callbacks`, the transaction will be asynchronous, and thus, this function will return directly, without blocking.
+ *       You will get finish information from callback. Besides, data buffer should always be completely prepared when callback is registered, otherwise, the data will get corrupt.
+ *
+ * @param[in] i2c_dev I2C master device handle that created by `i2c_master_bus_add_device`.
+ * @param[in] reg_buffer Register/command bytes to send on the I2C bus.
+ * @param[in] reg_size   Size, in bytes, of the register/command buffer.
+ * @param[in] write_buffer Data bytes to send on the I2C bus.
+ * @param[in] write_size Size, in bytes, of the write buffer.
+ * @param[in] xfer_timeout_ms Wait timeout, in ms. Note: -1 means wait forever.
+ * @return
+ *      - ESP_OK: I2C master transmit success
+ *      - ESP_ERR_INVALID_ARG: I2C master transmit parameter invalid.
+ *      - ESP_ERR_TIMEOUT: Operation timeout(larger than xfer_timeout_ms) because the bus is busy or hardware crash.
+ */
+esp_err_t i2c_master_prefixed_transmit(i2c_master_dev_handle_t i2c_dev, const uint8_t *reg_buffer, size_t reg_size, const uint8_t *write_buffer, size_t write_size, int xfer_timeout_ms);
+
+/**
  * @brief Perform a write-read transaction on the I2C bus.
  *        The transaction will be undergoing until it finishes or it reaches
  *        the timeout provided.

--- a/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.c
+++ b/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.c
@@ -25,7 +25,7 @@ esp_err_t i2c_eeprom_init(i2c_master_bus_handle_t bus_handle, const i2c_eeprom_c
 {
     esp_err_t ret = ESP_OK;
     i2c_eeprom_handle_t out_handle;
-    out_handle = (i2c_eeprom_handle_t)calloc(1, sizeof(i2c_eeprom_handle_t));
+    out_handle = (i2c_eeprom_handle_t)calloc(1, sizeof(i2c_eeprom_t));
     ESP_GOTO_ON_FALSE(out_handle, ESP_ERR_NO_MEM, err, TAG, "no memory for i2c eeprom device");
 
     i2c_device_config_t i2c_dev_conf = {

--- a/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.c
+++ b/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.c
@@ -16,7 +16,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#define I2C_EEPROM_MAX_TRANS_UNIT (48)
 // Different EEPROM device might share one I2C bus
 
 static const char TAG[] = "i2c-eeprom";
@@ -27,6 +26,7 @@ esp_err_t i2c_eeprom_init(i2c_master_bus_handle_t bus_handle, const i2c_eeprom_c
     i2c_eeprom_handle_t out_handle;
     out_handle = (i2c_eeprom_handle_t)calloc(1, sizeof(i2c_eeprom_t));
     ESP_GOTO_ON_FALSE(out_handle, ESP_ERR_NO_MEM, err, TAG, "no memory for i2c eeprom device");
+    ESP_GOTO_ON_FALSE(eeprom_config->addr_wordlen <= 4, ESP_ERR_NO_MEM, err, TAG, "max possible addr_wordlen is 4");
 
     i2c_device_config_t i2c_dev_conf = {
         .scl_speed_hz = eeprom_config->eeprom_device.scl_speed_hz,
@@ -36,9 +36,6 @@ esp_err_t i2c_eeprom_init(i2c_master_bus_handle_t bus_handle, const i2c_eeprom_c
     if (out_handle->i2c_dev == NULL) {
         ESP_GOTO_ON_ERROR(i2c_master_bus_add_device(bus_handle, &i2c_dev_conf, &out_handle->i2c_dev), err, TAG, "i2c new bus failed");
     }
-
-    out_handle->buffer = (uint8_t*)calloc(1, eeprom_config->addr_wordlen + I2C_EEPROM_MAX_TRANS_UNIT);
-    ESP_GOTO_ON_FALSE(out_handle->buffer, ESP_ERR_NO_MEM, err, TAG, "no memory for i2c eeprom device buffer");
 
     out_handle->addr_wordlen = eeprom_config->addr_wordlen;
     out_handle->write_time_ms = eeprom_config->write_time_ms;
@@ -58,21 +55,20 @@ esp_err_t i2c_eeprom_write(i2c_eeprom_handle_t eeprom_handle, uint32_t address, 
 {
     ESP_RETURN_ON_FALSE(eeprom_handle, ESP_ERR_NO_MEM, TAG, "no mem for buffer");
     for (int i = 0; i < eeprom_handle->addr_wordlen; i++) {
-        eeprom_handle->buffer[i] = (address & (0xff << ((eeprom_handle->addr_wordlen - 1 - i) * 8))) >> ((eeprom_handle->addr_wordlen - 1 - i) * 8);
+        eeprom_handle->addr_buffer[i] = (address & (0xff << ((eeprom_handle->addr_wordlen - 1 - i) * 8))) >> ((eeprom_handle->addr_wordlen - 1 - i) * 8);
     }
-    memcpy(eeprom_handle->buffer + eeprom_handle->addr_wordlen, data, size);
 
-    return i2c_master_transmit(eeprom_handle->i2c_dev, eeprom_handle->buffer, eeprom_handle->addr_wordlen + size, -1);
+    return i2c_master_prefixed_transmit(eeprom_handle->i2c_dev, eeprom_handle->addr_buffer, eeprom_handle->addr_wordlen, data, size, -1);
 }
 
 esp_err_t i2c_eeprom_read(i2c_eeprom_handle_t eeprom_handle, uint32_t address, uint8_t *data, uint32_t size)
 {
-    ESP_RETURN_ON_FALSE(eeprom_handle, ESP_ERR_NO_MEM, TAG, "no mem for buffer");
+    ESP_RETURN_ON_FALSE(eeprom_handle, ESP_ERR_NO_MEM, TAG, "no mem for address buffer");
     for (int i = 0; i < eeprom_handle->addr_wordlen; i++) {
-        eeprom_handle->buffer[i] = (address & (0xff << ((eeprom_handle->addr_wordlen - 1 - i) * 8))) >> ((eeprom_handle->addr_wordlen - 1 - i) * 8);
+        eeprom_handle->addr_buffer[i] = (address & (0xff << ((eeprom_handle->addr_wordlen - 1 - i) * 8))) >> ((eeprom_handle->addr_wordlen - 1 - i) * 8);
     }
 
-    return i2c_master_transmit_receive(eeprom_handle->i2c_dev, eeprom_handle->buffer, eeprom_handle->addr_wordlen, data, size, -1);
+    return i2c_master_transmit_receive(eeprom_handle->i2c_dev, eeprom_handle->addr_buffer, eeprom_handle->addr_wordlen, data, size, -1);
 }
 
 void i2c_eeprom_wait_idle(i2c_eeprom_handle_t eeprom_handle)

--- a/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.h
+++ b/examples/peripherals/i2c/i2c_eeprom/components/i2c_eeprom/i2c_eeprom.h
@@ -20,7 +20,7 @@ typedef struct {
 struct i2c_eeprom_t {
     i2c_master_dev_handle_t i2c_dev;      /*!< I2C device handle */
     uint8_t addr_wordlen;                 /*!< block address wordlen */
-    uint8_t *buffer;                      /*!< I2C transaction buffer */
+    uint8_t addr_buffer[4];                 /*!< I2C transaction address buffer */
     uint8_t write_time_ms;                /*!< I2C eeprom write time(ms)*/
 };
 


### PR DESCRIPTION
Adding this API can eliminate the need to allocate a temporary buffer to accommodate both memory address/command and data before the writing transaction, which is especially useful for large transactions, such as I2C EEPROM, I2C panels, and dataloggers. I2C EEPROM example has been modified accordingly. 
Tested on C3, S3, and C6 with a real AT24C256 EEPROM chip (LENGTH=pagesize=64B, can be seen on datasheet) in both sync and async mode.