### PR TITLE
esp_adc: Release the peripheral after calibration (IDFGH-15489)

### DIFF
--- a/components/esp_adc/adc_common.c
+++ b/components/esp_adc/adc_common.c
@@ -77,5 +77,6 @@ static __attribute__((constructor)) void adc_hw_calibration(void)
         }
     }
     ANALOG_CLOCK_DISABLE();
+    adc_apb_periph_free();
 }
 #endif //#if SOC_ADC_CALIBRATION_V1_SUPPORTED


### PR DESCRIPTION
The exact mechanism is not clear to me but this impacts BLE TX power on ESP32-C6: before the change, BLE adverisement signal is ~10dBm lower.