### PR TITLE
fix(esp_clk_tree): SOC_MOD_CLK_REF_TICK now uses the corresponding de…

### DIFF
--- a/components/esp_hw_support/port/esp32/esp_clk_tree.c
+++ b/components/esp_hw_support/port/esp32/esp_clk_tree.c
@@ -55,7 +55,7 @@ uint32_t *freq_value)
         clk_src_freq = esp_clk_tree_xtal32k_get_freq_hz(precision);
         break;
     case SOC_MOD_CLK_REF_TICK:
-        clk_src_freq = 1 * MHZ;
+        clk_src_freq = REF_CLK_FREQ;
         break;
     case SOC_MOD_CLK_APLL:
         clk_src_freq = clk_hal_apll_get_freq_hz();

--- a/components/esp_hw_support/port/esp32s2/esp_clk_tree.c
+++ b/components/esp_hw_support/port/esp32s2/esp_clk_tree.c
@@ -53,7 +53,7 @@ uint32_t *freq_value)
         clk_src_freq = esp_clk_tree_xtal32k_get_freq_hz(precision);
         break;
     case SOC_MOD_CLK_REF_TICK:
-        clk_src_freq = 1 * MHZ;
+        clk_src_freq = REF_CLK_FREQ;
         break;
     case SOC_MOD_CLK_APLL:
         clk_src_freq = clk_hal_apll_get_freq_hz();


### PR DESCRIPTION
the function `esp_clk_tree_src_get_freq_hz` now uses the define `REF_CLK_FREQ` provided for this purpose for the clk_src `SOC_MOD_CLK_REF_TICK`.

developers who play around with the ref_tick to fulfill special requirements can now use the drivers for the peripherals that can use the ref_tick as source without any problems.