### PR TITLE
fix(esp_http_server): WebSocket frame parsing errors (IDFGH-15086)

### DIFF
--- a/components/esp_http_server/src/esp_httpd_priv.h
+++ b/components/esp_http_server/src/esp_httpd_priv.h
@@ -132,6 +132,15 @@ struct httpd_data {
     httpd_err_handler_func_t *err_handler_fns;
 };
 
+/**
+ * @brief Options for receiving HTTP request data
+ */
+typedef enum {
+    HTTPD_RECV_OPT_NONE               = 0,
+    HTTPD_RECV_OPT_HALT_AFTER_PENDING = 1,   /*!< Halt immediately after receiving from pending buffer */
+    HTTPD_RECV_OPT_BLOCKING           = 2,   /*!< Receive blocking (don't return partial length) */
+} httpd_recv_opt_t;
+
 /******************* Group : Session Management ********************/
 /** @name Session Management
  * Functions related to HTTP session management
@@ -422,22 +431,27 @@ int httpd_send(httpd_req_t *req, const char *buf, size_t buf_len);
  *
  * @note    The exposed API httpd_recv() is simply this function with last parameter
  *          set as false. This function is used internally during reception and
- *          processing of a new request. The option to halt after receiving pending
- *          data prevents the server from requesting more data than is needed for
- *          completing a packet in case when all the remaining part of the packet is
- *          in the pending buffer.
+ *          processing of a new request.
+ *
+ *          There are 2 options available that affect the behavior of the function:
+ *          - HTTPD_RECV_OPT_HALT_AFTER_PENDING
+ *            The option to halt after receiving pending data prevents the server from
+ *            requesting more data than is needed for completing a packet in case when
+ *            all the remaining part of the packet is in the pending buffer.
+ *
+ *          - HTTPD_RECV_OPT_BLOCKING
+ *            The option to not return until the `buf_len` bytes have been read.
  *
  * @param[in]  req    Pointer to new HTTP request which only has the socket descriptor
  * @param[out] buf    Pointer to the buffer which will be filled with the received data
  * @param[in] buf_len Length of the buffer
- * @param[in] halt_after_pending When set true, halts immediately after receiving from
- *                               pending buffer
+ * @param[in] opt     Receive option
  *
  * @return
  *  - Length of data : if successful
  *  - ESP_FAIL       : if failed
  */
-int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, bool halt_after_pending);
+int httpd_recv_with_opt(httpd_req_t *r, char *buf, size_t buf_len, httpd_recv_opt_t opt);
 
 /**
  * @brief   For un-receiving HTTP request data

--- a/components/esp_http_server/src/httpd_ws.c
+++ b/components/esp_http_server/src/httpd_ws.c
@@ -296,7 +296,7 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
 
         /* Grab the second byte */
         uint8_t second_byte = 0;
-        if (httpd_recv_with_opt(req, (char *)&second_byte, sizeof(second_byte), false) <= 0) {
+        if (httpd_recv_with_opt(req, (char *)&second_byte, sizeof(second_byte), HTTPD_RECV_OPT_BLOCKING) < sizeof(second_byte)) {
             ESP_LOGW(TAG, LOG_FMT("Failed to receive the second byte"));
             return ESP_FAIL;
         }
@@ -313,7 +313,7 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
         } else if (init_len == 126) {
             /* Case 2: If length byte is 126, then this frame's length bit is 16 bits */
             uint8_t length_bytes[2] = { 0 };
-            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), false) <= 0) {
+            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), HTTPD_RECV_OPT_BLOCKING) < sizeof(length_bytes)) {
                 ESP_LOGW(TAG, LOG_FMT("Failed to receive 2 bytes length"));
                 return ESP_FAIL;
             }
@@ -322,8 +322,8 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
         } else if (init_len == 127) {
             /* Case 3: If length is byte 127, then this frame's length bit is 64 bits */
             uint8_t length_bytes[8] = { 0 };
-            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), false) <= 0) {
-                ESP_LOGW(TAG, LOG_FMT("Failed to receive 2 bytes length"));
+            if (httpd_recv_with_opt(req, (char *)length_bytes, sizeof(length_bytes), HTTPD_RECV_OPT_BLOCKING) < sizeof(length_bytes)) {
+                ESP_LOGW(TAG, LOG_FMT("Failed to receive 8 bytes length"));
                 return ESP_FAIL;
             }
 
@@ -338,7 +338,7 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
         }
         /* If this frame is masked, dump the mask as well */
         if (masked) {
-            if (httpd_recv_with_opt(req, (char *)aux->mask_key, sizeof(aux->mask_key), false) <= 0) {
+            if (httpd_recv_with_opt(req, (char *)aux->mask_key, sizeof(aux->mask_key), HTTPD_RECV_OPT_BLOCKING) < sizeof(aux->mask_key)) {
                 ESP_LOGW(TAG, LOG_FMT("Failed to receive mask key"));
                 return ESP_FAIL;
             }
@@ -375,7 +375,7 @@ esp_err_t httpd_ws_recv_frame(httpd_req_t *req, httpd_ws_frame_t *frame, size_t 
     size_t offset = 0;
 
     while (left_len > 0) {
-        int read_len = httpd_recv_with_opt(req, (char *)frame->payload + offset, left_len, false);
+        int read_len = httpd_recv_with_opt(req, (char *)frame->payload + offset, left_len, HTTPD_RECV_OPT_NONE);
         if (read_len <= 0) {
             ESP_LOGW(TAG, LOG_FMT("Failed to receive payload"));
             return ESP_FAIL;
@@ -483,7 +483,7 @@ esp_err_t httpd_ws_get_frame_type(httpd_req_t *req)
     /* Read the first byte from the frame to get the FIN flag and Opcode */
     /* Please refer to RFC6455 Section 5.2 for more details */
     uint8_t first_byte = 0;
-    if (httpd_recv_with_opt(req, (char *)&first_byte, sizeof(first_byte), false) <= 0) {
+    if (httpd_recv_with_opt(req, (char *)&first_byte, sizeof(first_byte), HTTPD_RECV_OPT_BLOCKING) < sizeof(first_byte)) {
         /* If the recv() return code is <= 0, then this socket FD is invalid (i.e. a broken connection) */
         /* Here we mark it as a Close message and close it later. */
         ESP_LOGW(TAG, LOG_FMT("Failed to read header byte (socket FD invalid), closing socket now"));


### PR DESCRIPTION
## Description
This PR fixes multiple WebSocket frame parsing errors. The issue arises due to `httpd_recv_with_opt` returning partial data. This is simply not an option in some cases, e.g. in the following one where two bytes of frame length must be successfully read

https://github.com/espressif/esp-idf/blob/1c468f68259065ef51afd114605d9122f13d9d72/components/esp_http_server/src/httpd_ws.c#L285-L292

`httpd_recv_with_opt` may very well return with just a single byte read and the resulting frame length will be garbage.

The issue has been fixed by extending the options which can be passed to `httpd_recv_with_opt`. In favor of readability the former boolean parameter has been switched to an enumeration, with a "blocking read" being one of the options now available.

```c
/**
 * @brief Options for receiving HTTP request data
 */
typedef enum {
    HTTPD_RECV_OPT_NONE               = 0,
    HTTPD_RECV_OPT_HALT_AFTER_PENDING = 1,   /*!< Halt immediately after receiving from pending buffer */
    HTTPD_RECV_OPT_BLOCKING           = 2,   /*!< Receive blocking (don't return partial length) */
} httpd_recv_opt_t;
```


## Related
Fixes #15235

## Testing
Repro example can be found in #15235

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
