### PR TITLE
(Menu)config range Bluedroid configuration

### DIFF
--- a/components/bt/host/bluedroid/Kconfig.in
+++ b/components/bt/host/bluedroid/Kconfig.in
@@ -383,7 +383,7 @@ config BT_GATTC_MAX_CACHE_CHAR
 config BT_GATTC_NOTIF_REG_MAX
     int "Max gattc notify(indication) register number"
     depends on BT_GATTC_ENABLE
-    range 1 64
+    range 1 96
     default 5
     help
         Maximum GATTC notify(indication) register number


### PR DESCRIPTION
## Description

Increase configuration range of the Bluedroid configuration BT_GATTC_NOTIF_REG_MAX (regarding BLE GATT client notifications).
This will only increase the allowable configuration range available in menuconfig and sdkconfig files.

## Rationale
In a recent project I needed more than the currently allowed maximum of 64 notifications.
Changing this line in the SDK allows for larger values (in case of my project 81 notifications were needed).

## Testing

No tests or examples should be affected.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.
