### PR TITLE
Add support for multiple console types in CLI (IDFGH-16697)

### DIFF
--- a/examples/ieee802154/ieee802154_cli/main/esp_ieee802154_cli.c
+++ b/examples/ieee802154/ieee802154_cli/main/esp_ieee802154_cli.c
@@ -51,8 +51,21 @@ void app_main(void)
     register_ieee802154_debug_cmd();
 #endif
 
-    esp_console_dev_uart_config_t hw_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_console_new_repl_uart(&hw_config, &repl_config, &repl));
+    #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
+        esp_console_dev_uart_config_t hw_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
+        ESP_ERROR_CHECK(esp_console_new_repl_uart(&hw_config, &repl_config, &repl));
+
+    #elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
+        esp_console_dev_usb_cdc_config_t hw_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
+        ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&hw_config, &repl_config, &repl));
+
+    #elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+        esp_console_dev_usb_serial_jtag_config_t hw_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+        ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&hw_config, &repl_config, &repl));
+        
+    #else
+    #error Unsupported console type
+    #endif
 
     ESP_ERROR_CHECK(esp_console_start_repl(repl));
 }


### PR DESCRIPTION
## Description

README.md states that is possible to use USB but this is not working for ESP21C6:

_... IEEE802.15.4 Command Line is enabled with UART as the default interface. Additionally, USB JTAG is also supported and can be activated through the menuconfig..._

Now we can choose the desired option in "Component config->ESP System Settings->Channel for console output" when compiling. For ESP32C6, for instance, only "UART0" was working and console could not be available using "USB Serial/JTAG Controller".

Now, refactored app_main to initialize the console REPL based on the selected configuration: UART, USB CDC/JTAG. This improves flexibility and allows the CLI to work with different hardware interfaces.

Snippet code added came from:
examples/system/console/basic/main/console_example_main.c

## Related


## Testing

idf.py menuconfig

Inside option "Component config->ESP System Settings->Channel for console output" select each option and build.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
