### PR TITLE
i2c_slave.c: fix buffer overrun on s_i2c_handle_complete() (IDFGH-13973)

### DIFF
--- a/components/esp_driver_i2c/i2c_slave.c
+++ b/components/esp_driver_i2c/i2c_slave.c
@@ -72,11 +72,12 @@ static IRAM_ATTR void s_i2c_handle_complete(i2c_slave_dev_handle_t i2c_slave, i2
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
     uint32_t rx_fifo_cnt;
     i2c_ll_get_rxfifo_cnt(hal->dev, &rx_fifo_cnt);
+    uint32_t fifo_cnt_rd = MIN(t->rcv_fifo_cnt, rx_fifo_cnt);
     if (rx_fifo_cnt != 0) {
-        i2c_ll_read_rxfifo(hal->dev, i2c_slave->data_buf, t->rcv_fifo_cnt);
-        memcpy(t->buffer + i2c_slave->already_receive_len, i2c_slave->data_buf, t->rcv_fifo_cnt);
-        i2c_slave->already_receive_len += t->rcv_fifo_cnt;
-        t->rcv_fifo_cnt -= t->rcv_fifo_cnt;
+        i2c_ll_read_rxfifo(hal->dev, i2c_slave->data_buf, fifo_cnt_rd);
+        memcpy(t->buffer + i2c_slave->already_receive_len, i2c_slave->data_buf, fifo_cnt_rd);
+        i2c_slave->already_receive_len += fifo_cnt_rd;
+        t->rcv_fifo_cnt -= fifo_cnt_rd;
     }
     if (i2c_slave->callbacks.on_recv_done) {
 


### PR DESCRIPTION
Fixing a buffer overrun of i2c_slave->data_buf. 

The i2c_ll_read_rxfifo function was using t->rcv_fifo_cnf (the I2C slave reading code's buffer size) as the limit for how many bytes on write on i2c_slave->data_buf.

This buffer size for i2c_slave->data_buf is generally smaller than the buffer that the I2C slave reading code has.

## Description

Issue #14803 explains the problem, but TL/DR the i2c_slave_receive() workflow causes memory corruption due to a buffer overrun. And then it generally gets to a `Core  0 panic'ed (StoreProhibited). Exception was unhandled.`  error on runtime. 

## Related

Fixes #14803 

Documentation used for my own test case: https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/api-reference/peripherals/i2c.html

## Testing

Tested locally on a couple of ESP32-DevKitC-V4 boards. 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
