### PR TITLE
fix(uart): Fix comments describing full/empty thresholds (ESP32) (IDFGH-15225)

### DIFF
--- a/components/soc/esp32/register/soc/uart_reg.h
+++ b/components/soc/esp32/register/soc/uart_reg.h
@@ -141,14 +141,14 @@
 #define UART_PARITY_ERR_INT_RAW_S  2
 /* UART_TXFIFO_EMPTY_INT_RAW : RO ;bitpos:[1] ;default: 1'b0 ; */
 /*description: This interrupt raw bit turns to high level when the amount of
- data in transmitter's fifo is less than ((tx_mem_cnttxfifo_cnt) .*/
+ data in transmitter's fifo is less than (tx_mem_empty_thrhd txfifo_empty_thrhd) .*/
 #define UART_TXFIFO_EMPTY_INT_RAW  (BIT(1))
 #define UART_TXFIFO_EMPTY_INT_RAW_M  (BIT(1))
 #define UART_TXFIFO_EMPTY_INT_RAW_V  0x1
 #define UART_TXFIFO_EMPTY_INT_RAW_S  1
 /* UART_RXFIFO_FULL_INT_RAW : RO ;bitpos:[0] ;default: 1'b0 ; */
 /*description: This interrupt raw bit turns to high level when receiver receives
- more data than (rx_flow_thrhd_h3 rx_flow_thrhd).*/
+ more data than (rx_mem_full_thrhd rxfifo_full_thrhd).*/
 #define UART_RXFIFO_FULL_INT_RAW  (BIT(0))
 #define UART_RXFIFO_FULL_INT_RAW_M  (BIT(0))
 #define UART_RXFIFO_FULL_INT_RAW_V  0x1
@@ -809,7 +809,7 @@
 #define UART_TXFIFO_EMPTY_THRHD_S  8
 /* UART_RXFIFO_FULL_THRHD : R/W ;bitpos:[6:0] ;default: 7'h60 ; */
 /*description: When receiver receives more data than its threshold value.receiver
- will produce rxfifo_full_int_raw interrupt.the threshold value is (rx_flow_thrhd_h3 rxfifo_full_thrhd).*/
+ will produce rxfifo_full_int_raw interrupt. the threshold value is (rx_mem_full_thrhd rxfifo_full_thrhd).*/
 #define UART_RXFIFO_FULL_THRHD  0x0000007F
 #define UART_RXFIFO_FULL_THRHD_M  ((UART_RXFIFO_FULL_THRHD_V)<<(UART_RXFIFO_FULL_THRHD_S))
 #define UART_RXFIFO_FULL_THRHD_V  0x7F

--- a/components/soc/esp32/register/soc/uart_struct.h
+++ b/components/soc/esp32/register/soc/uart_struct.h
@@ -22,8 +22,8 @@ typedef volatile struct uart_dev_s {
     } fifo;
     union {
         struct {
-            uint32_t rxfifo_full:      1;           /*This interrupt raw bit turns to high level when receiver receives more data than (rx_flow_thrhd_h3 rx_flow_thrhd).*/
-            uint32_t txfifo_empty:     1;           /*This interrupt raw bit turns to high level when the amount of data in transmitter's fifo is less than ((tx_mem_cnttxfifo_cnt) .*/
+            uint32_t rxfifo_full:      1;           /*This interrupt raw bit turns to high level when receiver receives more data than (rx_mem_full_thrhd rxfifo_full_thrhd).*/
+            uint32_t txfifo_empty:     1;           /*This interrupt raw bit turns to high level when the amount of data in transmitter's fifo is less than (tx_mem_empty_thrhd txfifo_empty_thrhd).*/
             uint32_t parity_err:       1;           /*This interrupt raw bit turns to high level when receiver detects the parity error of data.*/
             uint32_t frm_err:          1;           /*This interrupt raw bit turns to high level when receiver detects data's frame error .*/
             uint32_t rxfifo_ovf:       1;           /*This interrupt raw bit turns to high level when receiver receives more data than the fifo can store.*/
@@ -188,7 +188,7 @@ typedef volatile struct uart_dev_s {
     } conf0;
     union {
         struct {
-            uint32_t rxfifo_full_thrhd:  7;         /*When receiver receives more data than its threshold value，receiver will produce rxfifo_full_int_raw interrupt.the threshold value is (rx_flow_thrhd_h3 rxfifo_full_thrhd).*/
+            uint32_t rxfifo_full_thrhd:  7;         /*When receiver receives more data than its threshold value，receiver will produce rxfifo_full_int_raw interrupt.the threshold value is (rx_mem_full_thrhd rxfifo_full_thrhd).*/
             uint32_t reserved7:          1;
             uint32_t txfifo_empty_thrhd: 7;         /*when the data amount in transmitter fifo is less than its threshold value， it will produce txfifo_empty_int_raw interrupt. the threshold value is (tx_mem_empty_thrhd txfifo_empty_thrhd)*/
             uint32_t reserved15:         1;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

- [X] Fixes #15892

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Comment changes only
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
