### PR TITLE
Update spi_lcd_touch_example_main.c (IDFGH-14199)

### DIFF
--- a/examples/peripherals/lcd/spi_lcd_touch/main/spi_lcd_touch_example_main.c
+++ b/examples/peripherals/lcd/spi_lcd_touch/main/spi_lcd_touch_example_main.c
@@ -156,8 +156,8 @@ static void example_increase_lvgl_tick(void *arg)
 static void example_lvgl_port_task(void *arg)
 {
     ESP_LOGI(TAG, "Starting LVGL task");
-    uint32_t time_till_next_ms = 0;
-    uint32_t time_threshold_ms = 1000 / CONFIG_FREERTOS_HZ;
+    int32_t time_till_next_ms = 0;
+    int32_t time_threshold_ms = 1000 / CONFIG_FREERTOS_HZ;
     while (1) {
         _lock_acquire(&lvgl_api_lock);
         time_till_next_ms = lv_timer_handler();


### PR DESCRIPTION
## Description
Set uint32_t to int32_t. If lv_timer_handler() is called too fast, returns -1. If time_till_next_ms is unsigned, it becomes 0xFFFFFF... (very large). Therefore it overrides the threshold and code locks in usleep().