### PR TITLE
fix(schema): Add missing linux-armhf to tools_schema (IDFGH-13036)

### DIFF
--- a/tools/tools_schema.json
+++ b/tools/tools_schema.json
@@ -218,7 +218,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["linux-i686", "linux-amd64", "linux-armel", "linux-arm64", "macos", "macos-arm64", "win32", "win64"]
+            "enum": ["linux-i686", "linux-amd64", "linux-armel", "linux-armhf", "linux-arm64", "macos", "macos-arm64", "win32", "win64"]
           }
         },
         "export_paths": {


### PR DESCRIPTION
Adds `linux-armhf` to the list of platforms that can have overrides.

Fixes #13981