### PR TITLE
fix(i2c_master): use atomic operations for event (IDFGH-16368)

### DIFF
--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -134,7 +134,7 @@ struct i2c_master_bus_t {
     SemaphoreHandle_t bus_lock_mux;                                  // semaphore to lock bus process
     int cmd_idx;                                                     //record current command index, for master mode
     _Atomic i2c_master_status_t status;                              // record current command status, for master mode
-    i2c_master_event_t event;                                        // record current i2c bus event
+    _Atomic i2c_master_event_t event;                                // record current i2c bus event
     int rx_cnt;                                                      // record current read index, for master mode
     i2c_transaction_t i2c_trans;                                     // Pointer to I2C transfer structure
     i2c_operation_t i2c_ops[I2C_STATIC_OPERATION_ARRAY_MAX];         // I2C operation array


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

After searching for i2c issues on my board I got a lot of NACK related issues on the console.

```
E (2509388) i2c.master: I2C hardware NACK detected
E (2509388) i2c.master: I2C transaction unexpected nack detected
```

I found out that the i2c driver had a potential bug in the event handling because `i2c_master->event` was not atomic, unlike the status. This creates a race condition where:

- The ISR sets the atomic status to I2C_STATUS_ACK_ERROR.
- But `i2c_master->event` can be overwritten by another thread before being sent to the queue.
- The main thread receives an incorrect or corrupted event.

This PR implements `event` as atomic and prevents race condition and queue corruption.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

Potential fix for #17474

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested on my board, NACK are better handled and I have no more lots of error in my console. 

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
