### PR TITLE
fix(rmt): set rx filter resolution_hz to rmt_sclk

### DIFF
--- a/components/esp_driver_rmt/src/rmt_rx.c
+++ b/components/esp_driver_rmt/src/rmt_rx.c
@@ -283,7 +283,7 @@ esp_err_t rmt_new_rx_channel(const rmt_rx_channel_config_t *config, rmt_channel_
         ESP_LOGW(TAG, "channel resolution loss, real=%"PRIu32, rx_channel->base.resolution_hz);
     }
 
-    rx_channel->filter_clock_resolution_hz = group->resolution_hz;
+    rx_channel->filter_clock_resolution_hz = rx_channel->base.resolution_hz;
     // On esp32 and esp32s2, the counting clock used by the RX filter always comes from APB clock
     // no matter what the clock source is used by the RMT channel as the "core" clock
 #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2


### PR DESCRIPTION
Fixes assignment of `filter_clock_resolution_hz` to `rx_channel->base.resolution_hz`, which is the clock frequency after the fractional divider `RMT_SCLK_DIV` (also referenced as `rmt_sclk` in the TRM), instead of the previously used value from `group->resolution_hz`, which represents the full undivided frequency from clock selected by `RMT_SCLK_SEL` (APB, RC_FAST or XTAL). 
Before this fix, this mixup resulted in an error `signal_range_min_ns too big` being returned by the `rmt_receive` function due to [this check](https://github.com/espressif/esp-idf/blob/8e4454b285ad39881c5bf3f440d8be617a2f18a8/components/esp_driver_rmt/src/rmt_rx.c#L410-L413) failing no matter the `resolution_hz` used in the configuration of the channel.