### PR TITLE
feat(http_server): add 413 Payload Too Large response (IDFGH-12767)

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -608,6 +608,9 @@ typedef enum {
      */
     HTTPD_411_LENGTH_REQUIRED,
 
+    /* Incoming payload is too large */
+    HTTPD_413_PAYLOAD_TOO_LARGE,
+
     /* URI length greater than CONFIG_HTTPD_MAX_URI_LEN */
     HTTPD_414_URI_TOO_LONG,
 

--- a/components/esp_http_server/src/httpd_txrx.c
+++ b/components/esp_http_server/src/httpd_txrx.c
@@ -432,6 +432,10 @@ esp_err_t httpd_resp_send_err(httpd_req_t *req, httpd_err_code_t error, const ch
         status = "411 Length Required";
         msg    = "Client must specify Content-Length";
         break;
+    case HTTPD_413_PAYLOAD_TOO_LARGE:
+        status = "413 Payload Too Large";
+        msg    = "Payload is too large";
+        break;
     case HTTPD_431_REQ_HDR_FIELDS_TOO_LARGE:
         status = "431 Request Header Fields Too Large";
         msg    = "Header fields are too long";


### PR DESCRIPTION
While not useful for the HTTP parser itself, this is very useful for memory-limited consumers of the HTTP server API.