### PR TITLE
feat(esp-tls): Update headers for improved wolfssl support (IDFGH-16562)

### DIFF
--- a/components/esp-tls/private_include/esp_tls_private.h
+++ b/components/esp-tls/private_include/esp_tls_private.h
@@ -32,6 +32,9 @@
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/ssl.h"
+#include "wolfssl/openssl/x509.h"
+#include "wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h"
+#include "private_include/esp_tls_wolfssl.h"
 #endif
 
 struct esp_tls {
@@ -74,6 +77,11 @@ struct esp_tls {
     size_t client_session_len;                                                  /*!< Length of the serialized client session ticket context. */
 #endif /* CONFIG_MBEDTLS_SSL_PROTO_TLS1_3 && CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS */
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
+    #ifndef WOLFSSL_NO_CONF_COMPATIBILITY
+    wolfssl_ssl_config conf;
+    void (*sync)(struct esp_tls*);
+    #endif
+
     void *priv_ctx;
     void *priv_ssl;
 #endif

--- a/components/esp-tls/private_include/esp_tls_wolfssl.h
+++ b/components/esp-tls/private_include/esp_tls_wolfssl.h
@@ -7,6 +7,13 @@
 #pragma once
 #include "esp_tls.h"
 #include "esp_tls_private.h"
+#ifdef CONFIG_ESP_TLS_USING_WOLFSSL
+
+/* wolfssl_ssl_config is ESP-IDF specific helper for Certificate Bundles */
+#include "wolfssl/wolfcrypt/settings.h"
+#include "wolfssl/ssl.h"
+#include "wolfssl/openssl/x509.h"
+
 
 /**
  * Internal Callback for creating ssl handle for wolfssl
@@ -72,10 +79,7 @@ void *esp_wolfssl_get_ssl_context(esp_tls_t *tls);
 /**
  * wolfSSL function for Initializing socket wrappers (no-operation for wolfSSL)
  */
-static inline void esp_wolfssl_net_init(esp_tls_t *tls)
-{
-}
-
+void esp_wolfssl_net_init(esp_tls_t *tls);
 
 /**
  * Function to Create ESP-TLS Server session with wolfssl Stack
@@ -85,4 +89,7 @@ int esp_wolfssl_server_session_create(esp_tls_cfg_server_t *cfg, int sockfd, esp
 /*
  * Delete Server Session
  */
-void esp_wolfssl_server_session_delete(esp_tls_t *tls);
+int esp_wolfssl_server_session_delete(esp_tls_t *tls);
+
+
+#endif /* CONFIG_ESP_TLS_USING_WOLFSSL */


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This is the fourth in a series of pull requests to improve wolfSSL integration with the ESP-IDF as proposed in https://github.com/espressif/esp-idf/pull/16145

As there are multiple changes there, it was suggested that I break the update into smaller pieces.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

This PR updates the requirements for wolfSSL in the `components/esp-tls/private_include/esp_tls_private.h` and `components/esp-tls/private_include/esp_tls_wolfssl.h`

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

See:

- https://github.com/wolfSSL/wolfssl/pull/7936
- https://github.com/espressif/esp-idf/pull/17658
- https://github.com/espressif/esp-idf/pull/16145
- https://github.com/espressif/esp-idf/issues/13966
- https://github.com/wolfSSL/wolfssl/issues/7640
- https://github.com/wolfSSL/wolfssl/issues/6234

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

The fully-implemented update is on my [wolfssl-dev](https://github.com/gojimmypi/esp-idf/tree/wolfssl-dev) branch. I've been testing with [this esp_http_client_example](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix/IDE/Espressif/ESP-IDF/examples/esp_http_client_example).

See also the published [wolfSSL Managed component](https://components.espressif.com/components/wolfssl/wolfssl/) that already includes the Certificate Bundle feature introduced in https://github.com/wolfSSL/wolfssl/pull/7936

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds wolfSSL-specific includes (incl. cert bundle), introduces optional wolfSSL config/sync fields, and updates wolfSSL API signatures (net init, server session delete).
> 
> - **ESP-TLS (wolfSSL)**:
>   - Add includes: `wolfssl/openssl/x509.h`, `wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h`, and `private_include/esp_tls_wolfssl.h`.
>   - Conditionally add `wolfssl_ssl_config conf` and `void (*sync)(esp_tls*)` to `struct esp_tls` when `!WOLFSSL_NO_CONF_COMPATIBILITY`.
> - **wolfSSL Header (`esp_tls_wolfssl.h`)**:
>   - Wrap declarations with `#ifdef CONFIG_ESP_TLS_USING_WOLFSSL` and include wolfSSL headers (incl. `x509.h`).
>   - Change `esp_wolfssl_net_init` from inline no-op to a declared function.
>   - Change `esp_wolfssl_server_session_delete` signature from `void` to `int`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b6dcdab8b434f25ae92c46f2db7100744f3e325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->