### PR TITLE
Fix the ability to switch back to USB/JTAG after uninstalling TinyUSB (IDFGH-15273)

### DIFF
--- a/components/usb/usb_phy.c
+++ b/components/usb/usb_phy.c
@@ -13,6 +13,7 @@
 #include "esp_private/usb_phy.h"
 #include "esp_private/critical_section.h"
 #include "soc/usb_dwc_periph.h"
+#include "hal/usb_serial_jtag_hal.h"
 #include "hal/usb_wrap_hal.h"
 #include "hal/usb_utmi_hal.h"
 #include "esp_rom_gpio.h"
@@ -347,6 +348,12 @@ esp_err_t usb_new_phy(const usb_phy_config_t *config, usb_phy_handle_t *handle_r
         usb_wrap_hal_phy_set_external(&phy_context->wrap_hal, (phy_target == USB_PHY_TARGET_EXT));
 #endif
     }
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+    else if (config->controller == USB_PHY_CTRL_SERIAL_JTAG) {
+        usb_serial_jtag_hal_phy_set_external(NULL, (config->target == USB_PHY_TARGET_EXT));
+        phy_context->otg_mode = USB_OTG_MODE_DEVICE;
+    }
+#endif
 
     // For FSLS PHY that shares pads with GPIO peripheral, we must set drive capability to 3 (40mA)
     if (phy_target == USB_PHY_TARGET_INT) {


### PR DESCRIPTION
## Description

Before ESP-IDF v5.3.3 it was possible to disable TinyUSB and switch back to the USB/JTAG peripheral at runtime with code like this:

```C
tusb_cdc_acm_deinit(TINYUSB_CDC_ACM_0);
tinyusb_driver_uninstall();
usb_phy_config_t phy_config = {.controller = USB_PHY_CTRL_SERIAL_JTAG,
                               .target = USB_PHY_TARGET_INT};
usb_phy_handle_t jtag_phy;
usb_new_phy(&phy_config, &jtag_phy);
```

On v5.3.3 (as well as v5.4.1 and today's master `v5.5-dev-3568-g565cca2fee`) this no longer works and the device no longer enumerates.

It appears the regression happened in 005ae0554a, specifically this part:

```diff
diff --git a/components/usb/usb_phy.c b/components/usb/usb_phy.c
index 1de4ebee3b..43cceeb595 100644
--- a/components/usb/usb_phy.c
+++ b/components/usb/usb_phy.c
@@ -13,12 +13,9 @@
 #include "esp_private/usb_phy.h"
 #include "soc/usb_dwc_periph.h"
 #include "hal/usb_wrap_hal.h"
-#include "hal/usb_serial_jtag_hal.h"
 #include "esp_rom_gpio.h"
 #include "driver/gpio.h"
@@ -307,13 +307,6 @@ esp_err_t usb_new_phy(const usb_phy_config_t *config, usb_phy_handle_t *handle_r
         usb_wrap_hal_phy_set_external(&phy_context->wrap_hal, (config->target == USB_PHY_TARGET_EXT));
 #endif
     }
-#if SOC_USB_SERIAL_JTAG_SUPPORTED
-    else if (config->controller == USB_PHY_CTRL_SERIAL_JTAG) {
-        usb_serial_jtag_hal_phy_set_external(&phy_context->usj_hal, (config->target == USB_PHY_TARGET_EXT));
-        phy_context->otg_mode = USB_OTG_MODE_DEVICE;
-        phy_context->otg_speed = USB_PHY_SPEED_FULL;
-    }
-#endif
 
     if (config->target == USB_PHY_TARGET_INT) {
         gpio_set_drive_capability(USBPHY_DM_NUM, GPIO_DRIVE_CAP_3);
```

This PR reverts that change. It can also be backported to v5.3.3 and v5.4.1 in a very similar way:

```diff
diff --git i/components/usb/usb_phy.c w/components/usb/usb_phy.c
index 4c1241b83d..cfad1a64fa 100644
--- i/components/usb/usb_phy.c
+++ w/components/usb/usb_phy.c
@@ -13,6 +13,7 @@
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/usb_phy.h"
 #include "soc/usb_dwc_periph.h"
+#include "hal/usb_serial_jtag_hal.h"
 #include "hal/usb_wrap_hal.h"
 #include "hal/usb_utmi_hal.h"
 #include "esp_rom_gpio.h"
@@ -371,6 +372,13 @@ esp_err_t usb_new_phy(const usb_phy_config_t *config, usb_phy_handle_t *handle_r
         usb_wrap_hal_phy_set_external(&phy_context->wrap_hal, (phy_target == USB_PHY_TARGET_EXT));
 #endif
     }
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+    else if (config->controller == USB_PHY_CTRL_SERIAL_JTAG) {
+        usb_serial_jtag_hal_phy_set_external(NULL, (config->target == USB_PHY_TARGET_EXT));
+        phy_context->otg_mode = USB_OTG_MODE_DEVICE;
+        phy_context->otg_speed = USB_PHY_SPEED_FULL;
+    }
+#endif
 
     // For FSLS PHY that shares pads with GPIO peripheral, we must set drive capability to 3 (40mA)
     if (phy_target == USB_PHY_TARGET_INT) {
```

End-user code can work around this issue by calling `usb_serial_jtag_hal_phy_set_external(NULL, false)` manually after `tinyusb_driver_uninstall` and `usb_new_phy`. But I believe this change was unintentional since after 005ae0554a, the [`USB_PHY_CTRL_SERIAL_JTAG`](https://github.com/espressif/esp-idf/blob/565cca2feef765c0a24146b1392eccbf4b3a6276/components/hal/include/hal/usb_phy_types.h#L37) enum value is not used anywhere in the codebase.

A simple project for reproducing the issue is attached below. Build and flash this on an ESP32-S3 device using various IDF versions. Push the GPIO0 button to switch from TinyUSB CDC mode back to USB/JTAG mode. On v5.3.2 the `Espressif Device` will go away and the `USB JTAG/serial debug unit` will show up. On v5.3.3 and above, this won't happen.

[20250506_tinyusb_usb_jtag_regression_v3.zip](https://github.com/user-attachments/files/20129759/20250506_tinyusb_usb_jtag_regression_v3.zip)

## Related

Fixes #15912

## Testing

I've tested this on an ESP32-S3 running IDF master 565cca2fee (v5.5-dev-3568-g565cca2fee). I've also tested the above backport on v5.3.3 and v5.4.1.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
