### PR TITLE
Show stacktrace of task which failed timeout in task watchdog (IDFGH-16499)

### DIFF
--- a/components/esp_system/include/esp_debug_helpers.h
+++ b/components/esp_system/include/esp_debug_helpers.h
@@ -18,6 +18,9 @@ extern "C" {
 #include "esp_err.h"
 #include "esp_cpu.h"
 
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
 /*
  * @brief   Structure used for backtracing
  *
@@ -128,6 +131,8 @@ esp_err_t esp_backtrace_print(int depth);
  *      - ESP_FAIL  One or more backtraces are corrupt
  */
 esp_err_t esp_backtrace_print_all_tasks(int depth);
+
+esp_err_t esp_backtrace_print_task(TaskHandle_t pxTask, int depth, bool panic);
 
 /**
  * @brief Set a watchpoint to break/panic when a certain memory range is accessed.

--- a/components/esp_system/task_wdt/task_wdt.c
+++ b/components/esp_system/task_wdt/task_wdt.c
@@ -819,7 +819,10 @@ esp_err_t esp_task_wdt_print_triggered_tasks(task_wdt_msg_handler msg_handler, v
                 msg_handler(opaque, name);
                 msg_handler(opaque, cpu);
             }
+
+            esp_backtrace_print_task(entry->task_handle, 100, true);
         }
     }
+
     return ESP_OK;
 }


### PR DESCRIPTION
This change adds a stacktrace of tasks that fail the task watchdog timeout.

Too often I had timeouts in the main task but then the stacktrace only shows methods of task watchdog but not of main. This is completely useless.

What exactly in main halted execution so that the watchdog timed out?

This PR adds exactly this

<img width="1354" height="1178" alt="image" src="https://github.com/user-attachments/assets/6ae86e5e-1361-413a-86ad-8f996e302d86" />
