### PR TITLE
fix: Force wpa_supplicant to validate certificate when using the default certificate bundle (IDFGH-14823)

### DIFF
--- a/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/tls_mbedtls.c
@@ -532,6 +532,7 @@ static int set_client_config(const struct tls_connection_params *cfg, tls_contex
 #ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
     if (cfg->flags & TLS_CONN_USE_DEFAULT_CERT_BUNDLE) {
         wpa_printf(MSG_INFO, "Using default cert bundle");
+        mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
         if (esp_crt_bundle_attach_fn) {
             ret = (*esp_crt_bundle_attach_fn)(&tls->conf);
         }


### PR DESCRIPTION
## Description

My intension of using `esp_eap_client_use_default_cert_bundle(true)` was to enable validation, however that's not the case. You need to add another certificate in order to enable validation. I cannot think of a use case where the default cert bundle should be used without validating the certificate against it.
However if I'm wrong this is a breaking change. So maybe someone with a better overview might validate or falsify this PR:

## Related

This is somewhat related to https://github.com/espressif/esp-idf/pull/15550 because we want to validate the certificate by the cert bundle and the domain name.

## Testing

The change was tested with an ESP32 C3 and a TTLS/PAP setup.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
