### PR TITLE
fix(ws_transport): Fix crash when reading (IDFGH-13657)

### DIFF
--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -504,7 +504,7 @@ static int ws_read_header(esp_transport_handle_t t, char *buffer, int len, int t
             ESP_LOGE(TAG, "Error read data");
             return rlen;
         }
-        payload_len = data_ptr[0] << 8 | data_ptr[1];
+        payload_len = (uint8_t)data_ptr[0] << 8 | (uint8_t)data_ptr[1];
     } else if (payload_len == 127) {
         // headerLen += 8;
         header = 8;
@@ -517,7 +517,7 @@ static int ws_read_header(esp_transport_handle_t t, char *buffer, int len, int t
             // really too big!
             payload_len = 0xFFFFFFFF;
         } else {
-            payload_len = data_ptr[4] << 24 | data_ptr[5] << 16 | data_ptr[6] << 8 | data_ptr[7];
+            payload_len = (uint8_t)data_ptr[4] << 24 | (uint8_t)data_ptr[5] << 16 | (uint8_t)data_ptr[6] << 8 | data_ptr[7];
         }
     }
 


### PR DESCRIPTION
## Description

When parsing WS framing protocol integer promotion would cause invalid values to be read. Acting upon these values would eventually cause a crash


## Related

Fixes espressif/esp-protocols#645

## Testing

If you send a message longer then 128 to the websocket echo service the response will cause a crash. This can easily be reproduced with the esp-protocols websocket example.

```
diff --git a/components/esp_websocket_client/examples/linux/main/websocket_linux.c b/components/esp_websocket_client/examples/linux/main/websocket_linux.c
index 3329274..a8f0ba3 100644
--- a/components/esp_websocket_client/examples/linux/main/websocket_linux.c
+++ b/components/esp_websocket_client/examples/linux/main/websocket_linux.c
@@ -84,11 +84,11 @@ static void websocket_app_start(void)
     esp_websocket_register_events(client, WEBSOCKET_EVENT_ANY, websocket_event_handler, (void *)client);

     esp_websocket_client_start(client);
-    char data[32];
+    char data[256];
     int i = 0;
     while (i < 1) {
         if (esp_websocket_client_is_connected(client)) {
-            int len = sprintf(data, "hello %04d", i++);
+            int len = sprintf(data, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
             ESP_LOGI(TAG, "Sending %s", data);
             esp_websocket_client_send_text(client, data, len, portMAX_DELAY);
         }
```

Results in the following output

```
I (739925786) websocket: [APP] Startup..
I (739925786) websocket: [APP] Free memory: 4294967295 bytes
I (739925786) websocket: [APP] IDF version: v5.4-dev-1388-g5ca9f2a49a-dirty
I (739925790) websocket: Connecting to ws://echo.websocket.events...
W (739925790) websocket_client: `reconnect_timeout_ms` is not set, or it is less than or equal to zero, using default time out 10000 (milliseconds)
W (739925790) websocket_client: `network_timeout_ms` is not set, or it is less than or equal to zero, using default time out 10000 (milliseconds)
I (739925790) websocket: WEBSOCKET_EVENT_BEGIN
I (739925791) websocket_client: Started
I (739925912) websocket: WEBSOCKET_EVENT_CONNECTED
I (739926792) websocket: Sending ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ 0000
I (739926914) websocket: WEBSOCKET_EVENT_DATA
I (739926914) websocket: Received opcode=1
W (739926914) websocket: Received=echo.websocket.events sponsored by Lob.com
W (739926914) websocket: Total payload length=42, data_len=42, current payload offset=0

Segmentation fault (core dumped)
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
