### PR TITLE
fix(esp-tls): clean up is_tls flag (IDFGH-16662)

### DIFF
--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -468,15 +468,12 @@ static int esp_tls_low_level_conn(const char *hostname, int hostlen, int port, c
     switch (tls->conn_state) {
     case ESP_TLS_INIT:
         tls->sockfd = -1;
-        if (cfg != NULL && cfg->is_plain_tcp == false) {
-            _esp_tls_net_init(tls);
-            tls->is_tls = true;
-        }
+        _esp_tls_net_init(tls);
         if ((esp_ret = tcp_connect(hostname, hostlen, port, cfg, tls->error_handle, &tls->sockfd)) != ESP_OK) {
             ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_ESP, esp_ret);
             return -1;
         }
-        if (tls->is_tls == false) {
+        if (cfg && cfg->is_plain_tcp) {
             tls->read = tcp_read;
             tls->write = tcp_write;
             ESP_LOGD(TAG, "non-tls connection established");

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -456,12 +456,10 @@ void esp_mbedtls_conn_delete(esp_tls_t *tls)
 {
     if (tls != NULL) {
         esp_mbedtls_cleanup(tls);
-        if (tls->is_tls) {
-            if (tls->server_fd.fd != -1) {
-                mbedtls_net_free(&tls->server_fd);
-                /* Socket is already closed by `mbedtls_net_free` and hence also change assignment of its copy to an invalid value */
-                tls->sockfd = -1;
-            }
+        if (tls->server_fd.fd != -1) {
+            mbedtls_net_free(&tls->server_fd);
+            /* Socket is already closed by `mbedtls_net_free` and hence also change assignment of its copy to an invalid value */
+            tls->sockfd = -1;
         }
     }
 }

--- a/components/esp-tls/private_include/esp_tls_private.h
+++ b/components/esp-tls/private_include/esp_tls_private.h
@@ -91,8 +91,6 @@ struct esp_tls {
 
     fd_set wset;                                                                /*!< write file descriptors */
 
-    bool is_tls;                                                                /*!< indicates connection type (TLS or NON-TLS) */
-
     esp_tls_role_t role;                                                        /*!< esp-tls role
                                                                                      - ESP_TLS_CLIENT
                                                                                      - ESP_TLS_SERVER */


### PR DESCRIPTION
## Description

Commit https://github.com/espressif/esp-idf/commit/2dd280f1264bb8c77a05930c81e8890395867ad1 added a neat feature to support STARTTLS by doing something like this:
```c
esp_tls_t *ftp;
esp_tls_cfg_t cfg;

memset(&cfg, 0, sizeof(cfg));

ftp = esp_tls_init();

cfg.is_plain_tcp = true;
esp_tls_conn_new_sync("example.com", strlen("example.com"), 21, &cfg, ftp);

// ... AUTH TLS or STARTTLS or what not ...

cfg.is_plain_tcp = false;
esp_tls_set_conn_state(ftp, ESP_TLS_CONNECTING);
esp_tls_conn_new_sync("example.com", strlen("example.com"), 21, &cfg, ftp);
```
However, when doing this, `tls->is_tls` flag is never set to `true` internally ([as it is only set in ESP_TLS_INIT state](https://github.com/espressif/esp-idf/blob/ab149384e12ace1b8e8f7858d52ae47ab8af4563/components/esp-tls/esp_tls.c#L473)), which prevents calling `mbedtls_net_free()` [here](https://github.com/espressif/esp-idf/blob/ab149384e12ace1b8e8f7858d52ae47ab8af4563/components/esp-tls/esp_tls_mbedtls.c#L461C17-L461C33).

Luckily, despite its name, `mbedtls_net_free()` does not free anything and only does a graceful shutdown of the socket, so it is not a big issue (socket is closed by esp-tls anyway). But as this is the only usecase for `tls->is_tls` flag, then it makes sense to clean it up, fixing the small inconsistency in the process.
