### PR TITLE
feat(ws_transport): add header callback hook (IDFGH-15479)

### DIFF
--- a/components/tcp_transport/include/esp_transport_ws.h
+++ b/components/tcp_transport/include/esp_transport_ws.h
@@ -29,6 +29,8 @@ typedef enum ws_transport_opcodes {
                                           * from the API esp_transport_ws_get_read_opcode() */
 } ws_transport_opcodes_t;
 
+typedef void (*ws_header_hook)(void * userp, const char * line, int line_len);
+
 /**
  * WS transport configuration structure
  */
@@ -37,6 +39,8 @@ typedef struct {
     const char *sub_protocol;               /*!< WS subprotocol */
     const char *user_agent;                 /*!< WS user agent */
     const char *headers;                    /*!< WS additional headers */
+    ws_header_hook header_hook;             /*!< WS received header */
+    void *header_userp;                     /*!< WS received header user-pointer */
     const char *auth;                       /*!< HTTP authorization header */
     char *response_headers;                 /*!< The buffer to copy the http response header */
     size_t response_headers_len;            /*!< The length of the http response header */
@@ -98,6 +102,31 @@ esp_err_t esp_transport_ws_set_user_agent(esp_transport_handle_t t, const char *
  *      - One of the error codes
  */
 esp_err_t esp_transport_ws_set_headers(esp_transport_handle_t t, const char *headers);
+
+/**
+ * @brief               Set websocket header callback
+ *
+ * @param t             websocket transport handle
+ * @param hook          call function on header received. NULL to disable.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - One of the error codes
+ */
+esp_err_t esp_transport_ws_set_header_hook(esp_transport_handle_t t, ws_header_hook hook);
+
+
+/**
+ * @brief               Set websocket header callback user-pointer
+ *
+ * @param t             websocket transport handle
+ * @param userp         caller-controlled argument to ws_header_hook
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - One of the error codes
+ */
+esp_err_t esp_transport_ws_set_header_userp(esp_transport_handle_t t, void * userp);
 
 /**
  * @brief               Set websocket authorization headers


### PR DESCRIPTION
## Description

Add a callback for each line of header responses in the Websocket HTTP->WS transport upgrade. This is necessary to support AWS ALB and F5 cookie-based load-balancer sticky-sessions.

## Related

Please see https://github.com/espressif/esp-protocols/issues/715 . There is another part of this patchset https://github.com/espressif/esp-protocols/pull/827, as well as a different implementation https://github.com/espressif/esp-protocols/pull/794

## Testing

- Existing "Sec-WebSocket-Accept" header-parsing was tested by connecting to a websocket. Failure was tested by intentionally setting `server_key = NULL` and confirming we still reject the connection.
- New headers were tested by logging each header-line with `ESP_LOGI()` at the next layer up, in the esp_websocket_client.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
