### PR TITLE
Add exec permission to `entrypoint.sh` script in Dockerfile. (IDFGH-12668)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -102,5 +102,7 @@ ENV IDF_PYTHON_CHECK_CONSTRAINTS=no
 ENV IDF_CCACHE_ENABLE=1
 
 COPY entrypoint.sh /opt/esp/entrypoint.sh
+RUN chmod u+x /opt/esp/entrypoint.sh
+
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Hello Espressif team! This is a minor change to the Dockerfile in the tools folder.

The Dockerfile did not set exec permission for the `entrypoint.sh` script.

I know the exec bit for `entrypoint.sh` is set in this git repository. But when user uses self-provided `entrypoint.sh` without exec permission, it will break the Dock container. *"unable to start container process: exec: "/opt/esp/entrypoint.sh": permission denied: unknown"*

Better do `chmod u+x /opt/esp/entrypoint.sh` after `COPY` to make sure `entrypoint.sh` is always executable.

Also, it is better than `COPY --chmod=0755`, for older docker versions don't support the `--chmod` option after `COPY`.