### PR TITLE
fix(transport_ws): remove unnecessary noise from error message (IDFGH-14538)

### DIFF
--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -286,7 +286,7 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
     int header_len = 0;
     do {
         if ((len = esp_transport_read(ws->parent, ws->buffer + header_len, WS_BUFFER_SIZE - 1 - header_len, timeout_ms)) <= 0) {
-            ESP_LOGE(TAG, "Error read response for Upgrade header %s", ws->buffer);
+            ESP_LOGE(TAG, "Error read response for Upgrade header");
             return -1;
         }
         header_len += len;


### PR DESCRIPTION
A message reporting an error about `esp_transport_read()` prints contents of the buffer that was passed to this function. The contents of this buffer are irrelevant in the context of this message.

1) it can contain random, not NUL-terminated data from possibly partial read
2) it can contain data from previous `esp_transport_write()` call that is using the same buffer.

In either case this is just a noise:

![Screenshot_20250129_151900](https://github.com/user-attachments/assets/a3da78dc-57c6-4866-9648-9519adc1ee1b)
