### PR TITLE
fix(ble/bluedroid): Prevent esp_ble_gatts_send_indicate() with value_len > 512 (IDFGH-13782)

### DIFF
--- a/components/bt/host/bluedroid/api/esp_gatts_api.c
+++ b/components/bt/host/bluedroid/api/esp_gatts_api.c
@@ -260,6 +260,11 @@ esp_err_t esp_ble_gatts_stop_service(uint16_t service_handle)
 esp_err_t esp_ble_gatts_send_indicate(esp_gatt_if_t gatts_if, uint16_t conn_id, uint16_t attr_handle,
                                       uint16_t value_len, uint8_t *value, bool need_confirm)
 {
+    if (value_len > ESP_GATT_MAX_ATTR_LEN) {
+        LOG_ERROR("%s, value_len > ESP_GATT_MAX_ATTR_LEN.", __func__);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
     btc_msg_t msg = {0};
     btc_ble_gatts_args_t arg;
 
@@ -272,7 +277,7 @@ esp_err_t esp_ble_gatts_send_indicate(esp_gatt_if_t gatts_if, uint16_t conn_id, 
     }
 
     if (L2CA_CheckIsCongest(L2CAP_ATT_CID, p_tcb->peer_bda)) {
-        LOG_DEBUG("%s, the l2cap chanel is congest.", __func__);
+        LOG_DEBUG("%s, the l2cap channel is congest.", __func__);
         return ESP_FAIL;
     }
 

--- a/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatts_api.h
@@ -485,7 +485,7 @@ esp_err_t esp_ble_gatts_stop_service(uint16_t service_handle);
  *
  * @note
  *       1. This function triggers `ESP_GATTS_CONF_EVT`.
- *       2. The size of indication or notification data must be less than or equal to MTU size, see `esp_ble_gattc_send_mtu_req`.
+ *       2. The size of indication or notification data must be less than or equal to min(512, MTU - 3), see `esp_ble_gattc_send_mtu_req`.
  *       3. This function should be called only after the connection has been established.
  *
  * @return


### PR DESCRIPTION
## Description

BLE indications are limited by max attribute length (512) and also by MTU size - 3 (see https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/attribute-protocol--att-.html#UUID-fd156898-28db-9cd8-e6e1-94d0278d0d1c).

Checking for MTU size is the user's responsibility, however an easy mistake is to chunk data by MTU size - 3 only. At the maximum MTU size of 517 results in 514, which is greater than 512, and causes heap corruption due to a buffer overflow.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
