### PR TITLE
fix(gptimer): remove incorrect param from example (IDFGH-13420)

### DIFF
--- a/docs/en/api-reference/peripherals/gptimer.rst
+++ b/docs/en/api-reference/peripherals/gptimer.rst
@@ -258,7 +258,7 @@ Alarm value can be updated dynamically inside the ISR handler callback, by chang
     };
     ESP_ERROR_CHECK(gptimer_register_event_callbacks(gptimer, &cbs, queue));
     ESP_ERROR_CHECK(gptimer_enable(gptimer));
-    ESP_ERROR_CHECK(gptimer_start(gptimer, &alarm_config));
+    ESP_ERROR_CHECK(gptimer_start(gptimer));
 
 
 .. only:: SOC_TIMER_SUPPORT_ETM

--- a/docs/zh_CN/api-reference/peripherals/gptimer.rst
+++ b/docs/zh_CN/api-reference/peripherals/gptimer.rst
@@ -258,7 +258,7 @@
     };
     ESP_ERROR_CHECK(gptimer_register_event_callbacks(gptimer, &cbs, queue));
     ESP_ERROR_CHECK(gptimer_enable(gptimer));
-    ESP_ERROR_CHECK(gptimer_start(gptimer, &alarm_config));
+    ESP_ERROR_CHECK(gptimer_start(gptimer));
 
 
 .. only:: SOC_TIMER_SUPPORT_ETM


### PR DESCRIPTION
Fixes call to `gptimer_start` in one of the examples which includes extra second parameter `&alarm_config`, when the function takes only one.