### PR TITLE
fix PuTTY link in establish-serial-connection.rst (IDFGH-16292)

### DIFF
--- a/docs/en/get-started/establish-serial-connection.rst
+++ b/docs/en/get-started/establish-serial-connection.rst
@@ -282,7 +282,7 @@ Now verify that the serial connection is operational. You can do this using a se
 Windows and Linux
 ^^^^^^^^^^^^^^^^^
 
-In this example, we use `PuTTY SSH Client <https://www.putty.org/>`_ that is available for both Windows and Linux. You can use other serial programs and set communication parameters like below.
+In this example, we use `PuTTY SSH Client <https://putty.software/>`_ that is available for both Windows and Linux. You can use other serial programs and set communication parameters like below.
 
 Run terminal and set identified serial port. Baud rate = 115200 (if needed, change this to the default baud rate of the chip in use), data bits = 8, stop bits = 1, and parity = N. Below are example screenshots of setting the port and such transmission parameters (in short described as 115200-8-1-N) on Windows and Linux. Remember to select exactly the same serial port you have identified in steps above.
 


### PR DESCRIPTION
## Description
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
