### PR TITLE
fix(depgraph): Add double quotes around dependency names (IDFGH-16471)

### DIFF
--- a/tools/cmake/depgraph.cmake
+++ b/tools/cmake/depgraph.cmake
@@ -35,10 +35,10 @@ function(depgraph_add_edge dep_from dep_to)
         # However, show which components are "common" by adding an edge from a node named "common".
         # If necessary, add a new build property to customize this behavior.
         if(NOT dep_from IN_LIST common_reqs)
-            idf_build_set_property(__BUILD_COMPONENT_DEPGRAPH "common -> ${dep_to}" APPEND)
+            idf_build_set_property(__BUILD_COMPONENT_DEPGRAPH "\"common\" -> \"${dep_to}\"" APPEND)
         endif()
     else()
-        idf_build_set_property(__BUILD_COMPONENT_DEPGRAPH "${dep_from} -> ${dep_to} ${attr}" APPEND)
+        idf_build_set_property(__BUILD_COMPONENT_DEPGRAPH "\"${dep_from}\" -> \"${dep_to}\" ${attr}" APPEND)
     endif()
 endfunction()
 


### PR DESCRIPTION
## Description

When generating a dependency graph, wrap the Node ID string (dependency name) in double quotes in the generated component_deps.dot output.

Previously, component names with dashes in them (e.g. esp-tls) would cause a syntax error when attempting to use the generated graph. Without double quotes, only strings consisting of characters, underscores, and digits were accepted - same rules as variable names in c.

e.g. before:
```
esp_http_client -> tcp_transport [class="priv_requires" style="dotted"];                         
tcp_transport -> esp-tls [class="requires"];
```
after
```
"esp_http_client" -> "tcp_transport" [class="priv_requires" style="dotted"];                         
"tcp_transport" -> "esp-tls" [class="requires"];
```

## Related

Graphviz ID format
https://graphviz.org/doc/info/lang.html#ids

## Testing

Testing done with esp-idf-v5.4.1.

xdot (version 1.2.2) was used to view the output. Before this patch, it would fail with a syntax error at the first name with '-' in it.
https://github.com/jrfonseca/xdot.py

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
