### PR TITLE
feat(tls): Support runtime ATECC608A I2C address configuration in TLS

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -213,6 +213,9 @@ typedef struct esp_tls_cfg {
     const int *ciphersuites_list;           /*!< Pointer to a zero-terminated array of IANA identifiers of TLS ciphersuites.
                                                 Please check the list validity by esp_tls_get_ciphersuites_list() API */
     esp_tls_proto_ver_t tls_version;        /*!< TLS protocol version of the connection, e.g., TLS 1.2, TLS 1.3 (default - no preference) */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;            /*!< I2C address of the atecc608a chip */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 } esp_tls_cfg_t;
 
 #if defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
@@ -326,6 +329,10 @@ typedef struct esp_tls_cfg_server {
     esp_tls_handshake_callback cert_select_cb;  /*!< Certificate selection callback that gets called after ClientHello is processed.
                                                      Can be used as an SNI callback, but also has access to other
                                                      TLS extensions, such as ALPN and server_certificate_type . */
+#endif
+
+#if defined(CONFIG_ATECC608A_RUNTIME_SELECTION)
+    uint8_t atecc608a_i2c_addr;                 /*!< I2C address of the atecc608a chip */
 #endif
 
 #if defined(CONFIG_ESP_TLS_PSK_VERIFICATION)

--- a/components/esp-tls/private_include/esp_tls_private.h
+++ b/components/esp-tls/private_include/esp_tls_private.h
@@ -97,7 +97,9 @@ struct esp_tls {
                                                                                      - ESP_TLS_SERVER */
 
     esp_tls_error_handle_t error_handle;                                        /*!< handle to error descriptor */
-
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;                                                 /*!< I2C address of the ATECC608A device */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 };
 
 // Function pointer for the server configuration API

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -844,7 +844,11 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
 
 #if CONFIG_ESP_TLS_USE_SECURE_ELEMENT
     if (config->use_secure_element) {
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+        esp_transport_ssl_use_secure_element(ssl, config->atecc608a_i2c_addr);
+#else // CONFIG_ATECC608A_RUNTIME_SELECTION
         esp_transport_ssl_use_secure_element(ssl);
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
     }
 #endif
 

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -203,6 +203,9 @@ typedef struct {
 #endif
 #if CONFIG_ESP_TLS_USE_SECURE_ELEMENT
     bool use_secure_element;                /*!< Enable this option to use secure element */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;             /*!< ATECC608A I2C address */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 #endif
 #if CONFIG_ESP_TLS_USE_DS_PERIPHERAL
     void *ds_data;                          /*!< Pointer for digital signature peripheral context, see ESP-TLS Documentation for more details */

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -118,6 +118,9 @@ struct httpd_ssl_config {
     /** Enable secure element for server session */
     bool use_secure_element;
 
+    /** ATECC608A I2C address, used for secure element */
+    uint8_t atecc608a_i2c_addr;
+
     /** User callback for esp_https_server */
     esp_https_server_user_cb *user_cb;
 

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -183,8 +183,13 @@ void esp_transport_ssl_set_ciphersuites_list(esp_transport_handle_t t, const int
  * @note       Recommended to be used with ESP32 series interfaced to ATECC608A based secure element
  *
  * @param      t     ssl transport
+ * @param      atecc608a_i2c_addr i2c address of the ATECC608A chip to use
  */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+void esp_transport_ssl_use_secure_element(esp_transport_handle_t t, uint8_t atecc608a_i2c_addr);
+#else
 void esp_transport_ssl_use_secure_element(esp_transport_handle_t t);
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 
 /**
  * @brief      Set the ds_data handle in ssl context.(used for the digital signature operation)

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -467,10 +467,17 @@ void esp_transport_ssl_set_ciphersuites_list(esp_transport_handle_t t, const int
 }
 
 #ifdef CONFIG_ESP_TLS_USE_SECURE_ELEMENT
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+void esp_transport_ssl_use_secure_element(esp_transport_handle_t t, uint8_t atecc608a_i2c_addr)
+#else
 void esp_transport_ssl_use_secure_element(esp_transport_handle_t t)
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 {
     GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);
     ssl->cfg.use_secure_element = true;
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    ssl->cfg.atecc608a_i2c_addr = atecc608a_i2c_addr;
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 }
 #endif
 


### PR DESCRIPTION
## Description

Includes changes in MQTT and MBED-TLS to support setting the I2C address of a secure element during runtime. This is required for systems where it cannot be determined at compile-time which secure element (ATEC608A) is installed on the hardware, something which may be, for example, configured during production instead.

This way, a new option is added in the configuration to instead of selecting which secure element is used in hardware, a runtime selection item is chosen instead. Checks are added that require the I2C address to be actively set (default is 0, which is not a valid address).

## Related

None

## Testing

Testing has only been performed on our own proprietary hardware, with the libraries for our own purposes activated. We build locally in a clean docker environment.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ x] 🚨 This PR does not introduce breaking changes.
- [ x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ x] Code is well-commented, especially in complex areas.
- [ x] Git history is clean — commits are squashed to the minimum necessary.
