### PR TITLE
feat(freertos): Include pxStack in xTASK_SNAPSHOT

### DIFF
--- a/components/freertos/esp_additions/freertos_tasks_c_additions.h
+++ b/components/freertos/esp_additions/freertos_tasks_c_additions.h
@@ -1051,6 +1051,7 @@ BaseType_t vTaskGetSnapshot( TaskHandle_t pxTask,
 
     TCB_t * pxTCB = ( TCB_t * ) pxTask;
     pxTaskSnapshot->pxTCB = pxTCB;
+    pxTaskSnapshot->pxStack      = ( StackType_t * ) pxTCB->pxStack;
     pxTaskSnapshot->pxTopOfStack = ( StackType_t * ) pxTCB->pxTopOfStack;
     pxTaskSnapshot->pxEndOfStack = ( StackType_t * ) pxTCB->pxEndOfStack;
     return pdTRUE;

--- a/components/freertos/esp_additions/include/esp_private/freertos_debug.h
+++ b/components/freertos/esp_additions/include/esp_private/freertos_debug.h
@@ -31,6 +31,7 @@
 typedef struct xTASK_SNAPSHOT
 {
     void * pxTCB;               /*!< Address of the task control block. */
+    StackType_t * pxStack;      /*!< Points to the start of the stack. */
     StackType_t * pxTopOfStack; /*!< Points to the location of the last item placed on the tasks stack. */
     StackType_t * pxEndOfStack; /*!< Points to the end of the stack. pxTopOfStack < pxEndOfStack, stack grows hi2lo
                                  *  pxTopOfStack > pxEndOfStack, stack grows lo2hi*/


### PR DESCRIPTION
## Description

Adds `pxStack` to task snapshots to allow calculating the size of the stack (`pxEndOfStack - pxStack`).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
