### PR TITLE
feat(esp-ble-mesh): config vendor_model_client example

### DIFF
--- a/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/README.md
+++ b/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/README.md
@@ -12,7 +12,7 @@ This example demonstrates how to create a vendor client model in Provisioner, an
 3. When the unprovisioned device starts, it will initialize mesh stack and enable its functionality;
 4. When the Provisioner and unprovisioned device are ready, the Provisioner will start to provision the unprovisioned device;
 5. After the device is provisioned successfully, Provisioner will configure the node, i.e. add application key, bind application key with the vendor server model of the node;
-6. After the configuration is completed, users can press the "Boot" button on the development board to send a vendor client message to the node;
+6. After the configuration is completed, users can press the "Boot" button on the development board to send a vendor client message to the node (the button pin can also be configured using `idf.py menuconfig`);
 7. When the node receives the vendor client message, it will send a vendor server message as a response;
 8. After the Provisioner receives the response, it will calculate the latency (in microseconds).
 

--- a/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/Kconfig.projbuild
+++ b/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/Kconfig.projbuild
@@ -1,0 +1,16 @@
+menu "Board Configuration"
+
+    config BUTTON_IO_NUM
+        int "GPIO number for button"
+        default 0
+        help
+            GPIO number to use as a button input.
+
+    config BUTTON_ACTIVE_LEVEL
+        int "Active level for button (0 = LOW, 1 = HIGH)"
+        default 0
+        range 0 1
+        help
+            Logic level at which the button is considered pressed.
+
+endmenu

--- a/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/board.c
+++ b/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client/main/board.c
@@ -2,7 +2,7 @@
 
 /*
  * SPDX-FileCopyrightText: 2017 Intel Corporation
- * SPDX-FileContributor: 2018-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2018-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,11 +10,12 @@
 #include <stdio.h>
 #include "esp_log.h"
 #include "iot_button.h"
+#include "sdkconfig.h"
 
 #define TAG "BOARD"
 
-#define BUTTON_IO_NUM           0
-#define BUTTON_ACTIVE_LEVEL     0
+#define BUTTON_IO_NUM           CONFIG_BUTTON_IO_NUM
+#define BUTTON_ACTIVE_LEVEL     CONFIG_BUTTON_ACTIVE_LEVEL
 
 extern void example_ble_mesh_send_vendor_message(bool resend);
 


### PR DESCRIPTION
## Description

The example [esp_ble_mesh-vendor_client](https://github.com/espressif/esp-idf/tree/master/examples/bluetooth/esp_ble_mesh/vendor_models/vendor_client) uses the Boot button to send a message. However, if we want to change the button pin configuration, we currently need to modify the source code. To improve this, I added a Kconfig file that allows configuring both the button I/O and its active level through `idf.py menuconfig`, without needing to change the source code.

Before: 
```
#define TAG "BOARD"

#define BUTTON_IO_NUM           0
#define BUTTON_ACTIVE_LEVEL     0
```

After:
```
#define TAG "BOARD"

#define BUTTON_IO_NUM           CONFIG_BUTTON_IO_NUM
#define BUTTON_ACTIVE_LEVEL     CONFIG_BUTTON_ACTIVE_LEVEL
```
## Related

This is related to #11505, but in a different example.

## Testing

Verified using `idf.py menuconfig` and tested on an ESP32-C3-WROOM-02.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
