### PR TITLE
Allow the https server to request client certs only with OPTIONAL (IDFGH-16506)

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -282,6 +282,9 @@ typedef struct esp_tls_cfg_server {
     unsigned int cacert_pem_bytes;          /*!< Size of client CA certificate legacy name */
     };
 
+    bool cacert_authmode_optional;          /*!< Enable this option to set the authmode
+                                                 to OPTIONAL (only useful when cacert is set) */
+
     union {
     const unsigned char *servercert_buf;        /*!< Server certificate in a buffer
                                                      This buffer should be NULL terminated */

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -694,6 +694,8 @@ static esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
         if (esp_ret != ESP_OK) {
             return esp_ret;
         }
+        if (cfg->cacert_authmode_optional)
+            mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
     } else {
 #ifdef CONFIG_ESP_TLS_SERVER_MIN_AUTH_MODE_OPTIONAL
         mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -91,6 +91,9 @@ struct httpd_ssl_config {
     /** CA certificate byte length */
     size_t cacert_len;
 
+    /** CA certificate verification optional */
+    bool cacert_authmode_optional;
+
     /** Private key */
     const uint8_t *prvtkey_pem;
 

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -278,6 +278,7 @@ static esp_err_t create_secure_context(const struct httpd_ssl_config *config, ht
     cfg->userdata = config->ssl_userdata;
     cfg->alpn_protos = config->alpn_protos;
     cfg->tls_handshake_timeout_ms = config->tls_handshake_timeout_ms;
+    cfg->cacert_authmode_optional = config->cacert_authmode_optional;
 
 #if defined(CONFIG_ESP_HTTPS_SERVER_CERT_SELECT_HOOK)
     cfg->cert_select_cb = config->cert_select_cb;


### PR DESCRIPTION
I want to serve my webinterface via https to smartphones and the manufacturer should have special permissions and we authenticate developers or production using client key / cert. The end customer will not have such a cert. The connection should not fail, but our internal APIs will then refuse to work.