### PR TITLE
fix(esp-tls): Remove useless const from size paramter (IDFGH-14099)

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -49,7 +49,7 @@ typedef enum esp_tls_role {
  */
 typedef struct psk_key_hint {
     const uint8_t* key;                     /*!< key in PSK authentication mode in binary format */
-    const size_t   key_size;                /*!< length of the key */
+    size_t   key_size;                      /*!< length of the key */
     const char* hint;                       /*!< hint in PSK authentication mode in string format */
 } psk_hint_key_t;
 


### PR DESCRIPTION
Get rid of useless const from size parameter as it does not allow for easy setup of the struct