### PR TITLE
fix(ulp): Rework wakeup source cause collection and usage

### DIFF
--- a/components/ulp/lp_core/lp_core/include/ulp_lp_core_utils.h
+++ b/components/ulp/lp_core/lp_core/include/ulp_lp_core_utils.h
@@ -16,20 +16,71 @@ extern "C" {
 #include "soc/soc_caps.h"
 
 /**
- * @brief Traverse all possible wake-up sources and update the wake-up cause so that
- *        ulp_lp_core_get_wakeup_cause can obtain the bitmap of the wake-up reasons.
- * @note Do not call it from user ULP programs because it will clear the wake-up cause bits
- *       which were set at ULP startup in lp_core_startup().
+ * @brief Check if the HP CPU wake up interruption bit is set and clear in that case
+ * @return true if the wake up was triggered by HP CPU, false otherwise
+ *
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
  */
-void ulp_lp_core_update_wakeup_cause(void);
+bool ulp_lp_core_wakeup_assert_clear_hp_cpu(void);
 
 /**
- * @brief Get the wakeup source which caused LP_CPU to wakeup from sleep
+ * @brief Check if the LP UART wake up interruption bit is set and clear in that case
+ * @return true if the wake up was triggered by LP UART, false otherwise
  *
- * @return  Wakeup cause in bit map, for the meaning of each bit, refer
- *          to the definition of wakeup source in lp_core_ll.h
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
  */
-uint32_t ulp_lp_core_get_wakeup_cause(void);
+bool ulp_lp_core_wakeup_assert_clear_lp_uart(void);
+
+/**
+ * @brief Check if the LP IO wake up interruption bit is set and clear in that case
+ * @return true if the wake up was triggered by LP IO, false otherwise
+ *
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
+ */
+bool ulp_lp_core_wakeup_assert_clear_lp_io(void);
+
+/**
+ * @brief Check if the LP voice activity detection wake up interruption bit is set and
+          clear in that case
+ * @return true if the wake up was triggered by LP VAD, false otherwise
+ *
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
+ */
+bool ulp_lp_core_wakeup_assert_clear_lp_vad(void);
+
+/**
+ * @brief Check if the ETM wake up interruption bit is set and clear in that case
+ * @return true if the wake up was triggered by ETM, false otherwise
+ *
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
+ */
+bool ulp_lp_core_wakeup_assert_clear_etm(void);
+
+/**
+ * @brief Check if the LP timer wake up interruption bit is set and clear in that case
+ * @return true if the wake up was triggered by ETM, false otherwise
+ *
+ * @note Since wake up are interrupts, calling the function twice will return false
+ *       unless another interrupt happened meanwhile. It's recommended to call this
+ *       function just before halting the LP core to ensure no lingering interrupt, that
+ *       happened while the LP core was running, will wake up the LP core immediately
+ */
+bool ulp_lp_core_wakeup_assert_clear_lp_timer(void);
 
 /**
  * @brief Wakeup main CPU from sleep or deep sleep.

--- a/components/ulp/lp_core/lp_core/lp_core_startup.c
+++ b/components/ulp/lp_core/lp_core/lp_core_startup.c
@@ -22,8 +22,6 @@ void lp_core_startup()
     ets_install_putc1(lp_core_print_char);
 #endif
 
-    ulp_lp_core_update_wakeup_cause();
-
     main();
 
     ulp_lp_core_memory_shared_cfg_t* shared_mem = ulp_lp_core_memory_shared_cfg_get();


### PR DESCRIPTION
## Description

Fix #15851 

To follow the issue reported in #15851, this implements last solution proposed. After using it for few month, I think it's the best compromise for the issue.

To sum up the issue and the changes:

### Issue

1. Current code loops over all wakeup sources on LP core startup to collect all possible wakeup source. 
**This is wasteful for both users expecting a wakeup (since only one or two wakeup is programmed) and those who don't.**
2. A variable is used to store that collection/bitmap
**Again it's wasteful**
3. If an interrupt happens while the LP core is running for one of the selected wakeup source, the LP core will immediately wakeup  when halting

### Proposed solution

The user knows what wakeup source she enabled, so let her simply check **this** wake up source (and immediately clear the interrupt flag). No work is done if the user doesn't care about the wakeup source. Change wakeup source checking algorithm from O(N) to O(1).

This implies changing the *undocumented*:
```cpp
int main() {
   uint32_t cause = ulp_lp_core_get_wakeup_cause();
   if (cause & LP_CORE_LL_WAKEUP_SOURCE_HP_CPU) {
       // Do something
   } 
```
to 
```cpp
int main() {
   if (ulp_lp_core_wakeup_assert_clear_hp_cpu()) {
     // Do something
  }
```
No more *LowLevel* macro usage here too.

### Implications of the changes

1. The binary ULP code is smaller. 
2. Less RTC RAM is used (at least 8 bytes)
3. I've removed the function `ulp_lp_core_get_wakeup_cause` and the broken `ulp_lp_core_update_wakeup_cause` so previous code using it will break building. I think it's a good change since it force the user to update her code to the new API.
4. No magical/buggy spurious wake up for LP core. Previous code cleared the wakeup source so if the LP core halted, sometimes it actually halted, sometimes it re-run immediately (if the wakeup interrupt triggered again. It's very visible with a button on an IO due to bouncing). If the user doesn't call the `ulp_lp_core_wakeup_assert_clear_` function, it'll wake up immediately. It's documented that it should be called before halting too to ensure consistent behavior.

## Testing

Tested on my systems using ESP32C6 and both LPIO + LPTIMER wake up source (see linked issue).

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.

This PR introduces breaking changes as required to fix the currently buggy API.
 
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary. 

The modified functions aren't used in any tests, I haven't created new ones.

- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
