### PR TITLE
feat(esp-ble_mesh): config sensor_client example

### DIFF
--- a/examples/bluetooth/esp_ble_mesh/sensor_models/sensor_client/main/Kconfig.projbuild
+++ b/examples/bluetooth/esp_ble_mesh/sensor_models/sensor_client/main/Kconfig.projbuild
@@ -1,0 +1,16 @@
+menu "Board Configuration"
+
+    config BUTTON_IO_NUM
+        int "GPIO number for button"
+        default 0
+        help
+            GPIO number to use as a button input.
+
+    config BUTTON_ACTIVE_LEVEL
+        int "Active level for button (0 = LOW, 1 = HIGH)"
+        default 0
+        range 0 1
+        help
+            Logic level at which the button is considered pressed.
+
+endmenu

--- a/examples/bluetooth/esp_ble_mesh/sensor_models/sensor_client/main/board.c
+++ b/examples/bluetooth/esp_ble_mesh/sensor_models/sensor_client/main/board.c
@@ -2,7 +2,7 @@
 
 /*
  * SPDX-FileCopyrightText: 2017 Intel Corporation
- * SPDX-FileContributor: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2018-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,11 +11,12 @@
 #include "esp_log.h"
 #include "iot_button.h"
 #include "esp_ble_mesh_sensor_model_api.h"
+#include "sdkconfig.h"
 
 #define TAG "BOARD"
 
-#define BUTTON_IO_NUM           0
-#define BUTTON_ACTIVE_LEVEL     0
+#define BUTTON_IO_NUM           CONFIG_BUTTON_IO_NUM
+#define BUTTON_ACTIVE_LEVEL     CONFIG_BUTTON_ACTIVE_LEVEL
 
 extern void example_ble_mesh_send_sensor_message(uint32_t opcode);
 


### PR DESCRIPTION
## Description
The example [esp_ble_mesh-sensor_client](https://github.com/espressif/esp-idf/tree/master/examples/bluetooth/esp_ble_mesh/sensor_models/sensor_client) required a source code modification to assign the button I/O. To improve this, I added a Kconfig file that allows configuring both the button I/O and its active level, without needing to modify the source code.

Before: 
```
#define TAG "BOARD"

#define BUTTON_IO_NUM           0
#define BUTTON_ACTIVE_LEVEL     0
```

After:
```
#define TAG "BOARD"

#define BUTTON_IO_NUM           CONFIG_BUTTON_IO_NUM
#define BUTTON_ACTIVE_LEVEL     CONFIG_BUTTON_ACTIVE_LEVEL
```

## Related

This fix #11505 

## Testing

Verified using `idf.py menuconfig` and tested on an ESP32-C3-WROOM-02.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
