### PR TITLE
fix(freertos): Avoid core switch deadlock on start (IDFGH-15509)

### DIFF
--- a/components/freertos/app_startup.c
+++ b/components/freertos/app_startup.c
@@ -147,7 +147,7 @@ void esp_startup_start_app_other_cores(void)
 static const char* MAIN_TAG = "main_task";
 
 #if !CONFIG_FREERTOS_UNICORE
-static volatile bool s_other_cpu_startup_done[2];
+static volatile bool s_other_cpu_startup_done[2] = {false, false};
 static bool other_cpu_startup_idle_hook_cb(void)
 {
     s_other_cpu_startup_done[xPortGetCoreID()] = true;
@@ -162,7 +162,7 @@ static void main_task(void* args)
     // Wait for FreeRTOS initialization to finish on other core, before replacing its startup stack
     esp_register_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 0);
     esp_register_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 1);
-    while (!s_other_cpu_startup_done) {
+    while (!s_other_cpu_startup_done[!xPortGetCoreID()]) {
         ;
     }
     esp_deregister_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 0);

--- a/components/freertos/app_startup.c
+++ b/components/freertos/app_startup.c
@@ -147,10 +147,10 @@ void esp_startup_start_app_other_cores(void)
 static const char* MAIN_TAG = "main_task";
 
 #if !CONFIG_FREERTOS_UNICORE
-static volatile bool s_other_cpu_startup_done = false;
+static volatile bool s_other_cpu_startup_done[2];
 static bool other_cpu_startup_idle_hook_cb(void)
 {
-    s_other_cpu_startup_done = true;
+    s_other_cpu_startup_done[xPortGetCoreID()] = true;
     return true;
 }
 #endif
@@ -160,11 +160,13 @@ static void main_task(void* args)
     ESP_LOGI(MAIN_TAG, "Started on CPU%d", (int)xPortGetCoreID());
 #if !CONFIG_FREERTOS_UNICORE
     // Wait for FreeRTOS initialization to finish on other core, before replacing its startup stack
-    esp_register_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, !xPortGetCoreID());
+    esp_register_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 0);
+    esp_register_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 1);
     while (!s_other_cpu_startup_done) {
         ;
     }
-    esp_deregister_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, !xPortGetCoreID());
+    esp_deregister_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 0);
+    esp_deregister_freertos_idle_hook_for_cpu(other_cpu_startup_idle_hook_cb, 1);
 #endif
 
     // [refactor-todo] check if there is a way to move the following block to esp_system startup


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
With CONFIG_ESP_MAIN_TASK_AFFINITY_NO_AFFINITY=y the main task could switch core between registering the idle hook and the while loop.

This would cause a deadlock were the current task was waiting for the idle hook to run on the same core it's busy waiting.

Solve this by registering an idle hook on both cores. This ensure that the scheduler is started on the other core.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
This problem was discovered on an ESP32-S3 running 5.4.1 with QIO and CONFIG_ESP_MAIN_TASK_AFFINITY_NO_AFFINITY=y. It would randomly happen during boot.

With this change the problem hasn't been possible to reproduce.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
