### PR TITLE
fix(nvs_sec_provider): add option to skip reset when nvs_keys is missing

### DIFF
--- a/components/nvs_sec_provider/Kconfig
+++ b/components/nvs_sec_provider/Kconfig
@@ -36,6 +36,17 @@ menu "NVS Security Provider"
 
     endchoice
 
+    config NVS_SEC_PROVIDER_ABORT_IF_NVS_KEYS_MISSING
+        bool "Ensure NVS keys partition presence on app startup"
+        depends on NVS_SEC_KEY_PROTECT_USING_FLASH_ENC
+        default y
+        help
+            If set (default), there is a check if the NVS keys partition is present.
+            App will call abort if the NVS keys partition is not present.
+
+            If not set, the app does not care if the NVS keys partition is present or not.
+            NVS encryption may not work if the NVS keys partition is not present.
+
     config NVS_SEC_HMAC_EFUSE_KEY_ID
         int "eFuse key ID storing the HMAC key"
         depends on NVS_SEC_KEY_PROTECT_USING_HMAC

--- a/components/nvs_sec_provider/nvs_sec_provider.c
+++ b/components/nvs_sec_provider/nvs_sec_provider.c
@@ -95,7 +95,9 @@ ESP_SYSTEM_INIT_FN(nvs_sec_provider_register_flash_enc_scheme, SECONDARY, BIT(0)
 
     if (sec_scheme_cfg.nvs_keys_part == NULL) {
         ESP_EARLY_LOGE(TAG, "partition with subtype \"nvs_keys\" not found");
+#ifdef CONFIG_NVS_SEC_PROVIDER_ABORT_IF_NVS_KEYS_MISSING
         return ESP_FAIL;
+#endif  // CONFIG_NVS_SEC_PROVIDER_ABORT_IF_NVS_KEYS_MISSING
     }
 
     nvs_sec_scheme_t *sec_scheme_handle_out = NULL;


### PR DESCRIPTION
## Description

NVS flash encrytpion rely on nvs_keys partition and it will not work when such partition is missing. In aaf1f86 there was added a check if nvs_keys partition is present with strong enforcement - it will return ESP_FAIL in early startup step, which causes abort() and reset loop of an application.

aaf1f86 change was available since v5.4 and it was not even mentioned in release notes, but it creates a **regression which can brick devices**. This strong enforcement is blocking ability to develop an application which can operate with NVS encrytpion (based on nvs_keys) and also operate without NVS encryption (when nvs_keys is missing).

Current fix adds a menuconfig option which allow to skip returning ESP_FAIL when partition is missing. Then application can decide in runtime what should be done when it's missing - instead of reset in early startup phase.

## Related

Closes #17703

## Testing

In general, this "return ESP_FAIL" was not present in earlier versions of nvs_sec_provider and whole component can handle missing nvs_keys partition (there are error logs in such scenarios, which is expected).
I run code with this flag enabled and disabled, with and without nvs_keys partition. All work as expected.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
