### PR TITLE
fix(esp_http_client): Fix host header for IPv6 address literal (IDFGH-14640)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -703,10 +703,13 @@ static char *_get_host_header(char *host, int port)
 {
     int err = 0;
     char *host_name;
+    assert(host != NULL);
+    // Check if host is an IPv6 address literal that needs square brackets according to RFC3986
+    bool is_ipv6 = (host[0] != '[' && strchr(host, ':') != NULL);
     if (port != DEFAULT_HTTP_PORT && port != DEFAULT_HTTPS_PORT) {
-        err = asprintf(&host_name, "%s:%d", host, port);
+        err = asprintf(&host_name, is_ipv6 ? "[%s]:%d" : "%s:%d", host, port);
     } else {
-        err = asprintf(&host_name, "%s", host);
+        err = asprintf(&host_name, is_ipv6 ? "[%s]" : "%s", host);
     }
     if (err == -1) {
         return NULL;


### PR DESCRIPTION
An IPv6 IP that occurs in the 'Host:' header of an HTTP request must be enclosed in square brackets 

## Description

When performing an HTTP request to an IPv6 address via URL, for example

    esp_http_client_config_t config = {
        .url = "http://[2001:db8::1]/path",
    };

the HTTP request header of the ESP IDF will contain

    Host: 2001:db8::1

This IPv6 format is invalid and webservers will refuse to process the request.
The correct host in the header would be

    Host: [2001:db8::1]


### Background 
HTTP [RFC 7230 Section 5.4](https://datatracker.ietf.org/doc/html/rfc7230#section-5.4) defines the `Host` header field as:

    Host = uri-host [ ":" port ] ; Section 2.7.1

and explicitly references [Section 2.7.1](https://datatracker.ietf.org/doc/html/rfc7230#section-2.7.1), which specifies that host needs to conform to [RFC 3986 Section 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2).

The [RFC 3986 Section 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2) mandates that, a host identified by an Internet Protocol literal address, version 6 or later, needs to be enclosed in square brackets within an http URI:

    host        = IP-literal / IPv4address / reg-name
    IP-literal = "[" ( IPv6address / IPvFuture  ) "]"

Therefore, an IPv6 occuring in the `Host` header of an HTTP request must be enclosed by square brackets.

### Fix

The attached solution will test for a `:` character in the `_get_host_header` helper function to determine if the host is an IPv6 address, and in such a case create the header hostname with the address in square brackets.
This is a very simple approach and effectively the same check as [GNU Wget](https://github.com/mirror/wget/blob/master/src/http.c#L1896) uses.

*I have also considered alternatives:*
One would be testing for an valid IPv6 address (e.g., using `inet_pton`), however, this would probably add overhead and additional dependencies (`lwip`).

Another solutions would employ the parser to track if the URL contains an IPv6 literal.
While this would be a rather clean solution, it would require to changes `components/http_parser/http_parser.c`, in particular tracking the occurance of `s_http_host_v6_start`.
Such a solution would be similar to [Curl](https://github.com/curl/curl/blob/master/lib/http.c#L1880), which [sets an IPv6 IP flag](https://github.com/curl/curl/blob/master/lib/url.c#L1802). 
However, for ESP IDF such a solution would mean to adjust the HTTP parser (which, to the best of my knowledge, is an outdated version originating from the now unmaintained [Node.js HTTP parser](https://github.com/nodejs/http-parser/)).
Furthermore, it would not handle the case of providing `config->host` (instead of `config->url`) for the `esp_http_client_init` call.


## Related

There have been similar issues in other projects, e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=45891

## Testing

Without the fix, a request to a  [lighttpd](https://www.lighttpd.net/)) server fails.
With the fix, it succeeds.
Using network package capturing, the fixed host header can be seen:
![esp_http_client_ipv6_pcap](https://github.com/user-attachments/assets/e026df1c-ebde-4ac7-a12c-c166819652d9)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] ~~Documentation is updated as needed.~~
- [x] ~~Tests are updated or added as necessary.~~
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
