### PR TITLE
P4 touch channel 14 failure fix (IDFGH-16661)

### DIFF
--- a/components/hal/esp32p4/include/hal/touch_sensor_ll.h
+++ b/components/hal/esp32p4/include/hal/touch_sensor_ll.h
@@ -493,7 +493,7 @@ __attribute__((always_inline))
 static inline uint32_t touch_ll_get_current_meas_channel(void)
 {
     uint32_t curr_chan = LP_TOUCH.chn_status.scan_curr;
-    HAL_ASSERT(curr_chan < 14);
+    HAL_ASSERT(curr_chan <= 14);
     // Workaround: the curr channel read 0 when the actual channel is 14
     curr_chan = curr_chan == 0 ? 14 : curr_chan;
     return curr_chan;


### PR DESCRIPTION
Compilation fails when using all touch channels on a P4 unless curr_chan is allowed to be 14.

## Description

I spent a day fighting with the new v3 touch sensing driver for the P4, and no matter what I try it does a core dump when I try to use touch channel 13 on GPIO15. While I am rightly dubious that I could be the first person to notice this, it's also simply true that there aren't many P4's in the wild yet.

The source for `touch_ll_get_current_meas_channel` in `components\hal\esp32p4\include\hal\touch_sensor_ll.h` references a workaround but I cannot find any explanation or context for this note. What I can say is that attempting to use channel 0 doesn't cause a core dump, but it does report that it's trying to use an invalid channel (and the pad does not work).

Patching the assert to accept `<= 14` makes me nervous because I don't know the ramifications and it's clear that there's some concern with the value 14. However, when I do make this change, everything does seem to work fine. If it's not required and there's another approach, please do let me know and update the documentation for ESP-IDF's touch module changes.

## Related

```
assert failed: touch_ll_get_current_meas_channel /IDF/components/hal/esp32p4/include/hal/touch_sensor_ll.h:492 (curr_chan < 14)
Core  0 register dump:
MEPC    : 0x4ff0895a  RA      : 0x4ff0890c  SP      : 0x4ff1c2b0  GP      : 0x4ff15680
--- 0x4ff0895a: panic_abort at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/esp_system/panic.c:483
--- 0x4ff0890c: esp_vApplicationTickHook at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/esp_system/freertos_hooks.c:31
TP      : 0x4ff31860  T0      : 0x37363534  T1      : 0x7271706f  T2      : 0x33323130
S0/FP   : 0x00000048  S1      : 0x00000001  A0      : 0x4ff1c2ec  A1      : 0x4ff1b385
A2      : 0x00000001  A3      : 0x00000029  A4      : 0x00000001  A5      : 0x4ff50000
A6      : 0x0000000c  A7      : 0x76757473  S2      : 0x00000009  S3      : 0x4ff1c43f
S4      : 0x4ff1b384  S5      : 0x00000000  S6      : 0x00000000  S7      : 0x00000000
S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00000000  S11     : 0x00000000
T3      : 0x6e6d6c6b  T4      : 0x6a696867  T5      : 0x66656463  T6      : 0x62613938
MSTATUS : 0x00001880  MTVEC   : 0x4ff00003  MCAUSE  : 0x00000002  MTVAL   : 0x00000000
--- 0x4ff00003: _vector_table at ??:?
MHARTID : 0x00000000

Stack memory:
4ff1c2b0: 0x00000000 0x00000000 0x4009a964 0x4ff12920 0x4ff1ae8c 0x4009a964 0x4ff1ae9c 0x4008a718
--- 0x4ff12920: esp_libc_include_assert_impl at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/newlib/src/assert.c:96
4ff1c2d0: 0x4ff1aea0 0x4ff1c2e4 0x4ff1aea4 0x4008a944 0x4ff1b384 0x00323934 0x00000000 0x65737361
4ff1c2f0: 0x66207472 0x656c6961 0x74203a64 0x6863756f 0x5f6c6c5f 0x5f746567 0x72727563 0x5f746e65
4ff1c310: 0x7361656d 0x6168635f 0x6c656e6e 0x44492f20 0x6f632f46 0x6e6f706d 0x73746e65 0x6c61682f
4ff1c330: 0x7073652f 0x34703233 0x636e692f 0x6564756c 0x6c61682f 0x756f742f 0x735f6863 0x6f736e65
4ff1c350: 0x6c6c5f72 0x343a682e 0x28203239 0x72727563 0x6168635f 0x203c206e 0x00293431 0x4ff1c3dc
4ff1c370: 0x4ff3b6a8 0x00000000 0x00000001 0x4ff0c5c2 0x00000000 0x00000000 0x4ff3bb6c 0x4ff1c3dc
--- 0x4ff0c5c2: xTaskRemoveFromEventList at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/freertos/FreeRTOS-Kernel/tasks.c:3967
4ff1c390: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c3b0: 0x4ff1ca28 0x00000000 0x00000000 0x4f000000 0x00000000 0x00000001 0x00000000 0x00000000
4ff1c3d0: 0x00001880 0xb8000013 0x00000003 0x4ff017ca 0x4ff50760 0x4ff3e9e0 0x0000000d 0x00000000
--- 0x4ff017ca: touch_ll_get_current_meas_channel at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/hal/esp32p4/include/hal/touch_sensor_ll.h:494
--- (inlined by) touch_priv_default_intr_handler at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/esp_driver_touch_sens/hw_ver3/touch_version_specific.c:65
4ff1c3f0: 0x00001880 0xb8000013 0x00000000 0x4ff12bb4 0x4ff0b482 0xb8000012 0x00000000 0x4ff002d0
--- 0x4ff12bb4: _global_interrupt_handler at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/riscv/interrupt.c:69
--- 0x4ff0b482: restore_stack_pointer at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/freertos/FreeRTOS-Kernel/portable/riscv/portasm.S:704
--- 0x4ff002d0: _interrupt_handler at C:/Users/kabaragoya/esp/v5.5.1/esp-idf/components/riscv/vectors.S:460
4ff1c410: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c430: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c450: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c470: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c490: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c4b0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c4d0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c4f0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c510: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c530: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c550: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c570: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c590: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c5b0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c5d0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c5f0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c610: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c630: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c650: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c670: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
4ff1c690: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
```

## Testing

Full disclosure: I have no idea how to test this beyond being able to say that my application will not run properly without it.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
