### PR TITLE
change(esp-tls): add option to enable/disable the full set of OCSP checks for wolfSSL (IDFGH-13619)

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -115,4 +115,12 @@ menu "ESP-TLS"
         help
             Enable detailed debug prints for wolfSSL SSL library.
 
+    config ESP_TLS_OCSP_CHECKALL
+        bool "Enabled full OCSP checks for ESP-TLS"
+        depends on ESP_TLS_USING_WOLFSSL
+        default y
+        help
+            Enable a fuller set of OCSP checks: checking revocation status of intermediate certificates,
+            optional fallbacks to CRLs, etc.
+
 endmenu

--- a/components/esp-tls/esp_tls_wolfssl.c
+++ b/components/esp-tls/esp_tls_wolfssl.c
@@ -316,8 +316,12 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
     }
 
 #ifdef CONFIG_WOLFSSL_HAVE_OCSP
+    int ocsp_options = 0;
+#ifdef ESP_TLS_OCSP_CHECKALL
+    ocsp_options |= WOLFSSL_OCSP_CHECKALL;
+#endif
     /* enable OCSP certificate status check for this TLS context */
-    if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, WOLFSSL_OCSP_CHECKALL)) != WOLFSSL_SUCCESS) {
+    if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, ocsp_options)) != WOLFSSL_SUCCESS) {
         ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSP failed, returned %d", ret);
         return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
     }


### PR DESCRIPTION
I've added an option to enable/disable WOLFSSL_OCSP_CHECKALL when enabling OCSP in esp_tls_wolfssl.c .