### PR TITLE
feat(esp_eth): Enable EEE (802.3az) on DM9051 (IDFGH-15497)

### DIFF
--- a/components/esp_eth/include/esp_eth_mac_spi.h
+++ b/components/esp_eth/include/esp_eth_mac_spi.h
@@ -112,6 +112,14 @@ typedef struct
         .read = NULL,    \
         .write = NULL    \
     }
+
+/**
+ * @brief List of SPI EMAC specific commands for ioctl API
+ *
+ */
+typedef enum {
+    ETH_MAC_SPI_CMD_S_EEE = ETH_CMD_CUSTOM_MAC_CMDS_OFFSET, /*!< Enable or disable Energy Efficient Ethernet */
+} eth_mac_spi_io_cmd_t;
 #endif // CONFIG_ETH_USE_SPI_ETHERNET
 
 #if CONFIG_ETH_SPI_ETHERNET_DM9051

--- a/components/esp_eth/src/spi/dm9051/dm9051.h
+++ b/components/esp_eth/src/spi/dm9051/dm9051.h
@@ -131,6 +131,8 @@ extern "C" {
 #define TCSCR_TCPCSE (1 << 1) // TCP CheckSum Generation
 #define TCSCR_IPCSE (1 << 0)  // IPv4 CheckSum Generation
 
+#define EEE_EN (1 << 7)  // EEE Enable
+
 #define MPTRCR_RST_TX (1 << 1) // Reset TX Memory Pointer
 #define MPTRCR_RST_RX (1 << 0) // Reset RX Memory Pointer
 


### PR DESCRIPTION
Significant power savings on a 100baseT link.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This unconditionally enables EEE on DM9051. The resulting power savings are around 200 mW on a 100baseT link.  


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Briefly run tested on a PoE powered ESP32C3 using a DM9051, using the PoE switch to measure total power consumption for the module.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
