### PR TITLE
feat(dhcp server): only hand out DNS if explicitly specified (IDFGH-13195)

### DIFF
--- a/components/lwip/apps/dhcpserver/dhcpserver.c
+++ b/components/lwip/apps/dhcpserver/dhcpserver.c
@@ -454,18 +454,13 @@ static u8_t *add_offer_options(dhcps_t *dhcps, u8_t *optptr)
         }
     }
 
-    *optptr++ = DHCP_OPTION_DNS_SERVER;
-    *optptr++ = 4;
     if (dhcps_dns_enabled(dhcps->dhcps_dns)) {
+        *optptr++ = DHCP_OPTION_DNS_SERVER;
+        *optptr++ = 4;
         *optptr++ = ip4_addr1(&dhcps->dns_server);
         *optptr++ = ip4_addr2(&dhcps->dns_server);
         *optptr++ = ip4_addr3(&dhcps->dns_server);
         *optptr++ = ip4_addr4(&dhcps->dns_server);
-    }else {
-        *optptr++ = ip4_addr1(&ipadd);
-        *optptr++ = ip4_addr2(&ipadd);
-        *optptr++ = ip4_addr3(&ipadd);
-        *optptr++ = ip4_addr4(&ipadd);
     }
 
     ip4_addr_t broadcast_addr = { .addr = (ipadd.addr & dhcps->dhcps_mask.addr) | ~dhcps->dhcps_mask.addr };


### PR DESCRIPTION
By default there isn't any dns server running on the ESP32, and it does not make sense to hand out DNS config here. On the other hand, handing out DNS config will affect the client machine if we don't want DNS traffic to go through ESP32, and there's no way to disable it. So only hand it out if explicitly enabled.