### PR TITLE
refactor(components/fatfs): replace assert expression (IDFGH-14473)

### DIFF
--- a/components/fatfs/diskio/diskio_wl.c
+++ b/components/fatfs/diskio/diskio_wl.c
@@ -33,7 +33,7 @@ DRESULT ff_wl_read (BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 {
     ESP_LOGV(TAG, "ff_wl_read - pdrv=%i, sector=%i, count=%i", (unsigned int)pdrv, (unsigned int)sector, (unsigned int)count);
     wl_handle_t wl_handle = ff_wl_handles[pdrv];
-    assert(wl_handle + 1);
+    assert(wl_handle != WL_INVALID_HANDLE);
     esp_err_t err = wl_read(wl_handle, sector * wl_sector_size(wl_handle), buff, count * wl_sector_size(wl_handle));
     if (unlikely(err != ESP_OK)) {
         ESP_LOGE(TAG, "wl_read failed (0x%x)", err);
@@ -46,7 +46,7 @@ DRESULT ff_wl_write (BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 {
     ESP_LOGV(TAG, "ff_wl_write - pdrv=%i, sector=%i, count=%i", (unsigned int)pdrv, (unsigned int)sector, (unsigned int)count);
     wl_handle_t wl_handle = ff_wl_handles[pdrv];
-    assert(wl_handle + 1);
+    assert(wl_handle != WL_INVALID_HANDLE);
     esp_err_t err = wl_erase_range(wl_handle, sector * wl_sector_size(wl_handle), count * wl_sector_size(wl_handle));
     if (unlikely(err != ESP_OK)) {
         ESP_LOGE(TAG, "wl_erase_range failed (0x%x)", err);
@@ -64,7 +64,7 @@ DRESULT ff_wl_ioctl (BYTE pdrv, BYTE cmd, void *buff)
 {
     wl_handle_t wl_handle = ff_wl_handles[pdrv];
     ESP_LOGV(TAG, "ff_wl_ioctl: cmd=%i", cmd);
-    assert(wl_handle + 1);
+    assert(wl_handle != WL_INVALID_HANDLE);
     switch (cmd) {
     case CTRL_SYNC:
         return RES_OK;


### PR DESCRIPTION
**assert** expressions in the **diskio_wl.c** file contains a magical calculations. This PR replaces them with an equality check.

before:
`assert(wl_handle + 1); `
after:
`assert(wl_handle != WL_INVALID_HANDLE);`

## Related
Fixes #15246
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->


<!--
## Testing


- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
