### PR TITLE
fix(spinlock): comparison of integer expressions of different signedness (IDFGH-13581)

### DIFF
--- a/components/esp_hw_support/include/spinlock.h
+++ b/components/esp_hw_support/include/spinlock.h
@@ -134,7 +134,7 @@ static inline bool __attribute__((always_inline)) spinlock_acquire(spinlock_t *l
             break;
         }
         // Keep looping if we are waiting forever, or check if we have timed out
-    } while ((timeout == SPINLOCK_WAIT_FOREVER) || (esp_cpu_get_cycle_count() - start_count) <= timeout);
+    } while ((timeout == SPINLOCK_WAIT_FOREVER) || (esp_cpu_get_cycle_count() - start_count) <= (esp_cpu_cycle_count_t)timeout);
 
 exit:
     if (lock_set) {


### PR DESCRIPTION
developers who do not use idf.py but prefer classic CMake currently receive a lot of warnings because a comparison in the header file `spinlock.h` is not correct.

`comparison of integer expressions of different signedness: 'esp_cpu_cycle_count_t' {aka 'long unsigned int'} and 'int32_t' {aka 'long int'} [-Wsign-compare]`

since it is a header, the gcc option `-Wall`, which is relevant for the application code, unfortunately also applies to all includes.

this fix casts the signed `timeout` to the corresponding unsigned type `esp_cpu_cycle_count_t` for a correct comparison.