### PR TITLE
Fix s2 and s3 Cache_Count_Flash_Pages rom function wrapper

### DIFF
--- a/components/esp_rom/patches/esp_rom_cache_esp32s2_esp32s3.c
+++ b/components/esp_rom/patches/esp_rom_cache_esp32s2_esp32s3.c
@@ -21,14 +21,13 @@
 extern uint32_t rom_Cache_Count_Flash_Pages(uint32_t bus, uint32_t * page0_mapped);
 uint32_t Cache_Count_Flash_Pages(uint32_t bus, uint32_t * page0_mapped)
 {
-    uint32_t page0_before_count = *page0_mapped;
     uint32_t flash_pages = 0;
     flash_pages = rom_Cache_Count_Flash_Pages(bus, page0_mapped);
 
-/* No page mapped to page0, in this condition, the rom api will return
+/* No page mapped to page0 yet, in this condition, the rom api will return
  * unexpected value + 1.
  */
-    if (page0_before_count == *page0_mapped) {
+    if (*page0_mapped == 0) {
         flash_pages--;
     }
     return flash_pages;


### PR DESCRIPTION
## Description

The `Cache_Count_Flash_Pages` rom function on the s2 and s3 only counts one page for any pages which are mapped to page 0 of flash as the `Cache_Flash_To_SPIRAM_Copy` function attempts to map all flash page 0 mapped pages to one PSRAM page.

As this function can be called for multiple regions, it needs to track if a page mapped to page 0 has previously been accounted for by a previous call. It does this using the `page0_mapped` in-out parameter. This logic contains an error[0]:

```c
// This code was reverse engineered from the ROM with the help of Ghidra and
// then cleaned up
uint32_t Cache_Count_Flash_Pages(uint32_t bus, uint32_t *page0_mapped)
{
    volatile uint32_t *mmu_table = (volatile uint32_t *)DR_REG_MMU_TABLE;
    uint32_t start, end;
    if (bus == CACHE_IBUS) {
        start = CACHE_IROM_MMU_START;
        end = CACHE_IROM_MMU_END;
    } else {
        start = CACHE_DROM_MMU_START;
        end = CACHE_DROM_MMU_END;
    }

    uint32_t count, page0_count = 0, valid_flash_count = 0;
    for (uint32_t i = start >> 2; i < end >> 2; i++) {
        uint32_t mapping = mmu_table[i];
        if ((mapping & (SOC_MMU_INVALID | SOC_MMU_TYPE)) == (SOC_MMU_VALID | SOC_MMU_ACCESS_FLASH)) {
            if ((mapping & SOC_MMU_VALID_VAL_MASK) == 0) page0_count++;
            valid_flash_count++;
        }
    }
    // BUG: If page0_count is 0, 1 is still added
    // Should be `if (page0_count != 0 && *page0_mapped == 0) {`
    if (*page0_mapped == 0) {
        count = valid_flash_count + 1 - page0_count;
    } else {
        count = valid_flash_count - page0_count;
    }
    *page0_mapped += page0_count;
    return count;
}
```

The current `Cache_Count_Flash_Pages` wrapper in the idf attempts to compensate for this bug by checking if the `page0_mapped` parameter was changed by a call to the function and reducing the count if it has not.

This, however, will incorrectly over-compensate in situations where the initial value of `page0_mapped` was not zero as the code above only miscounts when it was zero.

This patch addresses the issue in this wrapper function by correctly compensating for the bug only in cases where the final `page0_mapped` value is 0.

## Testing

I used a ESP32-S3 based LCD board to run code which made use of `CONFIG_SPIRAM_FETCH_INSTRUCTIONS` and `CONFIG_SPIRAM_RODATA`, I added some additional verbose logging in `mmu_config_psram_text_segment` and `mmu_config_psram_rodata_segment` to check the calculated page count and compare it to the change in `page_id` after the SPIRAM copy is performed.

Since my code did not result in page0 getting mapped (I'm not sure how to arrange for that organically), I manually triggered the issue by initialising `page0_mapped` to 1 which resulted in the original code under-counting the total number of required pages by 1 in each instance of the function being called.

With the fix applied, the count matched the jump in page number that subsequent calls to `Cache_Flash_To_SPIRAM_Copy` resulted in. This was tested both in cases which did and cases which did not trigger the bug.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.  
      NOTE: This change would only break code which would already break due to a lack of PSRAM space.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.