### PR TITLE
feat: Add ESP_RETURN_ON_ERR macro (IDFGH-14787)

### DIFF
--- a/components/esp_common/include/esp_err.h
+++ b/components/esp_common/include/esp_err.h
@@ -95,8 +95,19 @@ void _esp_error_check_failed_without_abort(esp_err_t rc, const char *file, int l
 /**
  * Macro that returns the error code if an error occurs, optionally running extra code.
  * The extra code can be placed after the function thay may error and it will only run if the error occurs.
+ * 
+ * @example
+ * esp_err_t my_function()
+ * {
+ *     // Let's say `read_file()` returns esp_err_t and we want to `close_file()` on error.
+ *     ESP_ERROR_CHECK_RETURN(read_file(), close_file())
+ *     // If the code page gets here, `read_file()` succeeded.
+ *     process_file();
+ *     close_file();
+ *     return ESP_OK;
+ * }
  */
-#define ESP_RETURN_ON_ERR(x, ...) do {        \
+#define ESP_ERROR_CHECK_RETURN(x, ...) do {   \
         esp_err_t err_rc_ = (x);              \
         if (unlikely(err_rc_ != ESP_OK)) {    \
             __VA_ARGS__;                      \


### PR DESCRIPTION

## Description
This simple macro is a safe way of returning en error code rather than aborting like `ESP_ERROR_CHECK` would. It is intended to allow future pull requests by myself and/or my friend to replace unnecessary `ESP_ERROR_CHECK`s with this new `ESP_RETURN_ON_ERR` macro.

## Related
N/A

## Testing
This does not involve changing any C files and should not affect any existing code.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
