### PR TITLE
fix(nvs_flash): removed usage of 'using namepsace std' in a header file (IDFGH-14947)

### DIFF
--- a/components/nvs_flash/src/nvs_cxx_api.cpp
+++ b/components/nvs_flash/src/nvs_cxx_api.cpp
@@ -17,6 +17,8 @@
 #include "nvs_handle_locked.hpp"
 #include "nvs_platform.hpp"
 
+using namespace std;
+
 namespace nvs {
 
 std::unique_ptr<NVSHandle> open_nvs_handle_from_partition(const char *partition_name,

--- a/components/nvs_flash/src/nvs_pagemanager.cpp
+++ b/components/nvs_flash/src/nvs_pagemanager.cpp
@@ -5,6 +5,8 @@
  */
 #include "nvs_pagemanager.hpp"
 
+using namespace std;
+
 namespace nvs
 {
 esp_err_t PageManager::load(Partition *partition, uint32_t baseSector, uint32_t sectorCount)

--- a/components/nvs_flash/src/nvs_partition_manager.cpp
+++ b/components/nvs_flash/src/nvs_partition_manager.cpp
@@ -12,6 +12,8 @@
 #include "nvs_encrypted_partition.hpp"
 #endif // ! LINUX_TARGET
 
+using namespace std;
+
 namespace nvs {
 
 NVSPartitionManager* NVSPartitionManager::instance = nullptr;

--- a/components/nvs_flash/src/nvs_types.hpp
+++ b/components/nvs_flash/src/nvs_types.hpp
@@ -15,8 +15,6 @@
 #include "compressed_enum_table.hpp"
 #include "string.h"
 
-using namespace std;
-
 namespace nvs
 {
 
@@ -97,7 +95,7 @@ public:
 
     void getKey(char* dst, size_t dstSize)
     {
-        strncpy(dst, key, min(dstSize, sizeof(key)));
+        strncpy(dst, key, std::min(dstSize, sizeof(key)));
         dst[dstSize-1] = 0;
     }
 


### PR DESCRIPTION
## Description

Removed `using namespace std;` from a header file and moved it to individual c/cpp files. Including a header file with this might introduce problems, as the namespace std is then used primarily without noticing it.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
