### PR TITLE
Fix compile error on esp_cpu_int_has_handler on ESP32-P4

### DIFF
--- a/components/esp_hw_support/include/esp_cpu.h
+++ b/components/esp_hw_support/include/esp_cpu.h
@@ -364,7 +364,7 @@ FORCE_INLINE_ATTR bool esp_cpu_intr_has_handler(int intr_num)
 #ifdef __XTENSA__
     has_handler = xt_int_has_handler(intr_num, esp_cpu_get_core_id());
 #else
-    has_handler = intr_handler_get(intr_num);
+    has_handler = intr_handler_get(intr_num) != NULL;
 #endif
     return has_handler;
 }


### PR DESCRIPTION
## Description

It fixes #15941 by creating a bool operation from the pointer, so no implicit cast from a pointer to a bool occurs.

## Related

Fixes #15941

## Testing

I built it and the error was fone.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
