### PR TITLE
Add missing break statements to usb_serial_jtag_ll_phy_select (IDFGH-14760)

### DIFF
--- a/components/hal/esp32p4/include/hal/usb_serial_jtag_ll.h
+++ b/components/hal/esp32p4/include/hal/usb_serial_jtag_ll.h
@@ -229,8 +229,10 @@ FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_select(unsigned int phy_idx)
     switch (phy_idx) {
     case 0:
         LP_SYS.usb_ctrl.sw_usb_phy_sel = false;
+        break;
     case 1:
         LP_SYS.usb_ctrl.sw_usb_phy_sel = true;
+        break;
     default:
         break;
     }


### PR DESCRIPTION
This commits adds two missing "break" statements to the usb_serial_jtag_ll_phy_select HAL function. The missing statements prevent users from switching back the two PHYs to the default configuration as the statement will always fall through to the second case in the switch case.
