### PR TITLE
GPIO: Add gpio_get_io_config(). (IDFGH-14117)

### DIFF
--- a/components/esp_driver_gpio/include/driver/gpio.h
+++ b/components/esp_driver_gpio/include/driver/gpio.h
@@ -590,6 +590,24 @@ esp_err_t gpio_deep_sleep_wakeup_disable(gpio_num_t gpio_num);
  */
 esp_err_t gpio_dump_io_configuration(FILE *out_stream, uint64_t io_bit_mask);
 
+/**
+ * @brief Get the configuration for an IO
+ *
+ * @param gpio_num GPIO number
+ * @param pu Pull-up enabled or not
+ * @param pd Pull-down enabled or not
+ * @param ie Input enabled or not
+ * @param oe Output enabled or not
+ * @param od Open-drain enabled or not
+ * @param drv Drive strength value
+ * @param fun_sel IOMUX function selection value
+ * @param sig_out Outputting peripheral signal index
+ * @param slp_sel Pin sleep mode enabled or not
+ */
+void gpio_get_io_config(uint32_t gpio_num,
+                        bool *pu, bool *pd, bool *ie, bool *oe, bool *od, uint32_t *drv,
+                        uint32_t *fun_sel, uint32_t *sig_out, bool *slp_sel);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -1055,8 +1055,15 @@ esp_err_t gpio_dump_io_configuration(FILE *out_stream, uint64_t io_bit_mask)
         fprintf(out_stream, "  SleepSelEn: %d\n", slp_sel);
         fprintf(out_stream, "\n");
     }
-    fprintf(out_stream, "=================IO DUMP End==================\n");
+    fprintf(out_stream, "=================IO DUMP End=================\n");
     return ESP_OK;
+}
+
+void gpio_get_io_config(uint32_t gpio_num,
+                        bool *pu, bool *pd, bool *ie, bool *oe, bool *od, uint32_t *drv,
+                        uint32_t *fun_sel, uint32_t *sig_out, bool *slp_sel)
+{
+    gpio_hal_get_io_config(gpio_context.gpio_hal, gpio_num, pu, pd, ie, oe, od, drv, fun_sel, sig_out, slp_sel);
 }
 
 esp_err_t gpio_func_sel(gpio_num_t gpio_num, uint32_t func)


### PR DESCRIPTION
Add to API:
```
void gpio_get_io_config(uint32_t gpio_num,
                        bool *pu, bool *pd, bool *ie, bool *oe, bool *od, uint32_t *drv,
                        uint32_t *fun_sel, uint32_t *sig_out, bool *slp_sel);
bool gpio_pullup_is_enabled(uint32_t gpio_num);
bool gpio_pulldown_is_enabled(uint32_t gpio_num);
bool gpio_sleep_sel_is_enabled(uint32_t gpio_num);
bool gpio_sleep_pullup_is_enabled(uint32_t gpio_num);
bool gpio_sleep_pulldown_is_enabled(uint32_t gpio_num);
```

This PR is a continuation of
**GPIO feature: Add gpio_get_direction() and gpio_get_pull_mode() (IDFGH-10987)** #12176
