### PR TITLE
docs: Secure Boot V2: explain the removal of unused keys (IDFGH-13685)

### DIFF
--- a/docs/en/security/secure-boot-v2.rst
+++ b/docs/en/security/secure-boot-v2.rst
@@ -606,10 +606,11 @@ Secure Boot Best Practices
 
     .. _secure-boot-v2-key-revocation:
 
-    Key Revocation
+ Key Revocation
     --------------
 
     * Keys are processed in a linear order, i.e., key #0, key #1, key #2.
+    * After revoking a key, all remaining unrevoked keys can be used to sign applications. I.e, if key #1 gets revoked, both keys #0 and key #2 can still be used to sign firmwares.
     * Applications should be signed with only one key at a time, to minimize the exposure of unused private keys.
     * The bootloader can be signed with multiple keys from the factory.
 
@@ -634,6 +635,10 @@ Secure Boot Best Practices
 
     * A similar approach can also be used to physically re-flash with a new key. For physical re-flashing, the bootloader content can also be changed at the same time.
 
+    .. note::
+
+    It can be necessary to revoke a key that isn't currently being used. For example: if the running application is still signed with key #0, but key #1 becomes compromised, you should revoke this key using this approach.
+    The new OTA update should still be signed with key #0, but the API `esp_ota_revoke_secure_boot_public_key(SECURE_BOOT_PUBLIC_KEY_INDEX_[N])` can be used to revoke the key #N. Afterwards all remaining unrevoked keys can be used to sign future applications.
 
     .. _secure-boot-v2-aggressive-key-revocation:
 


### PR DESCRIPTION
This PR updates some of the Secure Boot V2 documentation to explain the removal of unused keys.


## Related

https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32s3/security/secure-boot-v2.html#multiple-keys

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
