### PR TITLE
fix(netif): take unmodified object by const pointer (IDFGH-15082)

### DIFF
--- a/components/esp_netif/include/esp_netif_ip_addr.h
+++ b/components/esp_netif/include/esp_netif_ip_addr.h
@@ -144,7 +144,7 @@ typedef enum {
  *
  * @return IPv6 type in form of enum esp_ip6_addr_type_t
  */
-esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(esp_ip6_addr_t* ip6_addr);
+esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(const esp_ip6_addr_t* ip6_addr);
 
 /**
  * @brief  Copy IP addresses

--- a/components/esp_netif/loopback/esp_netif_loopback.c
+++ b/components/esp_netif/loopback/esp_netif_loopback.c
@@ -470,7 +470,7 @@ int esp_netif_get_all_ip6(esp_netif_t *esp_netif, esp_ip6_addr_t if_ip6[])
     return 0;
 }
 
-esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(esp_ip6_addr_t* ip6_addr)
+esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(const esp_ip6_addr_t* ip6_addr)
 {
     return ESP_IP6_ADDR_IS_UNKNOWN;
 }

--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -2133,7 +2133,7 @@ static void netif_unset_mldv6_flag(esp_netif_t *esp_netif)
 
 #endif
 
-esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(esp_ip6_addr_t* ip6_addr)
+esp_ip6_addr_type_t esp_netif_ip6_get_addr_type(const esp_ip6_addr_t* ip6_addr)
 {
     ip6_addr_t* lwip_ip6_info = (ip6_addr_t*)ip6_addr;
 


### PR DESCRIPTION
## Description

This avoids downstream code from casting away const and the associated compiler safeties, to subsequently rely on hope that this stays correct.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

It doesn't change behavior at all. So the compiler is the required test tool!

I've been using this for a while now with some ESP32-S3's on top of 5.4. So this is probably worth backporting to the 5.4 release branch.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
