### PR TITLE
feat(tcp_transport): add API to configure SSL cipher suites (IDFGH-15197)

### DIFF
--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -163,6 +163,20 @@ void esp_transport_ssl_skip_common_name_check(esp_transport_handle_t t);
  */
 void esp_transport_ssl_set_common_name(esp_transport_handle_t t, const char *common_name);
 
+
+/**
+ * @brief      Set the SSL cipher suites list
+ *
+ * @note       This function stores a pointer to the data rather than making a copy.
+ *             Therefore, the data must remain valid until the connection is cleaned up.
+ *             The `ciphersuites_list` is a pointer to a zero-terminated array of IANA identifiers of TLS cipher suites.
+ *             You can verify the validity of the list using the `esp_tls_get_ciphersuites_list()` API.
+ *
+ * @param      t                  SSL transport
+ * @param[in]  ciphersuites_list  A pointer to a zero-terminated array of IANA identifiers of TLS cipher suites
+ */
+void esp_transport_ssl_set_ciphersuites_list(esp_transport_handle_t t, const int *ciphersuites_list);
+
 /**
  * @brief      Set the ssl context to use secure element (atecc608a) for client(device) private key and certificate
  *

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -460,6 +460,12 @@ void esp_transport_ssl_set_common_name(esp_transport_handle_t t, const char *com
     ssl->cfg.common_name = common_name;
 }
 
+void esp_transport_ssl_set_ciphersuites_list(esp_transport_handle_t t, const int *ciphersuites_list)
+{
+    GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);
+    ssl->cfg.ciphersuites_list = ciphersuites_list;
+}
+
 #ifdef CONFIG_ESP_TLS_USE_SECURE_ELEMENT
 void esp_transport_ssl_use_secure_element(esp_transport_handle_t t)
 {


### PR DESCRIPTION
## Description

Add new API esp_transport_ssl_set_ciphersuites_list() to allow configuring custom TLS cipher suites in SSL transport layer. This enables users to:
- Set specific cipher suites for SSL/TLS connections

## Related

Referring to this submission, users can specify TLS encryption suite in MQTTS to meet specific encryption authentication requirements.

https://github.com/espressif/esp-mqtt/pull/298#issue-3023988938

![image](https://github.com/user-attachments/assets/2627c619-8d02-4b6e-853f-974df342b009)


## Testing

Referring to this submission

https://github.com/espressif/esp-mqtt/pull/298#issue-3023988938

