### PR TITLE
Update gatts_demo.c (IDFGH-16207)

### DIFF
--- a/examples/bluetooth/bluedroid/ble/gatt_server/main/gatts_demo.c
+++ b/examples/bluetooth/bluedroid/ble/gatt_server/main/gatts_demo.c
@@ -204,7 +204,7 @@ void example_exec_write_event_env(prepare_type_env_t *prepare_write_env, esp_ble
 static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param)
 {
     switch (event) {
-#ifdef CONFIG_SET_RAW_ADV_DATA
+#ifdef CONFIG_EXAMPLE_SET_RAW_ADV_DATA
     case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT:
         adv_config_done &= (~adv_config_flag);
         if (adv_config_done==0){


### PR DESCRIPTION
Fix the problem of macro definition error.


## Description

在原代码中，gap_event_handler 函数中使用了错误混淆的宏定义，正确的宏定义判断应该是#ifdef CONFIG_EXAMPLE_SET_RAW_ADV_DATA
该错误会造成用户在menuconfig中，Example 'GATT SERVER' Config 选项下开启raw广播数据包格式（Use raw data for advertising packets and scan response data）时，会无法开启gap广播

In the original code, the gap_event_handler function used an incorrectly confused macro definition, and the correct macro definition judgment should be #ifdef CONFIG_EXAMPLE_SET_RAW_ADV_DATA
This error causes users to be unable to enable gap broadcasting when enabling "Use raw data for advertising packets and scan response data" in "Example 'GATT SERVER' Config" option in menuconfig 


## Related



## Testing

在我更正此宏定义后，ESP32能够使用raw格式数据包进行正常广播与连接
After I corrected this macro definition, the ESP32 was able to broadcast and connect normally using RAW format packets
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [✓] 🚨 This PR does not introduce breaking changes.
- [✓] All CI checks (GH Actions) pass.
- [✓] Documentation is updated as needed.
- [✓] Tests are updated or added as necessary.
- [✓] Code is well-commented, especially in complex areas.
- [✓] Git history is clean — commits are squashed to the minimum necessary.
