### PR TITLE
change: bump max sockets in lwip Kconfig (IDFGH-12906)

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -135,13 +135,19 @@ menu "LWIP"
 
     config LWIP_MAX_SOCKETS
         int "Max number of open sockets"
-        range 1 16
+        range 1 253
         default 10
         help
+            The practical maximum limit is
+            determined by available heap memory at runtime.
+
             Sockets take up a certain amount of memory, and allowing fewer
             sockets to be open at the same time conserves memory. Specify
             the maximum amount of sockets here. The valid value is from 1
-            to 16.
+            to 253. If using value above 61, update CMakeLists defining
+            FD_SETSIZE to the number of sockets used plus the
+            expected open files (minimum of +3 for stdout, stderr and stdin).
+
 
     config LWIP_USE_ONLY_LWIP_SELECT
         bool "Support LWIP socket select() only (DEPRECATED)"
@@ -669,7 +675,7 @@ menu "LWIP"
                 LWIP_TCP_RECCVMBOX_SIZE packets for each TCP socket, so the maximum possible cached TCP packets
                 for all TCP sockets is LWIP_TCP_RECCVMBOX_SIZE multiples the maximum TCP socket number. In other
                 words, the bigger LWIP_TCP_RECVMBOX_SIZE means more memory.
-                On the other hand, if the receiv mail box is too small, the mail box may be full. If the
+                On the other hand, if the receive mail box is too small, the mail box may be full. If the
                 mail box is full, the LWIP drops the packets. So generally we need to make sure the TCP
                 receive mail box is big enough to avoid packet drop between LWIP core and application.
 
@@ -813,7 +819,7 @@ menu "LWIP"
                 UDP_RECCVMBOX_SIZE packets for each UDP socket, so the maximum possible cached UDP packets
                 for all UDP sockets is UDP_RECCVMBOX_SIZE multiples the maximum UDP socket number. In other
                 words, the bigger UDP_RECVMBOX_SIZE means more memory.
-                On the other hand, if the receiv mail box is too small, the mail box may be full. If the
+                On the other hand, if the receive mail box is too small, the mail box may be full. If the
                 mail box is full, the LWIP drops the packets. So generally we need to make sure the UDP
                 receive mail box is big enough to avoid packet drop between LWIP core and application.
 
@@ -1060,12 +1066,12 @@ menu "LWIP"
                 SNTP callback for such replies should be set accordingly (see sntp_servermode_dhcp() func.)
 
         config LWIP_DHCP_MAX_NTP_SERVERS
-            int "Maximum number of NTP servers aquired via DHCP"
+            int "Maximum number of NTP servers acquired via DHCP"
             default 1
             range 1 16
             depends on LWIP_DHCP_GET_NTP_SRV
             help
-                Set maximum number of NTP servers aquired via DHCP-offer.
+                Set maximum number of NTP servers acquired via DHCP-offer.
                 Should be less or equal to "Maximum number of NTP servers", any extra servers would be just ignored.
 
         config LWIP_SNTP_UPDATE_DELAY

--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -21,10 +21,7 @@ components/esp_rom/include/esp32s2/rom/rsa_pss.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
-components/lwip/lwip/src/include/netif/ppp/
 
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
@@ -60,13 +57,9 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
-components/unity/unity/extras/
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/


### PR DESCRIPTION
Addresses #3840 

Tested under ESP32S3, running 50 tasks, each with a client, and a server listening to one client, totalizing 150 sockets/files open, forwarding data from PPP to Ethernet and vice versa.

Reasoning for 255 total sockets/files is VFS ``local_fd_t`` being a ``uint8_t``.

Since FD_SETSIZE is defined at tool level, a CMakeLists user definition is needed in cases above 64 (the default value).
