### PR TITLE
fix(components): Compiler reports some warnings (IDFGH-14275)

### DIFF
--- a/components/driver/twai/twai.c
+++ b/components/driver/twai/twai.c
@@ -547,8 +547,7 @@ esp_err_t twai_driver_install_v2(const twai_general_config_t *g_config, const tw
         .clock_source_hz = clock_source_hz,
         .controller_id = controller_id,
     };
-    bool res = twai_hal_init(&p_twai_obj->hal, &hal_config);
-    assert(res);
+    assert(twai_hal_init(&p_twai_obj->hal, &hal_config));
     twai_hal_configure(&p_twai_obj->hal, t_config, f_config, DRIVER_DEFAULT_INTERRUPTS, g_config->clkout_divider);
 
     //Assign GPIO and Interrupts

--- a/components/fatfs/diskio/diskio_rawflash.c
+++ b/components/fatfs/diskio/diskio_rawflash.c
@@ -91,9 +91,8 @@ DRESULT ff_raw_write (BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 
 DRESULT ff_raw_ioctl (BYTE pdrv, BYTE cmd, void *buff)
 {
-    const esp_partition_t* part = s_ff_raw_handles[pdrv];
     ESP_LOGV(TAG, "ff_raw_ioctl: cmd=%in", cmd);
-    assert(part);
+    assert(s_ff_raw_handles[pdrv]);
     switch (cmd) {
         case CTRL_SYNC:
             return RES_OK;

--- a/components/fatfs/vfs/vfs_fat_sdmmc.c
+++ b/components/fatfs/vfs/vfs_fat_sdmmc.c
@@ -500,8 +500,7 @@ esp_err_t esp_vfs_fat_sdcard_format_cfg(const char *base_path, sdmmc_card_t *car
 
     //format
     uint32_t id = FF_VOLUMES;
-    bool found = s_get_context_id_by_card(card, &id);
-    assert(found);
+    assert(s_get_context_id_by_card(card, &id));
 
     if (cfg) {
         s_ctx[id]->mount_config = *cfg;


### PR DESCRIPTION
## Description
Some variables inserted to asserts, but it produce the warning reports with CONFIG_COMPILER_ASSERT_NDEBUG_EVALUATE=n :
```
esp-idf/components/driver/twai/twai.c warning: unused variable 'res' [-Wunused-variable]
  XXX |     bool res = twai_hal_init(&p_twai_obj->hal, &hal_config);
      |          ^~~
esp-idf/components/fatfs/diskio/diskio_rawflash.c warning: unused variable 'part' [-Wunused-variable]
   XX |     const esp_partition_t* part = s_ff_raw_handles[pdrv];
      |                            ^~~~
esp-idf/components/fatfs/vfs/vfs_fat_sdmmc.c warning: unused variable 'found' [-Wunused-variable]
  XXX |     bool found = s_get_context_id_by_card(card, &id);
      |          ^~~~~
```

This PR fix it (remove temporary unused variables).
## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
