### PR TITLE
feat(esp_driver_uart): Add uart_write_bytes_with_timeout() (IDFGH-16708)

### DIFF
--- a/components/esp_driver_uart/include/driver/uart.h
+++ b/components/esp_driver_uart/include/driver/uart.h
@@ -557,6 +557,26 @@ int uart_write_bytes(uart_port_t uart_num, const void* src, size_t size);
  * @brief Send data to the UART port from a given buffer and length,
  *
  * If the UART driver's parameter 'tx_buffer_size' is set to zero:
+ * This function will return before all the data have been sent out, if it times out.
+ *
+ * Otherwise, if the 'tx_buffer_size' > 0, this function will return after copying all the data to tx ring buffer,
+ * UART ISR will then move data from the ring buffer to TX FIFO gradually.
+ *
+ * @param uart_num UART port number, the max port number is (UART_NUM_MAX -1).
+ * @param src   data buffer address
+ * @param size  data length to send
+ * @param ticks_to_wait Timeout, count in RTOS ticks
+ *
+ * @return
+ *     - (-1) Parameter error
+ *     - OTHERS (>=0) The number of bytes pushed to the TX FIFO
+ */
+int uart_write_bytes_with_timeout(uart_port_t uart_num, const void* src, size_t size, TickType_t ticks_to_wait);
+
+/**
+ * @brief Send data to the UART port from a given buffer and length,
+ *
+ * If the UART driver's parameter 'tx_buffer_size' is set to zero:
  * This function will not return until all the data and the break signal have been sent out.
  * After all data is sent out, send a break signal.
  *


### PR DESCRIPTION

## Description

Its easy to think that an write to an uart will always succeed eventually, but that not always the case. If you enable hardware flow control, and have someone on the receiving end, that is stubborn never to release the ReadyToReceive line.

In some cases this has caused a deadlock, when both devices are both sitting and waiting for the other to give up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `uart_write_bytes_with_timeout()` and refactors TX handling to support timeouts and partial-byte reporting across FIFO and ring buffer paths.
> 
> - **Driver (UART)**:
>   - **New API**: `uart_write_bytes_with_timeout(uart_port_t, const void*, size_t, TickType_t)` declared in `include/driver/uart.h` and implemented in `src/uart.c`.
>   - **TX Path Refactor**:
>     - Internal `uart_tx_all()` now takes `TickType_t ticks_to_wait`, enforces timeouts on `tx_mux`, ring buffer acquire, FIFO semaphores, and break wait; returns bytes sent or `-1` on timeout.
>     - Ring buffer flow switched to `xRingbufferSendAcquire`/`xRingbufferSendComplete` with explicit description item, uses current free size to chunk writes, tracks `bytes_transmitted`.
>     - FIFO (no TX buffer) path honors `ticks_to_wait` and supports partial sends.
>   - **API Wiring**: `uart_write_bytes()` and `uart_write_bytes_with_break()` updated to call `uart_tx_all(..., portMAX_DELAY)`; new `uart_write_bytes_with_timeout()` forwards caller-specified timeout.
>   - **Docs**: Header comments updated to describe timeout behavior and return values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dd58b856508ab915cbe252ee3b078779b6b679f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->