### PR TITLE
Refactor: Use enum values when assigning "pull_[up|down]_en" fields of "gpio_config" (IDFGH-16192)

### DIFF
--- a/components/app_update/test_apps/test_app_update/main/utils_update.c
+++ b/components/app_update/test_apps/test_app_update/main/utils_update.c
@@ -269,8 +269,8 @@ void set_output_pin(uint32_t num_pin)
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_OUTPUT;
     io_conf.pin_bit_mask = (1ULL << num_pin);
-    io_conf.pull_down_en = 0;
-    io_conf.pull_up_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     TEST_ESP_OK(gpio_config(&io_conf));
 
     TEST_ESP_OK(gpio_set_level(num_pin, 0));

--- a/components/bt/common/ble_log/ble_log_spi_out.c
+++ b/components/bt/common/ble_log/ble_log_spi_out.c
@@ -860,8 +860,8 @@ static int spi_out_ts_sync_init(void)
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_OUTPUT,
         .pin_bit_mask = BIT(SPI_OUT_SYNC_IO_NUM),
-        .pull_down_en = 0,
-        .pull_up_en = 0
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE
     };
     if (gpio_config(&io_conf) != ESP_OK) {
         goto failed;

--- a/components/esp_driver_cam/isp_dvp/src/esp_cam_ctlr_isp_dvp.c
+++ b/components/esp_driver_cam/isp_dvp/src/esp_cam_ctlr_isp_dvp.c
@@ -521,8 +521,8 @@ static esp_err_t s_isp_io_init(isp_dvp_controller_t *dvp_ctlr, const esp_cam_ctl
     gpio_config_t gpio_conf = {
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_INPUT,
-        .pull_down_en = false,
-        .pull_up_en = true,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
     };
 
     if (ctlr_config->pclk_io >= 0) {

--- a/components/esp_driver_gpio/test_apps/gpio/main/test_gpio.c
+++ b/components/esp_driver_gpio/test_apps/gpio/main/test_gpio.c
@@ -55,8 +55,8 @@ static gpio_config_t test_init_io(gpio_num_t num)
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_OUTPUT,
         .pin_bit_mask = (1ULL << num),
-        .pull_down_en = 0,
-        .pull_up_en = 0,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
     };
     return io_conf;
 }
@@ -68,7 +68,7 @@ static void test_gpio_config_mode_input_output(gpio_num_t num)
 {
     gpio_config_t input_output_io = test_init_io(num);
     input_output_io.mode = GPIO_MODE_INPUT_OUTPUT;
-    input_output_io.pull_up_en = 1;
+    input_output_io.pull_up_en = GPIO_PULLUP_ENABLE;
     TEST_ESP_OK(gpio_config(&input_output_io));
 }
 
@@ -813,8 +813,8 @@ TEST_CASE("GPIO_input_and_output_of_USB_pins_test", "[gpio]")
             .intr_type = GPIO_INTR_DISABLE,
             .mode = GPIO_MODE_INPUT_OUTPUT,
             .pin_bit_mask = BIT64(pin),
-            .pull_down_en = 0,
-            .pull_up_en = 0,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
         };
         gpio_config(&io_conf);
 
@@ -856,8 +856,8 @@ TEST_CASE("GPIO_USB_DP_pin_pullup_disable_test", "[gpio]")
         int pin = test_pins[i];
         gpio_config_t input_io = test_init_io(pin);
         input_io.mode = GPIO_MODE_INPUT;
-        input_io.pull_up_en = 0;
-        input_io.pull_down_en = 1;
+        input_io.pull_up_en = GPIO_PULLUP_DISABLE;
+        input_io.pull_down_en = GPIO_PULLDOWN_ENABLE;
         gpio_config(&input_io);
 
         TEST_ASSERT_EQUAL_INT(0, gpio_get_level(pin));
