### PR TITLE
fix(ulp): Write pin's output mode to the correct register (IDFGH-13065)

### DIFF
--- a/components/ulp/ulp_riscv/ulp_core/include/ulp_riscv_gpio.h
+++ b/components/ulp/ulp_riscv/ulp_core/include/ulp_riscv_gpio.h
@@ -109,7 +109,7 @@ static inline uint8_t ulp_riscv_gpio_get_level(gpio_num_t gpio_num)
 
 static inline void ulp_riscv_gpio_set_output_mode(gpio_num_t gpio_num, rtc_io_out_mode_t mode)
 {
-    REG_SET_FIELD(RTC_IO_TOUCH_PAD0_REG + gpio_num * 4, RTC_IO_TOUCH_PAD0_DRV, mode);
+    REG_SET_FIELD(RTC_GPIO_PIN0_REG + gpio_num * 4, RTC_GPIO_PIN0_PAD_DRIVER, mode);
 }
 
 static inline void ulp_riscv_gpio_pullup(gpio_num_t gpio_num)


### PR DESCRIPTION
Fixes register mixup. 
According to the [ESP32-S3 TRM](https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf) (pages 515 - 516), the output pin's mode is set in the `RTC_GPIO_PINn_REG`,
bit `RTC_GPIO_PINn_PAD_DRIVER`, not the `RTC_IO_TOUCH_PADn_REG` field `RTC_IO_TOUCH_PADn_DRV`, 
which instead controls the drive output strength.