### PR TITLE
change(rmt): change rx  buffer prints to debug instead of error (IDFGH-14448)

### DIFF
--- a/components/esp_driver_rmt/src/rmt_rx.c
+++ b/components/esp_driver_rmt/src/rmt_rx.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -630,12 +630,12 @@ static bool IRAM_ATTR rmt_isr_handle_rx_done(rmt_rx_channel_t *rx_chan)
 
                 // even user process the partial received data, the remain buffer may still be insufficient
                 if (mem_want > mem_have) {
-                    ESP_DRAM_LOGE(TAG, "user buffer too small, received symbols truncated");
+                    ESP_DRAM_LOGD(TAG, "user buffer too small, received symbols truncated");
                     copy_size = mem_have;
                 }
             }
         } else {
-            ESP_DRAM_LOGE(TAG, "user buffer too small, received symbols truncated");
+            ESP_DRAM_LOGD(TAG, "user buffer too small, received symbols truncated");
             copy_size = mem_have;
         }
     }
@@ -656,7 +656,7 @@ static bool IRAM_ATTR rmt_isr_handle_rx_done(rmt_rx_channel_t *rx_chan)
         portEXIT_CRITICAL_ISR(&channel->spinlock);
         // this clear operation can only take effect after we copy out the received data and reset the pointer
         rmt_ll_clear_interrupt_status(hal->regs, RMT_LL_EVENT_RX_ERROR(channel_id));
-        ESP_DRAM_LOGE(TAG, "hw buffer too small, received symbols truncated");
+        ESP_DRAM_LOGD(TAG, "hw buffer too small, received symbols truncated");
     }
 #endif // !SOC_RMT_SUPPORT_RX_PINGPONG
 
@@ -715,12 +715,12 @@ static bool IRAM_ATTR rmt_isr_handle_rx_threshold(rmt_rx_channel_t *rx_chan)
 
                 // even user process the partial received data, the remain buffer size still insufficient
                 if (mem_want > mem_have) {
-                    ESP_DRAM_LOGE(TAG, "user buffer too small, received symbols truncated");
+                    ESP_DRAM_LOGD(TAG, "user buffer too small, received symbols truncated");
                     copy_size = mem_have;
                 }
             }
         } else {
-            ESP_DRAM_LOGE(TAG, "user buffer too small, received symbols truncated");
+            ESP_DRAM_LOGD(TAG, "user buffer too small, received symbols truncated");
             copy_size = mem_have;
         }
     }


### PR DESCRIPTION
## Description

When using RF it is possible there is a lot of noise. The developer cannot control this noise. Noise could be very long and cause these prints to occur very often. If CONFIG_RMT_ISR_IRAM_SAFE is enabled these prints will be sent over the uart in ISR context. Each print will take a few milliseconds to send at 115200. The result is system instability because ISRs are blocked for long periods of time. Currently the only work around is to disable all logging or disable uart logging.

Since these are not real errors and occur all the time in noisy environments it would be better to use ESP_DRAM_LOGD instead of ESP_DRAM_LOGE.

## Related

## Testing

Verified prints are debug now and no longer cause instability. 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
