### PR TITLE
fix(ble/bluedroid): Allow 0 length indications (IDFGH-13783)

### DIFF
--- a/components/bt/host/bluedroid/bta/gatt/bta_gatts_act.c
+++ b/components/bt/host/bluedroid/bta/gatt/bta_gatts_act.c
@@ -723,8 +723,6 @@ void bta_gatts_indicate_handle (tBTA_GATTS_CB *p_cb, tBTA_GATTS_DATA *p_msg)
                 } else {
                     APPL_TRACE_ERROR("%s, malloc failed", __func__);
                 }
-            } else {
-                APPL_TRACE_ERROR("%s, incorrect length", __func__);
             }
             (*p_rcb->p_cback)(BTA_GATTS_CONF_EVT, &cb_data);
             if (cb_data.req_data.value != NULL) {

--- a/components/bt/host/bluedroid/bta/gatt/bta_gatts_act.c
+++ b/components/bt/host/bluedroid/bta/gatt/bta_gatts_act.c
@@ -733,7 +733,7 @@ void bta_gatts_indicate_handle (tBTA_GATTS_CB *p_cb, tBTA_GATTS_DATA *p_msg)
             }
         }
     } else {
-        APPL_TRACE_ERROR("Not an registered servce attribute ID: 0x%04x",
+        APPL_TRACE_ERROR("Not a registered service attribute ID: 0x%04x",
                          p_msg->api_indicate.attr_id);
     }
 }
@@ -923,7 +923,7 @@ void bta_gatts_listen(tBTA_GATTS_CB *p_cb, tBTA_GATTS_DATA *p_msg)
 **
 ** Function         bta_gatts_show_local_database
 **
-** Description      print loacl service database
+** Description      print local service database
 **
 ** Returns          none.
 **


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Fixes bug introduced in https://github.com/espressif/esp-idf/commit/d4b7be4a739cbab070e0c3dd2a195304cdf23cbf#diff-d62647524ad053d398406d804b8ac728ce5d74473823025ef907c5d895c3d54d

## Related

[3.4.7.2. ATT_HANDLE_VALUE_IND](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/attribute-protocol--att-.html#UUID-fd156898-28db-9cd8-e6e1-94d0278d0d1c) allows length 0.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
