### PR TITLE
fix(esp_http_client): Fix invalid content length header (IDFGH-14528)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1587,6 +1587,8 @@ static int http_client_prepare_first_line(esp_http_client_handle_t client, int w
                                       client->connection_info.method != HTTP_METHOD_DELETE);
         if (write_len != 0 || length_required) {
             http_header_set_format(client->request->headers, "Content-Length", "%d", write_len);
+        } else {
+            http_header_delete(client->request->headers, "Content-Length");
         }
     } else {
         esp_http_client_set_header(client, "Transfer-Encoding", "chunked");


### PR DESCRIPTION
In case a request with no content (e.g GET) is sent after one containing data the incorrect content length header of the previous request is sent with the subsequent one.

For instance, an empty GET request after a PUT request will still have the non-zero content length header set.
This is fixed by clearing the header in that case.

The bug was introduced as a side effect of #14459 