### PR TITLE
fix(http_server): Corrected initialization value for lru_counter at h… (IDFGH-16325)

### DIFF
--- a/components/esp_http_server/src/httpd_sess.c
+++ b/components/esp_http_server/src/httpd_sess.c
@@ -208,6 +208,7 @@ esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd)
     session->handle = (httpd_handle_t) hd;
     session->send_fn = httpd_default_send;
     session->recv_fn = httpd_default_recv;
+    session->lru_counter = hd->lru_counter;
 
     // increment number of sessions
     hd->hd_sd_active_count++;


### PR DESCRIPTION
## Description

In some scenarios http server sessions are purged (via Least Recently Used scheme) before being processed, causing the connection to be aborted before starting it.

I believe the root cause of the problem is the function httpd_sess_new() which initializes the session->lru_counter to 0 (Purge is done for the session with lower value). This counter is not updated until the session is processed (there is incoming data) but if before processing it there is a new incoming connection then the session is deleted since it is the one with lowest lru_counter.

Initializing the session->lru_counter with the value it would get if the session was processed at same time that is created solves the problem. 

## Related

## Testing

I have encountered this issue while switching from http to a https server. Probably because https server takes longer to process incoming connections (also because certificate validation fails due to I have an auto-signed certificate) then newer connections are purged before actually sending the data.

Specifically, I have the https server configured max_open_sockets = 7 and lru_purge_enable = true. I start a connection with a client that leave open the 7 sockets but without sending data (For instance, I send a request via Postman. Postman creates new session if requests are spaced for more than 1min). Then I try to load the embedded web of the device which triggers multiple new connections to download the data chunks. Some of the new connections for web download abort each other, instead of old (Postman) requests, making impossible to load the webpage in the browser.  This impossibility persist so far old connections keep open (Postman agent active). 

I monitored the currently opened sockets by adding logging message showing session FD in function enum_function() inside switch case HTTPD_TASK_FIND_LOWEST_LRU. I monitored the actual closed FD by using logging messages inside function httpd_sess_close_lru().


## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
