### PR TITLE
fix(touch_sens): Initialize user_filter_ctx in TOUCH_SENSOR_DEFAULT_FILTER_CONFIG to avoid compiler warning

### DIFF
--- a/components/esp_driver_touch_sens/hw_ver1/include/driver/touch_version_types.h
+++ b/components/esp_driver_touch_sens/hw_ver1/include/driver/touch_version_types.h
@@ -55,6 +55,7 @@ extern "C" {
 #define TOUCH_SENSOR_DEFAULT_FILTER_CONFIG() { \
     .interval_ms = 10,  \
     .data_filter_fn = NULL,  /* Set NULL to use default software filter */  \
+    .user_filter_ctx = NULL,  \
 }
 
 /**


### PR DESCRIPTION
Avoid compiler warnings(--warnings all)

## Description

This PR adds explicit initialization of the `user_filter_ctx` member in `TOUCH_SENSOR_DEFAULT_FILTER_CONFIG`.

### typedef 

https://github.com/espressif/esp-idf/blob/5c5eb99eabc7d3e7f704656ffe9ebf8f5a77afbd/components/esp_driver_touch_sens/hw_ver1/include/driver/touch_version_types.h#L141-L152

## Testing

### code

```c
#include <driver/touch_sens.h>

void setup()
{
    touch_sensor_filter_config_t filter_cfg = TOUCH_SENSOR_DEFAULT_FILTER_CONFIG();
}

void loop()
{
}
```

Sorry. It's Arduino.

### Before modification

```
C:\Users\tanaka\AppData\Local\Arduino15\internal\esp32_esp32-arduino-libs_idf-release_v5.5-129cd0d2-v4_e318b1efcc\esp32/include/esp_driver_touch_sens/hw_ver1/include/driver/touch_version_types.h:58:1: warning: missing initializer for member 'touch_sensor_filter_config_t::user_filter_ctx' [-Wmissing-field-initializers]
   58 | }
      | ^
C:\tmp\vstest\touch_test\touch_test.ino:5:47: note: in expansion of macro 'TOUCH_SENSOR_DEFAULT_FILTER_CONFIG'
    5 |     touch_sensor_filter_config_t filter_cfg = TOUCH_SENSOR_DEFAULT_FILTER_CONFIG();
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\tmp\vstest\touch_test\touch_test.ino:5:34: warning: unused variable 'filter_cfg' [-Wunused-variable]
    5 |     touch_sensor_filter_config_t filter_cfg = TOUCH_SENSOR_DEFAULT_FILTER_CONFIG();
      |                                  ^~~~~~~~~~
```

### After modification

```
C:\tmp\vstest\touch_test\touch_test.ino:5:34: warning: unused variable 'filter_cfg' [-Wunused-variable]
    5 |     touch_sensor_filter_config_t filter_cfg = TOUCH_SENSOR_DEFAULT_FILTER_CONFIG();
      |                                  ^~~~~~~~~~
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
