### PR TITLE
fix(bootloader_support): add cache management to bootloader_flash_write in case of flash encryption

### DIFF
--- a/components/bootloader_support/bootloader_flash/src/bootloader_flash.c
+++ b/components/bootloader_support/bootloader_flash/src/bootloader_flash.c
@@ -553,7 +553,34 @@ esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool 
     esp_rom_spiflash_result_t rc = ESP_ROM_SPIFLASH_RESULT_OK;
 
     if (write_encrypted && !ENCRYPTION_IS_VIRTUAL) {
+
+    /* NOTE: [Cache Coherency] Manual cache management for encrypted writes
+    *
+    * The `esp_rom_spiflash_write_encrypted` function modifies the physical
+    * flash memory but does not automatically manage CPU cache coherency.
+    * If a cache line holding the old data for the destination address
+    * exists, a subsequent read could be incorrectly served from this
+    * stale cache, returning outdated data.
+    *
+    * To prevent this cache coherency issue, we manually disable the
+    * cache before the write operation and re-enable it immediately
+    * after. This ensures that any subsequent read of this memory
+    * region will fetch the new, correct data from the physical flash.
+    */
+#if CONFIG_IDF_TARGET_ESP32
+        Cache_Read_Disable(0);
+        Cache_Flush(0);
+#else
+        cache_hal_disable(CACHE_TYPE_ALL);
+#endif
+
         rc = esp_rom_spiflash_write_encrypted(dest_addr, src, size);
+
+#if CONFIG_IDF_TARGET_ESP32
+        Cache_Read_Enable(0);
+#else
+        cache_hal_enable(CACHE_TYPE_ALL);
+#endif
     } else {
         rc = esp_rom_spiflash_write(dest_addr, src, size);
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

See issue https://github.com/espressif/esp-idf/issues/16819

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
