### PR TITLE
fix(storage/spiffs): fix readdir setting errno on directory end (IDFGH-16698)

### DIFF
--- a/components/spiffs/esp_spiffs.c
+++ b/components/spiffs/esp_spiffs.c
@@ -746,7 +746,15 @@ static int vfs_spiffs_readdir_r(void* ctx, DIR* pdir, struct dirent* entry,
     char * item_name;
     do {
         if (SPIFFS_readdir(&dir->d, &out) == 0) {
-            errno = spiffs_res_to_errno(SPIFFS_errno(efs->fs));
+            s32_t spiffs_res = SPIFFS_errno(efs->fs);
+            switch (spiffs_res) {
+                case SPIFFS_ERR_END_OF_OBJECT:
+                    errno = 0;
+                    break;
+                default:
+                    errno = spiffs_res_to_errno(spiffs_res);
+                    break;
+            }
             SPIFFS_clearerr(efs->fs);
             if (!errno) {
                 *out_dirent = NULL;


### PR DESCRIPTION


<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

spiffs_res_to_errno maps `SPIFFS_ERR_END_OF_OBJECT` to EIO which breaks the common contract where errno should be 0 if readdir iterated through all the entries in a directory.

The fix is explicitly checking for `SPIFFS_ERR_END_OF_OBJECT` and in that case set errno to 0.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

The issue was discovered because a c++ std::filesystem::directory_iterator on a spiffs vfs path threw an std::filesystem::filesystem_error with the following message `filesystem error: directory iterator cannot advance: I/O error`

## Testing

std::filesystem::directory_iterator on a spiffs vfs path now actually works without throwing exceptions
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
