### PR TITLE
docs: Add chip target to direct CMake example code snippet  in build system docs

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -70,7 +70,7 @@ When ``idf.py`` does something, it prints each command that it runs for easy ref
 
   mkdir -p build
   cd build
-  cmake .. -G Ninja   # or 'Unix Makefiles'
+  cmake .. -DIDF_TARGET={IDF_TARGET_PATH_NAME} -G Ninja   # or 'Unix Makefiles'
   ninja
 
 In the above list, the ``cmake`` command configures the project and generates build files for use with the final build tool. In this case, the final build tool is Ninja_: running ``ninja`` actually builds the project.

--- a/docs/zh_CN/api-guides/build-system.rst
+++ b/docs/zh_CN/api-guides/build-system.rst
@@ -70,7 +70,7 @@ idf.py
 
     mkdir -p build
     cd build
-    cmake .. -G Ninja   # 或者 'Unix Makefiles'
+    cmake .. -DIDF_TARGET={IDF_TARGET_PATH_NAME} -G Ninja   # 或者 'Unix Makefiles'
     ninja
 
 在上面的命令列表中，``cmake`` 命令对项目进行配置，并生成用于最终构建工具的构建文件。在这个例子中，最终构建工具是 Ninja_: 运行 ``ninja`` 来构建项目。


### PR DESCRIPTION
## Description

The Build System documentation provides and example code snippet on how to use CMake and Ninja directly, bypassing the `idf.py` frontend.

However,  the snippet does not demonstrate how to set the chip target using CMake (equivalent to `idf.py set-target`). This PR updates the example code snippets to set the chip target.

## Related

- Build System [documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/api-guides/build-system.html#using-cmake-directly)

## Testing

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
