### PR TITLE
fix(esp_http_client): fix spurious async open error (IDFGH-15429)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -1722,11 +1722,17 @@ esp_err_t esp_http_client_open(esp_http_client_handle_t client, int write_len)
     client->post_len = write_len;
     esp_err_t err;
     if ((err = esp_http_client_connect(client)) != ESP_OK) {
+        if (client->is_async && err == ESP_ERR_HTTP_CONNECTING) {
+            return ESP_ERR_HTTP_EAGAIN;
+        }
         http_dispatch_event(client, HTTP_EVENT_ERROR, esp_transport_get_error_handle(client->transport), 0);
         http_dispatch_event_to_event_loop(HTTP_EVENT_ERROR, &client, sizeof(esp_http_client_handle_t));
         return err;
     }
     if ((err = esp_http_client_request_send(client, write_len)) != ESP_OK) {
+        if (client->is_async && errno == EAGAIN) {
+            return ESP_ERR_HTTP_EAGAIN;
+        }
         http_dispatch_event(client, HTTP_EVENT_ERROR, esp_transport_get_error_handle(client->transport), 0);
         http_dispatch_event_to_event_loop(HTTP_EVENT_ERROR, &client, sizeof(esp_http_client_handle_t));
         return err;


### PR DESCRIPTION
## Description

> Please include a summary of the changes and the related issue.

Fix esp_http_client_open() often triggering a spurious HTTP_EVENT_ERROR when is_async=true.

> Also include the motivation (why this change) and context.

Spurious failure messages are confusing and make the event interface callback interface difficult to use when you must compute the meaningfulness of the messages yourself.


## Related

Fixes https://github.com/espressif/esp-idf/issues/16075

## Testing

Tested by running the example code on #16075 without this patch:

```
D (6363) esp-tls: [sock=54] Resolved IPv4 address: 44.212.217.153
D (6363) esp-tls: [sock=54] Connecting to server. HOST: postman-echo.com, Port: 443
D (6373) esp-tls: connecting...
D (6423) esp-tls: handshake in progress...
D (6423) HTTP_CLIENT: Connection not yet established
D (6423) HTTP_CLIENT: HTTP_EVENT_ERROR ###THIS IS SPURIOUS
I (6423) HTTP_CLIENT: esp_http_client_open()=28678
```

And with this patch:
```
D (6363) esp-tls: [sock=54] Resolved IPv4 address: 44.212.217.153
D (6363) esp-tls: [sock=54] Connecting to server. HOST: postman-echo.com, Port: 443
D (6373) esp-tls: connecting...
D (6423) esp-tls: handshake in progress...
D (6423) HTTP_CLIENT: Connection not yet established
I (6423) HTTP_CLIENT: esp_http_client_open()=28678
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
