### PR TITLE
fix(http): fix invalid content-length header in http get (IDFGH-13571)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1493,7 +1493,12 @@ static esp_err_t esp_http_client_connect(esp_http_client_handle_t client)
 static int http_client_prepare_first_line(esp_http_client_handle_t client, int write_len)
 {
     if (write_len >= 0) {
-        http_header_set_format(client->request->headers, "Content-Length", "%d", write_len);
+        const bool length_required = (client->connection_info.method != HTTP_METHOD_GET &&
+                                      client->connection_info.method != HTTP_METHOD_HEAD &&
+                                      client->connection_info.method != HTTP_METHOD_DELETE);
+        if (write_len != 0 || length_required) {
+            http_header_set_format(client->request->headers, "Content-Length", "%d", write_len);
+        }
     } else {
         esp_http_client_set_header(client, "Transfer-Encoding", "chunked");
     }


### PR DESCRIPTION
According to RFC9110 Section 8.6 "Content-Length":
``` A user agent SHOULD NOT send a Content-Length header field when the request message does not contain content and the method semantics do not anticipate such data. ```

This fix removes invalid(empty) Content-Length header for HTTP GET requests.

Presence of this header is causing error 400 to be returned by AWS services via secure connection in some cases:
```D (86867) HTTP_CLIENT: Begin connect to: https://<servername>:443
D (90345) HTTP_CLIENT: Write header[3]: GET /feed HTTP/1.1
User-Agent: IotDevice
Host: <servername>
Content-Length: 0
D (90651) HTTP_CLIENT: on_message_begin
D (90652) HTTP_CLIENT: HEADER=Server:awselb/2.0
D (90652) HTTP_CLIENT: HEADER=Date:Mon, 19 Aug 2024 18:55:53 GMT
D (90653) HTTP_CLIENT: HEADER=Content-Type:text/html
D (90655) HTTP_CLIENT: HEADER=Content-Length:122
D (90656) HTTP_CLIENT: HEADER=Connection:close
D (90656) HTTP_CLIENT: http_on_headers_complete, status=400, offset=150, nread=150
D (90656) HTTP_CLIENT: http_on_body 122
D (90657) HTTP_CLIENT: http_on_message_complete, parser=3f81f998
D (90657) HTTP_CLIENT: content_length = 122
D (90657) HTTP_CLIENT: Close connection
I (90661) OTA: HTTP GET Status = 400, content_length = 122```
