### PR TITLE
fix(bt/bluedroid): Resolve warning: unused variable 'pp' (IDFGH-13463)

### DIFF
--- a/components/bt/host/bluedroid/stack/btu/btu_hcif.c
+++ b/components/bt/host/bluedroid/stack/btu/btu_hcif.c
@@ -2162,7 +2162,9 @@ static void btu_ble_ext_adv_report_evt(UINT8 *p, UINT16 evt_len)
 {
     tBTM_BLE_EXT_ADV_REPORT ext_adv_report = {0};
     UINT8 num_reports = {0};
+#if (defined BLE_PRIVACY_SPT && BLE_PRIVACY_SPT == TRUE)
     UINT8 *pp = p;
+#endif
     //UINT8 legacy_event_type = 0;
     UINT16 evt_type = 0;
     uint8_t addr_type;


### PR DESCRIPTION
```
C:/Espressif/frameworks/esp-idf-v5.3/components/bt/host/bluedroid/stack/btu/btu_hcif.c:2162:12: warning: unused variable 'pp' [-Wunused-variable]
 2162 |     UINT8 *pp = p;
```