### PR TITLE
Add support for partial websocket frame payload reads

### DIFF
--- a/components/esp_http_server/src/httpd_ws.c
+++ b/components/esp_http_server/src/httpd_ws.c
@@ -228,7 +228,7 @@ static esp_err_t httpd_ws_check_req(httpd_req_t *req)
     return ESP_OK;
 }
 
-static esp_err_t httpd_ws_unmask_payload(uint8_t *payload, size_t len, const uint8_t *mask_key)
+static esp_err_t httpd_ws_unmask_payload(uint8_t *payload, size_t len, const uint8_t *mask_key, size_t mask_offset)
 {
     if (len < 1 || !payload) {
         ESP_LOGW(TAG, LOG_FMT("Invalid payload provided"));
@@ -236,13 +236,13 @@ static esp_err_t httpd_ws_unmask_payload(uint8_t *payload, size_t len, const uin
     }
 
     for (size_t idx = 0; idx < len; idx++) {
-        payload[idx] = (payload[idx] ^ mask_key[idx % 4]);
+        payload[idx] = (payload[idx] ^ mask_key[(idx + mask_offset) % 4]);
     }
 
     return ESP_OK;
 }
 
-esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t max_len)
+static esp_err_t httpd_ws_recv_frame_internal(httpd_req_t *req, httpd_ws_frame_t *frame, size_t max_len, bool partial)
 {
     esp_err_t ret = httpd_ws_check_req(req);
     if (ret != ESP_OK) {
@@ -307,6 +307,8 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
                     ((uint64_t)length_bytes[6] <<  8U) |
                     ((uint64_t)length_bytes[7]));
         }
+        frame->left_len = frame->len;
+
         /* If this frame is masked, dump the mask as well */
         if (masked) {
             if (httpd_recv_with_opt(req, (char *)aux->mask_key, sizeof(aux->mask_key), false) <= 0) {
@@ -320,20 +322,23 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
             return ESP_ERR_INVALID_STATE;
         }
     }
-    /* We only accept the incoming packet length that is smaller than the max_len (or it will overflow the buffer!) */
     /* If max_len is 0, regard it OK for userspace to get frame len */
+    if (max_len == 0) {
+        ESP_LOGD(TAG, "regard max_len == 0 is OK for user to get frame len");
+        return ESP_OK;
+    }
     if (frame->len > max_len) {
-        if (max_len == 0) {
-            ESP_LOGD(TAG, "regard max_len == 0 is OK for user to get frame len");
-            return ESP_OK;
+        /* When reading entire packet at once, we only accept the incoming packet length that is smaller than the max_len (or it will overflow the buffer!) */
+        if (!partial) {
+            ESP_LOGW(TAG, LOG_FMT("WS Message too long"));
+            return ESP_ERR_INVALID_SIZE;
         }
-        ESP_LOGW(TAG, LOG_FMT("WS Message too long"));
-        return ESP_ERR_INVALID_SIZE;
+        ESP_LOGD(TAG, LOG_FMT("WS Message too long. User will have to call read again"));
     }
 
     /* Receive buffer */
     /* If there's nothing to receive, return and stop here. */
-    if (frame->len == 0) {
+    if (frame->left_len == 0) {
         return ESP_OK;
     }
 
@@ -342,7 +347,7 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
         return ESP_FAIL;
     }
 
-    size_t left_len = frame->len;
+    size_t left_len = (max_len < frame->left_len) ? max_len : frame->left_len;
     size_t offset = 0;
 
     while (left_len > 0) {
@@ -357,10 +362,21 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
         ESP_LOGD(TAG, "Frame length: %"NEWLIB_NANO_COMPAT_FORMAT", Bytes Read: %"NEWLIB_NANO_COMPAT_FORMAT, NEWLIB_NANO_COMPAT_CAST(frame->len), NEWLIB_NANO_COMPAT_CAST(offset));
     }
 
+    size_t mask_offset = frame->len - frame->left_len;
+    frame->left_len -= offset;
+
     /* Unmask payload */
-    httpd_ws_unmask_payload(frame->payload, frame->len, aux->mask_key);
+    httpd_ws_unmask_payload(frame->payload, offset, aux->mask_key, mask_offset);
 
     return ESP_OK;
+}
+
+esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t max_len) {
+    return httpd_ws_recv_frame_internal(req, frame, max_len, false);
+}
+
+esp_err_t httpd_ws_recv_frame_part(httpd_req_t *req, httpd_ws_frame_t *frame, size_t max_len) {
+    return httpd_ws_recv_frame_internal(req, frame, max_len, true);
 }
 
 esp_err_t httpd_ws_send_frame(httpd_req_t *req, httpd_ws_frame_t *frame)


### PR DESCRIPTION
## Description

Added support for partial websocket frame payload reads. This was implemented as a separate function `httpd_ws_recv_frame_part` to keep the backwards compatibility with subtle `httpd_ws_recv_frame` behavior, that being that it returns an undocumented error when `max_len < pkt->len`.

`httpd_ws_frame_t` now also contains new `left_len` field, which is used to keep track of the yet to be received data and calculating the mask offset. In the future, it shall also be used for implementing partial frame sends.

## Related

## Testing

This feature was tested by me on my project and on some additional edge cases, including trying to over-receive (reading more data than there is in a frame payload) and to under-receive (leaving data unprocessed and unread and completing the request). No unexpected errors were identified.

The change itself is not very complex, however in my opinion it is imperative that someone with more knowledge about the ESP HTTP stack verifies that there is no deeper issues with this implementation (and the idea itself, for that matter), which I may have missed.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
