### PR TITLE
fix(bt/bluedroid): Reduce log verbosity of disconnect event (IDFGH-14748)

### DIFF
--- a/components/bt/host/bluedroid/stack/btu/btu_hcif.c
+++ b/components/bt/host/bluedroid/stack/btu/btu_hcif.c
@@ -767,7 +767,7 @@ static void btu_hcif_disconnection_comp_evt (UINT8 *p)
 
     btm_acl_disconnected(handle, reason);
 
-    HCI_TRACE_WARNING("hcif disc complete: hdl 0x%x, rsn 0x%x", handle, reason);
+    HCI_TRACE_EVENT("hcif disc complete: hdl 0x%x, rsn 0x%x", handle, reason);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Description

Changes "hcif disc complete" log from a warning to an info message.


This is printed even when the peer device initiates a normal disconnect and unnecessarily pollutes logs. The information is provided to the higher level layers (in this case `ESP_GATTS_DISCONNECT_EVT`) if the user wants to add their own warning logs.

```
W (51044) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x13
I (20:25:59.845) BLE#GATTS   : [dc:97:ba:bf:b7:55]<0> A03         ESP_GATTS_DISCONNECT_EVT [reason=ESP_GATT_CONN_TERMINATE_PEER_USER]
````

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
