### PR TITLE
change(esp_wifi): Improve handling group parameter A in H2E (IDFGH-14995)

### DIFF
--- a/components/wpa_supplicant/src/common/sae.c
+++ b/components/wpa_supplicant/src/common/sae.c
@@ -594,9 +594,7 @@ static struct crypto_ec_point * sswu(struct crypto_ec *ec, int group,
 
 	prime = crypto_ec_get_prime(ec);
 	prime_len = crypto_ec_prime_len(ec);
-	/* Value of 'a' defined for curve secp256r1 in 'y^2 = x^3 + ax + b' */
-	uint8_t buf[32] = {0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xfc};
-	a = crypto_bignum_init_set(buf, 32);
+	a = crypto_ec_get_a(ec);
 	b = crypto_ec_get_b(ec);
 
 	u2 = crypto_bignum_init();
@@ -615,7 +613,7 @@ static struct crypto_ec_point * sswu(struct crypto_ec *ec, int group,
 	gx2 = crypto_bignum_init();
 	tmp = crypto_bignum_init();
 	if (!u2 || !t1 || !t2 || !z || !t || !zero || !one || !two || !three ||
-	    !x1a || !x1b || !x2 || !gx1 || !gx2 || !tmp)
+	    !x1a || !x1b || !x2 || !gx1 || !gx2 || !a || !tmp)
 		goto fail;
 
 	if (z_int < 0 && crypto_bignum_sub(prime, z, z) < 0)

--- a/components/wpa_supplicant/src/crypto/crypto.h
+++ b/components/wpa_supplicant/src/crypto/crypto.h
@@ -796,6 +796,14 @@ const struct crypto_bignum * crypto_ec_get_order(struct crypto_ec *e);
  * Internal data structure for EC implementation to represent a point. The
  * contents is specific to the used crypto library.
  */
+struct crypto_ec_point;
+
+/**
+ * crypto_ec_get_a - Get 'a' coefficient of an EC group's curve
+ * @e: EC context from crypto_ec_init()
+ * Returns: 'a' coefficient (bignum) of the group
+ */
+struct crypto_bignum * crypto_ec_get_a(struct crypto_ec *e);
 
 /**
  * crypto_ec_get_b - Get 'b' coefficient of an EC group's curve
@@ -803,8 +811,6 @@ const struct crypto_bignum * crypto_ec_get_order(struct crypto_ec *e);
  * Returns: 'b' coefficient (bignum) of the group
  */
 const struct crypto_bignum * crypto_ec_get_b(struct crypto_ec *e);
-
-struct crypto_ec_point;
 
 /**
  * crypto_ec_point_init - Initialize data for an EC point


### PR DESCRIPTION
## Description

Fixes #15691 

## Related



## Testing

It was tested that ESP32-C6 could associate to a WPA3 H2E-only AP successfully.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
