### PR TITLE
fix(esp_hid): Fix Device ID for BT Classic

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_hidd_api.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_hidd_api.h
@@ -98,6 +98,10 @@ typedef struct {
     uint8_t subclass;                                /*!< HID device subclass */
     uint8_t *desc_list;                              /*!< HID descriptor list */
     int desc_list_len;                               /*!< size in bytes of HID descriptor list */
+    uint16_t vendor_id;                              /*!< HID Vendor ID */
+    uint16_t product_id;                             /*!< HID Product ID */
+    uint16_t version;                                /*!< HID Product Version */
+    uint8_t  vendor_id_source;                       /*!< HID Vendor Source ID (0x1=BT, 0x2=USB IF) */
 } esp_hidd_app_param_t;
 
 /**

--- a/components/bt/host/bluedroid/bta/hd/bta_hd_act.c
+++ b/components/bt/host/bluedroid/bta/hd/bta_hd_act.c
@@ -175,6 +175,15 @@ void bta_hd_register_act(tBTA_HD_DATA *p_data)
                      p_app_data->subclass, p_app_data->d_len, p_app_data->d_data);
     bta_sys_add_uuid(UUID_SERVCLASS_HUMAN_INTERFACE);
 
+    /* Set DI SDP record */
+    tBTA_DI_RECORD bta_device_info;
+    bta_device_info.vendor = p_app_data->vendor_id;
+    bta_device_info.vendor_id_source = p_app_data->vendor_id_source; // BTA_HH_VENDOR_ID_INVALID
+    bta_device_info.product = p_app_data->product_id;
+    bta_device_info.version = p_app_data->version;
+    bta_device_info.primary_record = TRUE;
+    BTA_DmSetLocalDiRecord(&bta_device_info, &bta_hd_cb.sdp_handle);
+
     HID_DevSetIncomingQos(p_app_data->in_qos.service_type, p_app_data->in_qos.token_rate,
                           p_app_data->in_qos.token_bucket_size, p_app_data->in_qos.peak_bandwidth,
                           p_app_data->in_qos.access_latency, p_app_data->in_qos.delay_variation);

