### PR TITLE
esp_partition.h uses the esp_flash_t and should therefore include esp_flash.h (IDFGH-12919)

### DIFF
--- a/components/esp_partition/include/esp_partition.h
+++ b/components/esp_partition/include/esp_partition.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include "esp_err.h"
+#include "esp_flash.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Found by unit testing. esp_partition.h needs the type definition of esp_flash_t which is found in esp_flash.h.

This commit partially reverts c9c7573f715534edf19e8290bc10d2a5d134c4a8