### PR TITLE
fix(usb_host): return ESP_ERR_NO_MEM on failed alloc in client register (IDFGH-14037)

### DIFF
--- a/components/usb/usb_host.c
+++ b/components/usb/usb_host.c
@@ -818,7 +818,7 @@ alloc_err:
         vSemaphoreDelete(event_sem);
     }
     heap_caps_free(client_obj);
-    return ESP_OK;
+    return ret;
 }
 
 esp_err_t usb_host_client_deregister(usb_host_client_handle_t client_hdl)


### PR DESCRIPTION


<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

Fixes issue where ESP_ERR_NO_MEM was being silently discarded after cleaning up after a failed malloc in usb_host_client_register.

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Verified that error is now properly return when forcing a memory alllocation failure.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
