### PR TITLE
Make esp_mbedtls_server_session_create async compatible (IDFGH-13606)

### DIFF
--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -73,6 +73,8 @@ static const char *TAG = "esp-tls";
 #define _esp_tls_free_client_session        esp_mbedtls_free_client_session
 #define _esp_tls_get_ssl_context            esp_mbedtls_get_ssl_context
 #define _esp_tls_server_session_create      esp_mbedtls_server_session_create
+#define _esp_tls_server_session_init        esp_mbedtls_server_session_init
+#define _esp_tls_server_session_continue_async     esp_mbedtls_server_session_continue_async
 #define _esp_tls_server_session_delete      esp_mbedtls_server_session_delete
 #define _esp_tls_server_session_ticket_ctx_init    esp_mbedtls_server_session_ticket_ctx_init
 #define _esp_tls_server_session_ticket_ctx_free    esp_mbedtls_server_session_ticket_ctx_free
@@ -90,6 +92,8 @@ static const char *TAG = "esp-tls";
 #define _esp_tls_conn_delete                esp_wolfssl_conn_delete
 #define _esp_tls_net_init                   esp_wolfssl_net_init
 #define _esp_tls_server_session_create      esp_wolfssl_server_session_create
+#define _esp_tls_server_session_init        esp_wolfssl_server_session_init
+#define _esp_tls_server_session_continue_async     esp_wolfssl_server_session_continue_async
 #define _esp_tls_server_session_delete      esp_wolfssl_server_session_delete
 #define _esp_tls_get_bytes_avail            esp_wolfssl_get_bytes_avail
 #define _esp_tls_init_global_ca_store       esp_wolfssl_init_global_ca_store
