### PR TITLE
fix(tools): python3.12 support: remove distutils use (IDFGH-13510)

### DIFF
--- a/tools/idf_py_actions/create_ext.py
+++ b/tools/idf_py_actions/create_ext.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import print_function
-
 import os
 import re
 import sys
-from distutils.dir_util import copy_tree
+from shutil import copy
+from shutil import copytree
 from typing import Dict
 
 import click
@@ -40,10 +39,11 @@ def is_empty_and_create(path: str, action: str) -> None:
 
 
 def create_project(target_path: str, name: str) -> None:
-    copy_tree(
+    copytree(
         os.path.join(os.environ['IDF_PATH'], 'examples', 'get-started', 'sample_project'),
         target_path,
-        preserve_mode=0,
+        copy_function=copy,
+        dirs_exist_ok=True,
     )
     main_folder = os.path.join(target_path, 'main')
     os.rename(os.path.join(main_folder, 'main.c'), os.path.join(main_folder, '.'.join((name, 'c'))))
@@ -53,10 +53,11 @@ def create_project(target_path: str, name: str) -> None:
 
 
 def create_component(target_path: str, name: str) -> None:
-    copy_tree(
+    copytree(
         os.path.join(os.environ['IDF_PATH'], 'tools', 'templates', 'sample_component'),
         target_path,
-        preserve_mode=0,
+        copy_function=copy,
+        dirs_exist_ok=True,
     )
     os.rename(os.path.join(target_path, 'main.c'), os.path.join(target_path, '.'.join((name, 'c'))))
     os.rename(os.path.join(target_path, 'include', 'main.h'),

--- a/tools/mass_mfg/mfg_gen.py
+++ b/tools/mass_mfg/mfg_gen.py
@@ -7,8 +7,8 @@ import argparse
 import csv
 import os
 from itertools import zip_longest
+from pathlib import Path
 
-import distutils.dir_util
 import esp_idf_nvs_partition_gen.nvs_partition_gen as nvs_partition_gen
 
 
@@ -208,7 +208,7 @@ def create_dir(filetype, output_dir_path):
     """
     output_target_dir = os.path.join(output_dir_path,filetype,'')
     if not os.path.isdir(output_target_dir):
-        distutils.dir_util.mkpath(output_target_dir)
+        Path(output_target_dir).mkdir(parents=True)
 
     return output_target_dir
 


### PR DESCRIPTION
Hi,

In python 3.12, the `distutils` module was removed from the standard library.
Here are simple ways to avoid it.

ref. https://docs.python.org/3/whatsnew/3.12.html#distutils