### PR TITLE
RMT save real resolution_hz in config (IDFGH-14281)

### DIFF
--- a/components/esp_driver_rmt/src/rmt_rx.c
+++ b/components/esp_driver_rmt/src/rmt_rx.c
@@ -285,6 +285,7 @@ esp_err_t rmt_new_rx_channel(const rmt_rx_channel_config_t *config, rmt_channel_
     rx_channel->base.resolution_hz = group->resolution_hz / real_div;
     if (rx_channel->base.resolution_hz != config->resolution_hz) {
         ESP_LOGW(TAG, "channel resolution loss, real=%"PRIu32, rx_channel->base.resolution_hz);
+        config->resolution_hz = rx_channel->base.resolution_hz;
     }
 
     rx_channel->filter_clock_resolution_hz = group->resolution_hz;

--- a/components/esp_driver_rmt/src/rmt_tx.c
+++ b/components/esp_driver_rmt/src/rmt_tx.c
@@ -340,6 +340,7 @@ esp_err_t rmt_new_tx_channel(const rmt_tx_channel_config_t *config, rmt_channel_
     tx_channel->base.resolution_hz = group->resolution_hz / real_div;
     if (tx_channel->base.resolution_hz != config->resolution_hz) {
         ESP_LOGW(TAG, "channel resolution loss, real=%"PRIu32, tx_channel->base.resolution_hz);
+        config->resolution_hz = tx_channel->base.resolution_hz;
     }
 
     rmt_ll_tx_set_mem_blocks(hal->regs, channel_id, tx_channel->base.mem_block_num);


### PR DESCRIPTION
This PR save the real resolution_hz in config, so that it is accessible for the user.

Currently there is AFAIK no easy way to access the real resolution_hz, which can differ considerably from the requested resolution_hz and thus will throw off timing of the RMT pulses.
