### PR TITLE
change(esp32): Calling gpio_reset_pin on an input only pin should not produce an error message.

### DIFF
--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -457,8 +457,10 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
 {
     GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
     gpio_intr_disable(gpio_num);
-    // for powersave reasons, the GPIO should not be floating, select pullup
-    gpio_pullup_en(gpio_num);
+    if(GPIO_IS_VALID_OUTPUT_GPIO(gpio_num)) {
+        // for powersave reasons, the GPIO should not be floating, select pullup
+        gpio_pullup_en(gpio_num);
+    }
     gpio_pulldown_dis(gpio_num);
     gpio_input_disable(gpio_num);
     gpio_output_disable(gpio_num);


### PR DESCRIPTION
## Description

The `gpio_reset_pin` function attempts to enable internal pullup on input only pins as well, which do not have configurable internal pullups.

For example, in the case of ESP32, 
```c
gpio_reset_pin(GPIO_NUM_39);
```
emits:
```bash
E (4535) gpio: gpio_pullup_en(78): GPIO number error (input-only pad has no internal PU)
```

This change adds the same guard inside `gpio_reset_pin` before calling `gpio_pullup_en` that makes `gpio_pullup_en` print the error in case of calling it with an input only pin.

I'm not familiar with the inside structure of IDF, maybe this is done by purpose, or if not, maybe other parts of the driver should be updated as well. Or maybe the error in gpio_pullup_en should be just a warning.

This change only makes the error log not to show up - the functional effect of calling `gpio_reset_pin` with any parameter remains identical.
---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
