### PR TITLE
fix(gptimer): race on FSM state in gptimer_start() (IDFGH-13929)

### DIFF
--- a/components/esp_driver_gptimer/src/gptimer.c
+++ b/components/esp_driver_gptimer/src/gptimer.c
@@ -337,12 +337,12 @@ esp_err_t gptimer_start(gptimer_handle_t timer)
         portENTER_CRITICAL_SAFE(&timer->spinlock);
         timer_ll_enable_alarm(timer->hal.dev, timer->timer_id, timer->flags.alarm_en);
         timer_ll_enable_counter(timer->hal.dev, timer->timer_id, true);
+        atomic_store(&timer->fsm, GPTIMER_FSM_RUN);
         portEXIT_CRITICAL_SAFE(&timer->spinlock);
     } else {
         ESP_RETURN_ON_FALSE_ISR(false, ESP_ERR_INVALID_STATE, TAG, "timer is not enabled yet");
     }
 
-    atomic_store(&timer->fsm, GPTIMER_FSM_RUN);
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Actual behaviour

`gptimer_start()` may be interrupted between timer start and setting fsm state GPTIMER_FSM_RUN, so other functions may see wrong state of gptimer and misbehave,
e.g. `gptimer_start()` may be interrupted by gptimer callback and in this callback called `gptimer_stop()` sees wrong fsm state.

## Expected behaviour

"APIs provided by the driver are guaranteed to be thread safe, (...) are allowed to run under ISR context."
as in https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/gptimer.html#thread-safety

## Description

it is 6 months since I encountered and described the problem, but it got no attention.
https://esp32.com/viewtopic.php?f=13&t=39428

Now I need the newer ESP-IDF and therefore need to fix the race condition in gptimer, as described on the forum.
I'm sure there is race, but I'm not sure if my fix is the right one, as the issue is caused by FSM design and it may still have similar issues.

## Testing

1. init the gptimer with 1 MHz and set callback on alarm:
```
    gptimer_config_t gptimer_config = {
        .clk_src = GPTIMER_CLK_SRC_DEFAULT,
        .direction = GPTIMER_COUNT_UP,
        .resolution_hz = 1000 * 1000,
        .flags.intr_shared = 0,
    };
    gptimer_new_timer(&gptimer_config, &timer_handle);

    gptimer_event_callbacks_t callbacks = {
        .on_alarm = timer_callback,
    };
    gptimer_register_event_callbacks(timer_handle, &callbacks, NULL);
    gptimer_enable(timer_handle); // enable but not start yet
```
2. set alarm action with some short time (e.g. 1 - 10 us), clear timer and run.
```
    gptimer_alarm_config_t alarm_config = {
        .alarm_count = 1, // tick = 1 us
        .flags.auto_reload_on_alarm = 0,
    };
    gptimer_set_alarm_action(timer_handle, &alarm_config);
    gptimer_set_raw_count(timer_handle, 0);
    gptimer_start(iu_timer_handle);
```
3. in the callback stop the timer
```
static bool IRAM_ATTR timer_callback(gptimer_handle_t timer, const gptimer_alarm_event_data_t* edata, void* user_data)
{
    if (gptimer_stop(timer) != ESP_OK)
    {
        ESP_DRAM_LOGE(TAG, "X");
    }
    return pdFALSE;
}
```

To reproduce this problem, it may be important that when this timer code is executed, simultaneously are received ADC samples at 16 kSPS, triggering gpio ISR at every sample. I tried it without doing SPI transfer and also without the ADC running, but the GPTimer race is the same.

There is alternative fix at application level: blocking sheduler while timer start fixes the race, actually masks the problem
```
vTaskSuspendAll();
gptimer_start(timer_handle);
xTaskResumeAll();
```