### PR TITLE
Fix off-by-one/memory corruption in transport_ws (IDFGH-13767)

### DIFF
--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -285,7 +285,7 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
     }
     int header_len = 0;
     do {
-        if ((len = esp_transport_read(ws->parent, ws->buffer + header_len, WS_BUFFER_SIZE - header_len, timeout_ms)) <= 0) {
+        if ((len = esp_transport_read(ws->parent, ws->buffer + header_len, WS_BUFFER_SIZE - header_len - 1, timeout_ms)) <= 0) {
             ESP_LOGE(TAG, "Error read response for Upgrade header %s", ws->buffer);
             return -1;
         }


### PR DESCRIPTION
Read doesn't take NULL terminator into account

Resolves #14473

## Description

Off-by-one caught by Valgrind

```
==5505== Invalid write of size 1
==5505==    at 0x1248BB: ws_connect (transport_ws.c:294)
==5505==    by 0x12293E: esp_transport_connect (transport.c:123)
==5505==    by 0x11F3D6: esp_websocket_client_task (esp_websocket_client.c:990)
==5505==    by 0x13581F: pthread_task (freertos_linux.c:210)
==5505==    by 0x4BBDA93: start_thread (pthread_create.c:447)
==5505==    by 0x4C4AA33: clone (clone.S:100)
==5505==  Address 0x4e45240 is 0 bytes after a block of size 1,024 alloc'd
==5505==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==5505==    by 0x124DE5: esp_transport_ws_init (transport_ws.c:726)
==5505==    by 0x12001C: esp_websocket_client_create_transport (esp_websocket_client.c:492)
==5505==    by 0x1210E3: esp_websocket_client_start (esp_websocket_client.c:1132)
==5505==    by 0x119503: app_websocket() (websocket.cpp:201)
==5505==    by 0x11880B: main (main.cpp:27)
```

## Related



## Testing

Running with Valgrind results in no errors. 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
