### PR TITLE
Fix/ws transport reject multisec (IDFGH-15569)

### DIFF
--- a/components/tcp_transport/include/esp_transport_ws.h
+++ b/components/tcp_transport/include/esp_transport_ws.h
@@ -29,6 +29,8 @@ typedef enum ws_transport_opcodes {
                                           * from the API esp_transport_ws_get_read_opcode() */
 } ws_transport_opcodes_t;
 
+typedef void (*ws_header_hook)(void * userp, const char * line, int line_len);
+
 /**
  * WS transport configuration structure
  */
@@ -37,6 +39,8 @@ typedef struct {
     const char *sub_protocol;               /*!< WS subprotocol */
     const char *user_agent;                 /*!< WS user agent */
     const char *headers;                    /*!< WS additional headers */
+    ws_header_hook header_hook;             /*!< WS received header */
+    void *header_userp;                     /*!< WS received header user-pointer */
     const char *auth;                       /*!< HTTP authorization header */
     char *response_headers;                 /*!< The buffer to copy the http response header */
     size_t response_headers_len;            /*!< The length of the http response header */
@@ -98,6 +102,31 @@ esp_err_t esp_transport_ws_set_user_agent(esp_transport_handle_t t, const char *
  *      - One of the error codes
  */
 esp_err_t esp_transport_ws_set_headers(esp_transport_handle_t t, const char *headers);
+
+/**
+ * @brief               Set websocket header callback
+ *
+ * @param t             websocket transport handle
+ * @param hook          call function on header received. NULL to disable.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - One of the error codes
+ */
+esp_err_t esp_transport_ws_set_header_hook(esp_transport_handle_t t, ws_header_hook hook);
+
+
+/**
+ * @brief               Set websocket header callback user-pointer
+ *
+ * @param t             websocket transport handle
+ * @param userp         caller-controlled argument to ws_header_hook
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - One of the error codes
+ */
+esp_err_t esp_transport_ws_set_header_userp(esp_transport_handle_t t, void * userp);
 
 /**
  * @brief               Set websocket authorization headers

--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -324,6 +324,11 @@ static int ws_connect(esp_transport_handle_t t, const char *host, int port, int 
         size_t header_sec_websocket_accept_len = strlen(header_sec_websocket_accept);
         if (line_len >= header_sec_websocket_accept_len && !strncasecmp(header_cursor, header_sec_websocket_accept, header_sec_websocket_accept_len)) {
             ESP_LOGD(TAG, "found server-key");
+            if(server_key || server_key_len){
+                // RFC6455: The |Sec-WebSocket-Accept| header MUST NOT appear more than once in an HTTP response.
+                ESP_LOGE(TAG, "Multiple Sec-WebSocket-Accept headers");
+                return -1;
+            }
             server_key = header_cursor + header_sec_websocket_accept_len;
             server_key_len = line_len - header_sec_websocket_accept_len;
         }


### PR DESCRIPTION
## Description

Enforce that a WebSocket server sends exactly one `Sec-WebSocket-Accept` header. See [RFC6455](https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.3).

## Related

Please review #16119 first, as this depends on its changes to the header line parsing.

## Testing

- confirmed does not impact WebSocket compliant servers by connecting to wss://echo.websocket.org

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
