### PR TITLE
fix: add dma_aligned_buffer and pwr_ctrl_handle fields to SDSPI_HOST_DEFAULT() (IDFGH-13376)

### DIFF
--- a/components/esp_driver_sdspi/include/driver/sdspi_host.h
+++ b/components/esp_driver_sdspi/include/driver/sdspi_host.h
@@ -54,6 +54,8 @@ typedef int sdspi_dev_handle_t;
     .get_real_freq = &sdspi_host_get_real_freq, \
     .input_delay_phase = SDMMC_DELAY_PHASE_0, \
     .set_input_delay = NULL, \
+    .dma_aligned_buffer = NULL, \
+    .pwr_ctrl_handle = NULL, \
     .get_dma_info = &sdspi_host_get_dma_info, \
 }
 


### PR DESCRIPTION
A warning is displayed at build time due to missing field initialization in the SDSPI_HOST_DEFAULT() macro.
```
/Volumes/Space/ghq/github.com/espressif/esp-idf/components/esp_driver_sdspi/include/driver/sdspi_host.h:58:1: warning: missing initializer for member 'sdmmc_host_t::dma_aligned_buffer' [-Wmissing-field-initializers]
   58 | }
      | ^
/Volumes/Space/ghq/github.com/nileworks/qianliyan_device/main/sd_logger.cpp:350:39: note: in expansion of macro 'SDSPI_HOST_DEFAULT'
  350 |         constexpr sdmmc_host_t host = SDSPI_HOST_DEFAULT();
      |                                       ^~~~~~~~~~~~~~~~~~
/Volumes/Space/ghq/github.com/espressif/esp-idf/components/esp_driver_sdspi/include/driver/sdspi_host.h:58:1: warning: missing initializer for member 'sdmmc_host_t::pwr_ctrl_handle' [-Wmissing-field-initializers]
   58 | }
      | ^
/Volumes/Space/ghq/github.com/nileworks/qianliyan_device/main/sd_logger.cpp:350:39: note: in expansion of macro 'SDSPI_HOST_DEFAULT'
  350 |         constexpr sdmmc_host_t host = SDSPI_HOST_DEFAULT();
      |                                       ^~~~~~~~~~~~~~~~~~
```