### PR TITLE
python-pip is also a required package on Arch Linux (IDFGH-14789)

### DIFF
--- a/docs/en/get-started/linux-macos-setup.rst
+++ b/docs/en/get-started/linux-macos-setup.rst
@@ -44,7 +44,7 @@ CentOS 7 is still supported but CentOS version 8 is recommended for a better use
 
 - Arch::
 
-    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb
+    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb python-pip
 
 .. note::
     - CMake version 3.16 or newer is required for use with ESP-IDF. Run "tools/idf_tools.py install cmake" to install a suitable version if your OS versions does not have one.

--- a/docs/zh_CN/get-started/linux-macos-setup.rst
+++ b/docs/zh_CN/get-started/linux-macos-setup.rst
@@ -44,7 +44,7 @@ Linux 用户
 
 - Arch::
 
-    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb
+    sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb python-pip
 
 .. note::
     - 使用 ESP-IDF 需要 CMake 3.16 或以上版本。较早的 Linux 发行版可能需要升级自身的软件源仓库，或开启 backports 套件库，或安装 "cmake3" 软件包（不是安装 "cmake"）。


### PR DESCRIPTION
`python-pip` is also a required package; but most people probably don't run into this documentation issue, since a lot of people already have this package installed for other projects/programs