### PR TITLE
feat(ulp): Add optional -msave-restore for RISC-V (U)LP targets (IDFGH-12976)

### DIFF
--- a/components/ulp/Kconfig
+++ b/components/ulp/Kconfig
@@ -72,6 +72,20 @@ menu "Ultra Low Power (ULP) Co-processor"
                 is invoked on.
     endmenu
 
+    config ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS
+        depends on ULP_COPROC_TYPE_LP_CORE || ULP_COPROC_TYPE_RISCV
+        bool
+        prompt "Enable -msave-restore flag to reduce code size for ULP RISC-V / LP Core"
+        default COMPILER_SAVE_RESTORE_LIBCALLS
+        help
+            Adds -msave-restore to C/C++ compilation flags.
+
+            When this flag is enabled, compiler will call library functions to
+            save/restore registers in function prologues/epilogues. This results
+            in lower overall code size, at the expense of slightly reduced performance.
+
+            This option can be enabled for LP Core or ULP RISC-V only.
+
     config ULP_SHARED_MEM
         depends on ULP_COPROC_TYPE_LP_CORE
         hex

--- a/components/ulp/cmake/toolchain-lp-core-riscv.cmake
+++ b/components/ulp/cmake/toolchain-lp-core-riscv.cmake
@@ -5,9 +5,14 @@ set(CMAKE_C_COMPILER "riscv32-esp-elf-gcc")
 set(CMAKE_CXX_COMPILER "riscv32-esp-elf-g++")
 set(CMAKE_ASM_COMPILER "riscv32-esp-elf-gcc")
 