@@ -702,6 +706,22 @@ void esp_tls_cfg_server_session_tickets_free(esp_tls_cfg_server_t *cfg)
 int esp_tls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
 {
     return _esp_tls_server_session_create(cfg, sockfd, tls);
+}
+/**
+ * @brief      Initialization part of esp_tls_server_session_create
+ */
+int esp_tls_server_session_init(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
+{
+    return _esp_tls_server_session_init(cfg, sockfd, tls);
+}
+/**
+ * @brief      Asynchronous continue of esp_tls_server_session_create, to be
+ *             called in a loop by the user until it returns 0,
+ *             ESP_TLS_ERR_SSL_WANT_READ or ESP_TLS_ERR_SSL_WANT_WRITE
+ */
+int esp_tls_server_session_continue_async(esp_tls_t *tls)
+{
+    return _esp_tls_server_session_continue_async(tls);
 }
 /**
  * @brief      Close the server side TLS/SSL connection and free any allocated resources.

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -789,7 +789,7 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
 #endif
 #ifdef CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
     } else if (cfg->client_session != NULL) {
-        ESP_LOGD(TAG, "Resuing the saved client session");
+        ESP_LOGD(TAG, "Reusing the saved client session");
 #endif
     } else {
 #ifdef CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY
@@ -915,6 +915,23 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
  */
 int esp_mbedtls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
 {
+    int ret = 0;
+    if ((ret = esp_mbedtls_server_session_init(cfg, sockfd, tls)) != 0) {
+        return ret;
+    }
+    while ((ret = esp_mbedtls_server_session_continue_async(tls)) != 0) {
+        if (ret != ESP_TLS_ERR_SSL_WANT_READ && ret != ESP_TLS_ERR_SSL_WANT_WRITE) {
+            return ret;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief      Initialization part of esp_mbedtls_server_session_create
+ */
+int esp_mbedtls_server_session_init(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
+{
     if (tls == NULL || cfg == NULL) {
         return -1;
     }
@@ -932,19 +949,28 @@ int esp_mbedtls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
 
     tls->read = esp_mbedtls_read;
     tls->write = esp_mbedtls_write;
-    int ret;
-    while ((ret = mbedtls_ssl_handshake(&tls->ssl)) != 0) {
-        if (ret != ESP_TLS_ERR_SSL_WANT_READ && ret != ESP_TLS_ERR_SSL_WANT_WRITE) {
-            ESP_LOGE(TAG, "mbedtls_ssl_handshake returned -0x%04X", -ret);
-            mbedtls_print_error_msg(ret);
-            ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
-            ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_ESP, ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED);
-            tls->conn_state = ESP_TLS_FAIL;
-            return ret;
-        }
-    }
     return 0;
 }
+
+/**
+ * @brief      Asynchronous continue of esp_mbedtls_server_session_create, to be
+ *             called in a loop by the user until it returns 0, ESP_TLS_ERR_SSL_WANT_READ
+ *             or ESP_TLS_ERR_SSL_WANT_WRITE
+ */
+int esp_mbedtls_server_session_continue_async(esp_tls_t *tls)
+{
+    int ret = mbedtls_ssl_handshake(&tls->ssl);
+    if (ret != 0 && ret != ESP_TLS_ERR_SSL_WANT_READ && ret != ESP_TLS_ERR_SSL_WANT_WRITE) {
+        ESP_LOGE(TAG, "mbedtls_ssl_handshake returned -0x%04X", -ret);
+        mbedtls_print_error_msg(ret);
+        ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
+        ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_ESP, ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED);
+        tls->conn_state = ESP_TLS_FAIL;
+        return ret;
+    }
+    return ret;
+}
+
 /**
  * @brief      Close the server side TLS/SSL connection and free any allocated resources.
  */

--- a/components/esp-tls/esp_tls_wolfssl.c
+++ b/components/esp-tls/esp_tls_wolfssl.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2019-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2019-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -501,9 +501,26 @@ void esp_wolfssl_cleanup(esp_tls_t *tls)
 }
 
 /**
- * @brief       Create TLS/SSL server session
+ * @brief      Create TLS/SSL server session
  */
 int esp_wolfssl_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
+{
+    int ret = 0;
+    if ((ret = esp_wolfssl_server_session_init(cfg, sockfd, tls)) != 0) {
+        return ret;
+    }
+    while ((ret = esp_mbedtls_server_session_continue_async(tls)) != 0) {
+        if (ret != ESP_TLS_ERR_SSL_WANT_READ && ret != ESP_TLS_ERR_SSL_WANT_WRITE) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * @brief      Initialization part of esp_wolfssl_server_session_create
+ */
+int esp_wolfssl_server_session_init(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls)
 {
     if (tls == NULL || cfg == NULL) {
         return -1;
@@ -521,15 +538,30 @@ int esp_wolfssl_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
     }
     tls->read = esp_wolfssl_read;
     tls->write = esp_wolfssl_write;
-    int ret;
-    while ((ret = wolfSSL_accept((WOLFSSL *)tls->priv_ssl)) != WOLFSSL_SUCCESS) {
+    return 0;
+}
+
+/**
+ * @brief      Asynchronous continue of esp_wolfssl_server_session_create, to be
+ *             called in a loop by the user until it returns 0, ESP_TLS_ERR_SSL_WANT_READ
+ *             or ESP_TLS_ERR_SSL_WANT_WRITE
+ */
+int esp_wolfssl_server_session_continue_async(esp_tls_t *tls)
+{
+    int ret = wolfSSL_accept((WOLFSSL *)tls->priv_ssl);
+    if (ret != WOLFSSL_SUCCESS) {
         int err = wolfSSL_get_error((WOLFSSL *)tls->priv_ssl, ret);
-        if (err != WOLFSSL_ERROR_WANT_READ && ret != WOLFSSL_ERROR_WANT_WRITE) {
-            ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_WOLFSSL, err);
-            ESP_LOGE(TAG, "wolfSSL_accept returned %d, error code: %d", ret, err);
-            wolfssl_print_error_msg(err);
-            tls->conn_state = ESP_TLS_FAIL;
-            return -1;
+        switch (err) {
+            case WOLFSSL_ERROR_WANT_READ:
+                return ESP_TLS_SSL_ERR_WANT_READ;
+            case WOLFSSL_ERROR_WANT_WRITE:
+                return ESP_TLS_SSL_ERR_WANT_WRITE;
+            default:
+                ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_WOLFSSL, err);
+                ESP_LOGE(TAG, "wolfSSL_accept returned %d, error code: %d", ret, err);
+                wolfssl_print_error_msg(err);
+                tls->conn_state = ESP_TLS_FAIL;
+                return err;
         }
     }
     return 0;

--- a/components/esp-tls/private_include/esp_tls_mbedtls.h
+++ b/components/esp-tls/private_include/esp_tls_mbedtls.h
@@ -70,6 +70,22 @@ void *esp_mbedtls_get_ssl_context(esp_tls_t *tls);
 int esp_mbedtls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls);
 
 /**
+ * Initialization part of internal callback for mbedtls_server_session_create
+ *
+ * /note :- The function can only be used with mbedtls ssl library
+ */
+int esp_mbedtls_server_session_init(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls_t *tls);
+
+/**
+ * Asynchronous continue of internal callback for mbedtls_server_session_create,
+ * to be called in a loop by the user until it returns 0,
+ * ESP_TLS_ERR_SSL_WANT_READ or ESP_TLS_ERR_SSL_WANT_WRITE
+ *
+ * /note :- The function can only be used with mbedtls ssl library
+ */
+int esp_mbedtls_server_session_continue_async(esp_tls_t *tls);
+
+/**
  * Internal Callback for mbedtls_server_session_delete
  *
  * /note :- The function can only be used with mbedtls ssl library


### PR DESCRIPTION
This makes `esp_mbedtls_server_session_create` async-friendly by splitting up the function into two parts. This change was originally proposed here in order to make an asynchronous TLS server possible: https://github.com/esp-rs/esp-idf-svc/pull/368#discussion_r1512376482