### PR TITLE
ci(dockerfile): Fixed entrypoint.sh is not executable issue (IDFGH-12681)

### DIFF
--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -21,10 +21,7 @@ components/esp_rom/include/esp32s2/rom/rsa_pss.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
-components/lwip/lwip/src/include/netif/ppp/
 
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
@@ -60,13 +57,9 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
-components/unity/unity/extras/
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -41,10 +41,10 @@ RUN : \
 
 # To build the image for a branch or a tag of IDF, pass --build-arg IDF_CLONE_BRANCH_OR_TAG=name.
 # To build the image with a specific commit ID of IDF, pass --build-arg IDF_CHECKOUT_REF=commit-id.
-# It is possibe to combine both, e.g.:
+# It is possible to combine both, e.g.:
 #   IDF_CLONE_BRANCH_OR_TAG=release/vX.Y
 #   IDF_CHECKOUT_REF=<some commit on release/vX.Y branch>.
-# Use IDF_CLONE_SHALLOW=1 to peform shallow clone (i.e. --depth=1 --shallow-submodules)
+# Use IDF_CLONE_SHALLOW=1 to perform shallow clone (i.e. --depth=1 --shallow-submodules)
 # Use IDF_CLONE_SHALLOW_DEPTH=X to define the depth if IDF_CLONE_SHALLOW is used (i.e. --depth=X)
 # Use IDF_INSTALL_TARGETS to install tools only for selected chip targets (CSV)
 
@@ -102,5 +102,7 @@ ENV IDF_PYTHON_CHECK_CONSTRAINTS=no
 ENV IDF_CCACHE_ENABLE=1
 
 COPY entrypoint.sh /opt/esp/entrypoint.sh
+RUN chmod u+x /opt/esp/entrypoint.sh
+
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
This is the new pull request for the already closed PR #13660 due to previous commit issues.

The new commit was created with the `pre-commit` hooks.

Besides the original change, there are a few new changes which were introduced by the `pre-commit` hooks, including word spelling, etc.

Attached pre-commit log:

```text
xiahua@fredrice:~/GitHub/esp-idf$ git commit
trim trailing whitespace.........................................................................................................Passed
fix end of files.................................................................................................................Passed
check that executables have shebangs.........................................................................(no files to check)Skipped
mixed line ending................................................................................................................Passed
fix double quoted strings....................................................................................(no files to check)Skipped
Do not use more than one slash in the branch name................................................................................Passed
Do not use uppercase letters in the branch name..................................................................................Passed
flake8.......................................................................................................(no files to check)Skipped
Reorder Python imports.......................................................................................(no files to check)Skipped
codespell........................................................................................................................Passed
Check File Permissions.......................................................................................(no files to check)Skipped
Validate executable-list.txt.....................................................................................................Passed
Check if any Kconfig Options Deprecated......................................................................(no files to check)Skipped
Check CMake Files Format.....................................................................................(no files to check)Skipped
Validate Codeowner File..........................................................................................................Passed
Check rules are generated (based on .gitlab/ci/dependencies/dependencies.yml)................................(no files to check)Skipped
Check type annotations in python files.......................................................................(no files to check)Skipped
Check requirement files......................................................................................(no files to check)Skipped
Check tools dir files patterns...................................................................................................Passed
check patterns-build_components in rules.yml.................................................................(no files to check)Skipped
Check soc caps kconfig files are generated (based on components/soc/IDF_TARGET/include/soc/soc_caps.h).......(no files to check)Skipped
Check if all apps readme files match given .build-test-rules.yml files. Modify the supported target tables...(no files to check)Skipped
sort yaml files..............................................................................................(no files to check)Skipped
sort yaml test...............................................................................................(no files to check)Skipped
check path in .build-test-rules.yml exists.......................................................................................Passed
Remove non-existing patterns from ignore lists...................................................................................Passed
Check gitlab yaml files......................................................................................(no files to check)Skipped
File Contents Sorter.........................................................................................(no files to check)Skipped
Check copyright notices......................................................................................(no files to check)Skipped
astyle formatter.............................................................................................(no files to check)Skipped
shellcheck bash..............................................................................................(no files to check)Skipped
shellcheck dash (export.sh)..................................................................................(no files to check)Skipped
Lint rST files in docs folder using Sphinx Lint..............................................................(no files to check)Skipped
Check ESP-IDF KConfig Files..................................................................................(no files to check)Skipped
Conventional Commit......................................................Passed
[fix/dockerfile 9b01c5a600] ci(dockerfile): Fixed entrypoint.sh is not executable issue
 2 files changed, 4 insertions(+), 9 deletions(-)
```

Thank you for your time.