### PR TITLE
feat(esp_event): Allow an event carry more data without malloc (IDFGH-16709)

### DIFF
--- a/components/esp_event/Kconfig
+++ b/components/esp_event/Kconfig
@@ -14,6 +14,14 @@ menu "Event Loop Library"
         help
             Enable posting events from interrupt handlers.
 
+    config ESP_EVENT_POST_FROM_ISR_SIZE
+        int "Max size of data from events"
+        default 4
+        depends on ESP_EVENT_POST_FROM_ISR
+        help
+            Enable posting events from interrupt handlers.
+
+
     config ESP_EVENT_POST_FROM_IRAM_ISR
         bool "Support posting events from ISRs placed in IRAM"
         default y

--- a/components/esp_event/esp_event.c
+++ b/components/esp_event/esp_event.c
@@ -924,6 +924,22 @@ esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop, esp_event_base_t
     memset((void*)(&post), 0, sizeof(post));
 
     if (event_data != NULL && event_data_size != 0) {
+#if CONFIG_ESP_EVENT_POST_FROM_ISR
+
+        if (event_data_size > sizeof(post.data.val)) {
+             post.data.ptr = calloc(1, event_data_size);
+
+            if (post.data.ptr == NULL) {
+                return ESP_ERR_NO_MEM;
+            }
+            post.data_allocated = true;
+            memcpy(post.data.ptr, event_data, event_data_size);
+        } else {
+            memcpy((void*)(&(post.data.val)), event_data, event_data_size);
+        }
+
+        post.data_set = true;
+#else
         // Make persistent copy of event data on heap.
         void* event_data_copy = calloc(1, event_data_size);
 
@@ -933,9 +949,6 @@ esp_err_t esp_event_post_to(esp_event_loop_handle_t event_loop, esp_event_base_t
 
         memcpy(event_data_copy, event_data, event_data_size);
         post.data.ptr = event_data_copy;
-#if CONFIG_ESP_EVENT_POST_FROM_ISR
-        post.data_allocated = true;
-        post.data_set = true;
 #endif
     }
     post.base = event_base;

--- a/components/esp_event/private_include/esp_event_internal.h
+++ b/components/esp_event/private_include/esp_event_internal.h
@@ -92,7 +92,7 @@ typedef struct esp_event_remove_handler_context_t {
 } esp_event_remove_handler_context_t;
 
 typedef union esp_event_post_data {
-    uint32_t val;
+    uint8_t val[CONFIG_ESP_EVENT_POST_FROM_ISR_SIZE];
     void *ptr;
 } esp_event_post_data_t;
 


### PR DESCRIPTION
This is both a feature and an optimization.

Feature:
Adjustable size of the internal storage in esp_event queue, currently used by ISR posting, as they wont be able to make a malloc.

Optimization:
When non-isr is posting an event, use the inernal storage in the struct instead of always allocating a new heap for the data. Most events in esp-idf only contains a few bytes event information, and we have that allocation payed for anyway.

This solved in a big part our memory fragmentation issue, as events happens freqvently and used to create small memory allocations for just 4 bytes, and then in the event handler we usually allocated a bigger chunk of heap for our feature. When returning from the event handler, the 4 byte allocation was freed, leaveing a hole in the heap.

