### PR TITLE
fix(esp32): delete the secondary judgment  in examples/mesh/internal_communication (IDFGH-13472)

### DIFF
--- a/examples/mesh/internal_communication/main/mesh_main.c
+++ b/examples/mesh/internal_communication/main/mesh_main.c
@@ -80,7 +80,7 @@ void esp_mesh_p2p_tx_main(void *arg)
         if (!esp_mesh_is_root()) {
             ESP_LOGI(MESH_TAG, "layer:%d, rtableSize:%d, %s", mesh_layer,
                      esp_mesh_get_routing_table_size(),
-                     (is_mesh_connected && esp_mesh_is_root()) ? "ROOT" : is_mesh_connected ? "NODE" : "DISCONNECT");
+                     is_mesh_connected ? "NODE" : "DISCONNECT");
             vTaskDelay(10 * 1000 / portTICK_PERIOD_MS);
             continue;
         }


### PR DESCRIPTION
Delete the secondary judgment of whether it is the root node in the sending task.