### PR TITLE
fix(esp_http_server): Fix incorrect spelling in the comments (IDFGH-15144)

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -1151,7 +1151,7 @@ esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len
 /**
  * @brief   API to send a complete string as HTTP response.
  *
- * This API simply calls http_resp_send with buffer length
+ * This API simply calls httpd_resp_send with buffer length
  * set to string length assuming the buffer contains a null
  * terminated string
  *
@@ -1172,7 +1172,7 @@ static inline esp_err_t httpd_resp_sendstr(httpd_req_t *r, const char *str) {
 /**
  * @brief   API to send a string as an HTTP response chunk.
  *
- * This API simply calls http_resp_send_chunk with buffer length
+ * This API simply calls httpd_resp_send_chunk with buffer length
  * set to string length assuming the buffer contains a null
  * terminated string
  *


### PR DESCRIPTION
## Description

Fix incorrect spelling in the comments of "esp_http_server" component.
For detail, please see the content of PR file.

## Related

None

## Testing

Only two spelling errors in the comments were corrected; no testing is needed.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
