### PR TITLE
feat(esp_http_client): Add function to delete all headers set by 'esp_http_client_set_header' (IDFGH-13628)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -369,6 +369,11 @@ esp_err_t esp_http_client_delete_header(esp_http_client_handle_t client, const c
     return http_header_delete(client->request->headers, key);
 }
 
+esp_err_t esp_http_client_delete_headers(esp_http_client_handle_t client)
+{
+    return http_header_clean(client->request->headers);
+}
+
 esp_err_t esp_http_client_get_username(esp_http_client_handle_t client, char **value)
 {
     if (client == NULL || value == NULL) {

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -488,6 +488,17 @@ esp_err_t esp_http_client_set_timeout_ms(esp_http_client_handle_t client, int ti
 esp_err_t esp_http_client_delete_header(esp_http_client_handle_t client, const char *key);
 
 /**
+ * @brief      Delete all http request headers
+ *
+ * @param[in]  client  The esp_http_client handle
+ *
+ * @return
+ *  - ESP_OK
+ *  - ESP_FAIL
+ */
+esp_err_t esp_http_client_delete_headers(esp_http_client_handle_t client);
+
+/**
  * @brief      This function will be open the connection, write all header strings and return
  *
  * @param[in]  client     The esp_http_client handle


### PR DESCRIPTION
Related to https://esp32.com/viewtopic.php?f=13&t=41695. TL;DR: Headers by persistent sessions created by `esp_http_client_init` are kept, and it is not easy to remove all headers unless you keep track of which one you set.

This PR adds a function that wraps the already existing `http_header_clean` function to help with that.

We still mis cleanup functions for other `esp_http_client_set_*` functions, but lets discuss this idea first :)