### PR TITLE
Fix for an infinite wait in spi-lcd-touch example (IDFGH-15181)

### DIFF
--- a/examples/peripherals/lcd/spi_lcd_touch/main/spi_lcd_touch_example_main.c
+++ b/examples/peripherals/lcd/spi_lcd_touch/main/spi_lcd_touch_example_main.c
@@ -164,9 +164,15 @@ static void example_lvgl_port_task(void *arg)
         _lock_acquire(&lvgl_api_lock);
         time_till_next_ms = lv_timer_handler();
         _lock_release(&lvgl_api_lock);
-        // in case of triggering a task watch dog time out
-        time_till_next_ms = MAX(time_till_next_ms, time_threshold_ms);
-        usleep(1000 * time_till_next_ms);
+        if ( time_till_next_ms == LV_NO_TIMER_READY ) {
+            //most probably lvgl display not ready yet
+            usleep( 1000 * 1000 );
+        }
+        else {
+            // in case of triggering a task watch dog time out
+            time_till_next_ms = MAX(time_till_next_ms, time_threshold_ms);
+            usleep(1000 * time_till_next_ms);
+        }
     }
 }
 


### PR DESCRIPTION
## Description
The issue is time_till_next_ms can be LV_NO_TIMER_READY, the value is actually a UINT32_MAX — not a valid delay duration. Which results in infinite sleep time.

## Testing
Compiles and fixes the issue I was facing with my LCD screen. 

## Checklist
- [ x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
