### PR TITLE
docs(esp32): Add note about including esp_check.h for error-handling.rst docs page in English

### DIFF
--- a/docs/en/api-guides/error-handling.rst
+++ b/docs/en/api-guides/error-handling.rst
@@ -83,6 +83,9 @@ Error message will typically look like this:
 
 :c:macro:`ESP_ERROR_CHECK_WITHOUT_ABORT` macro serves similar purpose as ``ESP_ERROR_CHECK``, except that it will not call ``abort()``.
 
+.. note::
+
+    Macros below require ``esp_check.h`` header file to be included
 
 .. _esp-return-on-error-macro:
 


### PR DESCRIPTION
## Description

Added note about required ```esp_check.h``` header to work with error handling macros mentioned in ```Error handling``` page. In my opinion it is useful information for people who starts working with esp-idf environment and don't do exact research through code base. Currently it is only in English, because my knowledge of Chinese is literally zero. I got down to perform commit and PR about this feature with trepidation, I've send feedback to ESP-IDF about 2 months ago, but nothing has been done in that case, even without any response.

## Testing

Docs are building properly, viewed the HTML result in web browser

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
