### PR TITLE
fix(tool/mfg_gen) allow encodings u64 and i64 (IDFGH-13224)

### DIFF
--- a/tools/mass_mfg/mfg_gen.py
+++ b/tools/mass_mfg/mfg_gen.py
@@ -72,7 +72,7 @@ def verify_keys_exist(values_file_keys, input_config_file):
 def verify_datatype_encoding(input_config_file):
     """ Verify datatype and encodings from config file is valid
     """
-    valid_encodings = {'string', 'binary', 'hex2bin','u8', 'i8', 'u16', 'u32', 'i32','base64'}
+    valid_encodings = {'string', 'binary', 'hex2bin','u8', 'i8', 'u16', 'u32', 'i32', 'u64', 'i64','base64'}
     valid_datatypes = {'file','data','namespace'}
 
     with open(input_config_file,'r') as config_file:


### PR DESCRIPTION
downstream tool `nvs_partition_gen` support encodings u64 and i64, but `mfg_gen` verify it invalid.