### PR TITLE
fix: I2C driver should use I2C_CLK_SRC_REF_TICK enum (IDFGH-16266)

### DIFF
--- a/components/driver/i2c/i2c.c
+++ b/components/driver/i2c/i2c.c
@@ -761,7 +761,7 @@ static uint32_t s_get_src_clk_freq(i2c_clock_source_t clk_src)
         break;
 #endif
 #if SOC_I2C_SUPPORT_REF_TICK
-    case RMT_CLK_SRC_REF_TICK:
+    case I2C_CLK_SRC_REF_TICK:
         periph_src_clk_hz = REF_CLK_FREQ;
         break;
 #endif


### PR DESCRIPTION
## Description

Fixed minor issue where the I2C driver uses `RMT_CLK_SRC_REF_TICK` instead of the `I2C_CLK_SRC_REF_TICK` enum value. Both enum values are the same under the hood, so this issue doesn't cause a bug.

## Related

## Testing

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
