### PR TITLE
change(esp-tls): Improve support for wolfssl (IDFGH-15505)

### DIFF
--- a/components/esp-tls/CMakeLists.txt
+++ b/components/esp-tls/CMakeLists.txt
@@ -5,8 +5,12 @@ if(CONFIG_ESP_TLS_USING_MBEDTLS)
 endif()
 
 if(CONFIG_ESP_TLS_USING_WOLFSSL)
+    message(STATUS "esp-tls configured for wolfssl")
     list(APPEND srcs
         "esp_tls_wolfssl.c")
+    set(wolfssl_esp_tls_lib "wolfssl")
+else()
+    unset(wolfssl_esp_tls_lib)
 endif()
 
 set(priv_req http_parser esp_timer)
@@ -14,17 +18,100 @@ if(NOT ${IDF_TARGET} STREQUAL "linux")
     list(APPEND priv_req lwip)
 endif()
 
+message(STATUS "idf_component_register wolfssl_esp_tls_lib: ${wolfssl_esp_tls_lib}")
+
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} esp-tls-crypto
                     PRIV_INCLUDE_DIRS "private_include"
                     # mbedtls is public requirements because esp_tls.h
                     # includes mbedtls header files.
-                    REQUIRES mbedtls
+                    REQUIRES mbedtls ${wolfssl_esp_tls_lib}
                     PRIV_REQUIRES ${priv_req})
 
+# When using wolfSSL for the ESP-TLS (see menuconfig),
+# There are two options:
+#   1) A specified source directory, typically a wolfssl git clone
+#   2) The esp-wolfssl
+# TODO this is duplicate code. See components/wap_supplicant
+message(STATUS "esp-tls config begin")
 if(CONFIG_ESP_TLS_USING_WOLFSSL)
