### PR TITLE
fix(ble-mesh): don't use dangling pointer in nimble gatt service

### DIFF
--- a/components/bt/esp_ble_mesh/core/nimble_host/adapter.c
+++ b/components/bt/esp_ble_mesh/core/nimble_host/adapter.c
@@ -1309,7 +1309,6 @@ int bt_mesh_gatts_service_stop(struct bt_mesh_gatt_service *svc)
 {
     int rc;
     uint16_t handle;
-    const ble_uuid_t *uuid;
 
     if (!svc) {
         BT_ERR("%s, Invalid parameter", __func__);
@@ -1317,12 +1316,11 @@ int bt_mesh_gatts_service_stop(struct bt_mesh_gatt_service *svc)
     }
 
     if (BLE_MESH_UUID_16(svc->attrs[0].user_data)->val == BT_UUID_MESH_PROXY_VAL) {
-        uuid = BLE_UUID16_DECLARE(BT_UUID_MESH_PROXY_VAL);
+        rc = ble_gatts_find_svc(BLE_UUID16_DECLARE(BT_UUID_MESH_PROXY_VAL), &handle);
     } else {
-        uuid = BLE_UUID16_DECLARE(BT_UUID_MESH_PROV_VAL);
+        rc = ble_gatts_find_svc(BLE_UUID16_DECLARE(BT_UUID_MESH_PROV_VAL), &handle);
     }
 
-    rc = ble_gatts_find_svc(uuid, &handle);
     assert(rc == 0);
     ble_gatts_svc_set_visibility(handle, 0);
 
@@ -1336,15 +1334,13 @@ int bt_mesh_gatts_service_start(struct bt_mesh_gatt_service *svc)
 {
     int rc;
     uint16_t handle;
-    const ble_uuid_t *uuid;
 
     if (BLE_MESH_UUID_16(svc->attrs[0].user_data)->val == BT_UUID_MESH_PROXY_VAL) {
-        uuid = BLE_UUID16_DECLARE(BT_UUID_MESH_PROXY_VAL);
+        rc = ble_gatts_find_svc(BLE_UUID16_DECLARE(BT_UUID_MESH_PROXY_VAL), &handle);
     } else {
-        uuid = BLE_UUID16_DECLARE(BT_UUID_MESH_PROV_VAL);
+        rc = ble_gatts_find_svc(BLE_UUID16_DECLARE(BT_UUID_MESH_PROV_VAL), &handle);
     }
 
-    rc = ble_gatts_find_svc(uuid, &handle);
     assert(rc == 0);
     ble_gatts_svc_set_visibility(handle, 1);
 


### PR DESCRIPTION
Pointer to the uuid was used out of scope which resulted in errors when building with size optimization.

This fixes #12883