### PR TITLE
fix(roaming_11kvr): Delete undeclared variable

### DIFF
--- a/examples/wifi/roaming/roaming_11kvr/main/roaming_example.c
+++ b/examples/wifi/roaming/roaming_11kvr/main/roaming_example.c
@@ -366,7 +366,6 @@ static void esp_bss_rssi_low_handler(void* arg, esp_event_base_t event_base,
 
 	ESP_LOGI(TAG, "%s:bss rssi is=%d", __func__, event->rssi);
 	/* Lets check channel conditions */
-	rrm_ctx++;
 	if (esp_rrm_send_neighbor_report_request() < 0) {
 		/* failed to send neighbor report request */
 		ESP_LOGI(TAG, "failed to send neighbor report request");


### PR DESCRIPTION
## Description
In the 802.11k/v/r roaming example, when setting the RSSI threshold, there is an undeclared variable 'rrm_ctx'.