### PR TITLE
fix(tcp_transport): Silence recoverable read failures (IDFGH-15309)

### DIFF
--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -269,9 +269,12 @@ static int ssl_read(esp_transport_handle_t t, char *buffer, int len, int timeout
 
     int ret = esp_tls_conn_read(ssl->tls, (unsigned char *)buffer, len);
     if (ret < 0) {
-        ESP_LOGE(TAG, "esp_tls_conn_read error, errno=%s", strerror(errno));
         if (ret == ESP_TLS_ERR_SSL_WANT_READ || ret == ESP_TLS_ERR_SSL_TIMEOUT) {
             ret = ERR_TCP_TRANSPORT_CONNECTION_TIMEOUT;
+            ESP_LOGD(TAG, "esp_tls_conn_read error, errno=%s", strerror(errno));
+        }
+        else {
+            ESP_LOGE(TAG, "esp_tls_conn_read error, errno=%s", strerror(errno));
         }
 
         esp_tls_error_handle_t esp_tls_error_handle;


### PR DESCRIPTION
## Description

Downgrade logging of ESP_TLS_ERR_SSL_WANT_READ and ESP_TLS_ERR_SSL_TIMEOUT from ERROR to DEBUG, as these are common results in some application which need handled at the next layer. 

## Testing

Tested by running a client on ESP32-S3 using this and verifying the result does not contain large numbers of spurious TLS transport errors.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
