### PR TITLE
refactor(soft_spi_master_main.c): remove dead code

### DIFF
--- a/examples/peripherals/dedicated_gpio/soft_spi/main/soft_spi_master_main.c
+++ b/examples/peripherals/dedicated_gpio/soft_spi/main/soft_spi_master_main.c
@@ -9,8 +9,6 @@
 #include "esp_check.h"
 #include "soft_spi.h"
 
-#define READ_COUNT  16
-
 const char* EXAMPLE_TAG = "soft_spi_master";
 
 void app_main(void)


### PR DESCRIPTION
## Description

Just removing a line that is no longer required. It seems to had been copy-pasted from dedicated_gpio/soft_uart example. It isn't found anywhere in the code for SPI example.

## Related

## Testing

Did a ctrl+f for any use of the define in code. Nothing appeared in SPI example, 1 use appeared in UART example (buffer length definition)

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass. // this has gotta be checked after I submit a PR
- [X] Documentation is updated as needed. // no need
- [X] Tests are updated or added as necessary. // no need
- [X] Code is well-commented, especially in complex areas. // guess so..
- [X] Git history is clean — commits are squashed to the minimum necessary. // yes
