### PR TITLE
feat(advanced console): Add support for ESP32-P4 and ESP32-C5 models … (IDFGH-13720)

### DIFF
--- a/examples/system/console/advanced/components/cmd_system/cmd_system_common.c
+++ b/examples/system/console/advanced/components/cmd_system/cmd_system_common.c
@@ -81,6 +81,12 @@ static int get_version(int argc, char **argv)
         case CHIP_ESP32C2:
             model = "ESP32-C2";
             break;
+        case CHIP_ESP32P4:
+            model = "ESP32-P4";
+            break;
+        case CHIP_ESP32C5:
+            model = "ESP32-C5";
+            break;
         default:
             model = "Unknown";
             break;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR enhances the `version` advanced console command output in the iPerf example to correctly display the model names for the ESP32-P4 and ESP32-C5 microcontrollers. The iPerf example now prints the ESP-IDF version number, chip information, **and** model name when the "version" command is executed.


### Previous Behavior
Before this change, the models ESP32-P4 and ESP32-C5 were displayed as "Unknown". 

As an example, the execution before modification serves 

```

IDF Version:v5.4-dev-2744-g59e1838270-dirty
Chip info:
        model:Unknown
        cores:1
        feature:/802.11bgn/BLE/External-Flash:8 MB
        revision number:0

```
The model is unknown.

### New Behavior
After the modification, the model names are correctly displayed. 
Here’s an example of the output when using the ESP32-C5:


```
IDF Version:v5.4-dev-2744-g59e1838270-dirty
Chip info:
        model:ESP32-C5
        cores:1
        feature:/802.11bgn/BLE/External-Flash:8 MB
        revision number:0
```

The model ESP32C5 is now known and is now correctly printed with the model name ESP32-C5.


The code [before](https://github.com/espressif/esp-idf/blob/3c99557eeea4e0945e77aabac672fbef52294d54/examples/system/console/advanced/components/cmd_system/cmd_system_common.c#L57-L87)

```

/* 'version' command */
static int get_version(int argc, char **argv)
{
    const char *model;
    esp_chip_info_t info;
    uint32_t flash_size;
    esp_chip_info(&info);

    switch(info.model) {
        case CHIP_ESP32:
            model = "ESP32";
            break;
        case CHIP_ESP32S2:
            model = "ESP32-S2";
            break;
        case CHIP_ESP32S3:
            model = "ESP32-S3";
            break;
        case CHIP_ESP32C3:
            model = "ESP32-C3";
            break;
        case CHIP_ESP32H2:
            model = "ESP32-H2";
            break;
        case CHIP_ESP32C2:
            model = "ESP32-C2";
            break;
        default:
            model = "Unknown";
            break;
    }


```


and  the code after the change / add



```

/* 'version' command */
static int get_version(int argc, char **argv)
{
    const char *model;
    esp_chip_info_t info;
    uint32_t flash_size;
    esp_chip_info(&info);

    switch(info.model) {
        case CHIP_ESP32:
            model = "ESP32";
            break;
        case CHIP_ESP32S2:
            model = "ESP32-S2";
            break;
        case CHIP_ESP32S3:
            model = "ESP32-S3";
            break;
        case CHIP_ESP32C3:
            model = "ESP32-C3";
            break;
        case CHIP_ESP32H2:
            model = "ESP32-H2";
            break;
        case CHIP_ESP32C2:
            model = "ESP32-C2";
            break;
        case CHIP_ESP32P4:
            model = "ESP32-P4";
            break;
        case CHIP_ESP32C5:
            model = "ESP32-C5";
            break;
        default:
            model = "Unknown";
            break;
    }


```

### Code Changes
The following cases were added to the `get_version` function:


```

        case CHIP_ESP32P4:
            model = "ESP32-P4";
            break;
        case CHIP_ESP32C5:
            model = "ESP32-C5";
            break;


```


The ESP32-P4 and ESP32-C5 models have been added.
Example ESP32-C5

```
iperf> version
IDF Version:v5.4-dev-2744-g59e1838270-dirty
Chip info:
        model:ESP32-C5
        cores:1
        feature:/802.11bgn/BLE/External-Flash:8 MB
        revision number:0
iperf>

```


[ Attached Picture as Link ](https://github.com/user-attachments/assets/1a8b4c7a-3bbb-49b3-b3ef-d280982379db) 

![addModel_ESP32C5_ESP32P4](https://github.com/user-attachments/assets/ff7e44bd-0fad-4d1b-9e25-1a580d46a215)

<img src="(https://github.com/user-attachments/assets/1a8b4c7a-3bbb-49b3-b3ef-d280982379db)" width=500px>





<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested with ESP32-C5-DevKitC-1 and iPerf example and modification 
successful printed out the right found model name

```
iperf> version
IDF Version:v5.4-dev-2744-g59e1838270-dirty
Chip info:
        model:ESP32-C5
        cores:1
        feature:/802.11bgn/BLE/External-Flash:8 MB
        revision number:0
iperf>

```

https://github.com/espressif/esp-idf/issues/14021#issuecomment-2350926729


<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.