### PR TITLE
Fix stack overflow bug for `examples/bluetooth/esp_hid_device` when using esp32s3 with nimble (IDFGH-13001)

### DIFF
--- a/components/esp_hid/src/nimble_hidd.c
+++ b/components/esp_hid/src/nimble_hidd.c
@@ -657,7 +657,7 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
         .queue_size = 5,
         .task_name = "ble_hidd_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = 4096,
         .task_core_id = tskNO_AFFINITY
     };
     rc = esp_event_loop_create(&event_task_args, &s_dev->event_loop_handle);


### PR DESCRIPTION
Related to https://github.com/espressif/esp-idf/commit/60354c39a9338961adce8e2fb536f83571ebd82c and https://github.com/espressif/esp-idf/issues/12879