### PR TITLE
feat(esp_system,ulp): LP core reserved mem optionally executable from HP core (IDFGH-13533)

### DIFF
--- a/components/esp_hw_support/port/esp32c5/cpu_region_protect.c
+++ b/components/esp_hw_support/port/esp32c5/cpu_region_protect.c
@@ -194,7 +194,11 @@ void esp_cpu_configure_region_protection(void)
     PMP_ENTRY_SET(11, SOC_RTC_IRAM_LOW, NONE);
 
     // First part of LP mem is reserved for ULP coprocessor
+#if CONFIG_ESP_SYSTEM_PMP_LP_CORE_RESERVE_MEM_EXECUTABLE
+    PMP_ENTRY_SET(12, (int)&_rtc_text_start, PMP_TOR | RWX);
+#else
     PMP_ENTRY_SET(12, (int)&_rtc_text_start, PMP_TOR | RW);
+#endif
 
     PMP_ENTRY_SET(13, (int)&_rtc_text_end, PMP_TOR | RX);
     PMP_ENTRY_SET(14, SOC_RTC_IRAM_HIGH, PMP_TOR | RW);

--- a/components/esp_hw_support/port/esp32c6/cpu_region_protect.c
+++ b/components/esp_hw_support/port/esp32c6/cpu_region_protect.c
@@ -190,8 +190,11 @@ void esp_cpu_configure_region_protection(void)
     PMP_ENTRY_SET(11, SOC_RTC_IRAM_LOW, NONE);
 
     // First part of LP mem is reserved for ULP coprocessor
+#if CONFIG_ESP_SYSTEM_PMP_LP_CORE_RESERVE_MEM_EXECUTABLE
+    PMP_ENTRY_SET(12, (int)&_rtc_text_start, PMP_TOR | RWX);
+#else
     PMP_ENTRY_SET(12, (int)&_rtc_text_start, PMP_TOR | RW);
-
+#endif
     PMP_ENTRY_SET(13, (int)&_rtc_text_end, PMP_TOR | RX);
     PMP_ENTRY_SET(14, SOC_RTC_IRAM_HIGH, PMP_TOR | RW);
 #else

--- a/components/esp_hw_support/port/esp32p4/cpu_region_protect.c
+++ b/components/esp_hw_support/port/esp32p4/cpu_region_protect.c
@@ -220,7 +220,11 @@ void esp_cpu_configure_region_protection(void)
     PMP_ENTRY_SET(9, SOC_RTC_IRAM_LOW, NONE);
     // First part of LP mem is reserved for RTC reserved mem (shared between bootloader and app)
     // as well as memory for ULP coprocessor
+#if CONFIG_ESP_SYSTEM_PMP_LP_CORE_RESERVE_MEM_EXECUTABLE
+    PMP_ENTRY_SET(10, (int)&_rtc_text_start, PMP_TOR | RWX);
+#else
     PMP_ENTRY_SET(10, (int)&_rtc_text_start, PMP_TOR | RW);
+#endif
     PMP_ENTRY_SET(11, (int)&_rtc_text_end, PMP_TOR | RX);
     PMP_ENTRY_SET(12, SOC_RTC_IRAM_HIGH, PMP_TOR | RW);
 #else

--- a/components/esp_system/Kconfig
+++ b/components/esp_system/Kconfig
@@ -138,6 +138,13 @@ menu "ESP System Settings"
                 for the data part (above the splitting address). The memory protection is effective
                 on all access through the IRAM0 and DRAM0 buses.
 
+        config ESP_SYSTEM_PMP_LP_CORE_RESERVE_MEM_EXECUTABLE
+            bool "Make LP core reserved memory executable from HP core"
+            depends on IDF_TARGET_ARCH_RISCV && SOC_LP_CORE_SUPPORTED && ESP_SYSTEM_PMP_IDRAM_SPLIT
+            default "n"
+            help
+                If enabled, user can run code available in LP Core image.
+
         config ESP_SYSTEM_MEMPROT_FEATURE
             bool "Enable memory protection"
             depends on SOC_MEMPROT_SUPPORTED


### PR DESCRIPTION
Make LP core reserved memory optionally executable in HP core. Currently its locked to RW in PMP.