### PR TITLE
Make spi_bus_free() abort early if something goes wrong (IDFGH-12895)

### DIFF
--- a/components/esp_driver_spi/src/gpspi/spi_common.c
+++ b/components/esp_driver_spi/src/gpspi/spi_common.c
@@ -921,6 +921,9 @@ esp_err_t spi_bus_free(spi_host_device_t host_id)
 
     if (ctx->destroy_func) {
         err = ctx->destroy_func(ctx->destroy_arg);
+        if (err != ESP_OK) {
+            return err;
+        }
     }
     spicommon_bus_free_io_cfg(&bus_attr->bus_cfg);
 


### PR DESCRIPTION
If for example there are still devices configured on the bus spi_bus_free() will report that with ESP_ERR_INVALID_STATE, but not before it frees all other things like IO and DMA. This means that after the function exits any other task that is still running and using those devices will all of a sudden stop working (and probably crash the device).

This commit prevents that situation by making the function return early so it can be called again safely later when all devices have been removed.