### PR TITLE
feat(bt) - Enable use of RESERVED bits in COD (IDFGH-13374)

### DIFF
--- a/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
+++ b/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
@@ -604,6 +604,7 @@ esp_err_t btc_gap_bt_get_cod(esp_bt_cod_t *cod)
         return ESP_BT_STATUS_FAIL;
     }
     cod->minor = p_cod.minor >> 2;
+    cod->reserved_2 = p_cod.minor & 0x03;
     cod->major = p_cod.major;
     cod->service = p_cod.service >> 5;
     return ESP_BT_STATUS_SUCCESS;

--- a/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
+++ b/components/bt/host/bluedroid/btc/profile/std/gap/btc_gap_bt.c
@@ -586,6 +586,7 @@ static void btc_gap_bt_set_cod(btc_gap_bt_args_t *arg)
     tBTA_UTL_COD p_cod;
     esp_bt_cod_t *cod = &(arg->set_cod.cod);
     p_cod.minor = cod->minor << 2;
+    p_cod.minor |= cod->reserved_2;
     p_cod.major = cod->major;
     p_cod.service = cod->service << 5;
     bool ret = utl_set_device_class(&p_cod, arg->set_cod.mode);

--- a/components/bt/host/bluedroid/stack/include/stack/btm_api.h
+++ b/components/bt/host/bluedroid/stack/include/stack/btm_api.h
@@ -468,7 +468,7 @@ typedef enum {
 
 /* the COD masks */
 #define BTM_COD_FORMAT_TYPE_MASK      0x03
-#define BTM_COD_MINOR_CLASS_MASK      0xFC
+#define BTM_COD_MINOR_CLASS_MASK      0xFF
 #define BTM_COD_MAJOR_CLASS_MASK      0x1F
 #define BTM_COD_SERVICE_CLASS_LO_B    0x00E0
 #define BTM_COD_SERVICE_CLASS_MASK    0xFFE0


### PR DESCRIPTION
This is a very niche-case patch, one that most people should never have need to bother with.

But in my case, trying to make a replacement for an obsolete Bluetooth board, I ran into an issue with a nonstandard use of the BT COD field: the two low "reserved" bits were used!  Without access to the controlling firmware (and having to maintain compatibility with the thousands of "obsolete Bluetooth boards" in the field which will not function without said "reserved" bits being transmitted in the outgoing COD), this is the neatest solution to the problem.

I did a deep dive straight into the Bluedroid stack, and found exactly where (amongst the multiple unnecessary data type changes the provided COD went through) the two bits were getting lost.  The very simple changes here were successful in allowing the ESP32 to work as a drop-in replacement for the obsolete board.