### PR TITLE
docs: clarify ESP_RETURN_ON_ERROR result (IDFGH-12678)

### DIFF
--- a/docs/en/api-guides/error-handling.rst
+++ b/docs/en/api-guides/error-handling.rst
@@ -85,7 +85,7 @@ Error message will typically look like this::
 ``ESP_RETURN_ON_ERROR`` Macro
 -----------------------------
 
-:c:macro:`ESP_RETURN_ON_ERROR` macro checks the error code, if the error code is not equal :c:macro:`ESP_OK`, it prints the message and returns.
+:c:macro:`ESP_RETURN_ON_ERROR` macro checks the error code, if the error code is not equal :c:macro:`ESP_OK`, it prints the message and returns the error code.
 
 
 .. _esp-goto-on-error-macro:


### PR DESCRIPTION
Expand documentation slightly to include what ESP_RETURN_ON_ERROR returns, an esp_err_t.

I had an issue where ESP_RETURN_ON_ERROR was called in a function returning bool, and it was not immediately clear from the documentation what it should return.