### PR TITLE
Fix spelling mistake in all soc/interrupts.h (IDFGH-14503)

### DIFF
--- a/components/soc/esp32/include/soc/interrupts.h
+++ b/components/soc/esp32/include/soc/interrupts.h
@@ -84,7 +84,7 @@ typedef enum {
     ETS_MPU_IA_INTR_SOURCE,                  /**< interrupt of MPU Invalid Access, LEVEL*/
     ETS_CACHE_IA_INTR_SOURCE,                /**< interrupt of Cache Invalied Access, LEVEL*/
     ETS_MAX_INTR_SOURCE,                     /**< total number of interrupt sources*/
-} periph_interrput_t;
+} periph_interrupt_t;
 
 #define ETS_CAN_INTR_SOURCE ETS_TWAI_INTR_SOURCE
 

--- a/components/soc/esp32c2/include/soc/interrupts.h
+++ b/components/soc/esp32c2/include/soc/interrupts.h
@@ -62,7 +62,7 @@ typedef enum {
     ETS_CORE0_PIF_PMS_SIZE_INTR_SOURCE,
     ETS_CACHE_CORE0_ACS_INTR_SOURCE,
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32c3/include/soc/interrupts.h
+++ b/components/soc/esp32c3/include/soc/interrupts.h
@@ -81,7 +81,7 @@ typedef enum {
     ETS_BAK_PMS_VIOLATE_INTR_SOURCE,
     ETS_CACHE_CORE0_ACS_INTR_SOURCE,
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32c6/include/soc/interrupts.h
+++ b/components/soc/esp32c6/include/soc/interrupts.h
@@ -97,7 +97,7 @@ typedef enum {
     ETS_RSA_INTR_SOURCE,                        /**< interrupt of RSA accelerator, level*/
     ETS_ECC_INTR_SOURCE,                        /**< interrupt of ECC accelerator, level*/
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32c61/include/soc/interrupts.h
+++ b/components/soc/esp32c61/include/soc/interrupts.h
@@ -80,7 +80,7 @@ typedef enum {
     ETS_ECC_INTR_SOURCE,
     ETS_ECDSA_INTR_SOURCE,
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32h2/include/soc/interrupts.h
+++ b/components/soc/esp32h2/include/soc/interrupts.h
@@ -85,7 +85,7 @@ typedef enum {
     ETS_ECC_INTR_SOURCE,                        /**< interrupt of ECC accelerator, level*/
     ETS_ECDSA_INTR_SOURCE,                      /**< interrupt of ECDSA accelerator, level*/
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32h21/include/soc/interrupts.h
+++ b/components/soc/esp32h21/include/soc/interrupts.h
@@ -82,7 +82,7 @@ typedef enum {
     ETS_ECC_INTR_SOURCE,
     ETS_ECDSA_INTR_SOURCE,
     ETS_MAX_INTR_SOURCE,
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32p4/include/soc/interrupts.h
+++ b/components/soc/esp32p4/include/soc/interrupts.h
@@ -153,7 +153,7 @@ typedef enum {
     ETS_ASSIST_DEBUG_INTR_SOURCE,
 
     ETS_MAX_INTR_SOURCE,                        /**< number of interrupt sources */
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char *const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32s2/include/soc/interrupts.h
+++ b/components/soc/esp32s2/include/soc/interrupts.h
@@ -114,7 +114,7 @@ typedef enum {
     ETS_DCACHE_SYNC_INTR_SOURCE,                /**< interrupt of data cache sync done, LEVEL*/
     ETS_ICACHE_SYNC_INTR_SOURCE,                /**< interrupt of instruction cache sync done, LEVEL*/
     ETS_MAX_INTR_SOURCE,                        /**< number of interrupt sources */
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 

--- a/components/soc/esp32s3/include/soc/interrupts.h
+++ b/components/soc/esp32s3/include/soc/interrupts.h
@@ -116,7 +116,7 @@ typedef enum {
     ETS_PERI_BACKUP_INTR_SOURCE,
     ETS_DMA_EXTMEM_REJECT_SOURCE,
     ETS_MAX_INTR_SOURCE,                        /**< number of interrupt sources */
-} periph_interrput_t;
+} periph_interrupt_t;
 
 extern const char * const esp_isr_names[ETS_MAX_INTR_SOURCE];
 


### PR DESCRIPTION
Description of change:
Fixed spelling mistake in components/soc/*/include/soc/interrupts.h.

periph_interrput_t -> periph_interrupt_t. 

Reason:
I am using the enum periph_interrput_t in my projects and I wanted to fix the spelling mistake.

Testing:
None performed, its a name change, and is not used anywhere in the codebase.

Closes #15272 