### PR TITLE
build: Reduce verbosity of disabled component manager warning (IDFGH-13156)

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -605,7 +605,7 @@ macro(idf_build_process target)
         endforeach()
 
         if(NOT "${__components_with_manifests}" STREQUAL "")
-            message(WARNING "\"idf_component.yml\" file was found for components:\n${__components_with_manifests}"
+            message(NOTICE "\"idf_component.yml\" file was found for components:\n${__components_with_manifests}"
                     "However, the component manager is not enabled.")
         endif()
     endif()


### PR DESCRIPTION
`IDF_COMPONENT_MANAGER=0` is an advanced user option which doesn't have much of an effect unless there are components that have an `idf_component.yml` file, and in most cases dependencies can be resolved manually. Thus there should be no need for such a severe warning.

The warning message results in a warning symbol shown in IDE (CLion):
![image](https://github.com/espressif/esp-idf/assets/506904/c177e953-cd39-43b7-9a29-ea83ba2b2396)
