### PR TITLE
fix(esp_http_client): Do not allocate client->if_name twice in esp_http_client_init. (IDFGH-12994)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -662,9 +662,11 @@ static bool init_common_tcp_transport(esp_http_client_handle_t client, const esp
     }
 
     if (config->if_name) {
-        client->if_name = calloc(1, sizeof(struct ifreq));
-        ESP_RETURN_ON_FALSE(client->if_name, false, TAG, "Memory exhausted");
-        memcpy(client->if_name, config->if_name, sizeof(struct ifreq));
+        if(client->if_name == NULL) {
+            client->if_name = calloc(1, sizeof(struct ifreq));
+            ESP_RETURN_ON_FALSE(client->if_name, false, TAG, "Memory exhausted");
+            memcpy(client->if_name, config->if_name, sizeof(struct ifreq));
+        }
         esp_transport_tcp_set_interface_name(transport, client->if_name);
     }
     return true;


### PR DESCRIPTION
When if_name is specified in esp_http_client_config_t like this :
```
esp_http_client_config_t config = {
.url = url,
.if_name = &ifr,
};
```
and CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS is set.
"client->if_name" is allocated twice because "init_common_tcp_transport" is called twice.
First allocation is never free.