### PR TITLE
feat(esp-tls): Update esp_tls CMakeLists.txt and Kconfig for wolfssl (IDFGH-16560)

### DIFF
--- a/components/esp-tls/CMakeLists.txt
+++ b/components/esp-tls/CMakeLists.txt
@@ -5,8 +5,12 @@ if(CONFIG_ESP_TLS_USING_MBEDTLS)
 endif()
 
 if(CONFIG_ESP_TLS_USING_WOLFSSL)
+    message(STATUS "esp-tls configured for wolfssl")
     list(APPEND srcs
         "esp_tls_wolfssl.c")
+    set(wolfssl_esp_tls_lib "wolfssl")
+else()
+    unset(wolfssl_esp_tls_lib)
 endif()
 
 set(priv_req http_parser esp_timer)
@@ -14,17 +18,100 @@ if(NOT ${IDF_TARGET} STREQUAL "linux")
     list(APPEND priv_req lwip)
 endif()
 
+message(STATUS "idf_component_register wolfssl_esp_tls_lib: ${wolfssl_esp_tls_lib}")
+
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} esp-tls-crypto
                     PRIV_INCLUDE_DIRS "private_include"
                     # mbedtls is public requirements because esp_tls.h
                     # includes mbedtls header files.
-                    REQUIRES mbedtls
+                    REQUIRES mbedtls ${wolfssl_esp_tls_lib}
                     PRIV_REQUIRES ${priv_req})
 
+# When using wolfSSL for the ESP-TLS (see menuconfig),
+# There are two options:
+#   1) A specified source directory, typically a wolfssl git clone
+#   2) The esp-wolfssl
+# TODO this is duplicate code. See components/wap_supplicant
+message(STATUS "esp-tls config begin")
 if(CONFIG_ESP_TLS_USING_WOLFSSL)
