### PR TITLE
feat(espcoredump): Include boot time and unix time in header

### DIFF
--- a/components/espcoredump/include_core_dump/esp_core_dump_types.h
+++ b/components/espcoredump/include_core_dump/esp_core_dump_types.h
@@ -66,8 +66,8 @@ extern "C" {
                                                 (((_maj_)&0xFF) << 8) | \
                                                 (((_min_)&0xFF) << 0) \
                                             )
-#define COREDUMP_VERSION_BIN                0
-#define COREDUMP_VERSION_ELF                1
+#define COREDUMP_VERSION_BIN                1
+#define COREDUMP_VERSION_ELF                2
 
 /* legacy bin coredumps (before IDF v4.1) has version set to 1 */
 #define COREDUMP_VERSION_BIN_LEGACY         COREDUMP_VERSION_MAKE(COREDUMP_VERSION_BIN, 1) // -> 0x0001
@@ -146,6 +146,8 @@ typedef struct _core_dump_header_t {
     uint32_t tcb_sz;    /*!< Size of a TCB, in bytes */
     uint32_t mem_segs_num; /*!< Number of memory segments */
     uint32_t chip_rev; /*!< Chip revision */
+    uint64_t boot_time; /*!< Boot time, in microseconds */
+    uint64_t unix_time; /*!< Unix time, in microseconds */
 } core_dump_header_t;
 
 /**

--- a/components/espcoredump/src/core_dump_binary.c
+++ b/components/espcoredump/src/core_dump_binary.c
@@ -185,6 +185,11 @@ static esp_err_t esp_core_dump_write_binary(void)
     hdr.version   = COREDUMP_VERSION_BIN_CURRENT;
     hdr.tcb_sz    = tcb_sz;
     hdr.chip_rev  = efuse_hal_chip_revision();
+    dump_hdr.boot_time = esp_timer_get_time();
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    dump_hdr.unix_time = tv.tv_sec * 1000000 + tv.tv_usec;
     err = esp_core_dump_write_data(&write_data, &hdr, sizeof(core_dump_header_t));
     if (err != ESP_OK) {
         ESP_COREDUMP_LOGE("Failed to write core dump header error=%d!", err);

--- a/components/espcoredump/src/core_dump_elf.c
+++ b/components/espcoredump/src/core_dump_elf.c
@@ -17,6 +17,7 @@
 
 #ifdef CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
 #include <sys/param.h>      // for the MIN macro
+#include <sys/time.h>
 #include "esp_app_desc.h"
 #endif
 
@@ -852,6 +853,12 @@ static esp_err_t esp_core_dump_write_elf(void)
     dump_hdr.tcb_sz = 0; // unused in ELF format
     dump_hdr.mem_segs_num = 0; // unused in ELF format
     dump_hdr.chip_rev = efuse_hal_chip_revision();
+    dump_hdr.boot_time = esp_timer_get_time();
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    dump_hdr.unix_time = tv.tv_sec * 1000000 + tv.tv_usec;
+
     err = esp_core_dump_write_data(&self.write_data, &dump_hdr, sizeof(core_dump_header_t));
     if (err != ESP_OK) {
         ESP_COREDUMP_LOGE("Failed to write core dump header (%d)!", err);


### PR DESCRIPTION
*Unfinished and untested but creating draft to gather feedback. Will create corresponding patch for esp-coredump python.*

Core dumps do not contain any form of timestamp to help identify when a crash occurred.

This patch adds two new fields to the core dump header - boot time and unix time:
- Boot time (microseconds since boot) is useful in determining whether a crash occurred immediately after boot or many hours in, which can aid in debugging. Observing the core dump data can indirectly provide this information but requires additional steps. In applications with known bugs (e.g. memory leaks) knowing this in advance can save time by reducing unnecessary debugging.
- Unix time (microseconds since epoch) may provide hints as to why the crash occurred in applications that depend on external inputs, and is useful when organizing files, both on local and remote storage. In my application we copy core dumps to an SD card, but we have no way of knowing whether a particular core dump occurred 1 week or 1 year ago. 