@@ -871,7 +871,7 @@ TEST_CASE("GPIO_light_sleep_wake_up_test", "[gpio][ignore]")
 {
     gpio_config_t io_config = test_init_io(TEST_GPIO_INPUT_LEVEL_LOW_PIN);
     io_config.mode = GPIO_MODE_INPUT;
-    io_config.pull_down_en = 1;
+    io_config.pull_down_en = GPIO_PULLDOWN_ENABLE;
     gpio_config(&io_config);
     TEST_ESP_OK(gpio_wakeup_enable(TEST_GPIO_INPUT_LEVEL_LOW_PIN, GPIO_INTR_HIGH_LEVEL));
     TEST_ESP_OK(esp_sleep_enable_gpio_wakeup());
@@ -898,8 +898,8 @@ static void gpio_deep_sleep_hold_test_first_stage(void)
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_INPUT_OUTPUT,
         .pin_bit_mask = (1ULL << io_num),
-        .pull_down_en = 0,
-        .pull_up_en = 0,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
     };
     TEST_ESP_OK(gpio_config(&io_conf));
     TEST_ESP_OK(gpio_set_level(io_num, 0));

--- a/components/esp_driver_gpio/test_apps/gpio/main/test_rtcio.c
+++ b/components/esp_driver_gpio/test_apps/gpio/main/test_rtcio.c
@@ -294,8 +294,8 @@ static void rtcio_deep_sleep_hold_test_first_stage(void)
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_INPUT_OUTPUT,
         .pin_bit_mask = (1ULL << io_num),
-        .pull_down_en = 0,
-        .pull_up_en = 0,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
     };
     gpio_config(&io_conf);
 

--- a/components/esp_driver_parlio/test_apps/parlio/main/test_parlio_rx.c
+++ b/components/esp_driver_parlio/test_apps/parlio/main/test_parlio_rx.c
@@ -97,8 +97,8 @@ static void connect_signal_internally(uint32_t gpio, uint32_t sigo, uint32_t sig
         .pin_bit_mask = BIT64(gpio),
         .mode = GPIO_MODE_INPUT_OUTPUT,
         .intr_type = GPIO_INTR_DISABLE,
-        .pull_down_en = false,
-        .pull_up_en = false,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
     };
     gpio_config(&gpio_conf);
     esp_rom_gpio_connect_out_signal(gpio, sigo, false, false);

