### PR TITLE
feat(ulp): RVfplib as alternative floating point library for ULP RISC-V and LP Core (IDFGH-12981)

### DIFF
--- a/.gitlab/ci/rules.yml
+++ b/.gitlab/ci/rules.yml
@@ -144,6 +144,7 @@
   - "components/bt/controller/lib_esp32c6/esp32c6-bt-lib"
   - "components/bt/controller/lib_esp32c5/esp32c5-bt-lib"
   - "components/bt/esp_ble_mesh/lib/lib"
+  - "components/ulp/RVfplib"
   - ".gitmodules"
 
 .patterns-idf-pytest-plugin: &patterns-idf-pytest-plugin

--- a/.gitmodules
+++ b/.gitmodules
@@ -147,3 +147,13 @@
 [submodule "components/bt/esp_ble_mesh/lib/lib"]
 	path = components/bt/esp_ble_mesh/lib/lib
 	url = ../../espressif/esp-ble-mesh-lib.git
+
+[submodule "components/ulp/RVfplib"]
+	path = components/ulp/RVfplib
+	url = ../../pulp-platform/RVfplib.git
+	sbom-version = 9de634e25a7130f1d08a2434100aabd12581841b
+	sbom-cpe = cpe:2.3:a:RVfplib:librvfp:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: pulp-platform community <https://pulp-platform.org>
+	sbom-url = https://github.com/pulp-platform/RVfplib
+	sbom-description = Optimized RISC-V FP emulation for 32-bit processors
+	sbom-hash = 9de634e25a7130f1d08a2434100aabd12581841b

--- a/components/ulp/Kconfig
+++ b/components/ulp/Kconfig
@@ -108,4 +108,22 @@ menu "Ultra Low Power (ULP) Co-processor"
 
     endmenu
 
+    menu "ULP float library source"
+        depends on ULP_COPROC_TYPE_LP_CORE || ULP_COPROC_TYPE_RISCV
+
+        config ULP_LP_CORE_FLOAT_LIB_FROM_RVFPLIB
+            bool
+            prompt "librvfp"
+            default "n"
+            help
+                In the soft-fp part of libgcc, RISC-V version is written in C,
+                and handles all edge cases in IEEE754, which makes it larger
+                and performance is slow.
+
+                RVfplib is an optimized RISC-V library for FP arithmetic on 32-bit
+                integer processors, for single and double-precision FP.
+                RVfplib is "fast", but it has a few exceptions from IEEE 754 compliance.
+
+    endmenu
+
 endmenu  # Ultra Low Power (ULP) Co-processor

--- a/components/ulp/cmake/CMakeLists.txt
+++ b/components/ulp/cmake/CMakeLists.txt
@@ -171,6 +171,15 @@ else()
 
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(CONFIG_ULP_LP_CORE_FLOAT_LIB_FROM_RVFPLIB)
+    file(GLOB ULP_S_LIBRVFP_SOURCES "${IDF_PATH}/components/ulp/RVfplib/src/asm/ieee754/*.S")
+    add_library(rvfp STATIC "${ULP_S_LIBRVFP_SOURCES}")
+    target_compile_definitions(rvfp PRIVATE "SIZE=1")
+    target_link_libraries(${ULP_APP_NAME} rvfp)
+endif()
+
 if(ULP_COCPU_IS_LP_CORE)
     set(ULP_BASE_ADDR "0x0")
 else()

--- a/components/ulp/project_include.cmake
+++ b/components/ulp/project_include.cmake
@@ -71,6 +71,7 @@ function(ulp_embed_binary app_name s_sources exp_dep_srcs)
                             -DULP_COCPU_IS_RISCV=${ULP_IS_RISCV}
                             -DULP_COCPU_IS_LP_CORE=${ULP_IS_LP_CORE_RISCV}
                             -DCONFIG_ESP_ROM_HAS_LP_ROM=${CONFIG_ESP_ROM_HAS_LP_ROM}
+                            -DCONFIG_ULP_LP_CORE_FLOAT_LIB_FROM_RVFPLIB=${CONFIG_ULP_LP_CORE_FLOAT_LIB_FROM_RVFPLIB}
                             ${extra_cmake_args}
                 BUILD_COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/${app_name} --target build
                 BUILD_BYPRODUCTS ${ulp_artifacts} ${ulp_artifacts_extras} ${ulp_ps_sources}


### PR DESCRIPTION
Add RVfplib as alternative soft-fp library, which might roughly reduce the code size by 1~3 KiB if only basic single precision arithmetics are used.
Though licensed under GPLv3 with library exeption, RVfplib has already been embedded into latest Cx, Hx and P4's rom code so it should not be an issue.