### PR TITLE
docs(esp_http_client): document default timeout behaviour (IDFGH-16274)

### DIFF
--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -182,7 +182,7 @@ typedef struct {
 #endif
     const char                  *user_agent;         /*!< The User Agent string to send with HTTP requests */
     esp_http_client_method_t    method;                   /*!< HTTP Method */
-    int                         timeout_ms;               /*!< Network timeout in milliseconds */
+    int                         timeout_ms;               /*!< Network timeout in milliseconds. 0 defaults to 5 seconds */
     bool                        disable_auto_redirect;    /*!< Disable HTTP automatic redirects */
     int                         max_redirection_count;    /*!< Max number of redirections on receiving HTTP redirect status code, using default value if zero*/
     int                         max_authorization_retries;    /*!< Max connection retries on receiving HTTP unauthorized status code, using default value if zero. Disables authorization retry if -1*/


### PR DESCRIPTION
## Description

Document that timeout=0 actually means 5 seconds.

## Testing

It's just a comment-change.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
