### PR TITLE
feat(examples): improved example for Ethernet SPI polling mode without interrupt (IDFGH-15933)

### DIFF
--- a/examples/common_components/protocol_examples_common/Kconfig.projbuild
+++ b/examples/common_components/protocol_examples_common/Kconfig.projbuild
@@ -295,10 +295,18 @@ menu "Example Connection Configuration"
 
             config EXAMPLE_ETH_SPI_INT_GPIO
                 int "Interrupt GPIO number"
-                range ENV_GPIO_RANGE_MIN ENV_GPIO_IN_RANGE_MAX
+                range -1 ENV_GPIO_IN_RANGE_MAX
                 default 4
                 help
                     Set the GPIO number used by the SPI Ethernet module interrupt line.
+                    Set -1 to use SPI Ethernet module in polling mode.
+            
+            config EXAMPLE_ETH_SPI_POLLING_MS_VAL
+                depends on EXAMPLE_ETH_SPI_INT_GPIO < 0
+                int "Polling period in msec of SPI Ethernet Module"
+                default 10
+                help
+                    Set SPI Ethernet module polling period.
         endif # EXAMPLE_USE_SPI_ETHERNET
 
         config EXAMPLE_ETH_PHY_RST_GPIO

--- a/examples/common_components/protocol_examples_common/eth_connect.c
+++ b/examples/common_components/protocol_examples_common/eth_connect.c
@@ -136,12 +136,18 @@ static esp_netif_t *eth_start(void)
     /* dm9051 ethernet driver is based on spi driver */
     eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(CONFIG_EXAMPLE_ETH_SPI_HOST, &spi_devcfg);
     dm9051_config.int_gpio_num = CONFIG_EXAMPLE_ETH_SPI_INT_GPIO;
+    #if CONFIG_EXAMPLE_ETH_SPI_INT_GPIO < 0
+        dm9051_config.poll_period_ms = CONFIG_EXAMPLE_ETH_SPI_POLLING_MS_VAL;
+    #endif 
     s_mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
     s_phy = esp_eth_phy_new_dm9051(&phy_config);
 #elif CONFIG_EXAMPLE_USE_W5500
     /* w5500 ethernet driver is based on spi driver */
     eth_w5500_config_t w5500_config = ETH_W5500_DEFAULT_CONFIG(CONFIG_EXAMPLE_ETH_SPI_HOST, &spi_devcfg);
     w5500_config.int_gpio_num = CONFIG_EXAMPLE_ETH_SPI_INT_GPIO;
+    #if CONFIG_EXAMPLE_ETH_SPI_INT_GPIO < 0
+        w5500_config.poll_period_ms = CONFIG_EXAMPLE_ETH_SPI_POLLING_MS_VAL;
+    #endif
     s_mac = esp_eth_mac_new_w5500(&w5500_config, &mac_config);
     s_phy = esp_eth_phy_new_w5500(&phy_config);
 #endif


### PR DESCRIPTION

## Description

EXAMPLE_ETH_SPI_INT_GPIO can not be set "-1", that is a compatible number of  _eth_w5500_config_t->int_gpio_num_

`Interrupt GPIO number, set -1 to not use interrupt and to poll rx status periodically`

If someone use W5500 without INT GPIO (in polling mode), with EXAMPLE_ETH_SPI_INT_GPIO=0, it will be blocked by "invalid configuration argument combination" error of _esp_eth_mac_new_w5500_ function.


## Testing
ESP-IDF 5.4.2

