### PR TITLE
Enable Timestamping for Non-PTP Ethernet frames (IDFGH-15359)

### DIFF
--- a/components/esp_eth/include/esp_eth_mac_esp.h
+++ b/components/esp_eth/include/esp_eth_mac_esp.h
@@ -197,7 +197,8 @@ typedef enum {
     ETH_MAC_ESP_CMD_ADJ_PTP_FREQ,                                           /*!< Adjust current PTP time frequency increment by scale factor */
     ETH_MAC_ESP_CMD_ADJ_PTP_TIME,                                           /*!< Adjust base PTP time frequency increment by PPS */
     ETH_MAC_ESP_CMD_S_TARGET_TIME,                                          /*!< Set Target Time at which interrupt is invoked when PTP time exceeds this value*/
-    ETH_MAC_ESP_CMD_S_TARGET_CB                                             /*!< Set pointer to a callback function invoked when PTP time exceeds Target Time */
+    ETH_MAC_ESP_CMD_S_TARGET_CB,                                            /*!< Set pointer to a callback function invoked when PTP time exceeds Target Time */
+    ETH_MAC_ESP_CMD_ENABLE_TS4ALL                                           /*!< Enable timestamp for all received frames */
 } eth_mac_esp_io_cmd_t;
 
 #ifdef SOC_EMAC_IEEE1588V2_SUPPORTED

--- a/components/esp_eth/src/mac/esp_eth_mac_esp.c
+++ b/components/esp_eth/src/mac/esp_eth_mac_esp.c
@@ -364,6 +364,12 @@ esp_err_t emac_esp_custom_ioctl(esp_eth_mac_t *mac, int cmd, void *data)
                             "failed to set PTP target time");
         break;
     }
+    case ETH_MAC_ESP_CMD_ENABLE_TS4ALL: {
+        ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "PTP enable TS for all invalid argument, cant' be NULL");
+        bool enable = *(bool *)data;
+        ESP_RETURN_ON_ERROR(emac_hal_ptp_enable_ts4all(&emac->hal, enable), TAG, "failed to enable timestamping for all frames");
+        break;
+    }
 #else
     case ETH_MAC_ESP_CMD_PTP_ENABLE:
     case ETH_MAC_ESP_CMD_S_PTP_TIME:
@@ -372,6 +378,7 @@ esp_err_t emac_esp_custom_ioctl(esp_eth_mac_t *mac, int cmd, void *data)
     case ETH_MAC_ESP_CMD_ADJ_PTP_FREQ:
     case ETH_MAC_ESP_CMD_S_TARGET_CB:
     case ETH_MAC_ESP_CMD_S_TARGET_TIME:
+    case ETH_MAC_ESP_CMD_ENABLE_TS4ALL:
         return ESP_ERR_NOT_SUPPORTED;
 #endif
     case ETH_MAC_ESP_CMD_SET_TDES0_CFG_BITS:

--- a/components/hal/emac_hal.c
+++ b/components/hal/emac_hal.c
@@ -517,6 +517,11 @@ esp_err_t emac_hal_ptp_set_target_time(emac_hal_context_t *hal, uint32_t seconds
     emac_ll_ts_target_int_trig_enable(hal->ptp_regs);
     return ESP_OK;
 }
+
+esp_err_t emac_hal_ptp_enable_ts4all(emac_hal_context_t *hal, bool enable) {
+    emac_ll_ts_all_enable(hal->ptp_regs, enable);
+    return ESP_OK;
+}
 #endif // SOC_EMAC_IEEE1588V2_SUPPORTED
 
 

--- a/components/hal/include/hal/emac_hal.h
+++ b/components/hal/include/hal/emac_hal.h
@@ -416,6 +416,16 @@ esp_err_t emac_hal_ptp_get_sys_time(emac_hal_context_t *hal, uint32_t *seconds, 
 esp_err_t emac_hal_ptp_set_target_time(emac_hal_context_t *hal, uint32_t seconds, uint32_t nano_seconds);
 
 /**
+ * @brief Enable rx/tx timestamps for all Ethernet frames
+ *
+ * @param hal EMAC HAL context infostructure
+ * @param enable timestamping for non-PTP Ethernet frames
+ * @return
+ *          - ESP_OK on success
+ */
+esp_err_t emac_hal_ptp_enable_ts4all(emac_hal_context_t *hal, bool enable);
+
+/**
  * @brief Get timestamp from receive descriptor
  *
  * @param hal EMAC HAL context infostructure


### PR DESCRIPTION
## Description

Feature: Add the functionality to enable PTP-based timestamping for non-PTP Ethernet frames via [esp_eth_ioctl](https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/network/esp_eth.html#_CPPv413esp_eth_ioctl16esp_eth_handle_t16esp_eth_io_cmd_tPv)
## Testing

Tested on [ESP32-P4-based Olimex Dev-Kit](https://www.olimex.com/Products/IoT/ESP32-P4/ESP32-P4-DevKit/open-source-hardware).