--- a/components/esp_driver_sdmmc/src/sd_host_sdmmc.c
+++ b/components/esp_driver_sdmmc/src/sd_host_sdmmc.c
@@ -1291,8 +1291,8 @@ static esp_err_t sdmmc_slot_io_config(sd_host_sdmmc_slot_t *slot, const sd_host_
                 gpio_config_t gpio_conf = {
                     .pin_bit_mask = BIT64(slot_gpio->d3_io),
                     .mode = GPIO_MODE_OUTPUT,
-                    .pull_up_en = 0,
-                    .pull_down_en = 0,
+                    .pull_up_en = GPIO_PULLUP_DISABLE,
+                    .pull_down_en = GPIO_PULLDOWN_DISABLE,
                     .intr_type = GPIO_INTR_DISABLE,
                 };
                 gpio_config(&gpio_conf);

--- a/components/esp_driver_sdspi/src/sdspi_host.c
+++ b/components/esp_driver_sdspi/src/sdspi_host.c
@@ -376,7 +376,7 @@ esp_err_t sdspi_host_init_device(const sdspi_device_config_t* slot_config, sdspi
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_INPUT,
         .pin_bit_mask = 0,
-        .pull_up_en = true
+        .pull_up_en = GPIO_PULLUP_ENABLE
     };
     if (slot_config->gpio_cd != SDSPI_SLOT_NO_CD) {
         io_conf.pin_bit_mask |= (1ULL << slot_config->gpio_cd);
@@ -390,8 +390,8 @@ esp_err_t sdspi_host_init_device(const sdspi_device_config_t* slot_config, sdspi
         slot->gpio_wp = slot_config->gpio_wp;
         slot->gpio_wp_polarity = slot_config->gpio_wp_polarity;
         if (slot->gpio_wp_polarity) {
-            io_conf.pull_down_en = true;
-            io_conf.pull_up_en = false;
+            io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+            io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
         }
     } else {
         slot->gpio_wp = GPIO_UNUSED;
@@ -410,7 +410,7 @@ esp_err_t sdspi_host_init_device(const sdspi_device_config_t* slot_config, sdspi
         io_conf = (gpio_config_t) {
             .intr_type = GPIO_INTR_LOW_LEVEL,
             .mode = GPIO_MODE_INPUT,
-            .pull_up_en = true,
+            .pull_up_en = GPIO_PULLUP_ENABLE,
             .pin_bit_mask = (1ULL << slot_config->gpio_int),
         };
         ret = gpio_config(&io_conf);

--- a/components/esp_hw_support/test_apps/wakeup_tests/main/src/io_wakeup_cmd.c
+++ b/components/esp_hw_support/test_apps/wakeup_tests/main/src/io_wakeup_cmd.c
@@ -182,8 +182,8 @@ static int process_rtcio_wakeup(int argc, char **argv)
         gpio_config_t config = {
             .pin_bit_mask = BIT64(io_wakeup_num),
             .mode = GPIO_MODE_INPUT,
-            .pull_down_en = false,
-            .pull_up_en = false,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
             .intr_type = GPIO_INTR_DISABLE
         };
         ESP_ERROR_CHECK(gpio_config(&config));
@@ -257,8 +257,8 @@ static int process_gpio_wakeup(int argc, char **argv)
         gpio_config_t config = {
             .pin_bit_mask = BIT64(io_wakeup_num),
             .mode = GPIO_MODE_INPUT,
-            .pull_down_en = false,
-            .pull_up_en = false,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
             .intr_type = (io_wakeup_level == 0) ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL
         };
         ESP_ERROR_CHECK(gpio_config(&config));

--- a/components/esp_phy/src/phy_common.c
+++ b/components/esp_phy/src/phy_common.c
@@ -159,8 +159,8 @@ static void phy_ant_set_gpio_output(uint32_t io_num)
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_OUTPUT;
     io_conf.pin_bit_mask = (1ULL << io_num);
-    io_conf.pull_down_en = 0;
-    io_conf.pull_up_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     gpio_config(&io_conf);
 }
 

--- a/docs/en/api-reference/peripherals/gpio.rst
+++ b/docs/en/api-reference/peripherals/gpio.rst
@@ -99,8 +99,8 @@ Do not rely on the default configurations values in the Technical Reference Manu
         gpio_config_t usb_phy_conf = {
             .pin_bit_mask = (1ULL << USB_PHY_DP_PIN) | (1ULL << USB_PHY_DM_PIN),
             .mode = GPIO_MODE_INPUT_OUTPUT,
-            .pull_up_en = 0,
-            .pull_down_en = 0,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
             .intr_type = GPIO_INTR_DISABLE,
         };
         gpio_config(&usb_phy_conf);

--- a/docs/zh_CN/api-reference/peripherals/gpio.rst
+++ b/docs/zh_CN/api-reference/peripherals/gpio.rst
@@ -99,8 +99,8 @@ GPIO 驱动提供了一个函数 :cpp:func:`gpio_dump_io_configuration` 用来�
         gpio_config_t usb_phy_conf = {
             .pin_bit_mask = (1ULL << USB_PHY_DP_PIN) | (1ULL << USB_PHY_DM_PIN),
             .mode = GPIO_MODE_INPUT_OUTPUT,
-            .pull_up_en = 0,
-            .pull_down_en = 0,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
             .intr_type = GPIO_INTR_DISABLE,
         };
         gpio_config(&usb_phy_conf);

--- a/examples/bluetooth/bluedroid/classic_bt/hfp_ag/main/gpio_pcm_config.c
+++ b/examples/bluetooth/bluedroid/classic_bt/hfp_ag/main/gpio_pcm_config.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -30,9 +30,9 @@ void app_gpio_pcm_io_cfg(void)
     //bit mask of the pins that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = GPIO_OUTPUT_PCM_PIN_SEL;
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
@@ -44,8 +44,8 @@ void app_gpio_pcm_io_cfg(void)
     //set as input mode
     io_conf.mode = GPIO_MODE_INPUT;
     //enable pull-up mode
-    io_conf.pull_up_en = 0;
-    io_conf.pull_down_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
@@ -73,9 +73,9 @@ void app_gpio_aec_io_cfg(void)
     //bit mask of the pins that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = GPIO_OUTPUT_AEC_PIN_SEL;
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 

--- a/examples/bluetooth/bluedroid/classic_bt/hfp_hf/main/gpio_pcm_config.c
+++ b/examples/bluetooth/bluedroid/classic_bt/hfp_hf/main/gpio_pcm_config.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -30,9 +30,9 @@ void app_gpio_pcm_io_cfg(void)
     //bit mask of the pins that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = GPIO_OUTPUT_PCM_PIN_SEL;
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
@@ -44,8 +44,8 @@ void app_gpio_pcm_io_cfg(void)
     //set as input mode
     io_conf.mode = GPIO_MODE_INPUT;
     //enable pull-up mode
-    io_conf.pull_up_en = 0;
-    io_conf.pull_down_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
@@ -73,9 +73,9 @@ void app_gpio_aec_io_cfg(void)
     //bit mask of the pins that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = GPIO_OUTPUT_AEC_PIN_SEL;
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 

--- a/examples/bluetooth/hci/controller_hci_uart_esp32c3_and_esp32s3/main/main.c
+++ b/examples/bluetooth/hci/controller_hci_uart_esp32c3_and_esp32s3/main/main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -170,8 +170,8 @@ static void uart_gpio_set(void)
         .intr_type = GPIO_INTR_DISABLE,    //disable interrupt
         .mode = GPIO_MODE_OUTPUT,    // output mode
         .pin_bit_mask = GPIO_OUTPUT_PIN_SEL,    // bit mask of the output pins
-        .pull_down_en = 0,    // disable pull-down mode
-        .pull_up_en = 0,    // disable pull-up mode
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,  // disable pull-down mode
+        .pull_up_en = GPIO_PULLUP_DISABLE,      // disable pull-up mode
     };
     gpio_config(&io_output_conf);
 
@@ -179,8 +179,8 @@ static void uart_gpio_set(void)
         .intr_type = GPIO_INTR_DISABLE,    //disable interrupt
         .mode = GPIO_MODE_INPUT,    // input mode
         .pin_bit_mask = GPIO_INPUT_PIN_SEL,  // bit mask of the input pins
-        .pull_down_en = 0,    // disable pull-down mode
-        .pull_up_en = 0,    // disable pull-down mode
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,  // disable pull-down mode
+        .pull_up_en = GPIO_PULLUP_DISABLE,      // disable pull-down mode
     };
     gpio_config(&io_input_conf);
 

--- a/examples/bluetooth/nimble/ble_cte/common_components/cte_config/cte_config.c
+++ b/examples/bluetooth/nimble/ble_cte/common_components/cte_config/cte_config.c
@@ -89,8 +89,8 @@ int ble_direction_finding_antenna_init(uint8_t* gpio_array,uint8_t gpio_array_le
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_OUTPUT,
         .pin_bit_mask = gpio_pin_maks,
-        .pull_down_en = false,
-        .pull_up_en = true,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
     };
     rc = gpio_config(&gpio_conf);
     if(rc != 0) {

--- a/examples/mesh/ip_internal_network/main/mesh_main.c
+++ b/examples/mesh/ip_internal_network/main/mesh_main.c
@@ -65,8 +65,8 @@ static void initialise_button(void)
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.pin_bit_mask = BIT64(EXAMPLE_BUTTON_GPIO);
     io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = 1;
-    io_conf.pull_down_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     gpio_config(&io_conf);
 }
 

--- a/examples/network/sta2eth/main/sta2eth_main.c
+++ b/examples/network/sta2eth/main/sta2eth_main.c
@@ -132,7 +132,7 @@ static void gpio_init(void)
     gpio_config_t io_conf = { .intr_type = GPIO_INTR_ANYEDGE,
                               .pin_bit_mask = (1ULL << GPIO_INPUT),
                               .mode = GPIO_MODE_INPUT,
-                              .pull_up_en = 1
+                              .pull_up_en = GPIO_PULLUP_ENABLE
                             };
     gpio_config(&io_conf);
     gpio_install_isr_service(0);

--- a/examples/peripherals/analog_comparator/main/ana_cmpr_example_main.c
+++ b/examples/peripherals/analog_comparator/main/ana_cmpr_example_main.c
@@ -14,8 +14,8 @@ void example_init_monitor_gpio(void)
         .intr_type = GPIO_INTR_DISABLE,
         .mode = GPIO_MODE_OUTPUT,
         .pin_bit_mask = (1ULL << EXAMPLE_MONITOR_GPIO_NUM),
-        .pull_down_en = false,
-        .pull_up_en = false,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
     };
     gpio_config(&io_conf);
     gpio_set_level(EXAMPLE_MONITOR_GPIO_NUM, 0);

