### PR TITLE
feat(bod): allow overriding brownout handling (IDFGH-14954)

### DIFF
--- a/components/esp_hw_support/power_supply/brownout.c
+++ b/components/esp_hw_support/power_supply/brownout.c
@@ -74,7 +74,7 @@ IRAM_ATTR static void rtc_brownout_isr_handler(void *arg)
 }
 #endif // CONFIG_ESP_BROWNOUT_USE_INTR
 
-void esp_brownout_init(void)
+__attribute__((weak)) void esp_brownout_init(void)
 {
 #if CONFIG_ESP_BROWNOUT_USE_INTR
     brownout_hal_config_t cfg = {


### PR DESCRIPTION
## Description

Weakly-link esp_brownout_init() so that a project may override it with their own implementation installed at the same point in startup.

Sometimes a device needs a brownout handler to trigger some quick hardware maintenance like setting or clearing a pin, and needs the handler setup early.

## Testing

Tested on ESP32-S3 by replacing `esp_brownout_init` and `rtc_brownout_isr_handler` with my own, then setting BOD level high so CPU still runs ok but triggers quickly, then verifying the new handler is hit.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
