### PR TITLE
fix(esp_eth): Fix order of fields in ETH_ESP32_EMAC_DEFAULT_CONFIG on P4

### DIFF
--- a/components/esp_eth/include/esp_eth_mac_esp.h
+++ b/components/esp_eth/include/esp_eth_mac_esp.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2019-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2019-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -275,14 +275,6 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
                 .clock_gpio = (emac_rmii_clock_gpio_t) 50                     \
             }                                                                 \
         },                                                                    \
-        .clock_config_out_in =                                                \
-        {                                                                     \
-            .rmii =                                                           \
-            {                                                                 \
-                .clock_mode = EMAC_CLK_EXT_IN,                                \
-                .clock_gpio = (emac_rmii_clock_gpio_t) -1                     \
-            }                                                                 \
-        },                                                                    \
         .dma_burst_len = ETH_DMA_BURST_LEN_32,                                \
         .intr_priority = 0,                                                   \
         .emac_dataif_gpio =                                                   \
@@ -295,6 +287,14 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
                 .crs_dv_num = 28,                                             \
                 .rxd0_num = 29,                                               \
                 .rxd1_num = 30                                                \
+            }                                                                 \
+        },                                                                    \
+        .clock_config_out_in =                                                \
+        {                                                                     \
+            .rmii =                                                           \
+            {                                                                 \
+                .clock_mode = EMAC_CLK_EXT_IN,                                \
+                .clock_gpio = (emac_rmii_clock_gpio_t) -1                     \
             }                                                                 \
         },                                                                    \
     }


### PR DESCRIPTION
## Description

Currently on P4:
```
.platformio/packages/framework-espidf/components/esp_eth/include/esp_eth_mac_esp.h:278:5: error: designator order for field 'eth_esp32_emac_config_t::dma_burst_len' does not match declaration order in 'eth_esp32_emac_config_t'
```

Need to fix the order of fields as they don't match the structure. 

## Related

## Testing

Built ethernet on P4

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