-    idf_component_get_property(wolfssl esp-wolfssl COMPONENT_LIB)
-    target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    message(STATUS "found CONFIG_ESP_TLS_USING_WOLFSSL")
+    # See https://github.com/wolfSSL/wolfssl/
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESPIDF")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
+    # The published wolfSSL 5.7.0 user_settings.h does not include some features that
+    # might be enabled in Kconfig, so enable them here:
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_ALPN")
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_SNI")
+    # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DOPENSSL_EXTRA_X509_SMALL")
+    # this only works for VisualGDB, not idf.py from command-line
+
+    message(STATUS "CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "CMAKE_PARENT_LIST_FILE = ${CMAKE_PARENT_LIST_FILE}")
+    message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
+    message(STATUS "COMPONENT_DIR = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "COMPONENT_LIB = ${COMPONENT_LIB}")
+    message(STATUS "FOUND_WOLFSSL = ${FOUND_WOLFSSL}")
+    message(STATUS "PROJECT_DIR = ${PROJECT_DIR}")
+    message(STATUS "WOLFSSL_PROJECT_DIR = ${WOLFSSL_PROJECT_DIR}")
+    message(STATUS "CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+
+    if(CONFIG_ESP_TLS_USING_WOLFSSL_SPECIFIED)
+        get_filename_component(CUSTOM_SETTING_WOLFSSL_ROOT_PATH "${CUSTOM_SETTING_WOLFSSL_ROOT}" ABSOLUTE)
+        if(EXISTS "${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}/wolfcrypt/src")
+            message(STATUS "ESP-TLS using wolfSSL in: ${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}")
+        else()
+            message(STATUS "ESP-TLS specified directory does not contain wolfSSL: ${CUSTOM_SETTING_WOLFSSL_ROOT_PATH}")
+        endif()
+        idf_component_get_property(wolfssl wolfssl COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    else()
+        # Is wolfSSL installed in the local project as a Managed Component?
+        set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/managed_components/wolfssl__wolfssl")
+        message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+        if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+            message(STATUS "Configuring ESP-IDF to use wolfssl in Managed Component: ${WOLFSSL_COMPONENT_SEARCH}")
+            idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+        else()
+            # Is wolfSSL installed in the local project as a Managed Component
+            # converted to regular project component?
+            set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/components/wolfssl__wolfssl")
+            message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+            if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                message(STATUS
+                      "Configuring ESP-IDF to use wolfssl in Converted Managed Component: ${WOLFSSL_COMPONENT_SEARCH}")
+                idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+            else()
+                # Is wolfSSL installed in the local project as a non-maged, regular component?
+                set(WOLFSSL_COMPONENT_SEARCH "${PROJECT_DIR}/components/wolfssl")
+                message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+                if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                    message(STATUS "Configuring ESP-IDF to use wolfssl in Component: ${WOLFSSL_COMPONENT_SEARCH}")
+                    idf_component_get_property(wolfssl wolfssl COMPONENT_LIB)
+                else()
+                    set(WOLFSSL_COMPONENT_SEARCH "${THIS_IDF_PATH}/components/esp-wolfssl")
+                    message(STATUS "Searching for wolfSSL in ${WOLFSSL_COMPONENT_SEARCH}")
+                    if(EXISTS "${WOLFSSL_COMPONENT_SEARCH}")
+                        message(STATUS "Configuring ESP-IDF to use wolfssl from: ${WOLFSSL_COMPONENT_SEARCH}")
+                        message(STATUS "Warning: Using legacy esp-wolfssl. Consider using a Managed Component")
+                        # See https://github.com/espressif/esp-idf
+                        message(STATUS "Configuring ESP-TLS to use esp-wolfssl")
+                        idf_component_get_property(wolfssl esp-wolfssl COMPONENT_LIB)
+                    else()
+                        message(STATUS "Consider installing wolfSSL from "
+                                       "https://components.espressif.com/components/wolfssl/wolfssl")
+                        message(FATAL_ERROR "Component ${component} not found")
+                    endif() # esp-wolfssl
+                endif() # project wolfssl
+            endif() # project converted wolfssl__wolfssl
+        endif() # project managed component wolfssl__wolfssl
+        # idf_component_get_property(wolfssl wolfssl__wolfssl COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${wolfssl})
+    endif()
+else()
+    message(STATUS "ESP-TLS is not configured to use wolfSSL.")
 endif()
 
 if(NOT ${IDF_TARGET} STREQUAL "linux")

--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -10,8 +10,11 @@ menu "ESP-TLS"
             bool "mbedTLS"
             select MBEDTLS_TLS_ENABLED
         config ESP_TLS_USING_WOLFSSL
-            depends on TLS_STACK_WOLFSSL
+            select TLS_STACK_WOLFSSL
             bool "wolfSSL (License info in wolfSSL directory README)"
+            help
+                This option enables wolfSSL for ESP-TLS.
+                Note: Ensure TLS_STACK_WOLFSSL is enabled to use this option.
     endchoice
 
     config ESP_TLS_USE_SECURE_ELEMENT
@@ -100,6 +103,15 @@ menu "ESP-TLS"
             WARNING : Enabling this option comes with a potential risk of establishing a TLS connection
             with a server which has a fake identity, provided that the server certificate
             is not provided either through API or other mechanism like ca_store etc.
+
+    config ESP_WOLFSSL_SMALL_CERT_VERIFY
+        bool "Enable SMALL_CERT_VERIFY"
+        depends on ESP_TLS_USING_WOLFSSL
+        default y
+        help
+            Enables server verification with Intermediate CA cert, does not authenticate full chain
+            of trust upto the root CA cert (After Enabling this option client only needs to have Intermediate
+            CA certificate of the server to authenticate server, root CA cert is not necessary).
 
     config ESP_DEBUG_WOLFSSL
         bool "Enable debug logs for wolfSSL"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This is the sixth in a series of pull requests to improve wolfSSL integration with the ESP-IDF as proposed in https://github.com/espressif/esp-idf/pull/16145

As there are multiple changes there, it was suggested that I break the update into smaller pieces.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

This PR updates the requirements for wolfSSL in the `components/esp-tls/CMakeLists.txt` and `components/esp-tls/Kconfig`

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

See:

- https://github.com/wolfSSL/wolfssl/pull/7936
- https://github.com/espressif/esp-idf/pull/17658
- https://github.com/espressif/esp-idf/pull/16145
- https://github.com/espressif/esp-idf/issues/13966
- https://github.com/wolfSSL/wolfssl/issues/7640
- https://github.com/wolfSSL/wolfssl/issues/6234

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

The fully-implemented update is on my [wolfssl-dev](https://github.com/gojimmypi/esp-idf/tree/wolfssl-dev) branch. I've been testing with [this esp_http_client_example](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix/IDE/Espressif/ESP-IDF/examples/esp_http_client_example).

See also the published [wolfSSL Managed component](https://components.espressif.com/components/wolfssl/wolfssl/) that already includes the Certificate Bundle feature introduced in https://github.com/wolfSSL/wolfssl/pull/7936

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves wolfSSL selection/linkage in `esp-tls` CMake and updates Kconfig (selects `TLS_STACK_WOLFSSL`, adds `ESP_WOLFSSL_SMALL_CERT_VERIFY`, and build diagnostics).
> 
> - **Build system (`components/esp-tls/CMakeLists.txt`)**:
>   - Add wolfSSL-aware build logic: set `wolfssl_esp_tls_lib`, include `esp_tls_wolfssl.c`, and add `${wolfssl_esp_tls_lib}` to `REQUIRES`.
>   - Introduce robust wolfSSL component discovery/linking across managed, converted, regular, and legacy `esp-wolfssl` locations; link `COMPONENT_LIB` to detected `wolfssl`.
>   - Define compile flags `-DWOLFSSL_ESPIDF` and `-DWOLFSSL_USER_SETTINGS`.
>   - Add extensive `message(STATUS ...)` diagnostics for configuration paths and decisions.
> - **Configuration (`components/esp-tls/Kconfig`)**:
>   - Change wolfSSL option to `select TLS_STACK_WOLFSSL` (replaces `depends on`).
>   - Add `ESP_WOLFSSL_SMALL_CERT_VERIFY` (default `y`) for reduced chain verification.
>   - Add help text for wolfSSL option; retain OCSP-related settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75df0a74d3f3530de218a335bb6538249f3b36da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->