### PR TITLE
Provisioning more than ssid and password (Discussion) (IDFGH-13601)

### DIFF
--- a/components/wifi_provisioning/CMakeLists.txt
+++ b/components/wifi_provisioning/CMakeLists.txt
@@ -29,5 +29,5 @@ endif()
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS include
                     PRIV_INCLUDE_DIRS src proto-c
-                    REQUIRES lwip protocomm
+                    REQUIRES lwip protocomm mbedtls nvs_flash
                     PRIV_REQUIRES protobuf-c bt json esp_timer esp_wifi)


### PR DESCRIPTION
Hi!
I've recently done a little change to wifi_provisioning library to support custom data provisioning along with wifi ssid and password.
Briefly, how it works:
If we pass this to password:
```!@CDATA_%DATA_LEN%%DATA%%WifiPassword%```
It would parse this string and place DATA in nvs as blob.
As example:
```!@CDATA_QwAAAA==tok=1234567890:AIHyuaZFjK6qegPCojGJI0_0l7GPUNV8_PD,userid=123456789asdfzxcvb```
where %DATA_LEN% is QwAAAA== (0x43),
wifi password - asdfzxcvb

Not ideal solution but it works!
Maybe some ideas for improvement or redesign to have this in idf?
Rationale: I needed to provision telegram bot token and my telegram user ID, apart from wifi credentials

