### PR TITLE
ESP_GATT_MAX_ATTR_LEN = 512

### DIFF
--- a/components/bt/host/bluedroid/api/include/api/esp_gatt_defs.h
+++ b/components/bt/host/bluedroid/api/include/api/esp_gatt_defs.h
@@ -478,7 +478,7 @@ typedef uint8_t esp_gatt_char_prop_t;
  *
  * This definition specifies the maximum number of bytes that a GATT attribute can hold.
  */
-#define ESP_GATT_MAX_ATTR_LEN   517 /*!< As same as GATT_MAX_ATTR_LEN. */
+#define ESP_GATT_MAX_ATTR_LEN   512 /*!< As same as GATT_MAX_ATTR_LEN. */
 
 /**
  * @brief Enumerates the possible sources of a GATT service discovery.

--- a/components/bt/host/bluedroid/stack/include/stack/gatt_api.h
+++ b/components/bt/host/bluedroid/stack/include/stack/gatt_api.h
@@ -139,7 +139,7 @@ typedef UINT16 tGATT_DISCONN_REASON;
 /* max length of an attribute value
 */
 #ifndef GATT_MAX_ATTR_LEN
-#define GATT_MAX_ATTR_LEN                   GATT_MAX_MTU_SIZE
+#define GATT_MAX_ATTR_LEN                   512
 #endif
 
 /* default GATT MTU size over LE link


### PR DESCRIPTION
## Description

The maximum attribute length as per the BLE GATT spec is 512 - see https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/attribute-protocol--att-.html#UUID-d24e0156-618e-728d-f19b-01349ced952b:~:text=The%20maximum%20length%20of%20an%20attribute%20value%20shall%20be%20512%20octets.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