--- a/examples/peripherals/gpio/generic_gpio/main/gpio_example_main.c
+++ b/examples/peripherals/gpio/generic_gpio/main/gpio_example_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -84,9 +84,9 @@ void app_main(void)
     //bit mask of the pins that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = GPIO_OUTPUT_PIN_SEL;
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 
@@ -97,7 +97,7 @@ void app_main(void)
     //set as input mode
     io_conf.mode = GPIO_MODE_INPUT;
     //enable pull-up mode
-    io_conf.pull_up_en = 1;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
     gpio_config(&io_conf);
 
     //change gpio interrupt type for one pin

--- a/examples/peripherals/sdio/host/main/app_main.c
+++ b/examples/peripherals/sdio/host/main/app_main.c
@@ -139,7 +139,7 @@ static void gpio_d2_set_high(void)
     gpio_config_t d2_config = {
         .pin_bit_mask = BIT64(PIN_D2),
         .mode = GPIO_MODE_OUTPUT,
-        .pull_up_en = true,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
     };
     gpio_config(&d2_config);
     gpio_set_level(PIN_D2, 1);
@@ -313,8 +313,8 @@ void slave_power_on(void)
     gpio_config_t cfg = {
         .pin_bit_mask = BIT64(GPIO_B1),
         .mode = GPIO_MODE_OUTPUT,
-        .pull_up_en = false,
-        .pull_down_en = false,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
         .intr_type = GPIO_INTR_DISABLE,
     };
     gpio_config(&cfg);

