### PR TITLE
fix(esp_netif): Fixed initializer order of ESP_IP macros for C++ (IDFGH-13520)

### DIFF
--- a/components/esp_netif/include/esp_netif_ip_addr.h
+++ b/components/esp_netif/include/esp_netif_ip_addr.h
@@ -79,8 +79,8 @@ extern "C" {
 
 #define ESP_IP4TOADDR(a,b,c,d) esp_netif_htonl(ESP_IP4TOUINT32(a, b, c, d))
 
-#define ESP_IP4ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V4, .u_addr = { .ip4 = { .addr = ESP_IP4TOADDR(a, b, c, d) }}}
-#define ESP_IP6ADDR_INIT(a, b, c, d)  { .type = ESP_IPADDR_TYPE_V6, .u_addr = { .ip6 = { .addr = { a, b, c, d }, .zone = 0 }}}
+#define ESP_IP4ADDR_INIT(a, b, c, d)  { .u_addr = { .ip4 = { .addr = ESP_IP4TOADDR(a, b, c, d) }}, .type = ESP_IPADDR_TYPE_V4 }
+#define ESP_IP6ADDR_INIT(a, b, c, d)  { .u_addr = { .ip6 = { .addr = { a, b, c, d }, .zone = 0 }}, .type = ESP_IPADDR_TYPE_V6 }
 
 #ifndef IP4ADDR_STRLEN_MAX
 #define IP4ADDR_STRLEN_MAX  16


### PR DESCRIPTION
The designated initializer order has to be the same as member declaration order in C++. This change enables C++ users to use `ESP_IP4ADDR_INIT` and `ESP_IP6ADDR_INIT` macros.