### PR TITLE
fix(esp_common): fix C++ variant of ESP_RETURN_VOID_ON_FALSE

### DIFF
--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -254,7 +254,7 @@ extern "C" {
  * Macro which can be used to check the condition. If the condition is not 'true', it prints the message
  * and returns without a value.
  */
-#define ESP_RETURN_VOID_ON_FALSE(a, err_code, log_tag, format, ...) do {                                   \
+#define ESP_RETURN_VOID_ON_FALSE(a, log_tag, format, ...) do {                                             \
         if (unlikely(!(a))) {                                                                              \
             ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return;                                                                                        \

--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -20,12 +20,7 @@ components/log/include/esp_log_internal.h
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
-components/lwip/lwip/src/include/netif/ppp/
-components/lwip/lwip/src/include/lwip/apps/tftp_server.h
-components/lwip/lwip/src/include/lwip/apps/tftp_client.h
 
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
@@ -60,20 +55,15 @@ components/json/cJSON/
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/
 
 # The following TLSF headers contain object definitions but have to be
 # made public to be used in esp_rom to help patching the TLSF in ROM.
-components/heap/tlsf/tlsf_block_functions.h
-components/heap/tlsf/tlsf_control_functions.h
 
 ### Here are the files that do not compile for some reason
 #


### PR DESCRIPTION
## Description

This PR fixes the `ESP_RETURN_VOID_ON_FALSE` macro used for newer versions of C++.

The macro parameter `err_code` is removed. It doesn't exist for other variants of the macro, and it isn't used in the changed macro definition.

This could be considered a breaking change, because existing C++ code might rely on the current definition of the macro.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
