### PR TITLE
fix(ulp): Add the missing extern "C" guard to ulp_lp_core_print.h (IDFGH-13423)

### DIFF
--- a/components/ulp/lp_core/lp_core/include/ulp_lp_core_print.h
+++ b/components/ulp/lp_core/lp_core/include/ulp_lp_core_print.h
@@ -5,6 +5,10 @@
  */
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "sdkconfig.h"
 
 /**
@@ -67,3 +71,7 @@ void lp_core_print_hex(int h);
  * @param d     integer to be printed
  */
 void lp_core_print_dec_two_digits(int d);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
It's a small patch aim to add the missing `extern "C"` guard to `ulp_lp_core_print.h`.