### PR TITLE
fix: detect ksh variants as ksh

### DIFF
--- a/tools/export_utils/activate_venv.py
+++ b/tools/export_utils/activate_venv.py
@@ -124,6 +124,9 @@ def detect_shell(args: Any) -> str:
         debug(f'Parent: pid: {parent_pid}, cmdline: {parent_cmdline}, exe: {parent_exe}, name: {parent_name}')
         if not parent_name.lower().startswith('python'):
             detected_shell_name = parent_name
+            # ksh variants often have a name like oksh, loksh, or pdksh.
+            if detected_shell_name.endswith('ksh'):
+                detected_shell_name = 'ksh'
             break
         current_pid = parent_pid
 


### PR DESCRIPTION
## Description
`ksh` variants are a perfectly usable shell (most notably OpenBSD `ksh` but I also suspect `mksh` works fine,) but they often aren't named `ksh` explicitly to avoid possible conflicts with `ksh93`. This is definitely some special casing but I'm also not aware of another shell whose name isn't usually its name.

## Testing
Fresh build/install on ksh (`oksh` on my system.) 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed. (no updates necessary)
- [x] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
