### PR TITLE
fix(cmake/signing): do not clean up the CONFIG_SECURE_BOOT_VERIFICATI… (IDFGH-13799)

### DIFF
--- a/components/bootloader_support/CMakeLists.txt
+++ b/components/bootloader_support/CMakeLists.txt
@@ -140,6 +140,7 @@ if(CONFIG_SECURE_SIGNED_APPS AND (CONFIG_SECURE_BOOT_V1_ENABLED OR CONFIG_SECURE
                 extract_public_key --keyfile "${secure_boot_signing_key}"
                 "${secure_boot_verification_key}"
                 DEPENDS ${secure_boot_signing_key}
+                BYPRODUCTS ${secure_boot_verification_key}
                 VERBATIM)
         else()
             # We expect to 'inherit' the verification key passed from main project.
@@ -169,6 +170,7 @@ if(CONFIG_SECURE_SIGNED_APPS AND (CONFIG_SECURE_BOOT_V1_ENABLED OR CONFIG_SECURE
                 "${secure_boot_verification_key}"
                 WORKING_DIRECTORY ${project_dir}
                 DEPENDS ${secure_boot_signing_key}
+                BYPRODUCTS ${secure_boot_verification_key}
                 VERBATIM)
         endif()
     endif()
@@ -177,9 +179,6 @@ if(CONFIG_SECURE_SIGNED_APPS AND (CONFIG_SECURE_BOOT_V1_ENABLED OR CONFIG_SECURE
     #
     target_add_binary_data(${COMPONENT_LIB} "${secure_boot_verification_key}" "BINARY"
         RENAME_TO signature_verification_key_bin)
-    set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-        APPEND PROPERTY ADDITIONAL_CLEAN_FILES
-        "${secure_boot_verification_key}")
 endif()
 
 if(BOOTLOADER_BUILD)


### PR DESCRIPTION
…ON_KEY file provided separately

## Description

with secure boot V1 remote signing, the private key is not part of the project, as the binaries are signed in a separate process. however, the derived verification key must be available at compile time.

if “Sign binaries during build” is deactivated according to the documentation and the generated verification key file is defined via CONFIG_SECURE_BOOT_VERIFICATION_KEY, then this verification key is currently deleted in a project clean!

this patch no longer deletes the file specified by the user.

## Related

https://docs.espressif.com/projects/esp-idf/en/stable/esp32/security/secure-boot-v1.html#remote-signing-of-images

## Testing

sdkconfig:
```
#
# Security features
#
CONFIG_SECURE_SIGNED_ON_UPDATE=y
CONFIG_SECURE_SIGNED_APPS=y
CONFIG_SECURE_BOOT_V2_RSA_SUPPORTED=y
CONFIG_SECURE_BOOT_V1_SUPPORTED=y
CONFIG_SECURE_BOOT_V2_PREFERRED=y
CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT=y
CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME=y
# CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME is not set
# CONFIG_SECURE_SIGNED_ON_BOOT_NO_SECURE_BOOT is not set
CONFIG_SECURE_SIGNED_ON_UPDATE_NO_SECURE_BOOT=y
# CONFIG_SECURE_BOOT is not set
# CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES is not set
CONFIG_SECURE_BOOT_VERIFICATION_KEY="signature_verification_key.bin"
# CONFIG_SECURE_FLASH_ENC_ENABLED is not set
```
