### PR TITLE
[I2S] removes code forcing two slots in PCM Short Slot (IDFGH-14064)

### DIFF
--- a/components/esp_driver_i2s/i2s_tdm.c
+++ b/components/esp_driver_i2s/i2s_tdm.c
@@ -104,8 +104,7 @@ static esp_err_t i2s_tdm_set_slot(i2s_chan_handle_t handle, const i2s_tdm_slot_c
     handle->active_slot = slot_cfg->slot_mode == I2S_SLOT_MODE_MONO ? 1 : __builtin_popcount(slot_cfg->slot_mask);
     uint32_t max_slot_num = 32 - __builtin_clz(slot_cfg->slot_mask);
     handle->total_slot = slot_cfg->total_slot < max_slot_num ? max_slot_num : slot_cfg->total_slot;
-    handle->total_slot = handle->total_slot < 2 ? 2 : handle->total_slot;  // At least two slots in a frame
-
+    
     uint32_t buf_size = i2s_get_buf_size(handle, slot_cfg->data_bit_width, handle->dma.frame_num);
     /* The DMA buffer need to re-allocate if the buffer size changed */
     if (handle->dma.buf_size != buf_size) {

--- a/components/hal/i2s_hal.c
+++ b/components/hal/i2s_hal.c
@@ -318,8 +318,7 @@ void i2s_hal_tdm_set_tx_slot(i2s_hal_context_t *hal, bool is_slave, const i2s_ha
     uint32_t msk = slot_cfg->tdm.slot_mask;
     /* Get the maximum slot number */
     cnt = 32 - __builtin_clz(msk);
-    /* There should be at least 2 slots in total even for mono mode */
-    cnt = cnt < 2 ? 2 : cnt;
+    
     uint32_t total_slot = slot_cfg->tdm.total_slot > cnt ? slot_cfg->tdm.total_slot : cnt;
     i2s_ll_tx_reset(hal->dev);
     i2s_ll_tx_set_slave_mod(hal->dev, is_slave); //TX Slave


### PR DESCRIPTION
## Description

Changes the i2s_hal and i2s_tdm configuration to not force two slots when only one slot is required.

This issue prevents a configuration of I2S_STD_SLOT_LEFT and I2S_SLOT_MODE_MONO.

If two slots are required, then I2S_STD_SLOT_BOTH could be specified by the use

This change was made because it was not possible to generate a 16-bit PCM output that's mono with only one slot, which is the case in some configurations

Explanation:
I2S_SLOT_MODE_MONO forces data to repeat across all slots. By definition, I2S_STD_SLOT_LEFT, I2S_STD_SLOT_RIGHT, or I2S_STD_SLOT_BOTH define whether we enable the left, right or both slots with 1 bit encoding.
However, requiring always at least 2 slots removes the ability to send out a single slot and makes I2S_STD_SLOT_BOTH useless.

The current code was enforcing the requirement of 2 slots at a low level for some reason in mono.

## Related

None

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested on ESP32-S3-DevKitC with a logic analyzer and can see properly that only a single slot is sent when configuring I2S_STD_SLOT_LEFT. Tested with I2S_STD_SLOT_BOTH and can see that both slots are being sent, as was the case before this cahnge.


Configuration example:

```c
i2s_tdm_config_t tdm_cfg = {
        .clk_cfg  = I2S_TDM_CLK_DEFAULT_CONFIG(8000),
       
        .slot_cfg = I2S_TDM_PCM_SHORT_SLOT_DEFAULT_CONFIG(config->data_width, I2S_SLOT_MODE_MONO, I2S_STD_SLOT_LEFT),
        .gpio_cfg = {
            .mclk = config->mclk_pin,    // some codecs may require mclk signal, this example doesn't need it
            .bclk = config->bclk_pin,
            .ws   = config->ws_pin,
            .dout = config->dout_pin,
            .din  = config->din_pin, // In duplex mode, bind output and input to a same gpio can loopback internally
            .invert_flags = {
                .mclk_inv = config->mclk_pin_inv,
                .bclk_inv = config->bclk_pin_inv,
                .ws_inv   = config->ws_pin_inv,
            },
        },
    };
``` 


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
