### PR TITLE
fix(tcp_transport): fix buffer overflow in ws connect

### DIFF
--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -285,7 +285,7 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
     }
     int header_len = 0;
     do {
-        if ((len = esp_transport_read(ws->parent, ws->buffer + header_len, WS_BUFFER_SIZE - header_len, timeout_ms)) <= 0) {
+        if ((len = esp_transport_read(ws->parent, ws->buffer + header_len, WS_BUFFER_SIZE - header_len - 1, timeout_ms)) <= 0) {
             ESP_LOGE(TAG, "Error read response for Upgrade header %s", ws->buffer);
             return -1;
         }
@@ -293,7 +293,7 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
         ws->buffer_len = header_len;
         ws->buffer[header_len] = '\0'; // We will mark the end of the header to ensure that strstr operations for parsing the headers don't fail.
         ESP_LOGD(TAG, "Read header chunk %d, current header size: %d", len, header_len);
-    } while (NULL == strstr(ws->buffer, delimiter) && header_len < WS_BUFFER_SIZE);
+    } while (NULL == strstr(ws->buffer, delimiter) && header_len < WS_BUFFER_SIZE - 1);
 
     char* delim_ptr = strstr(ws->buffer, delimiter);
 


### PR DESCRIPTION
This fixes a buffer overflow in `ws_connect` when the HTTP response size equals or exceeds `WS_BUFFER_SIZE` (1K by default).

This easily reproducible with [heap corruption detection](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/heap_debug.html#heap-corruption-detection) (light impact is enough) and a large HTTP response  received in one chunk and/or a header exceeding 1K. This happens typically when there's a HTTP error status code which contains a body.

Example:

```
D (24887) transport_ws: Read header chunk 1024, current header size: 1024
D (24897) transport_ws: HTTP status code is 404
E (24897) transport_ws: Sec-WebSocket-Accept not found
E (24897) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_OK, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=404, errno=119
CORRUPT HEAP: Bad tail at 0x3fce54bc. Expected 0xbaad5678 got 0xbaad5600

assert failed: multi_heap_free multi_heap_poisoning.c:279 (head != NULL)
```

I observed this on `v5.2.2` and `v5.3-rc1`.

Since `v5.2.2` there have been some changes (most notably https://github.com/espressif/esp-idf/commit/2267d4b6b5792c37577cdc2fe963868f6e055621) but the overflow is still there.

There are multiple solutions here. I picked the one that assumes that the last byte of `ws->buffer` will always be `\0`, so it reads one byte less from the transport. I guess that `strnstr` is not available.

@gabsuren