--- a/components/bt/host/bluedroid/bta/hd/bta_hd_api.c
+++ b/components/bt/host/bluedroid/bta/hd/bta_hd_api.c
@@ -114,6 +114,13 @@ extern void BTA_HdRegisterApp(tBTA_HD_APP_INFO *p_app_info, tBTA_HD_QOS_INFO *p_
         p_buf->subclass = p_app_info->subclass;
         p_buf->d_len = p_app_info->descriptor.dl_len;
         memcpy(p_buf->d_data, p_app_info->descriptor.dsc_list, p_app_info->descriptor.dl_len);
+
+        // copy DID profile SDP info
+        p_buf->vendor_id = p_app_info->vendor_id;
+        p_buf->product_id = p_app_info->product_id;
+        p_buf->version = p_app_info->version;
+        p_buf->vendor_id_source = p_app_info->vendor_id_source;
+
         // copy qos data as-is
         memcpy(&p_buf->in_qos, p_in_qos, sizeof(tBTA_HD_QOS_INFO));
         memcpy(&p_buf->out_qos, p_out_qos, sizeof(tBTA_HD_QOS_INFO));

--- a/components/bt/host/bluedroid/bta/hd/include/bta_hd_int.h
+++ b/components/bt/host/bluedroid/bta/hd/include/bta_hd_int.h
@@ -75,6 +75,10 @@ typedef struct {
     uint8_t subclass;
     uint16_t d_len;
     uint8_t d_data[BTA_HD_APP_DESCRIPTOR_LEN];
+    uint16_t vendor_id;
+    uint16_t product_id;
+    uint16_t version;
+    uint8_t vendor_id_source;
     tBTA_HD_QOS_INFO in_qos;
     tBTA_HD_QOS_INFO out_qos;
 } tBTA_HD_REGISTER_APP;

--- a/components/bt/host/bluedroid/bta/include/bta/bta_hd_api.h
+++ b/components/bt/host/bluedroid/bta/include/bta/bta_hd_api.h
@@ -69,6 +69,10 @@ typedef struct {
     char *p_description;
     char *p_provider;
     uint8_t subclass;
+    uint16_t vendor_id;         // 0x0201
+    uint16_t product_id;        // 0x0202
+    uint16_t version;           // 0x0203
+    uint8_t vendor_id_source;   // 0x0205
     tBTA_HD_DEV_DESCR descriptor;
 } tBTA_HD_APP_INFO;
 

--- a/components/bt/host/bluedroid/btc/profile/std/hid/btc_hd.c
+++ b/components/bt/host/bluedroid/btc/profile/std/hid/btc_hd.c
@@ -328,6 +328,12 @@ static void btc_hd_register_app(esp_hidd_app_param_t *p_app_param, esp_hidd_qos_
         btc_hd_cb.app_info.subclass = p_app_param->subclass;
         btc_hd_cb.app_info.descriptor.dl_len = p_app_param->desc_list_len;
 
+        // Copy SDP record information for DID (Device Identification Profile)
+        btc_hd_cb.app_info.vendor_id = p_app_param->vendor_id;
+        btc_hd_cb.app_info.product_id = p_app_param->product_id;
+        btc_hd_cb.app_info.version = p_app_param->version;
+        btc_hd_cb.app_info.vendor_id_source = p_app_param->vendor_id_source;
+
         btc_hd_cb.in_qos.service_type = p_in_qos->service_type;
         btc_hd_cb.in_qos.token_rate = p_in_qos->token_rate;
         btc_hd_cb.in_qos.token_bucket_size = p_in_qos->token_bucket_size;

--- a/components/esp_hid/include/esp_hid_common.h
+++ b/components/esp_hid/include/esp_hid_common.h
@@ -169,6 +169,7 @@ typedef struct {
     uint16_t vendor_id;                     /*!< HID Vendor ID */
     uint16_t product_id;                    /*!< HID Product ID */
     uint16_t version;                       /*!< HID Product Version */
+    uint8_t  vendor_id_source;              /*!< HID Vendor ID Source (0x1 BT, 0x2 USB) */
     const char *device_name;                /*!< HID Device Name */
     const char *manufacturer_name;          /*!< HID Manufacturer */
     const char *serial_number;              /*!< HID Serial Number */

--- a/components/esp_hid/src/ble_hidd.c
+++ b/components/esp_hid/src/ble_hidd.c
@@ -225,10 +225,10 @@ static esp_err_t create_info_db(esp_ble_hidd_dev_t *dev)
 
     if (dev->config.product_id || dev->config.vendor_id || dev->config.version) {
         uint8_t pnp_val[7] = {
-            0x02, //0x1=BT, 0x2=USB
+            dev->config.vendor_id_source & 0xFF, //0x1=BT, 0x2=USB
             dev->config.vendor_id & 0xFF, (dev->config.vendor_id >> 8) & 0xFF, //VID
-                       dev->config.product_id & 0xFF, (dev->config.product_id >> 8) & 0xFF, //PID
-                       dev->config.version & 0xFF, (dev->config.version >> 8) & 0xFF  //VERSION
+            dev->config.product_id & 0xFF, (dev->config.product_id >> 8) & 0xFF, //PID
+            dev->config.version & 0xFF, (dev->config.version >> 8) & 0xFF  //VERSION
         };
         memcpy(dev->pnp, pnp_val, 7);
         add_db_record(_last_db, index++, (uint8_t *)&s_character_declaration_uuid, ESP_GATT_PERM_READ, 1, 1, (uint8_t *)&s_char_prop_read);

--- a/components/esp_hid/src/bt_hidd.c
+++ b/components/esp_hid/src/bt_hidd.c
@@ -281,6 +281,12 @@ static void bt_hidd_init_app(void)
     s_hidd_param.app_param.subclass = get_subclass_by_appearance(s_hidd_param.dev->appearance);
     s_hidd_param.app_param.desc_list = (uint8_t *)s_hidd_param.dev->devices[0].reports_map.data;
     s_hidd_param.app_param.desc_list_len = s_hidd_param.dev->devices[0].reports_map.len;
+
+    // Information SDP record data
+    s_hidd_param.app_param.vendor_id = p_config->vendor_id;
+    s_hidd_param.app_param.product_id = p_config->product_id;
+    s_hidd_param.app_param.version = p_config->version;
+    s_hidd_param.app_param.vendor_id_source = s_hidd_param.app_param.vendor_id_source;
 }
 
 static void bt_hidd_init_qos(void)


### PR DESCRIPTION
Right now, the VID/PID/VID Source are unused for BT Classic HID. This resolves that particular issue. This also Implements VID Source for BLE. 