### PR TITLE
docs(shared_stack): Fix incorrect or misleading expressions (IDFGH-16521)

### DIFF
--- a/docs/en/api-reference/system/esp_function_with_shared_stack.rst
+++ b/docs/en/api-reference/system/esp_function_with_shared_stack.rst
@@ -6,7 +6,7 @@ Call Function with External Stack
 Overview
 --------
 
-A given function can be executed with a user-allocated stack space which is independent of current task stack. This mechanism can be used to save stack space wasted by tasks which call a common function with intensive stack usage such as ``printf``. The given function can be called inside the shared stack space, which is a callback function deferred by calling :cpp:func:`esp_execute_shared_stack_function`, passing that function as a parameter.
+A given function can be executed with a user-allocated stack space which is independent of current task stack. This mechanism can be used to save stack space wasted by tasks which call a common function with intensive stack usage such as ``printf``. The given function can be executed on the shared stack space by calling :cpp:func:`esp_execute_shared_stack_function` and passing it as a parameter.
 
 .. warning::
 
@@ -27,12 +27,12 @@ Usage
 
 :cpp:func:`esp_execute_shared_stack_function` takes four arguments:
 
-- a mutex object allocated by the caller, which is used to protect if the same function shares its allocated stack
-- a pointer to the top of stack used for that function
+- a mutex object allocated by the caller, which is used to protect the shared stack space
+- a pointer to the stack used for that function
 - the size of stack in bytes
 - a pointer to the shared stack function
 
-The user-defined function is deferred as a callback and can be called using the user-allocated space without taking space from current task stack.
+The user-defined function is executed immediately as a callback using the user-allocated space without taking space from current task stack.
 
 The usage may look like the code below:
 

--- a/docs/zh_CN/api-reference/system/esp_function_with_shared_stack.rst
+++ b/docs/zh_CN/api-reference/system/esp_function_with_shared_stack.rst
@@ -6,11 +6,11 @@
 概述
 --------
 
-执行某个给定函数时，可以使用用户分配的堆栈空间，且该堆栈空间独立于当前任务的堆栈。这一机制能够节省在调用常用函数时浪费大量堆栈空间，例如 ``printf`` 函数。具体而言，将给定函数作为参数传入 :cpp:func:`esp_execute_shared_stack_function` 中，给定函数便会在共享堆栈空间内作为回调函数延迟执行。
+执行某个给定函数时，可以使用用户分配的堆栈空间，且该堆栈空间独立于当前任务的堆栈。如果有多个任务需要调用同一个使用大量堆栈空间的函数，如 ``printf``，这一机制能够节省各个任务的堆栈空间。具体而言，将给定函数作为参数传入 :cpp:func:`esp_execute_shared_stack_function` 中，给定函数便会在共享堆栈空间内执行。
 
 .. warning::
 
-  :cpp:func:`esp_execute_shared_stack_function` 只会为所提供的共享堆栈内存做最基础的设置。传递给该函数以在共享堆栈空间上执行的函数，或调用该函数的任何函数，都不应执行以下任何操作：
+  :cpp:func:`esp_execute_shared_stack_function` 只会为所提供的共享堆栈内存做最基础的设置。传递给该函数以在共享堆栈空间上执行的函数，或该函数调用的任何函数，都不应执行以下任何操作：
 
   .. list::
     
@@ -19,7 +19,7 @@
      :esp32p4: - 使用 AI 协处理器
      - 调用 vTaskDelete(NULL) 删除当前运行的任务
 
-  此外，从共享堆栈上运行的函数或调用该函数的任何函数来调用回溯，回溯信息都可能不正确。这方面的限制十分严格，因此将来 :cpp:func:`esp_execute_shared_stack_function` 可能会被弃用。如有用例必须使用 :cpp:func:`esp_execute_shared_stack_function` 函数才能实现，请提交 `GitHub Issue <https://github.com/espressif/esp-idf/issues>`_。
+  此外，共享堆栈上运行的函数，或该函数调用的任何函数中调用回溯，回溯信息都可能不正确。这方面的限制十分严格，因此将来 :cpp:func:`esp_execute_shared_stack_function` 可能会被弃用。如有用例必须使用 :cpp:func:`esp_execute_shared_stack_function` 函数才能实现，请提交 `GitHub Issue <https://github.com/espressif/esp-idf/issues>`_。
 
 
 使用方法
@@ -27,12 +27,12 @@
 
 :cpp:func:`esp_execute_shared_stack_function` 需要四个参数：
 
-- 由调用者分配的互斥锁，防止同一函数共享分配的堆栈
-- 指向分配的堆栈顶部的指针
+- 由调用者分配的互斥锁，用于保护共享堆栈
+- 指向分配的堆栈的指针
 - 以字节为单位的堆栈的大小
-- 指向需要共享堆栈的函数的指针
+- 指向需要使用共享堆栈的函数的指针
 
-通过这一功能，用户指定的函数被作为回调函数延迟执行，并在用户分配的空间中调用，无需从当前任务堆栈中获取空间。
+通过这一功能，用户指定的函数被作为回调函数立即执行，并在用户分配的空间中调用，无需从当前任务堆栈中获取空间。
 
 该函数的使用方式如下所示：
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

From #17639

- The word "deferred" is not used to avoid being misleading.
- Clarify the purpose of mutex.
- The pointer passed to `esp_execute_shared_stack_function` does not point to the top of the stack, but to the starting (lowest) address of the stack.

In the Chinese version:

- 和上面的英文版一致的修改
- “调用该函数的任何函数”（caller）改为 “该函数调用的任何函数”（callee）
- 其他翻译优化

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Fixes #17639

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
