### PR TITLE
support for rfc7692 message deflate

### DIFF
--- a/components/tcp_transport/include/esp_transport_ws.h
+++ b/components/tcp_transport/include/esp_transport_ws.h
@@ -150,6 +150,16 @@ int esp_transport_ws_send_raw(esp_transport_handle_t t, ws_transport_opcodes_t o
 bool esp_transport_ws_get_fin_flag(esp_transport_handle_t t);
 
 /**
+ * @brief               Returns websocket rsv1 flag for last received data
+ *
+ * @param t             websocket transport handle
+ *
+ * @return
+ *      - Rsv1 flag as a boolean
+ */
+bool esp_transport_ws_get_rsv1_flag(esp_transport_handle_t t);
+
+/**
  * @brief               Returns the HTTP status code of the websocket handshake
  *
  * This API should be called after the connection atempt otherwise its result is meaningless

--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -492,6 +492,7 @@ static int ws_read_header(esp_transport_handle_t t, char *buffer, int len, int t
     }
     ws->frame_state.header_received = true;
     ws->frame_state.fin = (*data_ptr & 0x80) != 0;
+    ws->frame_state.rsv1 = (*data_ptr & 0x40) != 0;
     ws->frame_state.opcode = (*data_ptr & 0x0F);
     data_ptr ++;
     mask = ((*data_ptr >> 7) & 0x01);
@@ -856,6 +857,12 @@ bool esp_transport_ws_get_fin_flag(esp_transport_handle_t t)
 {
   transport_ws_t *ws = esp_transport_get_context_data(t);
   return ws->frame_state.fin;
+}
+
+bool esp_transport_ws_get_rsv1_flag(esp_transport_handle_t t)
+{
+  transport_ws_t *ws = esp_transport_get_context_data(t);
+  return ws->frame_state.rsv1;
 }
 
 int esp_transport_ws_get_upgrade_request_status(esp_transport_handle_t t)


### PR DESCRIPTION
## Description

Adds support for querying rsv1 flag of websocket header. Needed to implement per message deflate as RFC7692.

https://datatracker.ietf.org/doc/html/rfc7692#section-9.2