### PR TITLE
fix(timer): change return type to uint64_t instead of int64_t (IDFGH-12980)

### DIFF
--- a/components/efuse/test_apps/main/test_efuse.c
+++ b/components/efuse/test_apps/main/test_efuse.c
@@ -670,9 +670,9 @@ static void task2(void* arg)
 {
     xSemaphoreTake(sema, portMAX_DELAY);
     uint8_t mac[6];
-    int64_t t1 = esp_timer_get_time();
+    uint64_t t1 = esp_timer_get_time();
     TEST_ESP_OK(esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, &mac, sizeof(mac) * 8));
-    int64_t t2 = esp_timer_get_time();
+    uint64_t t2 = esp_timer_get_time();
     int diff_ms = (t2 - t1) / 1000;
     TEST_ASSERT_GREATER_THAN(diff_ms, delay_ms);
     ESP_LOGI(TAG, "read MAC address: %02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
@@ -685,10 +685,10 @@ static void task3(void* arg)
 {
     xSemaphoreTake(sema, portMAX_DELAY);
     size_t test3_len_6 = 2;
-    int64_t t1 = esp_timer_get_time();
+    uint64_t t1 = esp_timer_get_time();
     TEST_ESP_OK(esp_efuse_write_field_cnt(ESP_EFUSE_TEST3_LEN_6, test3_len_6));
     TEST_ESP_OK(esp_efuse_read_field_cnt(ESP_EFUSE_TEST3_LEN_6, &test3_len_6));
-    int64_t t2 = esp_timer_get_time();
+    uint64_t t2 = esp_timer_get_time();
     ESP_LOGI(TAG, "write&read test3_len_6: %d", test3_len_6);
     int diff_ms = (t2 - t1) / 1000;
     TEST_ASSERT_GREATER_THAN(delay_ms, diff_ms);

--- a/components/esp_coex/include/private/esp_coexist_adapter.h
+++ b/components/esp_coex/include/private/esp_coexist_adapter.h
@@ -36,7 +36,7 @@ typedef struct {
     int (* _is_in_isr)(void);
     void * (* _malloc_internal)(size_t size);
     void (* _free)(void *p);
-    int64_t (* _esp_timer_get_time)(void);
+    uint64_t (* _esp_timer_get_time)(void);
     bool (* _env_is_chip)(void);
 #if CONFIG_IDF_TARGET_ESP32C2
     // this function is only used on esp32c2

--- a/components/esp_driver_sdio/test_apps/sdio/sdio_common_tests/host_sdmmc/main/test_sdio_sdhost.c
+++ b/components/esp_driver_sdio/test_apps/sdio/sdio_common_tests/host_sdmmc/main/test_sdio_sdhost.c
@@ -310,7 +310,7 @@ static void test_from_host(bool check_data)
 
         // Two counters are used. The `esp_timer_get_time()` is for the typical time, and the
         // `ccomp_timer` is for performance test to reduce influence caused by cache miss.
-        int64_t pre_us = esp_timer_get_time();
+        uint64_t pre_us = esp_timer_get_time();
         TEST_ESP_OK(ccomp_timer_start());
         uint32_t expected_length = TEST_TRANS_NUMS * TEST_RX_BUFFER_SIZE;
 
@@ -324,7 +324,7 @@ static void test_from_host(bool check_data)
         }
 
         int64_t c_time_ms = ccomp_timer_stop() / 1000;
-        int64_t end_us = esp_timer_get_time();
+        uint64_t end_us = esp_timer_get_time();
 
         uint32_t total_time_ms = (end_us - pre_us) / 1000;
         ESP_LOGI(TAG, "test done, total time: %" PRIu32 " ms (%d ms compensated), bytes transferred: %"PRIu32, total_time_ms, (int)c_time_ms, expected_length);
@@ -373,7 +373,7 @@ static void test_to_host(bool check_data)
 
         // Two counters are used. The `esp_timer_get_time()` is for the typical time, and the
         // `ccomp_timer` is for performance test to reduce influence caused by cache miss.
-        int64_t pre_us = esp_timer_get_time();
+        uint64_t pre_us = esp_timer_get_time();
         TEST_ESP_OK(ccomp_timer_start());
         do {
             size_t rcv_len;
@@ -395,7 +395,7 @@ static void test_to_host(bool check_data)
         } while (remain_length > 0);
 
         int64_t c_time_ms = ccomp_timer_stop() / 1000;
-        int64_t end_us = esp_timer_get_time();
+        uint64_t end_us = esp_timer_get_time();
 
         uint32_t total_time_ms = (end_us - pre_us) / 1000;
         ESP_LOGI(TAG, "test done, total time: %" PRIu32 " ms (%d ms compensated), bytes transferred: %"PRIu32, total_time_ms, (int)c_time_ms, expected_length);

--- a/components/esp_driver_sdmmc/src/sdmmc_host.c
+++ b/components/esp_driver_sdmmc/src/sdmmc_host.c
@@ -82,7 +82,7 @@ esp_err_t sdmmc_host_reset(void)
 
     // Wait for the reset bits to be cleared by hardware
     int64_t yield_delay_us = 100 * 1000; // initially 100ms
-    int64_t t0 = esp_timer_get_time();
+    uint64_t t0 = esp_timer_get_time();
     int64_t t1 = 0;
     while (SDMMC.ctrl.controller_reset || SDMMC.ctrl.fifo_reset || SDMMC.ctrl.dma_reset) {
         t1 = esp_timer_get_time();
@@ -148,7 +148,7 @@ static esp_err_t sdmmc_host_clock_update_command(int slot)
         ESP_RETURN_ON_ERROR(sdmmc_host_start_command(slot, cmd_val, 0), TAG, "sdmmc_host_start_command returned 0x%x", err_rc_);
 
         int64_t yield_delay_us = 100 * 1000; // initially 100ms
-        int64_t t0 = esp_timer_get_time();
+        uint64_t t0 = esp_timer_get_time();
         int64_t t1 = 0;
         while (true) {
             t1 = esp_timer_get_time();
@@ -359,7 +359,7 @@ esp_err_t sdmmc_host_start_command(int slot, sdmmc_hw_cmd_t cmd, uint32_t arg)
     cmd.use_hold_reg = 1;
 
     int64_t yield_delay_us = 100 * 1000; // initially 100ms
-    int64_t t0 = esp_timer_get_time();
+    uint64_t t0 = esp_timer_get_time();
     int64_t t1 = 0;
     while (SDMMC.cmd.start_command == 1) {
         t1 = esp_timer_get_time();

--- a/components/esp_driver_sdspi/src/sdspi_host.c
+++ b/components/esp_driver_sdspi/src/sdspi_host.c
@@ -578,7 +578,7 @@ static esp_err_t poll_busy(slot_info_t *slot, int timeout_ms, bool polling)
     };
     esp_err_t ret;
 
-    int64_t t_end = esp_timer_get_time() + timeout_ms * 1000;
+    uint64_t t_end = esp_timer_get_time() + timeout_ms * 1000;
     int nonzero_count = 0;
     do {
         t_rx = SDSPI_MOSI_IDLE_VAL;
@@ -613,7 +613,7 @@ static esp_err_t poll_data_token(slot_info_t *slot, uint8_t *extra_ptr, size_t *
         .length = sizeof(t_rx) * 8,
     };
     esp_err_t ret;
-    int64_t t_end = esp_timer_get_time() + timeout_ms * 1000;
+    uint64_t t_end = esp_timer_get_time() + timeout_ms * 1000;
     do {
         memset(t_rx, SDSPI_MOSI_IDLE_VAL, sizeof(t_rx));
         ret = spi_device_polling_transmit(slot->spi_handle, &t);

--- a/components/esp_eth/src/spi/dm9051/esp_eth_mac_dm9051.c
+++ b/components/esp_eth/src/spi/dm9051/esp_eth_mac_dm9051.c
@@ -653,7 +653,7 @@ static esp_err_t emac_dm9051_transmit(esp_eth_mac_t *mac, uint8_t *buf, uint32_t
     ESP_GOTO_ON_FALSE(length <= ETH_MAX_PACKET_SIZE, ESP_ERR_INVALID_ARG, err,
                       TAG, "frame size is too big (actual %" PRIu32 ", maximum %d)", length, ETH_MAX_PACKET_SIZE);
 
-    int64_t wait_time =  esp_timer_get_time();
+    uint64_t wait_time =  esp_timer_get_time();
     do {
         ESP_GOTO_ON_ERROR(dm9051_register_read(emac, DM9051_TCR, &tcr), err, TAG, "read TCR failed");
     } while ((tcr & TCR_TXREQ) && ((esp_timer_get_time() - wait_time) < 100));

--- a/components/esp_event/test_apps/main/test_event_target.c
+++ b/components/esp_event/test_apps/main/test_event_target.c
@@ -594,7 +594,7 @@ static void performance_test(bool dedicated_task)
             }
 
             // Post the events
-            int64_t start = esp_timer_get_time();
+            uint64_t start = esp_timer_get_time();
             for (int base = 0; base < bases; base++) {
                 for (int id = 0; id < ids; id++) {
                     TEST_ESP_OK(esp_event_post_to(loop, test_base + post_bases[base], post_ids[id], NULL, 0, portMAX_DELAY));
@@ -602,7 +602,7 @@ static void performance_test(bool dedicated_task)
             }
 
             xSemaphoreTake(data.done, portMAX_DELAY);
-            int64_t elapsed = esp_timer_get_time() - start;
+            uint64_t elapsed = esp_timer_get_time() - start;
 
             // Record data
             TEST_ASSERT_EQUAL(data.expected, data.performed);

--- a/components/esp_hw_support/esp_ds.c
+++ b/components/esp_hw_support/esp_ds.c
@@ -365,7 +365,7 @@ esp_err_t esp_ds_start_sign(const void *message,
     ds_hal_start();
 
     // check encryption key from HMAC
-    int64_t start_time = esp_timer_get_time();
+    uint64_t start_time = esp_timer_get_time();
     while (ds_ll_busy() != 0) {
         if ((esp_timer_get_time() - start_time) > SOC_DS_KEY_CHECK_MAX_WAIT_US) {
             ds_disable_release();

--- a/components/esp_pm/pm_impl.c
+++ b/components/esp_pm/pm_impl.c
@@ -792,11 +792,11 @@ void IRAM_ATTR vApplicationSleep( TickType_t xExpectedIdleTime )
     if (!should_skip_light_sleep(core_id)) {
         /* Calculate how much we can sleep */
         int64_t next_esp_timer_alarm = esp_timer_get_next_alarm_for_wake_up();
-        int64_t now = esp_timer_get_time();
-        int64_t time_until_next_alarm = next_esp_timer_alarm - now;
-        int64_t wakeup_delay_us = portTICK_PERIOD_MS * 1000LL * xExpectedIdleTime;
-        int64_t sleep_time_us = MIN(wakeup_delay_us, time_until_next_alarm);
-        int64_t slept_us = 0;
+        uint64_t now = esp_timer_get_time();
+        uint64_t time_until_next_alarm = next_esp_timer_alarm - now;
+        uint64_t wakeup_delay_us = portTICK_PERIOD_MS * 1000LL * xExpectedIdleTime;
+        uint64_t sleep_time_us = MIN(wakeup_delay_us, time_until_next_alarm);
+        uint64_t slept_us = 0;
 #if CONFIG_PM_LIGHT_SLEEP_CALLBACKS
         uint32_t cycle = esp_cpu_get_cycle_count();
         esp_pm_execute_enter_sleep_callbacks(sleep_time_us);
@@ -810,7 +810,7 @@ void IRAM_ATTR vApplicationSleep( TickType_t xExpectedIdleTime )
 #endif
             /* Enter sleep */
             ESP_PM_TRACE_ENTER(SLEEP, core_id);
-            int64_t sleep_start = esp_timer_get_time();
+            uint64_t sleep_start = esp_timer_get_time();
             if (esp_light_sleep_start() != ESP_OK){
 #ifdef WITH_PROFILING
                 s_light_sleep_reject_counts++;

--- a/components/esp_pm/test_apps/esp_pm/main/test_pm.c
+++ b/components/esp_pm/test_apps/esp_pm/main/test_pm.c
@@ -215,12 +215,12 @@ TEST_CASE("Can wake up from automatic light sleep by GPIO", "[pm][ignore]")
         const int delay_ticks = delay_ms / portTICK_PERIOD_MS;
 
         int64_t start_rtc = esp_clk_rtc_time();
-        int64_t start_hs = esp_timer_get_time();
+        uint64_t start_hs = esp_timer_get_time();
         uint32_t start_tick = xTaskGetTickCount();
         /* Will enter sleep here */
         vTaskDelay(delay_ticks);
         int64_t end_rtc = esp_clk_rtc_time();
-        int64_t end_hs = esp_timer_get_time();
+        uint64_t end_hs = esp_timer_get_time();
         uint32_t end_tick = xTaskGetTickCount();
 
         printf("%lld %lld %u\n", end_rtc - start_rtc, end_hs - start_hs, end_tick - start_tick);

--- a/components/esp_system/test_apps/esp_system_unity_tests/main/test_sleep.c
+++ b/components/esp_system/test_apps/esp_system_unity_tests/main/test_sleep.c
@@ -197,9 +197,9 @@ TEST_CASE("light sleep duration is correct", "[deepsleep][ignore]")
         esp_sleep_enable_timer_wakeup(sleep_time);
         for (int repeat = 0; repeat < 5; ++repeat) {
             uint64_t start = esp_clk_rtc_time();
-            int64_t start_hs = esp_timer_get_time();
+            uint64_t start_hs = esp_timer_get_time();
             esp_light_sleep_start();
-            int64_t stop_hs = esp_timer_get_time();
+            uint64_t stop_hs = esp_timer_get_time();
             uint64_t stop = esp_clk_rtc_time();
 
             int diff_us = (int)(stop - start);

--- a/components/esp_timer/include/esp_timer.h
+++ b/components/esp_timer/include/esp_timer.h
@@ -220,7 +220,7 @@ esp_err_t esp_timer_delete(esp_timer_handle_t timer);
  * @brief Get time in microseconds since boot
  * @return Number of microseconds since the initialization of ESP Timer
  */
-int64_t esp_timer_get_time(void);
+uint64_t esp_timer_get_time(void);
 
 /**
  * @brief Get the timestamp of the next expected timeout

--- a/components/esp_timer/private_include/esp_timer_impl.h
+++ b/components/esp_timer/private_include/esp_timer_impl.h
@@ -91,7 +91,7 @@ void esp_timer_impl_advance(int64_t time_us);
  * @brief Get time, in microseconds, since esp_timer_impl_init was called
  * @return timestamp in microseconds
  */
-int64_t esp_timer_impl_get_time(void);
+uint64_t esp_timer_impl_get_time(void);
 
 /**
  * @brief Get minimal timer period, in microseconds

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -170,7 +170,7 @@ esp_err_t IRAM_ATTR esp_timer_restart(esp_timer_handle_t timer, uint64_t timeout
     esp_timer_dispatch_t dispatch_method = timer->flags & FL_ISR_DISPATCH_METHOD;
     timer_list_lock(dispatch_method);
 
-    const int64_t now = esp_timer_impl_get_time();
+    const uint64_t now = esp_timer_impl_get_time();
     const uint64_t period = timer->period;
 
     /* We need to remove the timer to the list of timers and reinsert it at
@@ -208,7 +208,7 @@ esp_err_t IRAM_ATTR esp_timer_start_once(esp_timer_handle_t timer, uint64_t time
     if (!is_initialized()) {
         return ESP_ERR_INVALID_STATE;
     }
-    int64_t alarm = esp_timer_get_time() + timeout_us;
+    uint64_t alarm = esp_timer_get_time() + timeout_us;
     esp_timer_dispatch_t dispatch_method = timer->flags & FL_ISR_DISPATCH_METHOD;
     esp_err_t err;
 
@@ -242,7 +242,7 @@ esp_err_t IRAM_ATTR esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t 
         return ESP_ERR_INVALID_STATE;
     }
     period_us = MAX(period_us, esp_timer_impl_get_min_period_us());
-    int64_t alarm = esp_timer_get_time() + period_us;
+    uint64_t alarm = esp_timer_get_time() + period_us;
     esp_timer_dispatch_t dispatch_method = timer->flags & FL_ISR_DISPATCH_METHOD;
     esp_err_t err;
     timer_list_lock(dispatch_method);
@@ -292,7 +292,7 @@ esp_err_t esp_timer_delete(esp_timer_handle_t timer)
         return ESP_ERR_INVALID_ARG;
     }
 
-    int64_t alarm = esp_timer_get_time();
+    uint64_t alarm = esp_timer_get_time();
     esp_err_t err;
     timer_list_lock(ESP_TIMER_TASK);
 
@@ -417,7 +417,7 @@ static bool timer_process_alarm(esp_timer_dispatch_t dispatch_method)
     esp_timer_handle_t it;
     while (1) {
         it = LIST_FIRST(&s_timers[dispatch_method]);
-        int64_t now = esp_timer_impl_get_time();
+        uint64_t now = esp_timer_impl_get_time();
         if (it == NULL || it->alarm > now) {
             break;
         }

--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -137,12 +137,12 @@ uint64_t IRAM_ATTR esp_timer_impl_get_counter_reg(void)
     return result.val;
 }
 
-int64_t IRAM_ATTR esp_timer_impl_get_time(void)
+uint64_t IRAM_ATTR esp_timer_impl_get_time(void)
 {
     return esp_timer_impl_get_counter_reg() / TICKS_PER_US;
 }
 
-int64_t esp_timer_get_time(void) __attribute__((alias("esp_timer_impl_get_time")));
+uint64_t esp_timer_get_time(void) __attribute__((alias("esp_timer_impl_get_time")));
 
 void IRAM_ATTR esp_timer_impl_set_alarm_id(uint64_t timestamp, unsigned alarm_id)
 {

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -65,14 +65,14 @@ uint64_t IRAM_ATTR esp_timer_impl_get_counter_reg(void)
     return systimer_hal_get_counter_value(&systimer_hal, SYSTIMER_COUNTER_ESPTIMER);
 }
 
-int64_t IRAM_ATTR esp_timer_impl_get_time(void)
+uint64_t IRAM_ATTR esp_timer_impl_get_time(void)
 {
     // we hope the execution time of this function won't > 1us
     // thus, to save one function call, we didn't use the existing `systimer_hal_get_time`
     return systimer_hal.ticks_to_us(systimer_hal_get_counter_value(&systimer_hal, SYSTIMER_COUNTER_ESPTIMER));
 }
 
-int64_t esp_timer_get_time(void) __attribute__((alias("esp_timer_impl_get_time")));
+uint64_t esp_timer_get_time(void) __attribute__((alias("esp_timer_impl_get_time")));
 
 void IRAM_ATTR esp_timer_impl_set_alarm_id(uint64_t timestamp, unsigned alarm_id)
 {

--- a/components/esp_timer/test_apps/main/test_esp_timer.c
+++ b/components/esp_timer/test_apps/main/test_esp_timer.c
@@ -92,8 +92,8 @@ static void set_alarm_task(void* arg)
 {
     SemaphoreHandle_t done = (SemaphoreHandle_t) arg;
 
-    int64_t start = esp_timer_impl_get_time();
-    int64_t now = start;
+    uint64_t start = esp_timer_impl_get_time();
+    uint64_t now = start;
     int count = 0;
     const int delays[] = {50, 5000, 10000000};
     const int delays_count = sizeof(delays) / sizeof(delays[0]);
@@ -390,8 +390,8 @@ TEST_CASE("esp_timer for very short intervals", "[esp_timer]")
 
 TEST_CASE("esp_timer_get_time call takes less than 1us", "[esp_timer]")
 {
-    int64_t begin = esp_timer_get_time();
-    volatile int64_t end;
+    uint64_t begin = esp_timer_get_time();
+    volatile uint64_t end;
     const int iter_count = 10000;
     for (int i = 0; i < iter_count; ++i) {
         end = esp_timer_get_time();
@@ -582,11 +582,11 @@ TEST_CASE("Can delete timer from a separate task, triggered from callback", "[es
 
 TEST_CASE("esp_timer_impl_advance moves time base correctly", "[esp_timer]")
 {
-    int64_t t0 = esp_timer_get_time();
+    uint64_t t0 = esp_timer_get_time();
     const int64_t diff_us = 1000000;
     esp_timer_impl_advance(diff_us);
-    int64_t t1 = esp_timer_get_time();
-    int64_t t_delta = t1 - t0;
+    uint64_t t1 = esp_timer_get_time();
+    uint64_t t_delta = t1 - t0;
     printf("diff_us=%lld t0=%lld t1=%lld t1-t0=%lld\n", diff_us, t0, t1, t_delta);
     TEST_ASSERT_INT_WITHIN(1000, diff_us, (int) t_delta);
 }
@@ -826,7 +826,7 @@ TEST_CASE("Test case when esp_timer_impl_set_alarm needs set timer < now_time", 
 
 static void timer_callback5(void* arg)
 {
-    *(int64_t *)arg = esp_timer_get_time();
+    *(uint64_t *)arg = esp_timer_get_time();
 }
 
 TEST_CASE("Test a latency between a call of callback and real event", "[esp_timer]")

--- a/components/esp_wifi/include/esp_private/wifi_os_adapter.h
+++ b/components/esp_wifi/include/esp_private/wifi_os_adapter.h
@@ -97,7 +97,7 @@ typedef struct wifi_osi_funcs_t {
     void (* _wifi_clock_disable)(void);
     void (* _wifi_rtc_enable_iso)(void);
     void (* _wifi_rtc_disable_iso)(void);
-    int64_t (* _esp_timer_get_time)(void);
+    uint64_t (* _esp_timer_get_time)(void);
     int (* _nvs_set_i8)(uint32_t handle, const char* key, int8_t value);
     int (* _nvs_get_i8)(uint32_t handle, const char* key, int8_t* out_value);
     int (* _nvs_set_u8)(uint32_t handle, const char* key, uint8_t value);

--- a/components/fatfs/test_apps/sdcard/main/test_fatfs_sdmmc.c
+++ b/components/fatfs/test_apps/sdcard/main/test_fatfs_sdmmc.c
@@ -339,7 +339,7 @@ TEST_CASE("(SD) mount FAT partitions and readdir to get stat structure", "[fatfs
     }
 
     //Start the timer to get time needed to calculate the directory size
-    int64_t start = esp_timer_get_time();
+    uint64_t start = esp_timer_get_time();
     DIR* dir = opendir(dir_prefix);
     TEST_ASSERT_NOT_NULL(dir);
     struct stat st;
@@ -357,8 +357,8 @@ TEST_CASE("(SD) mount FAT partitions and readdir to get stat structure", "[fatfs
         dir_size += st.st_size;
     }
     TEST_ASSERT_EQUAL(0, closedir(dir));
-    int64_t end = esp_timer_get_time();
-    int64_t total_time_readdir = end-start;
+    uint64_t end = esp_timer_get_time();
+    uint64_t total_time_readdir = end-start;
     printf("Time in us for calculating directory size by calling readdir first and then stat func:  %lld \n",total_time_readdir);
     printf("Size of the directory %s is %"PRIu32"Kb\n", dir_prefix, (dir_size/1000));
     TEST_ASSERT_EQUAL(file_num*strlen(fatfs_test_hello_str), dir_size); //each file size is 14 bytes

--- a/components/fatfs/test_apps/test_fatfs_common/test_fatfs_common.c
+++ b/components/fatfs/test_apps/test_fatfs_common/test_fatfs_common.c
@@ -772,7 +772,7 @@ void test_fatfs_readdir_stat(const char* dir_prefix)
     }
 
     printf("Start counting\n");
-    int64_t start = esp_timer_get_time();
+    uint64_t start = esp_timer_get_time();
     DIR* dir = opendir(dir_prefix);
     TEST_ASSERT_NOT_NULL(dir);
     struct stat st;

--- a/components/openthread/src/port/esp_openthread_alarm.c
+++ b/components/openthread/src/port/esp_openthread_alarm.c
@@ -41,7 +41,7 @@ static inline uint32_t calculate_duration(uint32_t target, uint32_t now)
 
 uint64_t otPlatTimeGet(void)
 {
-    return (uint64_t)esp_timer_get_time();
+    return esp_timer_get_time();
 }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)

--- a/components/sdmmc/sdmmc_cmd.c
+++ b/components/sdmmc/sdmmc_cmd.c
@@ -473,8 +473,8 @@ esp_err_t sdmmc_write_sectors_dma(sdmmc_card_t* card, const void* src,
     uint32_t status = 0;
     size_t count = 0;
     int64_t yield_delay_us = 100 * 1000; // initially 100ms
-    int64_t t0 = esp_timer_get_time();
-    int64_t t1 = 0;
+    uint64_t t0 = esp_timer_get_time();
+    uint64_t t1 = 0;
     /* SD mode: wait for the card to become idle based on R1 status */
     while (!host_is_spi(card) && !(status & MMC_R1_READY_FOR_DATA)) {
         t1 = esp_timer_get_time();

--- a/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/main.c
+++ b/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/main.c
@@ -480,12 +480,12 @@ void example_ble_mesh_send_vendor_message(bool resend)
 static void example_ble_mesh_custom_model_cb(esp_ble_mesh_model_cb_event_t event,
                                              esp_ble_mesh_model_cb_param_t *param)
 {
-    static int64_t start_time;
+    static uint64_t start_time;
 
     switch (event) {
     case ESP_BLE_MESH_MODEL_OPERATION_EVT:
         if (param->model_operation.opcode == ESP_BLE_MESH_VND_MODEL_OP_STATUS) {
-            int64_t end_time = esp_timer_get_time();
+            uint64_t end_time = esp_timer_get_time();
             ESP_LOGI(TAG, "Recv 0x06%" PRIx32 ", tid 0x%04x, time %lldus",
                 param->model_operation.opcode, store.vnd_tid, end_time - start_time);
         }

--- a/examples/peripherals/usb/host/uvc/main/main.c
+++ b/examples/peripherals/usb/host/uvc/main/main.c
@@ -132,7 +132,7 @@ void frame_callback(uvc_frame_t *frame, void *ptr)
     static size_t bytes_per_second;
     static int64_t start_time;
 
-    int64_t current_time = esp_timer_get_time();
+    uint64_t current_time = esp_timer_get_time();
     bytes_per_second += frame->data_bytes;
     fps++;
 

--- a/examples/system/esp_timer/main/esp_timer_example_main.c
+++ b/examples/system/esp_timer/main/esp_timer_example_main.c
@@ -61,13 +61,13 @@ void app_main(void)
     /* Timekeeping continues in light sleep, and timers are scheduled
      * correctly after light sleep.
      */
-    int64_t t1 = esp_timer_get_time();
+    uint64_t t1 = esp_timer_get_time();
     ESP_LOGI(TAG, "Entering light sleep for 0.5s, time since boot: %lld us", t1);
 
     ESP_ERROR_CHECK(esp_sleep_enable_timer_wakeup(500000));
     esp_light_sleep_start();
 
-    int64_t t2 = esp_timer_get_time();
+    uint64_t t2 = esp_timer_get_time();
     ESP_LOGI(TAG, "Woke up from light sleep, time since boot: %lld us", t2);
 
     assert(llabs((t2 - t1) - 500000) < 1200);
@@ -84,13 +84,13 @@ void app_main(void)
 
 static void periodic_timer_callback(void* arg)
 {
-    int64_t time_since_boot = esp_timer_get_time();
+    uint64_t time_since_boot = esp_timer_get_time();
     ESP_LOGI(TAG, "Periodic timer called, time since boot: %lld us", time_since_boot);
 }
 
 static void oneshot_timer_callback(void* arg)
 {
-    int64_t time_since_boot = esp_timer_get_time();
+    uint64_t time_since_boot = esp_timer_get_time();
     ESP_LOGI(TAG, "One-shot timer called, time since boot: %lld us", time_since_boot);
     esp_timer_handle_t periodic_timer_handle = (esp_timer_handle_t) arg;
     /* To start the timer which is running, need to stop it first */

--- a/examples/system/light_sleep/main/light_sleep_example_main.c
+++ b/examples/system/light_sleep/main/light_sleep_example_main.c
@@ -27,13 +27,13 @@ static void light_sleep_task(void *args)
         uart_wait_tx_idle_polling(CONFIG_ESP_CONSOLE_UART_NUM);
 
         /* Get timestamp before entering sleep */
-        int64_t t_before_us = esp_timer_get_time();
+        uint64_t t_before_us = esp_timer_get_time();
 
         /* Enter sleep mode */
         esp_light_sleep_start();
 
         /* Get timestamp after waking up from sleep */
-        int64_t t_after_us = esp_timer_get_time();
+        uint64_t t_after_us = esp_timer_get_time();
 
         /* Determine wake up reason */
         const char* wakeup_reason;


### PR DESCRIPTION
If we "trace" the implementation of the esp_timer_get_time() function, we eventually find out that it calls a tick_to_us_func_t, which is a function that returns an unsigned 64-bit wide integer.

Eventually, the uint64_t is cast to int64_t (apparently this is a mistake).

I have refactored the code replacing all int64_t related to calls to these functions to uint64_t.

It should be noted that with 64 bits we won't have overflow after about 70 minutes, so I think this is an improvement.

I have successfully built the example esp_timer after my changes, but an exhaustive test for all examples involved might be needed, if it is not done automatically with CI.