### PR TITLE
docs(c++): std::filesystem is generally supported (#5003) (IDFGH-12755)

### DIFF
--- a/docs/en/api-guides/cplusplus.rst
+++ b/docs/en/api-guides/cplusplus.rst
@@ -188,7 +188,6 @@ Limitations
 - Linker script generator does not support function level placements for functions with C++ linkage.
 - Various section attributes (such as ``IRAM_ATTR``) are ignored when used with template functions.
 - Vtables are placed into Flash and are not accessible when the flash cache is disabled. Therefore, virtual function calls should be avoided in :ref:`iram-safe-interrupt-handlers`. Placement of Vtables cannot be adjusted using the linker script generator, yet.
-- C++ filesystem (``std::filesystem``) features are not supported.
 
 
 What to Avoid


### PR DESCRIPTION
Have been using most `std::filesystem` features successfully since IDF v5.1, and now `std::filesystem::directory_iterator` is also fixed since 994b4ed459269be1f6548137eac84ec3f9a8e37f. 