--- a/examples/peripherals/spi_master/lcd/main/spi_master_example_main.c
+++ b/examples/peripherals/spi_master/lcd/main/spi_master_example_main.c
@@ -244,7 +244,7 @@ void lcd_init(spi_device_handle_t spi)
     gpio_config_t io_conf = {};
     io_conf.pin_bit_mask = ((1ULL << PIN_NUM_DC) | (1ULL << PIN_NUM_RST) | (1ULL << PIN_NUM_BCKL));
     io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pull_up_en = true;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
     gpio_config(&io_conf);
 
     //Reset the display

--- a/examples/peripherals/spi_slave/sender/main/app_main.c
+++ b/examples/peripherals/spi_slave/sender/main/app_main.c
@@ -100,7 +100,7 @@ void app_main(void)
     gpio_config_t io_conf = {
         .intr_type = GPIO_INTR_POSEDGE,
         .mode = GPIO_MODE_INPUT,
-        .pull_up_en = 1,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
         .pin_bit_mask = BIT64(GPIO_HANDSHAKE),
     };
 

--- a/examples/peripherals/timer_group/gptimer_capture_hc_sr04/main/gptimer_capture_hc_sr04.c
+++ b/examples/peripherals/timer_group/gptimer_capture_hc_sr04/main/gptimer_capture_hc_sr04.c
@@ -80,7 +80,7 @@ void app_main(void)
     gpio_config_t echo_io_conf = {
         .mode = GPIO_MODE_INPUT,
         .intr_type = GPIO_INTR_ANYEDGE, // capture signal on both edge
-        .pull_up_en = true, // pull up internally
+        .pull_up_en = GPIO_PULLUP_ENABLE, // pull up internally
         .pin_bit_mask = 1ULL << HC_SR04_ECHO_GPIO,
     };
     ESP_ERROR_CHECK(gpio_config(&echo_io_conf));

