### PR TITLE
feat(driver/gpio): funtion to read pin-holders

### DIFF
--- a/components/esp_driver_gpio/include/driver/gpio.h
+++ b/components/esp_driver_gpio/include/driver/gpio.h
@@ -429,6 +429,18 @@ esp_err_t gpio_hold_en(gpio_num_t gpio_num);
   */
 esp_err_t gpio_hold_dis(gpio_num_t gpio_num);
 
+/**
+  * @brief Get gpio pad hold function.
+  *
+  * @param gpio_num GPIO number, only support output-capable GPIOs
+  * @param out pointer
+  *
+  * @return
+  *     - ESP_OK Success
+  *     - ESP_ERR_NOT_SUPPORTED Not support pad hold function
+  */
+esp_err_t gpio_hold_get(gpio_num_t gpio_num, bool * out);
+
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
 /**
   * @brief Enable all digital gpio pads hold function during Deep-sleep.

--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -753,6 +753,26 @@ esp_err_t gpio_hold_dis(gpio_num_t gpio_num)
     return ret;
 }
 
+esp_err_t gpio_hold_get(gpio_num_t gpio_num, bool * out)
+{
+    GPIO_CHECK(GPIO_IS_VALID_OUTPUT_GPIO(gpio_num), "Only output-capable GPIO support this function", ESP_ERR_NOT_SUPPORTED);
+    int ret = ESP_OK;
+
+    if (rtc_gpio_is_valid_gpio(gpio_num)) {
+#if SOC_RTCIO_HOLD_SUPPORTED
+        ret = ESP_ERR_NOT_SUPPORTED;
+#endif
+    } else if (GPIO_HOLD_MASK[gpio_num]) {
+        portENTER_CRITICAL(&gpio_context.gpio_spinlock);
+        *out = gpio_hal_is_digital_io_hold(gpio_context.gpio_hal, gpio_num);
+        portEXIT_CRITICAL(&gpio_context.gpio_spinlock);
+    } else {
+        ret = ESP_ERR_NOT_SUPPORTED;
+    }
+
+    return ret;
+}
+
 #if SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP && !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
 void gpio_deep_sleep_hold_en(void)
 {


### PR DESCRIPTION
## Description

Add a GPIO layer function to get the state of GPIO pin holders.

This is useful when using GPIO pin holders to keep a peripheral enabled across a chip reset.
Each external peripheral's pins can be checked individually to see if the peripheral needs reconfigured(if pin holder was not enabled) or has already been enabled by a previous planned reset. An example of this would be a SPI LCD with a reset and chip-select line that must be kept high across a reset or risk garbage on the screen.

## Related

Fixes #14841 

## Testing

I tested this on ESP32-S3 by holding my display signals before resetting the CPU, then printing them on startup. On a new power-cycle the holders were not engaged, on a reset the holders were engaged.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