-    idf_component_get_property(wolfssl esp-wolfssl COMPONENT_LIB)
-    target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    message(STATUS "found CONFIG_ESP_TLS_USING_WOLFSSL")
+    # See https://github.com/wolfSSL/wolfssl/
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESPIDF")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
+    # The published wolfSSL 5.7.0 user_settings.h does not include some features that
+    # might be enabled in Kconfig, so enable them here:
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_ALPN")
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_SNI")
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL_EXTRA_X509_SMALL")
+    # this only works for VisualGDB, not idf.py from command-line
+
+    message(STATUS "CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "CMAKE_PARENT_LIST_FILE = ${CMAKE_PARENT_LIST_FILE}")
+    message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
+    message(STATUS "COMPONENT_DIR = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "COMPONENT_LIB = ${COMPONENT_LIB}")
+    message(STATUS "FOUND_WOLFSSL = ${FOUND_WOLFSSL}")
+    message(STATUS "PROJECT_DIR = ${PROJECT_DIR}")
+    message(STATUS "WOLFSSL_PROJECT_DIR = ${WOLFSSL_PROJECT_DIR}")
+    message(STATUS "CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+
+    if(CONFIG_ESP_TLS_USING_WOLFSSL_SPECIFIED)
+        get_filename_component(CUSTOM_SETTING_WOLFSSL_ROOT_PATH "${CUSTOM_SETTING_WOLFSSL_ROOT}" ABSOLUTE)
+        if(EXISTS "${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}/wolfcrypt/src")
+            message(STATUS "ESP-TLS using wolfSSL in: ${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}")
+        else()
+            message(STATUS "ESP-TLS specified directory does not contain wolfSSL: ${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}")
+        endif()
+        idf_component_get_property(wolfssl wolfssl COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    else()
+        # Is wolfSSL installed in the local project as a Managed Component?
+        set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/managed_components/wolfssl__wolfssl")
+        message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+        if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+            message(STATUS "Configuring ESP-IDF to use wolfssl in Managed Component: ${WOLFSSL_COMPONENT_SEARCH}")
+            idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+        else()
+            # Is wolfSSL installed in the local project as a Managed Component
+            # converted to regular project component?
+            set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/components/wolfssl__wolfssl")
+            message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+            if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                message(STATUS
+                      "Configuring ESP-IDF to use wolfssl in Converted Managed Component: ${WOLFSSL_COMPONENT_SEARCH}")
+                idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+            else()
+                # Is wolfSSL installed in the local project as a non-maged, regular component?
+                set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/components/wolfssl")
+                message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+                if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                    message(STATUS "Configuring ESP-IDF to use wolfssl in Component: ${WOLFSSL_COMPONENT_SEARCH}")
+                    idf_component_get_property(wolfssl wolfssl COMPONENT_LIB)
+                else()
+                    set(WOLFSSL_COMPONENT_SEARCH "${THIS_IDF_PATH}/components/esp-wolfssl")
+                    message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+                    if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                        message(STATUS "Configuring ESP-IDF to use wolfssl from: ${WOLFSSL_COMPONENT_SEARCH}")
+                        message(STATUS "Warning: Using legacy esp-wolfssl. Consider using a Managed Component")
+                        # See https://github.com/espressif/esp-idf
+                        message(STATUS "Configuring ESP-TLS to use esp-wolfssl")
+                        idf_component_get_property(wolfssl esp-wolfssl COMPONENT_LIB)
+                    else()
+                        message(STATUS "Consider installing wolfSSL from "
+                                       "https://components.espressif.com/components/wolfssl/wolfssl")
+                        message(FATAL_ERROR "Component ${component} not found")
+                    endif() # esp-wolfssl
+                endif() # project wolfssl
+            endif() # project converted wolfssl__wolfssl
+        endif() # project managed component wolfssl__wolfssl
+        # idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    endif()
+else()
+    message(STATUS "ESP-TLS is not configured to use wolfSSL.")
 endif()
 
 if(NOT ${IDF_TARGET} STREQUAL "linux")

--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -6,11 +6,17 @@ menu "ESP-TLS"
             The ESP-TLS APIs support multiple backend TLS libraries. Currently mbedTLS and WolfSSL are
             supported. Different TLS libraries may support different features and have different resource
             usage. Consult the ESP-TLS documentation in ESP-IDF Programming guide for more details.
+
         config ESP_TLS_USING_MBEDTLS
             bool "mbedTLS"
+
         config ESP_TLS_USING_WOLFSSL
-            depends on TLS_STACK_WOLFSSL
             bool "wolfSSL (License info in wolfSSL directory README)"
+            select TLS_STACK_WOLFSSL
+            help
+                This option enables wolfSSL for ESP-TLS.
+                Note: Ensure TLS_STACK_WOLFSSL is enabled to use this option.
+
     endchoice
 
     config ESP_TLS_USE_SECURE_ELEMENT
@@ -99,6 +105,15 @@ menu "ESP-TLS"
             WARNING : Enabling this option comes with a potential risk of establishing a TLS connection
             with a server which has a fake identity, provided that the server certificate
             is not provided either through API or other mechanism like ca_store etc.
+
+    config ESP_WOLFSSL_SMALL_CERT_VERIFY
+        bool "Enable SMALL_CERT_VERIFY"
+        depends on ESP_TLS_USING_WOLFSSL
+        default y
+        help
+            Enables server verification with Intermediate CA cert, does not authenticate full chain
+            of trust upto the root CA cert (After Enabling this option client only needs to have Intermediate
+            CA certificate of the server to authenticate server, root CA cert is not necessary).
 
     config ESP_DEBUG_WOLFSSL
         bool "Enable debug logs for wolfSSL"

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -114,7 +114,11 @@ static const char *TAG = "esp-tls";
 
 static esp_err_t create_ssl_handle(const char *hostname, size_t hostlen, const void *cfg, esp_tls_t *tls)
 {
+#if defined(ESP_IDF_VERSION) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
     return _esp_create_ssl_handle(hostname, hostlen, cfg, tls, NULL);
+#else
+    return _esp_create_ssl_handle(hostname, hostlen, cfg, tls);
+#endif
 }
 
 static esp_err_t esp_tls_handshake(esp_tls_t *tls, const esp_tls_cfg_t *cfg)
@@ -134,7 +138,7 @@ static ssize_t tcp_write(esp_tls_t *tls, const char *data, size_t datalen)
 
 ssize_t esp_tls_conn_read(esp_tls_t *tls, void  *data, size_t datalen)
 {
-    if (!tls) {
+    if (!tls || !data) {
         return -1;
     }
     return tls->read(tls, (char *)data, datalen);
@@ -461,7 +465,10 @@ err:
 
 static int esp_tls_low_level_conn(const char *hostname, int hostlen, int port, const esp_tls_cfg_t *cfg, esp_tls_t *tls)
 {
-
+    if (!tls) {
+        ESP_LOGE(TAG, "empty esp_tls parameter");
+        return -1;
+    }
     esp_err_t esp_ret;
     /* These states are used to keep a tab on connection progress in case of non-blocking connect,
     and in case of blocking connect these cases will get executed one after the other */
@@ -737,11 +744,17 @@ int esp_tls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls
 /**
  * @brief      Close the server side TLS/SSL connection and free any allocated resources.
  */
+#ifdef CONFIG_ESP_TLS_USING_WOLFSSL
+int esp_tls_server_session_delete(esp_tls_t *tls)
+    {
+        return _esp_tls_server_session_delete(tls);
+    }
+#else
 void esp_tls_server_session_delete(esp_tls_t *tls)
 {
     return _esp_tls_server_session_delete(tls);
 }
-
+#endif
 ssize_t esp_tls_get_bytes_avail(esp_tls_t *tls)
 {
     return _esp_tls_get_bytes_avail(tls);

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -19,6 +19,8 @@
 #include "mbedtls/ctr_drbg.h"
 #endif
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
+/* ESP_TLS_HAS_WOLFSSL defined only for versions properly supporting wolfSSL */
+#define  ESP_TLS_HAS_WOLFSSL
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/ssl.h"
 #endif
@@ -759,8 +761,11 @@ int esp_tls_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp_tls
  *
  * @param[in]  tls  pointer to esp_tls_t
  */
+#ifdef CONFIG_ESP_TLS_USING_WOLFSSL
+int esp_tls_server_session_delete(esp_tls_t *tls);
+#else
 void esp_tls_server_session_delete(esp_tls_t *tls);
-
+#endif
 /**
  * @brief Creates a plain TCP connection, returning a valid socket fd on success or an error handle
  *

--- a/components/esp-tls/private_include/esp_tls_private.h
+++ b/components/esp-tls/private_include/esp_tls_private.h
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include "esp_err.h"
 #include "esp_tls_errors.h"
+
 #ifdef CONFIG_ESP_TLS_USING_MBEDTLS
 #include "mbedtls/platform.h"
 #include "mbedtls/net_sockets.h"
@@ -30,8 +31,11 @@
 #include "psa/crypto.h"
 #endif
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
-#include "wolfssl/wolfcrypt/settings.h"
-#include "wolfssl/ssl.h"
+    #include "wolfssl/wolfcrypt/settings.h"
+    #include "wolfssl/ssl.h"
+    #include "wolfssl/openssl/x509.h" /* TODO not wolfssl internal WOLFSSL_X509 ? */
+    #include "wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h"
+    #include "private_include/esp_tls_wolfssl.h"
 #endif
 
 struct esp_tls {
@@ -73,6 +77,11 @@ struct esp_tls {
     size_t client_session_len;                                                  /*!< Length of the serialized client session ticket context. */
 #endif /* CONFIG_MBEDTLS_SSL_PROTO_TLS1_3 && CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS */
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
+    #ifndef WOLFSSL_NO_CONF_COMPATIBILITY
+    wolfssl_ssl_config conf;
+    void (*sync)(struct esp_tls*);
+    #endif
+
     void *priv_ctx;
     void *priv_ssl;
 #endif

--- a/components/esp-tls/private_include/esp_tls_wolfssl.h
+++ b/components/esp-tls/private_include/esp_tls_wolfssl.h
@@ -7,11 +7,22 @@
 #pragma once
 #include "esp_tls.h"
 #include "esp_tls_private.h"
+#ifdef CONFIG_ESP_TLS_USING_WOLFSSL
+
+/* wolfssl_ssl_config is ESP-IDF specific helper for Certificate Bundles */
+#include "wolfssl/wolfcrypt/settings.h"
+#include "wolfssl/ssl.h"
+#include "wolfssl/openssl/x509.h"
+
 
 /**
  * Internal Callback for creating ssl handle for wolfssl
  */
-int esp_create_wolfssl_handle(const char *hostname, size_t hostlen, const void *cfg, esp_tls_t *tls, void *server_params);
+#if defined(ESP_IDF_VERSION) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0))
+    int esp_create_wolfssl_handle(const char *hostname, size_t hostlen, const void *cfg, esp_tls_t *tls, void *server_params);
+#else
+    int esp_create_wolfssl_handle(const char *hostname, size_t hostlen, const void *cfg, esp_tls_t *tls);
+#endif
 
 /**
  * Internal Callback for wolfssl_handshake
@@ -72,10 +83,7 @@ void *esp_wolfssl_get_ssl_context(esp_tls_t *tls);
 /**
  * wolfSSL function for Initializing socket wrappers (no-operation for wolfSSL)
  */
-static inline void esp_wolfssl_net_init(esp_tls_t *tls)
-{
-}
-
+void esp_wolfssl_net_init(esp_tls_t *tls);
 
 /**
  * Function to Create ESP-TLS Server session with wolfssl Stack
@@ -85,4 +93,7 @@ int esp_wolfssl_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
 /*
  * Delete Server Session
  */
-void esp_wolfssl_server_session_delete(esp_tls_t *tls);
+int esp_wolfssl_server_session_delete(esp_tls_t *tls);
+
+
+#endif /* CONFIG_ESP_TLS_USING_WOLFSSL */

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -818,11 +818,17 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
     ESP_GOTO_ON_FALSE(init_common_tcp_transport(client, config, ssl), ESP_FAIL, error, TAG, "Failed to set SSL config");
 
     if (config->crt_bundle_attach != NULL) {
-#ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#if defined(CONFIG_MBEDTLS_CERTIFICATE_BUNDLE) || defined(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE)
         esp_transport_ssl_crt_bundle_attach(ssl, config->crt_bundle_attach);
-#else //CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#else /* CONFIG_[PROVIDER]_CERTIFICATE_BUNDLE */
+    #if defined(CONFIG_ESP_TLS_USING_MBEDTLS)
         ESP_LOGE(TAG, "use_crt_bundle configured but not enabled in menuconfig: Please enable MBEDTLS_CERTIFICATE_BUNDLE option");
-#endif
+    #elif defined(CONFIG_ESP_TLS_USING_WOLFSSL)
+        ESP_LOGE(TAG, "use_crt_bundle configured but not enabled in menuconfig: Please enable WOLFSSL_CERTIFICATE_BUNDLE option");
+    #else
+        ESP_LOGE(TAG, "use_crt_bundle configured but a cryptographic provider not enabled in menuconfig: Please enable CONFIG_ESP_TLS_USING_WOLFSSL or CONFIG_ESP_TLS_USING_MBEDTLS");
+    #endif
+#endif /* !CONFIG_[PROVIDER]_CERTIFICATE_BUNDLE */
     } else if (config->use_global_ca_store == true) {
         esp_transport_ssl_enable_global_ca_store(ssl);
     } else if (config->cert_pem) {

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -474,7 +474,7 @@ void esp_transport_ssl_use_secure_element(esp_transport_handle_t t)
 }
 #endif
 
-#ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#if defined(CONFIG_MBEDTLS_CERTIFICATE_BUNDLE) || defined(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE)
 void esp_transport_ssl_crt_bundle_attach(esp_transport_handle_t t, esp_err_t ((*crt_bundle_attach)(void *conf)))
 {
     GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Improves support for wolfSSL in the  ESP-IDF `esp-tls` component.

I realize that `v5.5` is already in [beta1](https://github.com/espressif/esp-idf/releases/tag/v5.5-beta1) as of a few days ago. I'm hopeful that this update can be included. 

Works best with wolfSSL v5.7.6 or later; v5.7.8 is better, more polish coming to `master` branch. 

The wolfssl source code can also be set via `WOLFSSL_ROOT` via environment variable, cmake variable, or `idf.py menuconfig`. 

See ESP Registry for [wolfssl](https://components.espressif.com/components/wolfssl/wolfssl) and other [components in the wolfssl namespace](https://components.espressif.com/components?q=namespace:wolfssl).

For getting started, see:

- [YouTube: Getting Started with wolfSSL for Espressif ESP32](https://www.youtube.com/watch?v=CzwA3ZBZBZ8)
- [YouTube DevCon24 - Getting Started with wolfSSL encryption](https://www.youtube.com/watch?v=04DGXkZ1IC4)
- [Blog: wolfSSL now available in Espressif Component Registry](https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/)
- [Other Espressif resources at wolfSSL](https://www.wolfssl.com/?s=Espressif)
- [wolfSSL Documentation](https://www.wolfssl.com/docs/)
- [wolfssl Espressif examples](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples)

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Recent `esp-tls` specific changes to wolfSSL:

- https://github.com/wolfSSL/wolfssl/pull/7936
- https://github.com/wolfSSL/wolfssl/pull/8847

Overview:

- https://github.com/espressif/esp-idf/issues/13966
- https://github.com/wolfSSL/wolfssl/issues/7640
- https://github.com/wolfSSL/wolfssl/issues/6234

Also:

- https://github.com/wolfSSL/wolfssl/pull/8251
- https://github.com/wolfSSL/wolfssl/pull/7893
- https://github.com/wolfSSL/wolfssl/pull/5800

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Tested with my slightly revised [esp_http_client_example](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix/IDE/Espressif/ESP-IDF/examples/esp_http_client_example).

Note the problem references in: 

- https://github.com/espressif/esp-idf/issues/16132
- https://github.com/espressif/esp-idf/issues/14496

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