-set(CMAKE_C_FLAGS "-Os -ggdb -march=rv32imac_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections"
+set(ulp_cflags "")
+if(CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS)
+    list(APPEND ulp_cflags "-msave-restore")
+endif()
+
+set(CMAKE_C_FLAGS "-Os -ggdb -march=rv32imac_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections ${ulp_cflags}"
     CACHE STRING "C Compiler Base Flags")
-set(CMAKE_CXX_FLAGS "-Os -ggdb -march=rv32imac_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections"
+set(CMAKE_CXX_FLAGS "-Os -ggdb -march=rv32imac_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections ${ulp_cflags}"
     CACHE STRING "C++ Compiler Base Flags")
 set(CMAKE_ASM_FLAGS "-Os -ggdb -march=rv32imac_zicsr_zifencei -x assembler-with-cpp"
     CACHE STRING "Assembler Base Flags")

--- a/components/ulp/cmake/toolchain-ulp-riscv.cmake
+++ b/components/ulp/cmake/toolchain-ulp-riscv.cmake
@@ -5,11 +5,16 @@ set(CMAKE_C_COMPILER "riscv32-esp-elf-gcc")
 set(CMAKE_CXX_COMPILER "riscv32-esp-elf-g++")
 set(CMAKE_ASM_COMPILER "riscv32-esp-elf-gcc")
 
-set(CMAKE_C_FLAGS "-Os -march=rv32imc_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections"
+set(ulp_cflags "")
+if(CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS)
+    list(APPEND ulp_cflags "-msave-restore")
+endif()
+
+set(CMAKE_C_FLAGS "-Os -ggdb -march=rv32imc_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections ${ulp_cflags}"
     CACHE STRING "C Compiler Base Flags")
-set(CMAKE_CXX_FLAGS "-Os -march=rv32imc_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections"
+set(CMAKE_CXX_FLAGS "-Os -ggdb -march=rv32imc_zicsr_zifencei -mdiv -fdata-sections -ffunction-sections ${ulp_cflags}"
     CACHE STRING "C++ Compiler Base Flags")
-set(CMAKE_ASM_FLAGS "-march=rv32imc -x assembler-with-cpp"
+set(CMAKE_ASM_FLAGS "-ggdb -march=rv32imc -x assembler-with-cpp"
     CACHE STRING "Assembler Base Flags")
 set(CMAKE_EXE_LINKER_FLAGS "-march=rv32imc_zicsr_zifencei --specs=nano.specs --specs=nosys.specs"
     CACHE STRING "Linker Base Flags")

--- a/components/ulp/project_include.cmake
+++ b/components/ulp/project_include.cmake
@@ -71,6 +71,7 @@ function(ulp_embed_binary app_name s_sources exp_dep_srcs)
                             -DULP_COCPU_IS_RISCV=${ULP_IS_RISCV}
                             -DULP_COCPU_IS_LP_CORE=${ULP_IS_LP_CORE_RISCV}
                             -DCONFIG_ESP_ROM_HAS_LP_ROM=${CONFIG_ESP_ROM_HAS_LP_ROM}
+                            -DCONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS=${CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS}
                             ${extra_cmake_args}
                 BUILD_COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/${app_name} --target build
                 BUILD_BYPRODUCTS ${ulp_artifacts} ${ulp_artifacts_extras} ${ulp_ps_sources}

--- a/docs/en/api-reference/system/ulp-lp-core.rst
+++ b/docs/en/api-reference/system/ulp-lp-core.rst
@@ -34,7 +34,9 @@ The first argument to ``ulp_embed_binary`` specifies the ULP binary name. The na
 
 1. Enable both :ref:`CONFIG_ULP_COPROC_ENABLED` and :ref:`CONFIG_ULP_COPROC_TYPE` in menucofig, and set :ref:`CONFIG_ULP_COPROC_TYPE` to ``CONFIG_ULP_COPROC_TYPE_LP_CORE``. The :ref:`CONFIG_ULP_COPROC_RESERVE_MEM` option reserves RTC memory for the ULP, and must be set to a value big enough to store both the ULP LP-Core code and data. If the application components contain multiple ULP programs, then the size of the RTC memory must be sufficient to hold the largest one.
 
-2. Build the application as usual (e.g., ``idf.py app``).
+2. If you want to reduce the code size at the expense of possible performance loss, you can turn on :ref:`CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS` to enable GCC's ``-msave-restore`` feature.
+
+3. Build the application as usual (e.g., ``idf.py app``).
 
 During the build process, the following steps are taken to build ULP program:
 

--- a/docs/en/api-reference/system/ulp-risc-v.rst
+++ b/docs/en/api-reference/system/ulp-risc-v.rst
@@ -120,7 +120,9 @@ Starting the ULP RISC-V Program
 
 To run a ULP RISC-V program, the main application needs to load the ULP program into RTC memory using the :cpp:func:`ulp_riscv_load_binary` function, and then start it using the :cpp:func:`ulp_riscv_run` function.
 
-Note that the ``CONFIG_ULP_COPROC_ENABLED`` and ``CONFIG_ULP_COPROC_TYPE_RISCV`` options must be enabled in menuconfig to work with ULP RISC-V. To reserve memory for the ULP, the ``RTC slow memory reserved for coprocessor`` option must be set to a value big enough to store ULP RISC-V code and data. If the application components contain multiple ULP programs, then the size of the RTC memory must be sufficient to hold the largest one.
+Note that the :ref:`CONFIG_ULP_COPROC_ENABLED` and :ref:`CONFIG_ULP_COPROC_TYPE_RISCV` options must be enabled in menuconfig to work with ULP RISC-V. To reserve memory for the ULP, the ``RTC slow memory reserved for coprocessor`` option must be set to a value big enough to store ULP RISC-V code and data. If the application components contain multiple ULP programs, then the size of the RTC memory must be sufficient to hold the largest one.
+
+If you want to reduce the code size at the expense of some performance loss, you can turn on :ref:`CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS` to enable GCC's ``-msave-restore`` feature.
 
 Each ULP RISC-V program is embedded into the ESP-IDF application as a binary blob. The application can reference this blob and load it in the following way (suppose ULP_APP_NAME was defined to ``ulp_app_name``):
 

--- a/docs/zh_CN/api-reference/system/ulp-lp-core.rst
+++ b/docs/zh_CN/api-reference/system/ulp-lp-core.rst
@@ -34,7 +34,9 @@ ULP LP-Core 代码会与 ESP-IDF 项目共同编译，生成一个单独的二�
 
 1. 在 menuconfig 中启用 :ref:`CONFIG_ULP_COPROC_ENABLED` 和 :ref:`CONFIG_ULP_COPROC_TYPE` 选项，并将 :ref:`CONFIG_ULP_COPROC_TYPE` 设置为 ``CONFIG_ULP_COPROC_TYPE_LP_CORE``。:ref:`CONFIG_ULP_COPROC_RESERVE_MEM` 选项为 ULP 保留 RTC 内存，因此必须设置为一个足够大的值，以存储 ULP LP-Core 代码和数据。如果应用程序组件包含多个 ULP 程序，那么 RTC 内存的大小必须足够容纳其中最大的程序。
 
-2. 按照常规步骤构建应用程序（例如 ``idf.py app``）。
+2. 如须减少程序体积，可启用 :ref:`CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS` 。此选项会开启GCC的 ``-msave-restore`` 功能，并可能些微影响程序性能。
+
+3. 按照常规步骤构建应用程序（例如 ``idf.py app``）。
 
 在构建过程中，采取以下步骤来构建 ULP 程序：
 

--- a/docs/zh_CN/api-reference/system/ulp-risc-v.rst
+++ b/docs/zh_CN/api-reference/system/ulp-risc-v.rst
@@ -120,7 +120,9 @@ ULP 中的所有硬件指令都不支持互斥，所以 Lock API 需通过一种
 
 要运行 ULP RISC-V 程序，主程序需要调用 :cpp:func:`ulp_riscv_load_binary` 函数，将 ULP 程序加载到 RTC 内存中，然后调用 :cpp:func:`ulp_riscv_run` 函数，启动 ULP RISC-V 程序。
 
-注意，必须在 menuconfig 中启用 ``CONFIG_ULP_COPROC_ENABLED`` 和 ``CONFIG_ULP_COPROC_TYPE_RISCV`` 选项，以便正常运行 ULP RISC-V 程序。``RTC slow memory reserved for coprocessor`` 选项设置的值必须足够存储 ULP RISC-V 代码和数据。如果应用程序组件包含多个 ULP 程序，RTC 内存必须足以容纳最大的程序。
+注意，必须在 menuconfig 中启用 :ref:`CONFIG_ULP_COPROC_ENABLED` 和 :ref:`CONFIG_ULP_COPROC_TYPE_RISCV` 选项，以便正常运行 ULP RISC-V 程序。``RTC slow memory reserved for coprocessor`` 选项设置的值必须足够存储 ULP RISC-V 代码和数据。如果应用程序组件包含多个 ULP 程序，RTC 内存必须足以容纳最大的程序。
+
+如须减少程序体积，可启用 :ref:`CONFIG_ULP_LP_RISCV_SAVE_RESTORE_LIBCALLS` 。此选项会开启GCC的 ``-msave-restore`` 功能，并可能些微影响程序性能。
 
 每个 ULP RISC-V 程序均以二进制 BLOB 的形式嵌入到 ESP-IDF 应用程序中。应用程序可以引用此 BLOB，并以下面的方式加载此 BLOB（假设 ULP_APP_NAME 已被定义为 ``ulp_app_name``）：
 


### PR DESCRIPTION
Possibly useful for larger apps on C6 and P4's LP core.