### PR TITLE
fix(nan_console): Error when NAN Discovery is started more than once (IDFGH-13923)

### DIFF
--- a/examples/wifi/wifi_aware/nan_console/main/nan_main.c
+++ b/examples/wifi/wifi_aware/nan_console/main/nan_main.c
@@ -103,7 +103,7 @@ static struct {
 } ping_args;
 
 static const char *TAG = "nan_console";
-static esp_netif_t *g_nan_netif = NULL;
+static esp_netif_t *g_nan_netif;
 
 #define NAN_EXAMPLE_SERVICE_NAME    "ESP_NAN-Service"
 

--- a/examples/wifi/wifi_aware/nan_console/main/nan_main.c
+++ b/examples/wifi/wifi_aware/nan_console/main/nan_main.c
@@ -103,7 +103,7 @@ static struct {
 } ping_args;
 
 static const char *TAG = "nan_console";
-static esp_netif_t *g_nan_netif;
+static esp_netif_t *g_nan_netif = NULL;
 
 #define NAN_EXAMPLE_SERVICE_NAME    "ESP_NAN-Service"
 
@@ -235,6 +235,11 @@ static int wifi_cmd_nan_disc(int argc, char **argv)
             nan_cfg.warm_up_sec = nan_args.warmup_time->ival[0];
         }
 
+        if(!g_nan_netif)
+        {
+            g_nan_netif = esp_netif_create_default_wifi_nan();    
+        }
+
         g_nan_netif = esp_netif_create_default_wifi_nan();
         if ((esp_wifi_nan_start(&nan_cfg)) != ESP_OK) {
             ESP_LOGI(TAG, "Failed to start NAN");
@@ -252,6 +257,7 @@ static int wifi_cmd_nan_disc(int argc, char **argv)
             return 1;
         }
         esp_netif_destroy_default_wifi(g_nan_netif);
+        g_nan_netif = NULL;
     }
 
     return 0;

--- a/examples/wifi/wifi_aware/nan_console/main/nan_main.c
+++ b/examples/wifi/wifi_aware/nan_console/main/nan_main.c
@@ -242,6 +242,7 @@ static int wifi_cmd_nan_disc(int argc, char **argv)
         if ((esp_wifi_nan_start(&nan_cfg)) != ESP_OK) {
             ESP_LOGI(TAG, "Failed to start NAN");
             esp_netif_destroy_default_wifi(g_nan_netif);
+            g_nan_netif = NULL;
             return 1;
         }
         return 0;

--- a/examples/wifi/wifi_aware/nan_console/main/nan_main.c
+++ b/examples/wifi/wifi_aware/nan_console/main/nan_main.c
@@ -235,12 +235,10 @@ static int wifi_cmd_nan_disc(int argc, char **argv)
             nan_cfg.warm_up_sec = nan_args.warmup_time->ival[0];
         }
 
-        if(!g_nan_netif)
-        {
+        if(!g_nan_netif){
             g_nan_netif = esp_netif_create_default_wifi_nan();    
         }
 
-        g_nan_netif = esp_netif_create_default_wifi_nan();
         if ((esp_wifi_nan_start(&nan_cfg)) != ESP_OK) {
             ESP_LOGI(TAG, "Failed to start NAN");
             esp_netif_destroy_default_wifi(g_nan_netif);


### PR DESCRIPTION
## Description

- Development board: ESP32-WROOM-32
- ESP-IDF version: 5.4.0

In nan_console example, when NAN is started more than once, triggers this netif error: `esp_netif_lwip: esp_netif_new_api: Failed to configure netif with config=0x3ffc85e0 (config or if_key is NULL or duplicate key)`. This means that the existence of a created network interface was not checked.

To resolve this problem, three actions were taken: 

1. Declaration of variable as null `g_nan_netif`;
2. Before creating the network interface, `g_nan_netif` is checked;
3. When NAN is stopped, `g_nan_netif` gets NULL.

## Testing
Error log:
![Screenshot from 2024-10-21 23-30-57](https://github.com/user-attachments/assets/d27c73dc-d243-4230-ad97-2e2acbcaa971)

Fixed log:
![Screenshot from 2024-10-21 23-34-33](https://github.com/user-attachments/assets/dab44703-f503-4312-aa14-08250a00428f)

