### PR TITLE
fix(mbedtls): prevent vectorization fault in clang O2 optimization (IDFGH-16450)

### DIFF
--- a/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c
+++ b/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c
@@ -45,7 +45,7 @@ static int esp_ds_rsaes_pkcs1_v15_unpadding(unsigned char *input,
     for (size_t i = 2; i < ilen; i++) {
         unsigned char found = (input[i] == 0x00);
         /* Prevent vectorization fault for clang O2 optimization */
-        __asm__ __volatile__("" ::: "memory");
+        __asm__ __volatile__("" : "+r" (found));
         pad_done = pad_done | found;
         pad_count += (pad_done == 0) ? 1 : 0;
     }
@@ -68,7 +68,7 @@ static int esp_ds_rsaes_pkcs1_v15_unpadding(unsigned char *input,
         unsigned char in_padding = (i < pad_count + 2);
         unsigned char is_zero = (input[i] == 0x00);
         /* Prevent vectorization fault for clang O2 optimization */
-        __asm__ __volatile__("" ::: "memory");
+        __asm__ __volatile__("" : "+r" (in_padding));
         bad |= in_padding & is_zero;
     }
 

--- a/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c
+++ b/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c
@@ -44,6 +44,8 @@ static int esp_ds_rsaes_pkcs1_v15_unpadding(unsigned char *input,
     /* Scan for separator (0x00) and count padding bytes in constant time */
     for (size_t i = 2; i < ilen; i++) {
         unsigned char found = (input[i] == 0x00);
+        /* Prevent vectorization fault for clang O2 optimization */
+        __asm__ __volatile__("" ::: "memory");
         pad_done = pad_done | found;
         pad_count += (pad_done == 0) ? 1 : 0;
     }
@@ -65,6 +67,8 @@ static int esp_ds_rsaes_pkcs1_v15_unpadding(unsigned char *input,
     for (size_t i = 2; i < ilen; i++) {
         unsigned char in_padding = (i < pad_count + 2);
         unsigned char is_zero = (input[i] == 0x00);
+        /* Prevent vectorization fault for clang O2 optimization */
+        __asm__ __volatile__("" ::: "memory");
         bad |= in_padding & is_zero;
     }
 


### PR DESCRIPTION
## Description

The ESP RSA decryption code fails to compile with LLVM Clang O2 optimization, producing the following error:

```
fatal error: error in backend: Cannot select: 0x14b0697d0: i32 = extract_vector_elt 0x14993bc40, Constant:i32<0>, Toolings/Espressif/esp-idf/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c:68:13
  0x14993bc40: v2i1 = and 0x14b07d890, 0x149925880, Toolings/Espressif/esp-idf/components/mbedtls/port/esp_ds/esp_rsa_dec_alt.c:68:13
In function: esp_ds_rsaes_pkcs1_v15_unpadding
```

LLVM Clang's aggressive auto-vectorization attempts to vectorize the boolean operations in the constant-time padding verification loops. The generated vector IR (v2i1 = and) cannot be properly lowered by the ESP32 LLVM backend, causing compilation to fail.

This issue is specific to LLVM Clang - GCC compiles the same code successfully at O2 because it uses more conservative vectorization strategies.

So I added memory barriers (`__asm__ __volatile__("" ::: "memory")`) at strategic points in the constant-time loops to prevent vectorization while preserving other optimizations.

## Testing

The changes has been successfully tested on both GCC and Clang using O2 optimization.

Env: macOS 15.6.1 with GNU 15.1.0 GCC and Clang 19.1.2

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
