### PR TITLE
fix(http_server): Don't require LWIP_NETIF_LOOPBACK for Linux target (IDFGH-13519)

### DIFF
--- a/components/esp_http_server/src/util/ctrl_sock.c
+++ b/components/esp_http_server/src/util/ctrl_sock.c
@@ -15,24 +15,22 @@
 #include "ctrl_sock.h"
 
 #if CONFIG_IDF_TARGET_LINUX
-#define IPV4_ENABLED    1
-#define IPV6_ENABLED    1
+#define IPV4_ENABLED      1
+#define IPV6_ENABLED      1
+#define LOOPBACK_ENABLED  1
 #else   // CONFIG_IDF_TARGET_LINUX
-#define IPV4_ENABLED    CONFIG_LWIP_IPV4
-#define IPV6_ENABLED    CONFIG_LWIP_IPV6
+#define IPV4_ENABLED      CONFIG_LWIP_IPV4
+#define IPV6_ENABLED      CONFIG_LWIP_IPV6
+#define LOOPBACK_ENABLED  CONFIG_LWIP_NETIF_LOOPBACK
 #endif  // !CONFIG_IDF_TARGET_LINUX
-
-#if !CONFIG_LWIP_NETIF_LOOPBACK
-static const char *TAG = "esp_http_server";
-#endif
 
 /* Control socket, because in some network stacks select can't be woken up any
  * other way
  */
 int cs_create_ctrl_sock(int port)
 {
-#if !CONFIG_LWIP_NETIF_LOOPBACK
-    ESP_LOGE(TAG, "Please enable LWIP_NETIF_LOOPBACK for %s API", __func__);
+#if !LOOPBACK_ENABLED
+    ESP_LOGE("esp_http_server", "Please enable LWIP_NETIF_LOOPBACK for %s API", __func__);
     return -1;
 #endif
 


### PR DESCRIPTION
The commit https://github.com/espressif/esp-idf/commit/ef5e4ddee8c1667e32e1252e97c5a95604a003cc introduced a dependency on the LWIP_NETIF_LOOPBACK configuration option for all targets.

This makes it impossible to build esp_http_server without lwIP as the option can't be set. Also, the option is not necessary on Linux builds without lwIP.