### PR TITLE
fix(diskio): Remove const keyword from VolToPart (IDFGH-13213)

### DIFF
--- a/components/fatfs/diskio/diskio.c
+++ b/components/fatfs/diskio/diskio.c
@@ -19,7 +19,7 @@
 static ff_diskio_impl_t * s_impls[FF_VOLUMES] = { NULL };
 
 #if FF_MULTI_PARTITION		/* Multiple partition configuration */
-const PARTITION VolToPart[FF_VOLUMES] = {
+PARTITION VolToPart[FF_VOLUMES] = {
     {0, 0},    /* Logical drive 0 ==> Physical drive 0, auto detection */
 #if FF_VOLUMES > 1
     {1, 0},    /* Logical drive 1 ==> Physical drive 1, auto detection */

--- a/components/fatfs/src/ff.h
+++ b/components/fatfs/src/ff.h
@@ -116,7 +116,7 @@ typedef struct {
 	BYTE pd;	/* Physical drive number */
 	BYTE pt;	/* Partition: 0:Auto detect, 1-4:Forced partition) */
 } PARTITION;
-extern const PARTITION VolToPart[];	/* Volume - Partition mapping table */
+extern PARTITION VolToPart[];	/* Volume - Partition mapping table */
 #endif
 
 #if FF_STR_VOLUME_ID


### PR DESCRIPTION
Remove const keyword from VolToPart
So user can modify VolToPart while app is running
In Fatfs code source, no const on VolToPart
This is useful when physical drive has more than one partition