### PR TITLE
feat(ota-mqtt): simple example to make an ota over mqtt

### DIFF
--- a/examples/system/ota/simple_mqtt_ota/CMakeLists.txt
+++ b/examples/system/ota/simple_mqtt_ota/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+project(simple_mqtt_ota)

--- a/examples/system/ota/simple_mqtt_ota/README.md
+++ b/examples/system/ota/simple_mqtt_ota/README.md
@@ -1,0 +1,128 @@
+| Supported Targets | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C5 | ESP32-C6 | ESP32-C61 | ESP32-H2 | ESP32-H21 | ESP32-H4 | ESP32-P4 | ESP32-S2 | ESP32-S3 |
+| ----------------- | ----- | -------- | -------- | -------- | -------- | --------- | -------- | --------- | -------- | -------- | -------- | -------- |
+
+# Simple MQTT OTA Example
+
+This is an **ESP-IDF example** demonstrating how to perform **Over-the-Air (OTA) firmware updates using MQTT** and the `esp_ota_ops` APIs.
+
+Firmware is transmitted in binary chunks over MQTT topics. The device subscribes to specific topics to initiate, receive, and finalize the OTA update process.
+
+---
+
+## Configuration
+
+### MQTT OTA Settings
+
+Use `idf.py menuconfig → MQTT OTA Example Configuration` to configure:
+
+- **MQTT Broker URI** (e.g., `mqtt://mosquitto.:1883`).
+- **Start Update Topic**: default `ota/update`.
+- **Firmware Chunk Topic**: default `ota/firmware`.
+- **Done Topic**: default `ota/done`.
+
+---
+
+## OTA Workflow
+
+The device listens for commands via the following MQTT topics:
+
+| Topic         | Purpose                      |
+|---------------|------------------------------|
+| `ota/update`  | Initiates the OTA process    |
+| `ota/firmware`| Receives firmware binary     |
+| `ota/done`    | Finalizes OTA and reboots    |
+
+**OTA flow**:
+1. Receive `start` on `ota/update`.
+2. Download firmware from `ota/firmware` in chunks.
+3. Upon `ota/done`, verify and apply the update.
+
+OTA status and errors are published back to `ota/update` as well.
+
+---
+
+## Using the Python Script
+
+A helper script is provided to push firmware(.bin) to the device over MQTT.
+This script can read the sdkconfig to match the broker, port and topics.
+
+### Install Requirements
+
+```bash
+pip install paho-mqtt
+```
+
+---
+
+## Notes
+
+- This example uses plain MQTT (mqtt://). For production use, consider switching to MQTTS (mqtts://) with proper certificates.
+
+- This method has been tested with both local brokers and public MQTT services (e.g., HiveMQ, Mosquitto). Some public brokers may drop chunks under load.
+
+- You can update multiple devices at once, since the firmware is broadcast to a shared topic. Devices don't send responses during transfer.
+
+- The OTA result (success, failure, time taken, bytes written) is published back to the same MQTT topic (ota/update) for monitoring.
+
+- The size of the chunk can be reduced inside ***mqtt_bin_sender.py***.
+
+- OTA status feedback published back over MQTT.
+
+- The default mqtt buffer size for esp-idf is 1024 but for this example is 4096 (`CONFIG_MQTT_BUFFER_SIZE=4096`).
+
+---
+
+## Example output
+
+### ESP UART log
+
+```log
+I (488) simple_mqtt_ota_example: [APP] Startup..
+I (488) simple_mqtt_ota_example: [APP] Free memory: 277836 bytes
+I (488) simple_mqtt_ota_example: [APP] IDF version: v5.5-dev-3511-g875df72342
+I (498) simple_mqtt_ota_example: Starting MQTT OTA example...
+I (498) simple_mqtt_ota_example: Running partition type: 0 subtype: 16 at offset 0x20000
+I (538) simple_mqtt_ota_example: SHA-256 for bootloader:  bad2fbaeb7ad2675f71509253247d196cb74dc3b0dee166b0fe608a50f522c57
+I (728) simple_mqtt_ota_example: SHA-256 for current firmware:  ccc93782b37a0528395b0a5656019d5be8fc66ff2df63b4ed79a50545530bcbb
+I (728) example_connect: Start example_connect.
+.
+.
+.
+I (5938) simple_mqtt_ota_example: MQTT connected to broker: mqtt://192.168.31.171:1883
+I (5938) simple_mqtt_ota_example: Subscribed to topic 'ota/update', msg_id=31565
+I (5948) simple_mqtt_ota_example: Subscribed to topic 'ota/done', msg_id=39260
+I (5958) simple_mqtt_ota_example: MQTT_EVENT_SUBSCRIBED, msg_id=31565
+I (5958) simple_mqtt_ota_example: MQTT_EVENT_SUBSCRIBED, msg_id=39260
+I (23368) simple_mqtt_ota_example: MQTT received data on topic ota/update
+I (23368) simple_mqtt_ota_example: Received firmware update command. Starting OTA...
+I (23368) simple_mqtt_ota_example: Subscribed to topic 'ota/firmware', msg_id=20233
+I (29028) simple_mqtt_ota_example: OTA started. Ready to receive firmware.
+I (29028) simple_mqtt_ota_example: MQTT_EVENT_SUBSCRIBED, msg_id=20233
+I (29028) simple_mqtt_ota_example: MQTT received data on topic ota/firmware
+.
+.
+.
+I (138178) simple_mqtt_ota_example: Bytes received: 894752 bytes
+I (138668) simple_mqtt_ota_example: MQTT received data on topic ota/done
+I (138668) simple_mqtt_ota_example: Received OTA DONE message, total size written: 894752 bytes
+I (138668) esp_image: segment 0: paddr=001d0020 vaddr=3f400020 size=1f528h (128296) map
+I (138708) esp_image: segment 1: paddr=001ef550 vaddr=3ff80000 size=0001ch (    28)
+I (138718) esp_image: segment 2: paddr=001ef574 vaddr=3ffb0000 size=00aa4h (  2724)
+I (138718) esp_image: segment 3: paddr=001f0020 vaddr=400d0020 size=9f668h (652904) map
+I (138898) esp_image: segment 4: paddr=0028f690 vaddr=3ffb0aa4 size=0339ch ( 13212)
+I (138898) esp_image: segment 5: paddr=00292a34 vaddr=40080000 size=17cc4h ( 97476)
+I (138928) esp_image: segment 0: paddr=001d0020 vaddr=3f400020 size=1f528h (128296) map
+I (138968) esp_image: segment 1: paddr=001ef550 vaddr=3ff80000 size=0001ch (    28)
+I (138968) esp_image: segment 2: paddr=001ef574 vaddr=3ffb0000 size=00aa4h (  2724)
+I (138968) esp_image: segment 3: paddr=001f0020 vaddr=400d0020 size=9f668h (652904) map
+I (139148) esp_image: segment 4: paddr=0028f690 vaddr=3ffb0aa4 size=0339ch ( 13212)
+I (139158) esp_image: segment 5: paddr=00292a34 vaddr=40080000 size=17cc4h ( 97476)
+I (144268) simple_mqtt_ota_example: OTA update successful. Rebooting...
+```
+
+### MQTT Messages log
+
+```log 
+Topic ota/done message: done.
+Topic ota/update message: OTA successful time: 115s, bytes written: 894752.
+```

--- a/examples/system/ota/simple_mqtt_ota/main/CMakeLists.txt
+++ b/examples/system/ota/simple_mqtt_ota/main/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Embed the server root certificate into the final binary
+idf_build_get_property(project_dir PROJECT_DIR)
+idf_component_register(SRCS "simple_mqtt_ota_example.c"
+                    INCLUDE_DIRS "."
+                    PRIV_REQUIRES app_update mqtt esp_netif mbedtls nvs_flash
+                                    esp_wifi)

--- a/examples/system/ota/simple_mqtt_ota/main/Kconfig.projbuild
+++ b/examples/system/ota/simple_mqtt_ota/main/Kconfig.projbuild
@@ -1,0 +1,27 @@
+menu "MQTT OTA Example Configuration"
+
+    config MQTT_BROKER_URI
+        string "MQTT Broker URI"
+        default "mqtt://test.mosquitto.org:1883"
+        help
+            URI of the MQTT broker the device connects to.
+
+    config MQTT_TOPIC_FIRMWARE
+        string "MQTT Topic for Firmware Data"
+        default "ota/firmware"
+        help
+            Topic name where firmware data will be published.
+
+    config MQTT_TOPIC_START_UPDATE
+        string "MQTT Topic for Starting Update"
+        default "ota/update"
+        help
+            Topic name to trigger OTA start.
+
+    config MQTT_TOPIC_DONE
+        string "MQTT Topic for OTA Done"
+        default "ota/done"
+        help
+            Topic name that signals OTA completion.
+
+endmenu

--- a/examples/system/ota/simple_mqtt_ota/main/idf_component.yml
+++ b/examples/system/ota/simple_mqtt_ota/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/examples/system/ota/simple_mqtt_ota/main/simple_mqtt_ota_example.c
+++ b/examples/system/ota/simple_mqtt_ota/main/simple_mqtt_ota_example.c
@@ -1,0 +1,325 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ */
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_ota_ops.h"
+#include "esp_wifi.h"
+#include "esp_timer.h"
+#include "nvs_flash.h"
+#include "mqtt_client.h"
+#include <string.h>
+#include "protocol_examples_common.h"
+
+#define MQTT_BROKER_URI CONFIG_MQTT_BROKER_URI
+#define TOPIC_FIRMWARE CONFIG_MQTT_TOPIC_FIRMWARE
+#define TOPIC_START_UPDATE CONFIG_MQTT_TOPIC_START_UPDATE
+#define TOPIC_DONE CONFIG_MQTT_TOPIC_DONE
+
+#define HASH_LEN 32
+
+static const char *TAG = "simple_mqtt_ota_example";
+size_t total_bytes_written = 0;
+
+// Global OTA handle
+esp_ota_handle_t ota_handle = 0;
+bool ota_in_progress = false;
+bool ota_data_written = false;
+esp_mqtt_client_handle_t mqtt_client = NULL;
+uint64_t timeoutotainit = 0;
+
+/**
+ * @brief Start the OTA update process by selecting the update partition and
+ * initializing OTA handle.
+ *
+ * This function ensures OTA is not already in progress before beginning.
+ *
+ * @return esp_err_t ESP_OK on success, error code otherwise.
+ */
+esp_err_t start_ota(void)
+
+{
+    if (ota_in_progress)
+    {
+        ESP_LOGW(TAG, "OTA already in progress, ignoring start command.");
+        return ESP_OK;
+    }
+    // Get the next available OTA partition (where the firmware will be written)
+    const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
+
+    if (update_partition == NULL)
+    {
+        ESP_LOGE(TAG, "Failed to get update partition");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Start OTA (this opens the OTA partition for writing)
+    esp_err_t err = esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &ota_handle);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Failed to start OTA: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    ota_in_progress = true;
+    ota_data_written = false;
+    ESP_LOGI(TAG, "OTA started. Ready to receive firmware.");
+    return ESP_OK;
+}
+
+/**
+ * @brief Finalize the OTA process and reboot if successful.
+ *
+ * Verifies that data has been written and completes the OTA process. If successful,
+ * sets the boot partition and restarts the device. Sends MQTT feedback on the result.
+ *
+ * @return esp_err_t ESP_OK on success, error code otherwise.
+ */
+esp_err_t finalize_ota(void)
+
+{
+    int msg_id = 0;
+    char buff[60];
+    if (!ota_in_progress || !ota_data_written)
+    {
+        ESP_LOGE(TAG, "OTA not properly started or no data written");
+        msg_id = esp_mqtt_client_publish(mqtt_client, TOPIC_START_UPDATE, "ota not properly started", 0, 1, 0);
+        ESP_LOGD(TAG, "sent publish successful, msg_id=%d", msg_id);
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = esp_ota_end(ota_handle);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_end failed: %s, bytes written: %d", esp_err_to_name(err),total_bytes_written);
+        snprintf(buff,sizeof(buff),"esp_ota_end failed: %s", esp_err_to_name(err));
+        msg_id = esp_mqtt_client_publish(mqtt_client, TOPIC_START_UPDATE, "OTA failed", 0, 1, 0);
+        ESP_LOGD(TAG, "sent publish successful, msg_id=%d", msg_id);
+        return err;
+    }
+
+    const esp_partition_t *update_partition = esp_ota_get_next_update_partition(NULL);
+    err = esp_ota_set_boot_partition(update_partition);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_set_boot_partition failed: %s", esp_err_to_name(err));
+        snprintf(buff,sizeof(buff),"esp_ota_set_boot_partition failed: %s, bytes written: %d", esp_err_to_name(err),total_bytes_written);
+        msg_id = esp_mqtt_client_publish(mqtt_client, TOPIC_START_UPDATE, "OTA set_boot fails", 0, 1, 0);
+        ESP_LOGD(TAG, "sent publish successful, msg_id=%d", msg_id);
+        return err;
+    }
+    uint16_t otaTimeDelta = ((esp_timer_get_time() - timeoutotainit) / 1000000);
+    snprintf(buff,sizeof(buff),"OTA successful time: %ds, bytes written: %d",otaTimeDelta,total_bytes_written);
+    msg_id = esp_mqtt_client_publish(mqtt_client, TOPIC_START_UPDATE, buff, 0, 1, 0);
+    ESP_LOGD(TAG, "sent publish successful, msg_id=%d", msg_id);
+    vTaskDelay(500);
+    ESP_LOGI(TAG, "OTA update successful. Rebooting...");
+    esp_restart();
+    return ESP_OK;
+}
+
+static void log_error_if_nonzero(const char *message, int error_code)
+{
+    if (error_code != 0) {
+        ESP_LOGE(TAG, "Last error %s: 0x%x", message, error_code);
+    }
+}
+
+/**
+ * @brief Event handler registered to receive MQTT events
+ *
+ * This function processes MQTT events like connection, disconnection, data received, and errors.
+ * It responds to subscribed topics to manage the OTA update lifecycle.
+ *
+ * @param handler_args user data registered to the event.
+ * @param base Event base for the handler(always MQTT Base in this example).
+ * @param event_id The id for the received event.
+ * @param event_data The data for the event, esp_mqtt_event_handle_t.
+ */
+
+static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)
+{
+    esp_mqtt_event_handle_t event = event_data;
+    int msg_id = 0;
+    switch ((esp_mqtt_event_id_t)event_id)
+    {
+    case MQTT_EVENT_CONNECTED:
+        ESP_LOGI(TAG, "MQTT connected to broker: %s",MQTT_BROKER_URI);
+        msg_id = esp_mqtt_client_subscribe(mqtt_client, TOPIC_START_UPDATE, 0);
+        ESP_LOGI(TAG, "Subscribed to topic '%s', msg_id=%d", TOPIC_START_UPDATE, msg_id);
+        msg_id = esp_mqtt_client_subscribe(mqtt_client, TOPIC_DONE, 0);
+        ESP_LOGI(TAG, "Subscribed to topic '%s', msg_id=%d", TOPIC_DONE, msg_id);
+        break;
+
+    case MQTT_EVENT_DISCONNECTED:
+        ESP_LOGI(TAG, "MQTT_EVENT_DISCONNECTED");
+        break;
+    case MQTT_EVENT_SUBSCRIBED:
+        ESP_LOGI(TAG, "MQTT_EVENT_SUBSCRIBED, msg_id=%d", event->msg_id);
+        break;
+    case MQTT_EVENT_UNSUBSCRIBED:
+        ESP_LOGI(TAG, "MQTT_EVENT_UNSUBSCRIBED, msg_id=%d", event->msg_id);
+        break;
+    case MQTT_EVENT_PUBLISHED:
+        ESP_LOGI(TAG, "MQTT_EVENT_PUBLISHED, msg_id=%d", event->msg_id);
+        break;
+
+    case MQTT_EVENT_DATA:
+        ESP_LOGI(TAG, "MQTT received data on topic %.*s", event->topic_len, event->topic);
+
+        if (event->topic_len == strlen(TOPIC_START_UPDATE) &&
+            strncmp(event->topic, TOPIC_START_UPDATE, event->topic_len) == 0)
+        {
+            timeoutotainit = esp_timer_get_time();
+            ESP_LOGI(TAG, "Received firmware update command. Starting OTA...");
+            msg_id = esp_mqtt_client_subscribe(mqtt_client, TOPIC_FIRMWARE, 0);
+            ESP_LOGI(TAG, "Subscribed to topic '%s', msg_id=%d", TOPIC_FIRMWARE, msg_id);
+            esp_err_t err = start_ota();
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "Failed to start OTA");
+                return;
+            }
+        }
+
+        else if (event->topic_len == strlen(TOPIC_FIRMWARE) &&
+                 strncmp(event->topic, TOPIC_FIRMWARE, event->topic_len) == 0)
+        {
+            if (!ota_in_progress)
+            {
+                ESP_LOGE(TAG, "OTA not started yet. Ignoring firmware chunk.");
+                return;
+            }
+
+            esp_err_t err = esp_ota_write(ota_handle, event->data, event->data_len);
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "OTA write failed: %s", esp_err_to_name(err));
+                return;
+            }
+            ota_data_written = true;
+            total_bytes_written += event->data_len;
+            ESP_LOGD(TAG, "Received chunk: %d bytes", event->data_len);
+            ESP_LOGI(TAG, "Bytes received: %d bytes", total_bytes_written);
+        }
+
+        else if (event->topic_len == strlen(TOPIC_DONE) &&
+                 strncmp(event->topic, TOPIC_DONE, event->topic_len) == 0)
+        {
+            ESP_LOGI(TAG, "Received OTA DONE message, total size written: %d bytes",total_bytes_written);
+            esp_err_t err = finalize_ota();
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "OTA finalization failed: %s", esp_err_to_name(err));
+            }
+        }
+        break;
+
+    case MQTT_EVENT_ERROR:
+        ESP_LOGI(TAG, "MQTT_EVENT_ERROR");
+        if (event->error_handle->error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT) {
+            log_error_if_nonzero("reported from esp-tls", event->error_handle->esp_tls_last_esp_err);
+            log_error_if_nonzero("reported from tls stack", event->error_handle->esp_tls_stack_err);
+            log_error_if_nonzero("captured as transport's socket errno",  event->error_handle->esp_transport_sock_errno);
+            ESP_LOGI(TAG, "Last errno string (%s)", strerror(event->error_handle->esp_transport_sock_errno));
+        }
+        break;
+    default:
+        ESP_LOGI(TAG, "Other event id:%d", event->event_id);
+        break;
+    }
+}
+
+/**
+ * @brief Start the MQTT client and register event handlers.
+ *
+ * Initializes MQTT using the configured broker URI and starts the client.
+ */
+void mqtt_app_start(void)
+{
+    esp_mqtt_client_config_t mqtt_cfg = {
+        .broker.address.uri = MQTT_BROKER_URI,
+    };
+    mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
+    esp_mqtt_client_register_event(mqtt_client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
+    ESP_ERROR_CHECK(esp_mqtt_client_start(mqtt_client));
+}
+
+/**
+ * @brief Print SHA-256 hash of a firmware image.
+ *
+ * Formats and logs a hash using the provided label.
+ *
+ * @param image_hash Pointer to the 32-byte hash.
+ * @param label Description of the hash being printed.
+ */
+static void print_sha256(const uint8_t *image_hash, const char *label)
+{
+    char hash_print[HASH_LEN * 2 + 1];
+    hash_print[HASH_LEN * 2] = 0;
+    for (int i = 0; i < HASH_LEN; ++i) {
+        sprintf(&hash_print[i * 2], "%02x", image_hash[i]);
+    }
+    ESP_LOGI(TAG, "%s %s", label, hash_print);
+}
+
+/**
+ * @brief Compute and log SHA-256 hashes of the bootloader and current firmware.
+ */
+static void get_sha256_of_partitions(void)
+{
+    uint8_t sha_256[HASH_LEN] = { 0 };
+    esp_partition_t partition;
+
+    // get sha256 digest for bootloader
+    partition.address   = ESP_BOOTLOADER_OFFSET;
+    partition.size      = ESP_PARTITION_TABLE_OFFSET;
+    partition.type      = ESP_PARTITION_TYPE_APP;
+    esp_partition_get_sha256(&partition, sha_256);
+    print_sha256(sha_256, "SHA-256 for bootloader: ");
+
+    // get sha256 digest for running partition
+    esp_partition_get_sha256(esp_ota_get_running_partition(), sha_256);
+    print_sha256(sha_256, "SHA-256 for current firmware: ");
+}
+
+void app_main(void)
+{
+    ESP_LOGI(TAG, "[APP] Startup..");
+    ESP_LOGI(TAG, "[APP] Free memory: %" PRIu32 " bytes", esp_get_free_heap_size());
+    ESP_LOGI(TAG, "[APP] IDF version: %s", esp_get_idf_version());
+    ESP_LOGI(TAG, "Starting MQTT OTA example...");
+
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    if (running != NULL)
+    {
+        ESP_LOGI(TAG, "Running partition type: %d subtype: %d at offset 0x%x",
+                 running->type, running->subtype, running->address);
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Failed to get running partition");
+    }
+    // Initialize NVS
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        err = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(err);
+
+    get_sha256_of_partitions();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.
+     * Read "Establishing Wi-Fi or Ethernet Connection" section in
+     * examples/protocols/README.md for more information about this function.
+     */
+    ESP_ERROR_CHECK(example_connect());
+    mqtt_app_start();
+}

--- a/examples/system/ota/simple_mqtt_ota/mqtt_bin_sender.py
+++ b/examples/system/ota/simple_mqtt_ota/mqtt_bin_sender.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+import os
+import time
+
+import paho.mqtt.client as mqtt
+
+# ==== Configuration ====
+
+
+def get_broker_from_sdkconfig(path='sdkconfig'):  # type: ignore[no-untyped-def]
+    if not os.path.exists(path):
+        print(f"[WARN] sdkconfig file not found at '{path}'. Using default broker.")
+        return 'localhost', 1883  # Default broker and port
+    with open(path, 'r') as f:
+        for line in f:
+            if line.startswith('CONFIG_MQTT_BROKER_URI'):
+                broker_uri = line.split('=')[1].strip().strip('"')
+                if broker_uri.startswith('mqtt://'):
+                    broker_uri = broker_uri[7:]
+                parts = broker_uri.split(':')
+                broker = parts[0]
+                port = int(parts[1]) if len(parts) > 1 else 1883  # Default to 1883 if port is not specified
+                return broker, port
+    print('[WARN] CONFIG_MQTT_BROKER_URI not found in sdkconfig. Using default broker.')
+    return 'localhost', 1883  # Default to localhost and port 1883
+
+
+def get_topic_from_sdkconfig(path='sdkconfig', topic_key='CONFIG_MQTT_TOPIC_'):  # type: ignore[no-untyped-def]
+    topics = {}
+    if not os.path.exists(path):
+        print(f"[WARN] sdkconfig file not found at '{path}'. Using default topics.")
+        return {'update': 'ota/update', 'firmware': 'ota/firmware', 'done': 'ota/done'}
+
+    with open(path, 'r') as f:
+        for line in f:
+            if line.startswith(f'{topic_key}'):
+                key = line.split('=')[0].strip().replace(f'{topic_key}', '').lower()
+                value = line.split('=')[1].strip().strip('"')
+                topics[key] = value
+
+    # Return default values if some topics are not found in sdkconfig
+    return {
+        'update': topics.get('update', 'ota/update'),
+        'firmware': topics.get('firmware', 'ota/firmware'),
+        'done': topics.get('done', 'ota/done'),
+    }
+
+
+# Get broker and topics from sdkconfig
+BROKER, PORT = get_broker_from_sdkconfig()
+TOPICS = get_topic_from_sdkconfig()
+BIN_PATH = 'build/simple_mqtt_ota.bin'  # Path to your firmware binary
+CHUNK_SIZE = 4000  # Chunk size in bytes, if you can't change the buffer size you need to set CHUNK_SIZE to 1000
+
+# Extract topics
+TOPIC_UPDATE = TOPICS['update']
+TOPIC_FIRMWARE = TOPICS['firmware']
+TOPIC_DONE = TOPICS['done']
+
+# ==== MQTT Setup ====
+client = mqtt.Client()
+print(f'[INFO] Connecting to MQTT broker: {BROKER}:{PORT}')
+client.connect(BROKER, PORT)
+client.loop_start()
+
+# ==== Step 1: Trigger OTA start ====
+print('[1/3] Sending OTA start command...')
+client.publish(TOPIC_UPDATE, payload='start')
+time.sleep(1)
+
+# ==== Step 2: Send .bin in chunks ====
+print('[2/3] Sending firmware:', BIN_PATH)
+
+# Sanity check: make sure the file starts with magic byte 0xE9
+with open(BIN_PATH, 'rb') as f:
+    magic = f.read(1)
+    if magic != b'\xe9':
+        print('Invalid firmware file: expected 0xE9 at start, got', magic.hex())
+        client.loop_stop()
+        exit(1)
+time.sleep(2)
+
+# Now send the whole file
+with open(BIN_PATH, 'rb') as f:
+    total_sent = 0
+    while True:
+        chunk = f.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        client.publish(TOPIC_FIRMWARE, payload=chunk)
+        total_sent += len(chunk)
+        print(f'Sent {total_sent} bytes', end='\r')
+        time.sleep(0.5)  # Delay to allow ESP time to read from mqtt and write
+
+print(f'\nFirmware upload complete: {total_sent} bytes sent.')
+
+# ==== Step 3: Send OTA done ====
+print('[3/3] Sending OTA done command...')
+client.publish(TOPIC_DONE, payload='done')
+time.sleep(2)
+
+client.loop_stop()
+client.disconnect()
+print('OTA update pushed successfully via MQTT.')

--- a/examples/system/ota/simple_mqtt_ota/sdkconfig.defaults
+++ b/examples/system/ota/simple_mqtt_ota/sdkconfig.defaults
@@ -1,0 +1,9 @@
+# === Flash Configuration ===
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y  # Set flash size to 4MB
+
+# === Partition Table ===
+CONFIG_PARTITION_TABLE_TWO_OTA_LARGE=y  # Use two OTA partitions with larger sizes (suitable for OTA updates)
+
+# === MQTT Configuration ===
+CONFIG_MQTT_USE_CUSTOM_CONFIG=y   # Enable custom MQTT buffer config
+CONFIG_MQTT_BUFFER_SIZE=4096      # Increase MQTT buffer to 4KB for larger firmware chunks


### PR DESCRIPTION
## Description

This example demonstrates how to perform a simple OTA update over MQTT. The ESP32 connects to Wi-Fi and then to an MQTT broker. A script sends a start signal (e.g., "start") to a topic like ota/update. The ESP32 then listens for firmware data chunks on another topic (e.g., ota/firmware). Each chunk it receives is written to the OTA partition. Once all data has been received, a done signal (e.g., "done") is sent to another topic (e.g., ota/done). The ESP32 then finalizes the update, verifies the firmware, and reboots if the update was successful.

The example includes a script to send the .bin over mqtt to the device.

## Related

This contribution is not related to any current issue.

## Testing

Tested on ESP32 and ESP32-C3 with a local broker, private broker, and public broker.
Note: When using a public broker, message drops may occur under heavy load.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
