### PR TITLE
fix: indexing in DNS server IP address retrieval #17751 (IDFGH-16654)

### DIFF
--- a/examples/protocols/http_server/captive_portal/components/dns_server/dns_server.c
+++ b/examples/protocols/http_server/captive_portal/components/dns_server/dns_server.c
@@ -158,7 +158,7 @@ static int parse_dns_request(char *req, size_t req_len, char *dns_reply, size_t 
                         esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey(h->entry[i].if_key), &ip_info);
                         ip.addr = ip_info.ip.addr;
                         break;
-                    } else if (h->entry->ip.addr != IPADDR_ANY) {
+                    } else if (h->entry[i].ip.addr != IPADDR_ANY) {
                         ip.addr = h->entry[i].ip.addr;
                         break;
                     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Fix #17751 :

Bug in DNS server: Incorrect array indexing when checking IP address (IDFGH-16653)

### Answers checklist.

https://github.com/espressif/esp-idf/blob/ab149384e12ace1b8e8f7858d52ae47ab8af4563/examples/protocols/http_server/captive_portal/components/dns_server/dns_server.c#L161

The DNS server does not use the correct entry index when checking the IP address.
```c
h->entry->ip.addr 
```
instead of 
```c
h->entry[i].ip.addr
```
which causes it to always check entry 0 regardless of which entry matched in the loop.

This bug prevents proper DNS resolution when multiple entries are configured and the matching entry is not at index 0.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
