### PR TITLE
EAP domain check (IDFGH-14822)

### DIFF
--- a/components/wpa_supplicant/esp_supplicant/include/esp_eap_client.h
+++ b/components/wpa_supplicant/esp_supplicant/include/esp_eap_client.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/components/wpa_supplicant/esp_supplicant/include/esp_eap_client.h
+++ b/components/wpa_supplicant/esp_supplicant/include/esp_eap_client.h
@@ -319,6 +319,30 @@ esp_err_t esp_eap_client_set_fast_params(esp_eap_fast_config config);
  */
 esp_err_t esp_eap_client_use_default_cert_bundle(bool use_default_bundle);
 
+/**
+ * @brief Set name for certificate domain name validation
+ *
+ * Enabling this option will only accept certificate with the provided subject name
+ *
+ * @param[in] domain_match The expected domain name
+ * @param[in] len      Length of the domain name (limited to 1~127 bytes).
+ *
+ * @return
+ *    - ESP_OK: The identity was set successfully.
+ *    - ESP_ERR_INVALID_ARG: Invalid argument (len <= 0 or len >= 128).
+ *    - ESP_ERR_NO_MEM: Memory allocation failure.
+ */
+esp_err_t esp_eap_client_set_domain_match(const char *domain_match);
+
+/**
+ * @brief Clear the domain name for certificate validation
+ *
+ * This function clears the domain name that was previously set for the EAP client.
+ * After calling this function, the EAP client will no longer use the previously
+ * configured domain name during the authentication process.
+ */
+void esp_eap_client_clear_domain_match(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
@@ -529,6 +529,11 @@ static int set_client_config(const struct tls_connection_params *cfg, tls_contex
     mbedtls_ssl_set_verify(&tls->ssl, tls_disable_key_usages, NULL);
 #endif /*CONFIG_ESP_WIFI_DISABLE_KEY_USAGE_CHECK*/
 
+    if (cfg->domain_match) {
+        mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+        mbedtls_ssl_set_hostname(&tls->ssl, cfg->domain_match);
+    }
+
 #ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
     if (cfg->flags & TLS_CONN_USE_DEFAULT_CERT_BUNDLE) {
         wpa_printf(MSG_INFO, "Using default cert bundle");

--- a/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
@@ -1191,3 +1191,33 @@ esp_err_t esp_eap_client_use_default_cert_bundle(bool use_default_bundle)
     return ESP_FAIL;
 #endif
 }
+
+#define MAX_DOMAIN_MATCH_LEN 128
+esp_err_t esp_eap_client_set_domain_match(const char *domain_match)
+{
+    if (g_wpa_domain_match) {
+        os_free(g_wpa_domain_match);
+        g_wpa_domain_match = NULL;
+    }
+
+    int len = os_strlen(domain_match);
+    if (len > MAX_DOMAIN_MATCH_LEN) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    g_wpa_domain_match = (char *)os_zalloc(len+1);
+    if (g_wpa_domain_match == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    os_strlcpy(g_wpa_domain_match, domain_match, len+1);
+
+    return ESP_OK;
+}
+
+void esp_eap_client_clear_domain_match(void)
+{
+    if (g_wpa_domain_match) {
+        os_free(g_wpa_domain_match);
+    }
+    g_wpa_domain_match = NULL;
+}

--- a/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2019-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2019-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1204,12 +1204,12 @@ esp_err_t esp_eap_client_set_domain_match(const char *domain_match)
     if (len > MAX_DOMAIN_MATCH_LEN) {
         return ESP_ERR_INVALID_ARG;
     }
-    g_wpa_domain_match = (char *)os_zalloc(len+1);
+    g_wpa_domain_match = (char *)os_zalloc(len + 1);
     if (g_wpa_domain_match == NULL) {
         return ESP_ERR_NO_MEM;
     }
 
-    os_strlcpy(g_wpa_domain_match, domain_match, len+1);
+    os_strlcpy(g_wpa_domain_match, domain_match, len + 1);
 
     return ESP_OK;
 }

--- a/components/wpa_supplicant/src/eap_peer/eap.c
+++ b/components/wpa_supplicant/src/eap_peer/eap.c
@@ -67,6 +67,7 @@ bool g_wpa_suiteb_certification;
 bool g_wpa_default_cert_bundle;
 int (*esp_crt_bundle_attach_fn)(void *conf);
 #endif
+char *g_wpa_domain_match;
 
 void eap_peer_config_deinit(struct eap_sm *sm);
 void eap_peer_blob_deinit(struct eap_sm *sm);
@@ -529,7 +530,7 @@ int eap_peer_config_init(
 	sm->config.identity = NULL;
 	sm->config.password = NULL;
 	sm->config.new_password = NULL;
-
+	sm->config.domain_match = g_wpa_domain_match;
 	sm->config.private_key_passwd = private_key_passwd;
 	sm->config.client_cert = (u8 *)sm->blob[0].name;
 	sm->config.private_key = (u8 *)sm->blob[1].name;
@@ -592,6 +593,7 @@ int eap_peer_config_init(
 		sm->config.flags |= TLS_CONN_USE_DEFAULT_CERT_BUNDLE;
 	}
 #endif
+
 	/* To be used only for EAP-FAST */
 	if (g_wpa_phase1_options) {
 		sm->config.phase1 = g_wpa_phase1_options;

--- a/components/wpa_supplicant/src/eap_peer/eap.h
+++ b/components/wpa_supplicant/src/eap_peer/eap.h
@@ -49,6 +49,8 @@ extern bool g_wpa_suiteb_certification;
 extern bool g_wpa_default_cert_bundle;
 extern int (*esp_crt_bundle_attach_fn)(void *conf);
 
+extern char *g_wpa_domain_match;
+
 const u8 * eap_get_eapKeyData(struct eap_sm *sm, size_t *len);
 void eap_deinit_prev_method(struct eap_sm *sm, const char *txt);
 struct wpabuf * eap_sm_build_nak(struct eap_sm *sm, EapType type, u8 id);

--- a/components/wpa_supplicant/src/eap_peer/eap_config.h
+++ b/components/wpa_supplicant/src/eap_peer/eap_config.h
@@ -160,6 +160,21 @@ struct eap_peer_config {
 	const u8 *private_key_passwd;
 
 	/**
+	 * domain_match - Constraint for server domain name
+	 *
+	 * If set, this FQDN is used as a full match requirement for the
+	 * server certificate in SubjectAltName dNSName element(s). If a
+	 * matching dNSName is found, this constraint is met. If no dNSName
+	 * values are present, this constraint is matched against SubjectName CN
+	 * using same full match comparison. This behavior is similar to
+	 * domain_suffix_match, but has the requirement of a full match, i.e.,
+	 * no subdomains or wildcard matches are allowed. Case-insensitive
+	 * comparison is used, so "Example.com" matches "example.com", but would
+	 * not match "test.Example.com".
+	 */
+	char *domain_match;
+
+	/**
 	 * Phase 2
 	 */
 	u8 *ca_cert2;

--- a/components/wpa_supplicant/src/eap_peer/eap_tls_common.c
+++ b/components/wpa_supplicant/src/eap_peer/eap_tls_common.c
@@ -74,6 +74,7 @@ static void eap_tls_params_from_conf1(struct tls_connection_params *params,
 	params->client_cert = (char *) config->client_cert;
 	params->private_key = (char *) config->private_key;
 	params->private_key_passwd = (char *) config->private_key_passwd;
+	params->domain_match = config->domain_match;
 	eap_tls_params_flags(params, config->phase1);
 	if (wifi_sta_get_enterprise_disable_time_check())
 		params->flags |= TLS_CONN_DISABLE_TIME_CHECKS;

--- a/examples/wifi/wifi_enterprise/main/Kconfig.projbuild
+++ b/examples/wifi/wifi_enterprise/main/Kconfig.projbuild
@@ -98,4 +98,16 @@ menu "Example Configuration"
         default n
         help
             Use default CA certificate bundle for WiFi enterprise connection
+
+    config EXAMPLE_USE_SERVER_DOMAIN_MATCH
+        bool "Validate server cert domain"
+        help
+            Validate the certificate domain
+
+    config EXAMPLE_SERVER_DOMAIN_MATCH_VALUE
+        string "Server cert domain"
+        depends on EXAMPLE_USE_SERVER_DOMAIN_MATCH
+        default "espressif.com"
+        help
+            Accept only server certificates matching this domain
 endmenu

--- a/examples/wifi/wifi_enterprise/main/wifi_enterprise_main.c
+++ b/examples/wifi/wifi_enterprise/main/wifi_enterprise_main.c
@@ -156,6 +156,9 @@ static void initialise_wifi(void)
 #ifdef CONFIG_EXAMPLE_USE_DEFAULT_CERT_BUNDLE
     ESP_ERROR_CHECK(esp_eap_client_use_default_cert_bundle(true));
 #endif
+#ifdef CONFIG_EXAMPLE_USE_SERVER_DOMAIN_MATCH
+    ESP_ERROR_CHECK(esp_eap_client_set_domain_match(CONFIG_EXAMPLE_SERVER_DOMAIN_MATCH_VALUE));
+#endif
     ESP_ERROR_CHECK(esp_wifi_sta_enterprise_enable());
     ESP_ERROR_CHECK(esp_wifi_start());
 }


### PR DESCRIPTION
## Description

For security we want to be able to validate the name of a certificate provided by a RADIUS server when using eap_client.
When using a crt bundle for validating the certificate this is required to prevent sending credentials to a malicious access point.

Feedback appreciated. 
## Related

This PR intends to fix the issue https://github.com/espressif/esp-idf/issues/247.

## Testing

We've tested this in a setup with TTLS/PAP using an ESP32 C3. Together with an embedded crt bundle. Both positive and negative test were successful.
However tesing in other situations would be indicated.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
