### PR TITLE
fix(bootloader_support): Add missing C linkage to some headers (IDFGH-12930)

### DIFF
--- a/components/bootloader_support/private_include/bootloader_console.h
+++ b/components/bootloader_support/private_include/bootloader_console.h
@@ -1,10 +1,14 @@
 /*
- * SPDX-FileCopyrightText: 2020-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Initialize console output (UART or USB)
@@ -21,3 +25,7 @@ void bootloader_console_deinit(void);
  * Only defined if USB CDC is used for console output.
  */
 void bootloader_console_write_char_usb(char c);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/private_include/bootloader_init.h
+++ b/components/bootloader_support/private_include/bootloader_init.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,10 @@
 
 #include "esp_err.h"
 #include "esp_image_format.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**@{*/
 /**
@@ -49,3 +53,7 @@ void bootloader_print_banner(void);
  *          ESP_FAIL - If the setting is not successful.
  */
 esp_err_t bootloader_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/private_include/bootloader_sha.h
+++ b/components/bootloader_support/private_include/bootloader_sha.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,10 @@
 #include <stdlib.h>
 #include "esp_err.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void *bootloader_sha256_handle_t;
 
 bootloader_sha256_handle_t bootloader_sha256_start(void);
@@ -23,3 +27,7 @@ bootloader_sha256_handle_t bootloader_sha256_start(void);
 void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len);
 
 void bootloader_sha256_finish(bootloader_sha256_handle_t handle, uint8_t *digest);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/private_include/bootloader_signature.h
+++ b/components/bootloader_support/private_include/bootloader_signature.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,10 @@
 #include "esp32h2/rom/secure_boot.h"
 #elif CONFIG_IDF_TARGET_ESP32P4
 #include "esp32p4/rom/secure_boot.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #if !CONFIG_IDF_TARGET_ESP32 || CONFIG_ESP32_REV_MIN_FULL >= 300
@@ -57,4 +61,8 @@ esp_err_t esp_secure_boot_verify_rsa_signature_block(const ets_secure_boot_signa
 
 #endif /* CONFIG_SECURE_BOOT_V2_ENABLED || CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT */
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/components/bootloader_support/private_include/bootloader_soc.h
+++ b/components/bootloader_support/private_include/bootloader_soc.h
@@ -1,9 +1,14 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 /**
  * @brief Configure analog super WDT reset
@@ -25,3 +30,7 @@ void bootloader_ana_bod_reset_config(bool enable);
  * @param enable Boolean to enable or disable clock glitch reset
  */
 void bootloader_ana_clock_glitch_reset_config(bool enable);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/private_include/bootloader_utility.h
+++ b/components/bootloader_support/private_include/bootloader_utility.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,11 @@
 #include "bootloader_config.h"
 #include "esp_image_format.h"
 #include "bootloader_config.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 /**
  * @brief Load partition table.
@@ -120,3 +125,7 @@ void bootloader_debug_buffer(const void *buffer, size_t length, const char *labe
  * @return ESP_OK if secure boot digest is generated successfully.
  */
 esp_err_t bootloader_sha256_flash_contents(uint32_t flash_offset, uint32_t len, uint8_t *digest);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
I'm developing some bootloader hooks in C++ and just found some headers lack ```extern "C" {}``` guard.
This issue can also be found in `release/v5.3` and `master`.