### PR TITLE
fix(psram): correct heap vaddr calculation (IDFGH-14775)

### DIFF
--- a/components/esp_psram/esp_psram.c
+++ b/components/esp_psram/esp_psram.c
@@ -307,21 +307,31 @@ static void s_psram_mapping(uint32_t psram_available_size, uint32_t start_page)
     * After mapping, we DON'T care about the PSRAM PHYSICAL ADDRESS ANYMORE!
     *----------------------------------------------------------------------------*/
 
-    //------------------------------------Configure .bss in PSRAM-------------------------------------//
+    //------------------------------------Configure heap in PSRAM-------------------------------------//
+    uintptr_t ext_segment_start = UINTPTR_MAX;
+    uintptr_t ext_segment_end = 0;
+
 #if CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
-    //should never be negative number
-    uint32_t ext_bss_size = ((intptr_t)&_ext_ram_bss_end - (intptr_t)&_ext_ram_bss_start);
-    ESP_EARLY_LOGV(TAG, "ext_bss_size is %" PRIu32, ext_bss_size);
-    s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].vaddr_start += ext_bss_size;
-    s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].size -= ext_bss_size;
+    ext_segment_start = (uintptr_t)&_ext_ram_bss_start;
+    ext_segment_end = (uintptr_t)&_ext_ram_bss_end;
 #endif  //#if CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
 
 #if CONFIG_SPIRAM_ALLOW_NOINIT_SEG_EXTERNAL_MEMORY
-    uint32_t ext_noinit_size = ((intptr_t)&_ext_ram_noinit_end - (intptr_t)&_ext_ram_noinit_start);
-    ESP_EARLY_LOGV(TAG, "ext_noinit_size is %" PRIu32, ext_noinit_size);
-    s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].vaddr_start += ext_noinit_size;
-    s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].size -= ext_noinit_size;
-#endif
+    if ((uintptr_t)&_ext_ram_noinit_start < ext_segment_start) {
+        ext_segment_start = (uintptr_t)&_ext_ram_noinit_start;
+    }
+    if ((uintptr_t)&_ext_ram_noinit_end > ext_segment_end) {
+        ext_segment_end = (uintptr_t)&_ext_ram_noinit_end;
+    }
+#endif  //#if CONFIG_SPIRAM_ALLOW_NOINIT_SEG_EXTERNAL_MEMORY
+
+    if ((ext_segment_start != UINTPTR_MAX) || (ext_segment_end != 0)) {
+        assert(ext_segment_end >= ext_segment_start);
+        uint32_t ext_segment_size = ext_segment_end - ext_segment_start;
+        ESP_EARLY_LOGV(TAG, "ext_segment_size is %" PRIu32, ext_segment_size);
+        s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].vaddr_start += ext_segment_size;
+        s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].size -= ext_segment_size;
+    }
 
 #if CONFIG_IDF_TARGET_ESP32
     s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].size -= esp_himem_reserved_area_size() - 1;


### PR DESCRIPTION
## Description

In case both `.ext_ram_bss` and `.ext_ram_noinit` segments exist, the heap start calculation may be incorrect when there is a gap between two sections. This is because the heap start calculation only considers segment sizes and not a possible gap between them. This gap may be introduced when using `__attribute__((aligned(...)))` on the first buffer in `.ext_ram_noinit` segment, i.e.:
```
...
 .bss.gEapSm    0x3c2038e4        0x4 esp-idf/wpa_supplicant/libwpa_supplicant.a(esp_eap_client.c.obj)
 *libwpa_supplicant.a:(COMMON)
                0x3c2038e8                        . = ALIGN (0x4)
                0x3c2038e8                        _ext_ram_bss_end = ABSOLUTE (.)

.ext_ram_noinit
                0x3c203900     0x8000
                0x3c203900                        _ext_ram_noinit_start = ABSOLUTE (.)
 *(.ext_ram_noinit*)
 .ext_ram_noinit.2
                0x3c203900     0x8000 esp-idf/main/libmain.a(logger.cpp.obj)
                0x3c203900                pucRingbufferStorage
                0x3c20b900                        . = ALIGN (0x4)
                0x3c20b900                        _ext_ram_noinit_end = ABSOLUTE (.)
...
```
In this case, `s_psram_ctx.regions_to_heap[PSRAM_MEM_8BIT_ALIGNED].vaddr_start` is incorrectly calculated to be `0x3c20b8e8`, while this address obviously resides inside the allocated buffer. 

Correct address would be: `0x3c203900 + 0x8000 = 0x3c20b900`

This PR changes the calculation so that the beginning of the first segment and the end of the last segment is used to calculate the true allocated size of the both regions. It keeps the (theoretical?) possibility of these segments being in random order (don't know if this was the intention of the previous implementation).

## Related

Fixes https://github.com/espressif/esp-idf/issues/15496
