### PR TITLE
[Fix] Add 'esp_netif' as requirements in CMakeLists

### DIFF
--- a/components/esp_local_ctrl/CMakeLists.txt
+++ b/components/esp_local_ctrl/CMakeLists.txt
@@ -23,7 +23,7 @@ list(APPEND srcs
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS "${include_dirs}"
                     PRIV_INCLUDE_DIRS "${priv_include_dirs}"
-                    REQUIRES protocomm esp_https_server
+                    REQUIRES esp_netif protocomm esp_https_server
                     PRIV_REQUIRES protobuf-c)
 
 idf_component_optional_requires(PRIVATE espressif__mdns mdns)


### PR DESCRIPTION
## Description

By encounter error through the following, that might be some missing components defined with the build stage.
```
esp-idf/components/esp_local_ctrl/src/esp_local_ctrl_transport_httpd.c:19:10: fatal error: esp_netif.h: No such file or directory
```

I figured that the `REQUIRES` section should include `esp_netif` as calling `#include` within the src.

Target:
```
idf_component_register(SRCS "${srcs}"
                    INCLUDE_DIRS "${include_dirs}"
                    PRIV_INCLUDE_DIRS "${priv_include_dirs}"
                    REQUIRES esp_netif protocomm esp_https_server                    <- [Fix] add 'esp_netif'
                    PRIV_REQUIRES protobuf-c)
```

## Testing

Passed.
