### PR TITLE
fix(ulp): Prevent silent breaking change with master

### DIFF
--- a/components/ulp/lp_core/lp_core/include/ulp_lp_core_utils.h
+++ b/components/ulp/lp_core/lp_core/include/ulp_lp_core_utils.h
@@ -16,11 +16,12 @@ extern "C" {
 #include "soc/soc_caps.h"
 
 /**
- * @brief Traverse all possible wake-up sources and update the wake-up cause so that
- *        ulp_lp_core_get_wakeup_cause can obtain the bitmap of the wake-up reasons.
+ * Deprecated - Not needed anymore, please remove from your code
+ *
  * @note Do not call it from user ULP programs because it will clear the wake-up cause bits
  *       which were set at ULP startup in lp_core_startup().
  */
+[[deprecated("This function is removed and does nothing, please remove its call")]]
 void ulp_lp_core_update_wakeup_cause(void);
 
 /**

--- a/components/ulp/lp_core/lp_core/lp_core_startup.c
+++ b/components/ulp/lp_core/lp_core/lp_core_startup.c
@@ -13,6 +13,7 @@
 #include "ulp_lp_core_print.h"
 
 extern void main();
+extern uint32_t lp_wakeup_cause;
 
 /* Initialize lp core related system functions before calling user's main*/
 void lp_core_startup()
@@ -22,7 +23,7 @@ void lp_core_startup()
     ets_install_putc1(lp_core_print_char);
 #endif
 
-    ulp_lp_core_update_wakeup_cause();
+    lp_wakeup_cause = (uint32_t) -1;
 
     main();
 

--- a/components/ulp/lp_core/lp_core/lp_core_utils.c
+++ b/components/ulp/lp_core/lp_core/lp_core_utils.c
@@ -38,9 +38,11 @@
 #define LP_CORE_CPU_FREQUENCY_HZ 16000000
 #endif
 
-static uint32_t lp_wakeup_cause = 0;
+uint32_t lp_wakeup_cause = (uint32_t) -1;
 
-void ulp_lp_core_update_wakeup_cause(void)
+void ulp_lp_core_update_wakeup_cause(void) {}
+
+static void lp_core_ll_update_wakeup_cause(void)
 {
     lp_wakeup_cause = 0;
     if ((lp_core_ll_get_wakeup_source() & LP_CORE_LL_WAKEUP_SOURCE_HP_CPU) \
@@ -94,6 +96,9 @@ void ulp_lp_core_update_wakeup_cause(void)
 
 uint32_t ulp_lp_core_get_wakeup_cause()
 {
+    if (lp_wakeup_cause == (uint32_t) -1) {
+        lp_core_ll_update_wakeup_cause();
+    }
     return lp_wakeup_cause;
 }
 


### PR DESCRIPTION
## Description

Issue #15794 was closed but the fix is not correct.
It introduce a silent breaking change to master, since previous code using `ulp_lp_core_update_wakeup_cause` will now receive 0 instead of the (expected) wake up cause they previously received.
Also, it added additional latency for the LP core boot which, if you don't care about the wake up cause (as most do), is unforgivable.

This PR attempt to fix it like this:
1. It deprecates the `ulp_lp_core_update_wakeup_cause` function so users can update their code to remove this function call
2. It replaces the original function content to nothing (so it doesn't break the previous user code)
3. It moves the computation of the wakeup cause to the `ulp_lp_core_get_wakeup_cause` only on first call. This is done by setting a sentinel value for the `lp_wakeup_cause` variable in the startup code (so a **single** variable assignment instead of the whole query of all possible wake up source and clearing of the peripherals registers)
4. It renames the previous `ulp_lp_core_update_wakeup_cause` to a private `lp_core_ll_update_wakeup_cause` function so no breaking change here

## Related

Truely fixes #15794


## Testing

Tested on ESP32C6. I haven't checked the OP issue in the linked issue is fixed with this code, I'll report here if it's not.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes (unlike what's in master)
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
