### PR TITLE
change(ble_mesh): Allow setting the default pb-gatt device name

### DIFF
--- a/components/bt/esp_ble_mesh/api/core/esp_ble_mesh_provisioning_api.c
+++ b/components/bt/esp_ble_mesh/api/core/esp_ble_mesh_provisioning_api.c
@@ -170,6 +170,11 @@ esp_err_t esp_ble_mesh_set_unprovisioned_device_name(const char *name)
             == BT_STATUS_SUCCESS ? ESP_OK : ESP_FAIL);
 }
 
+esp_err_t esp_ble_mesh_set_default_unprovisioned_device_name(const char *name)
+{
+    return bt_mesh_set_default_device_name(name) ? ESP_FAIL : ESP_OK;
+}
+
 #if CONFIG_BLE_MESH_PROVISIONER
 esp_err_t esp_ble_mesh_provisioner_read_oob_pub_key(uint8_t link_idx, uint8_t pub_key_x[32],
                                                     uint8_t pub_key_y[32])

--- a/components/bt/esp_ble_mesh/api/core/include/esp_ble_mesh_provisioning_api.h
+++ b/components/bt/esp_ble_mesh/api/core/include/esp_ble_mesh_provisioning_api.h
@@ -117,6 +117,19 @@ esp_err_t esp_ble_mesh_node_input_string(const char *string);
 esp_err_t esp_ble_mesh_set_unprovisioned_device_name(const char *name);
 
 /**
+ * @brief        Using this function, you can set the default name set during init.
+ *
+ * @param[in]    name: Unprovisioned device name
+ *
+ * @note         This API applicable to PB-GATT mode only by setting the name to the scan response data,
+ *               it doesn't apply to PB-ADV mode.
+ *
+ * @return       ESP_OK on success or error code otherwise.
+ *
+ */
+esp_err_t esp_ble_mesh_set_default_unprovisioned_device_name(const char *name);
+
+/**
  * @brief        Provisioner inputs unprovisioned device's oob public key.
  *
  * @note         In order to avoid suffering brute-forcing attack (CVE-2020-26559).

--- a/components/bt/esp_ble_mesh/core/proxy_server.c
+++ b/components/bt/esp_ble_mesh/core/proxy_server.c
@@ -88,6 +88,7 @@ static enum {
     MESH_GATT_PROXY,
 } gatt_svc = MESH_GATT_NONE;
 
+static char default_device_name[DEVICE_NAME_SIZE + 1] = "ESP-BLE-MESH";
 static char device_name[DEVICE_NAME_SIZE + 1];
 
 struct bt_mesh_proxy_client *bt_mesh_proxy_server_get_client(uint8_t index)
@@ -98,6 +99,24 @@ struct bt_mesh_proxy_client *bt_mesh_proxy_server_get_client(uint8_t index)
 uint8_t bt_mesh_proxy_server_get_client_count(void)
 {
     return ARRAY_SIZE(clients);
+}
+
+int bt_mesh_set_default_device_name(const char *name)
+{
+    if (!name) {
+        BT_ERR("%s, Invalid parameter", __func__);
+        return -EINVAL;
+    }
+
+    if (strlen(name) > DEVICE_NAME_SIZE) {
+        BT_ERR("Too long device name (len %d)", strlen(name));
+        return -EINVAL;
+    }
+
+    memset(default_device_name, 0x0, sizeof(default_device_name));
+    strncpy(default_device_name, name, DEVICE_NAME_SIZE);
+
+    return 0;
 }
 
 int bt_mesh_set_device_name(const char *name)
@@ -1943,7 +1962,7 @@ int bt_mesh_proxy_server_init(void)
 
     bt_mesh_gatts_conn_cb_register(&conn_callbacks);
 
-    strncpy(device_name, "ESP-BLE-MESH", DEVICE_NAME_SIZE);
+    strncpy(device_name, default_device_name, DEVICE_NAME_SIZE);
     return bt_mesh_gatts_set_local_device_name(device_name);
 }
 

--- a/components/bt/esp_ble_mesh/core/proxy_server.h
+++ b/components/bt/esp_ble_mesh/core/proxy_server.h
@@ -68,6 +68,7 @@ struct bt_mesh_proxy_client {
 typedef void (*proxy_server_connect_cb_t)(uint8_t conn_handle);
 typedef void (*proxy_server_disconnect_cb_t)(uint8_t conn_handle, uint8_t reason);
 
+int bt_mesh_set_default_device_name(const char *name);
 int bt_mesh_set_device_name(const char *name);
 
 const char *bt_mesh_get_device_name(void);


### PR DESCRIPTION
## Description

Currently, even if you call esp_ble_mesh_set_unprovisioned_device_name immediately after esp_ble_mesh_init, you can end up sending out an advertisement using the default 'ESP-BLE-MESH' name.  Unfortunately, due to iOS limitations, this can be problematic as there's no way for a user app to flush the cached names.

Resolve this by allowing the default name to be set before calling esp_ble_mesh_init.

## Testing

Modified our esp_ble_mesh test hardware and confirmed iOS never saw ESP-BLE-MESH advertised.  Backported to esp-idf 5.2 for testing.
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