--- a/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c
+++ b/examples/peripherals/usb/device/tusb_hid/main/tusb_hid_example_main.c
@@ -158,8 +158,8 @@ void app_main(void)
         .pin_bit_mask = BIT64(APP_BUTTON),
         .mode = GPIO_MODE_INPUT,
         .intr_type = GPIO_INTR_DISABLE,
-        .pull_up_en = true,
-        .pull_down_en = false,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
     };
     ESP_ERROR_CHECK(gpio_config(&boot_button_config));
 

--- a/examples/phy/cert_test/main/cmd_phy.c
+++ b/examples/phy/cert_test/main/cmd_phy.c
@@ -417,9 +417,9 @@ void esp_phy_gpio_output_set(int number, int level) {
     //bit mask of the pin that you want to set,e.g.GPIO18/19
     io_conf.pin_bit_mask = (1ULL<<number);
     //disable pull-down mode
-    io_conf.pull_down_en = 0;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     //disable pull-up mode
-    io_conf.pull_up_en = 0;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     //configure GPIO with the given settings
     gpio_config(&io_conf);
 

--- a/examples/storage/sd_card/sdmmc/components/sd_card/sd_test_io.c
+++ b/examples/storage/sd_card/sdmmc/components/sd_card/sd_test_io.c
@@ -111,8 +111,8 @@ void check_sd_card_pins(pin_configuration_t *config, const int pin_count)
         io_conf.intr_type = GPIO_INTR_DISABLE;
         io_conf.mode = GPIO_MODE_INPUT_OUTPUT_OD;
         io_conf.pin_bit_mask = GPIO_INPUT_PIN_SEL(config->pins[i]);
-        io_conf.pull_down_en = 0;
-        io_conf.pull_up_en = 0;
+        io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+        io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
         gpio_config(&io_conf);
     }
 

--- a/examples/system/light_sleep/main/gpio_wakeup.c
+++ b/examples/system/light_sleep/main/gpio_wakeup.c
@@ -44,8 +44,8 @@ esp_err_t example_register_gpio_wakeup(void)
     gpio_config_t config = {
             .pin_bit_mask = BIT64(GPIO_WAKEUP_NUM),
             .mode = GPIO_MODE_INPUT,
-            .pull_down_en = false,
-            .pull_up_en = false,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
             .intr_type = GPIO_INTR_DISABLE
     };
     ESP_RETURN_ON_ERROR(gpio_config(&config), TAG, "Initialize GPIO%d failed", GPIO_WAKEUP_NUM);

--- a/examples/zigbee/light_sample/HA_on_off_switch/main/switch_driver.c
+++ b/examples/zigbee/light_sample/HA_on_off_switch/main/switch_driver.c
@@ -149,7 +149,7 @@ static bool switch_driver_gpio_init(switch_func_pair_t *button_func_pair, uint8_
     io_conf.intr_type = GPIO_INTR_NEGEDGE;
     io_conf.pin_bit_mask = pin_bit_mask;
     io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = 1;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
     /* configure GPIO with the given settings */
     gpio_config(&io_conf);
     /* create a queue to handle gpio event from isr */


### PR DESCRIPTION
## Description

Various places in ESP-IDF use `0|1` or `true|false` when assigning the `pull_up_en|pull_down_en` fields of `gpio_config_t`. This is fine in C, but will lead to a `invalid conversion` build error when building those code snippets under C++. It's also a bit unsafe if the order of those enums are changed.

This PR refactors all assignments of `pull_up_en|pull_down_en` to use the corresponding `GPIO_PULL[UP|DOWN]_[ENABLE|DISABLE]` enums.

## Related

## Testing

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
