### PR TITLE
fix(i2c_master): NULL pointer dereference in `i2c_master_bus_destroy` when `i2c_master->base` is NULL

### DIFF
--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -790,30 +790,27 @@ static esp_err_t i2c_master_bus_destroy(i2c_master_bus_handle_t bus_handle)
         i2c_common_deinit_pins(i2c_master->base);
 
         if (i2c_release_bus_handle(i2c_master->base) == ESP_OK) {
-            if (i2c_master) {
-                if (i2c_master->bus_lock_mux) {
-                    vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
-                    i2c_master->bus_lock_mux = NULL;
-                }
-                if (i2c_master->cmd_semphr) {
-                    vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
-                    i2c_master->cmd_semphr = NULL;
-                }
-                if (i2c_master->event_queue) {
-                    vQueueDeleteWithCaps(i2c_master->event_queue);
-                }
-                if (i2c_master->queues_storage) {
-                    free(i2c_master->queues_storage);
-                }
-                free(i2c_master->i2c_async_ops);
-                for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
-                    if (i2c_master->trans_queues[i]) {
-                        vQueueDelete(i2c_master->trans_queues[i]);
-                    }
-                }
-                bus_handle = NULL;
+            if (i2c_master->bus_lock_mux) {
+                vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
+                i2c_master->bus_lock_mux = NULL;
             }
-
+            if (i2c_master->cmd_semphr) {
+                vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
+                i2c_master->cmd_semphr = NULL;
+            }
+            if (i2c_master->event_queue) {
+                vQueueDeleteWithCaps(i2c_master->event_queue);
+            }
+            if (i2c_master->queues_storage) {
+                free(i2c_master->queues_storage);
+            }
+            free(i2c_master->i2c_async_ops);
+            for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
+                if (i2c_master->trans_queues[i]) {
+                    vQueueDelete(i2c_master->trans_queues[i]);
+                }
+            }
+            bus_handle = NULL;
             free(i2c_master);
         } else {
             free(i2c_master);

--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -811,14 +811,10 @@ static esp_err_t i2c_master_bus_destroy(i2c_master_bus_handle_t bus_handle)
                 }
             }
             bus_handle = NULL;
-            free(i2c_master);
-        } else {
-            free(i2c_master);
-        }
-    } else {
-        free(i2c_master);
+        } 
     }
-
+    
+    free(i2c_master);
     return ESP_OK;
 }
 

--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -784,39 +784,47 @@ static esp_err_t i2c_master_bus_destroy(i2c_master_bus_handle_t bus_handle)
 {
     ESP_RETURN_ON_FALSE(bus_handle, ESP_ERR_INVALID_ARG, TAG, "no memory for i2c master bus");
     i2c_master_bus_handle_t i2c_master = bus_handle;
-    i2c_common_deinit_pins(i2c_master->base);
-    if (i2c_release_bus_handle(i2c_master->base) == ESP_OK) {
-        if (i2c_master) {
-            if (i2c_master->bus_lock_mux) {
-                vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
-                i2c_master->bus_lock_mux = NULL;
-            }
-            if (i2c_master->cmd_semphr) {
-                vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
-                i2c_master->cmd_semphr = NULL;
-            }
-            if (i2c_master->event_queue) {
-                vQueueDeleteWithCaps(i2c_master->event_queue);
-            }
-            if (i2c_master->queues_storage) {
-                free(i2c_master->queues_storage);
-            }
-            free(i2c_master->i2c_async_ops);
-            for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
-                if (i2c_master->trans_queues[i]) {
-                    vQueueDelete(i2c_master->trans_queues[i]);
-                }
-            }
-            bus_handle = NULL;
-        }
 
-        free(i2c_master);
+    // Check if i2c_master->base is not NULL before using it
+    if (i2c_master->base) {
+        i2c_common_deinit_pins(i2c_master->base);
+
+        if (i2c_release_bus_handle(i2c_master->base) == ESP_OK) {
+            if (i2c_master) {
+                if (i2c_master->bus_lock_mux) {
+                    vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
+                    i2c_master->bus_lock_mux = NULL;
+                }
+                if (i2c_master->cmd_semphr) {
+                    vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
+                    i2c_master->cmd_semphr = NULL;
+                }
+                if (i2c_master->event_queue) {
+                    vQueueDeleteWithCaps(i2c_master->event_queue);
+                }
+                if (i2c_master->queues_storage) {
+                    free(i2c_master->queues_storage);
+                }
+                free(i2c_master->i2c_async_ops);
+                for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
+                    if (i2c_master->trans_queues[i]) {
+                        vQueueDelete(i2c_master->trans_queues[i]);
+                    }
+                }
+                bus_handle = NULL;
+            }
+
+            free(i2c_master);
+        } else {
+            free(i2c_master);
+        }
     } else {
         free(i2c_master);
     }
 
     return ESP_OK;
 }
+
 
 static esp_err_t s_i2c_asynchronous_transaction(i2c_master_dev_handle_t i2c_dev, i2c_operation_t *i2c_ops, size_t ops_dim, int timeout_ms)
 {


### PR DESCRIPTION
**Description:**

This pull request addresses a potential crash in the `i2c_master_bus_destroy` function of the ESP-IDF I2C master driver. The issue arises when `i2c_master->base` is `NULL`, leading to a NULL pointer dereference and subsequent program crash.

---

**Issue Details:**

- **Scenario:**
  - When attempting to create a new I2C master bus using `i2c_new_master_bus`, if the bus is not available (e.g., all I2C ports are in use), the function `i2c_acquire_bus_handle` fails.
  - As a result, `i2c_master->base` remains `NULL`.
  - When `i2c_new_master_bus` encounters this failure, it calls `i2c_master_bus_destroy` to clean up.
  - The `i2c_master_bus_destroy` function does not check if `i2c_master->base` is `NULL` before using it.
  - This leads to a NULL pointer dereference when calling functions like `i2c_common_deinit_pins(i2c_master->base)` and `i2c_release_bus_handle(i2c_master->base)`, causing a crash.

**Proposed Fix:**

- **Add NULL Check:**
- Introduced a check to verify if `i2c_master->base` is not `NULL` before dereferencing it in `i2c_master_bus_destroy`.
- This ensures that functions which require `i2c_master->base` only execute when it's valid.

- **Minimal Changes:**
- The fix is minimal and preserves the existing logic and flow of the function.
- The conditional checks and resource cleanup are maintained as per the original implementation.