### PR TITLE
fix(examples): Modified code to led turn on/off properly

### DIFF
--- a/examples/bluetooth/ble_get_started/bluedroid/Bluedroid_GATT_Server/main/main.c
+++ b/examples/bluetooth/ble_get_started/bluedroid/Bluedroid_GATT_Server/main/main.c
@@ -362,14 +362,17 @@ static void auto_io_gatts_profile_event_handler(esp_gatts_cb_event_t event, esp_
     case ESP_GATTS_WRITE_EVT:
         ESP_LOGI(GATTS_TAG, "Characteristic write, value len %u, value ", param->write.len);
         ESP_LOG_BUFFER_HEX(GATTS_TAG, param->write.value, param->write.len);
-        if (param->write.value[0]) {
-            ESP_LOGI(GATTS_TAG, "LED ON!");
-            led_on();
-        } else {
-            ESP_LOGI(GATTS_TAG, "LED OFF!");
-            led_off();
-        }
         example_write_event_env(gatts_if, param);
+
+	if (param->write.len == 2 && memcmp(param->write.value, "ON", 2) == 0) {
+        ESP_LOGI(GATTS_TAG, "LED ON!");
+        led_on();
+    	}
+    	else if (param->write.len == 3 && memcmp(param->write.value, "OFF", 3) == 0) {
+        ESP_LOGI(GATTS_TAG, "LED OFF!");
+        led_off();
+    	}
+
         break;
     case ESP_GATTS_DELETE_EVT:
         break;

--- a/examples/bluetooth/ble_get_started/bluedroid/Bluedroid_GATT_Server/main/src/led.c
+++ b/examples/bluetooth/ble_get_started/bluedroid/Bluedroid_GATT_Server/main/src/led.c
@@ -25,8 +25,7 @@ uint8_t get_led_state(void)
 void led_on(void)
 {
     /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
-    led_strip_set_pixel(led_strip, 0, 16, 16, 16);
-
+    led_strip_set_pixel(led_strip, 0, 0, 255, 0);
     /* Refresh the strip to send data */
     led_strip_refresh(led_strip);
 


### PR DESCRIPTION
## Description

I was studying with the Bluetooth examples, and notice that this script was suppose to check if was written on an specific GATT attribute the value ON or OFF, and turn on/ off the led, but the code was only checking if was written any value on the attribute and the OFF wasn't working. I corrected the main/main.c file and it worked, but I notice too that when the device starts, starts with the led GREEN, but when you write the attribute to turn OFF, them ON, the device turn ON in a white color led, so I changed the main/src/led.c file too, to make it turn GREEN when you apply the command, the same color as when the device starts.

## Related

## Testing

Build on idf.py, flashed and tested on esp32c6

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
