### PR TITLE
feat(esp_http_server): Make HTTP(S)_SERVER_EVENT events optional (IDFGH-16707)

### DIFF
--- a/components/esp_http_server/Kconfig
+++ b/components/esp_http_server/Kconfig
@@ -57,8 +57,16 @@ menu "HTTP Server"
             It internally uses a counting semaphore with count set to `LWIP_UDP_RECVMBOX_SIZE` to achieve this.
             This config will slightly change API behavior to block until message gets delivered on control socket.
 
+    config HTTPD_ENABLE_EVENTS
+        bool "Enable ESP_HTTP_SERVER_EVENT"
+        default y
+        help
+            This enables the ESP_HTTP_SERVER_EVENT event type. Generating these eventes adds some overhead.
+            If you are not using this event type, you can disable it to save some memory and add performance.
+
     config HTTPD_SERVER_EVENT_POST_TIMEOUT
         int "Time in millisecond to wait for posting event"
+        depends on HTTPD_ENABLE_EVENTS
         default 2000
         help
             This config option helps in setting the time in millisecond to wait for event to be posted to the

--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -23,8 +23,6 @@ extern "C" {
 
 #define ESP_HTTPD_DEF_CTRL_PORT         (32768)    /*!< HTTP Server control socket port*/
 
-ESP_EVENT_DECLARE_BASE(ESP_HTTP_SERVER_EVENT);
-
 /**
  * @brief   HTTP Server events id
  */
@@ -40,11 +38,15 @@ typedef enum {
     HTTP_SERVER_EVENT_STOP,            /*!< This event occurs when HTTP Server is stopped */
 } esp_http_server_event_id_t;
 
+#if CONFIG_HTTPD_ENABLE_EVENTS || __DOXYGEN_
+ESP_EVENT_DECLARE_BASE(ESP_HTTP_SERVER_EVENT);
+
 /** Argument structure for HTTP_SERVER_EVENT_ON_DATA and HTTP_SERVER_EVENT_SENT_DATA event */
 typedef struct {
     int fd;         /*!< Session socket file descriptor */
     int data_len;   /*!< Data length */
 } esp_http_server_event_data;
+#endif // CONFIG_HTTPD_ENABLE_EVENTS || __DOXYGEN_
 
 /*
 note: esp_https_server.h includes a customized copy of this

--- a/components/esp_http_server/src/esp_httpd_priv.h
+++ b/components/esp_http_server/src/esp_httpd_priv.h
@@ -17,6 +17,7 @@
 
 #include <esp_http_server.h>
 #include "osal.h"
+#include "sdkconfig.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -581,6 +582,8 @@ esp_err_t httpd_sess_trigger_close_(httpd_handle_t handle, struct sock_db *sessi
  * @}
  */
 
+#ifdef CONFIG_HTTPD_ENABLE_EVENTS
+
 #if CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT == -1
 #define ESP_HTTP_SERVER_EVENT_POST_TIMEOUT portMAX_DELAY
 #else
@@ -593,7 +596,13 @@ esp_err_t httpd_sess_trigger_close_(httpd_handle_t handle, struct sock_db *sessi
  */
 void esp_http_server_dispatch_event(int32_t event_id, const void* event_data, size_t event_data_size);
 
+#else // CONFIG_HTTPD_ENABLE_EVENTS
+#define esp_http_server_dispatch_event(event_id, event_data, event_data_size) do {} while(0)
+#endif // CONFIG_HTTPD_ENABLE_EVENTS
+
+
 esp_err_t httpd_crypto_sha1(const uint8_t *data, size_t data_len, uint8_t *hash);
+
 
 #ifdef __cplusplus
 }

--- a/components/esp_http_server/src/httpd_main.c
+++ b/components/esp_http_server/src/httpd_main.c
@@ -38,6 +38,7 @@ typedef struct {
 
 static const char *TAG = "httpd";
 
+#ifdef CONFIG_HTTPD_ENABLE_EVENTS
 ESP_EVENT_DEFINE_BASE(ESP_HTTP_SERVER_EVENT);
 
 void esp_http_server_dispatch_event(int32_t event_id, const void* event_data, size_t event_data_size)
@@ -47,6 +48,7 @@ void esp_http_server_dispatch_event(int32_t event_id, const void* event_data, si
         ESP_LOGE(TAG, "Failed to post esp_http_server event: %s", esp_err_to_name(err));
     }
 }
+#endif // CONFIG_HTTPD_ENABLE_EVENTS
 
 static esp_err_t httpd_accept_conn(struct httpd_data *hd, int listen_fd)
 {

--- a/components/esp_http_server/src/httpd_txrx.c
+++ b/components/esp_http_server/src/httpd_txrx.c
@@ -312,12 +312,14 @@ esp_err_t httpd_resp_send(httpd_req_t *r, const char *buf, ssize_t buf_len)
             return ESP_ERR_HTTPD_RESP_SEND;
         }
     }
+    hd->http_server_state = HTTP_SERVER_EVENT_SENT_DATA;
+#ifdef CONFIG_HTTPD_ENABLE_EVENTS
     esp_http_server_event_data evt_data = {
         .fd = ra->sd->fd,
         .data_len = buf_len,
     };
-    hd->http_server_state = HTTP_SERVER_EVENT_SENT_DATA;
     esp_http_server_dispatch_event(HTTP_SERVER_EVENT_SENT_DATA, &evt_data, sizeof(esp_http_server_event_data));
+#endif // CONFIG_HTTPD_ENABLE_EVENTS
     return ESP_OK;
 }
 
@@ -412,12 +414,14 @@ esp_err_t httpd_resp_send_chunk(httpd_req_t *r, const char *buf, ssize_t buf_len
     if (httpd_send_all(r, "\r\n", strlen("\r\n")) != ESP_OK) {
         return ESP_ERR_HTTPD_RESP_SEND;
     }
+    hd->http_server_state = HTTP_SERVER_EVENT_SENT_DATA;
+#ifdef CONFIG_HTTPD_ENABLE_EVENTS
     esp_http_server_event_data evt_data = {
         .fd = ra->sd->fd,
         .data_len = buf_len,
     };
-    hd->http_server_state = HTTP_SERVER_EVENT_SENT_DATA;
     esp_http_server_dispatch_event(HTTP_SERVER_EVENT_SENT_DATA, &evt_data, sizeof(esp_http_server_event_data));
+#endif // CONFIG_HTTPD_ENABLE_EVENTS
 
     return ESP_OK;
 }
@@ -628,11 +632,13 @@ int httpd_req_recv(httpd_req_t *r, char *buf, size_t buf_len)
     ESP_LOGD(TAG, LOG_FMT("received length = %d"), ret);
     struct httpd_data *hd = (struct httpd_data *) r->handle;
     hd->http_server_state = HTTP_SERVER_EVENT_ON_DATA;
+#ifdef CONFIG_HTTPD_ENABLE_EVENTS
     esp_http_server_event_data evt_data = {
         .fd = ra->sd->fd,
         .data_len = ret,
     };
     esp_http_server_dispatch_event(HTTP_SERVER_EVENT_ON_DATA, &evt_data, sizeof(esp_http_server_event_data));
+#endif // CONFIG_HTTPD_ENABLE_EVENTS
     return ret;
 }
 

--- a/components/esp_https_server/Kconfig
+++ b/components/esp_https_server/Kconfig
@@ -6,8 +6,18 @@ menu "ESP HTTPS server"
         help
             Enable ESP HTTPS server component
 
+    config ESP_HTTPS_SERVER_EVENTS
+        bool "Enable ESP_HTTPS_SERVER_EVENT event type"
+        depends on ESP_HTTPS_SERVER_ENABLE
+        default y
+        help
+            This enables the ESP_HTTPS_SERVER_EVENT event type. Generating these eventes adds some overhead.
+            If you are not using this event type, you can disable it to save some memory.
+
+
     config ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT
         int "Time in millisecond to wait for posting event"
+        depends on (ESP_HTTPS_SERVER_ENABLE && ESP_HTTPS_SERVER_EVENTS)
         default 2000
         help
             This config option helps in setting the time in millisecond to wait for event to be posted to the

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -18,6 +18,7 @@
 extern "C" {
 #endif
 
+#if CONFIG_ESP_HTTPS_SERVER_EVENTS || __DOXYGEN__
 ESP_EVENT_DECLARE_BASE(ESP_HTTPS_SERVER_EVENT);
 
 typedef enum {
@@ -29,6 +30,7 @@ typedef enum {
     HTTPS_SERVER_EVENT_DISCONNECTED,    /*!< The connection has been disconnected */
     HTTPS_SERVER_EVENT_STOP,            /*!< This event occurs when HTTPS Server is stopped */
 } esp_https_server_event_id_t;
+#endif // CONFIG_ESP_HTTPS_SERVER_EVENTS || __DOXYGEN__
 
 typedef enum {
     HTTPD_SSL_TRANSPORT_SECURE,      // SSL Enabled

--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@ typedef struct httpd_ssl_transport_ctx {
     httpd_ssl_ctx_t *global_ctx;
 } httpd_ssl_transport_ctx_t;
 
+#ifdef CONFIG_ESP_HTTPS_SERVER_EVENTS
 ESP_EVENT_DEFINE_BASE(ESP_HTTPS_SERVER_EVENT);
 
 #if CONFIG_ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT == -1
@@ -31,7 +32,6 @@ ESP_EVENT_DEFINE_BASE(ESP_HTTPS_SERVER_EVENT);
 #define ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT pdMS_TO_TICKS(CONFIG_ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT)
 #endif
 
-
 static void http_dispatch_event_to_event_loop(int32_t event_id, const void* event_data, size_t event_data_size)
 {
     esp_err_t err = esp_event_post(ESP_HTTPS_SERVER_EVENT, event_id, event_data, event_data_size, ESP_HTTPS_SERVER_EVENT_POST_TIMEOUT);
@@ -39,6 +39,9 @@ static void http_dispatch_event_to_event_loop(int32_t event_id, const void* even
         ESP_LOGE(TAG, "Failed to post http_client event: %"PRId32", error: %s", event_id, esp_err_to_name(err));
     }
 }
+#else // CONFIG_ESP_HTTPS_SERVER_EVENTS
+#define http_dispatch_event_to_event_loop(event_id, event_data, event_data_size) do {} while (0)
+#endif // CONFIG_ESP_HTTPS_SERVER_EVENTS
 
 /**
  * SSL socket close handler

--- a/examples/protocols/https_server/simple/main/main.c
+++ b/examples/protocols/https_server/simple/main/main.c
@@ -31,6 +31,7 @@
 
 static const char *TAG = "example";
 
+#ifdef CONFIG_ESP_HTTPS_SERVER_EVENTS
 /* Event handler for catching system events */
 static void event_handler(void* arg, esp_event_base_t event_base,
                           int32_t event_id, void* event_data)
@@ -42,6 +43,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
         }
     }
 }
+#endif // CONFIG_ESP_HTTPS_SERVER_EVENTS
 
 /* An HTTP GET handler */
 static esp_err_t root_get_handler(httpd_req_t *req)
@@ -257,7 +259,9 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &connect_handler, &server));
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ETHERNET_EVENT_DISCONNECTED, &disconnect_handler, &server));
 #endif // CONFIG_EXAMPLE_CONNECT_ETHERNET
+#ifdef CONFIG_ESP_HTTPS_SERVER_EVENTS
     ESP_ERROR_CHECK(esp_event_handler_register(ESP_HTTPS_SERVER_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
+#endif // CONFIG_ESP_HTTPS_SERVER_EVENTS
 
     /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.
      * Read "Establishing Wi-Fi or Ethernet Connection" section in


### PR DESCRIPTION

## Description

In my quest to improve heap fragmentation, i noticed that the webserver was a big issue, but not for the reasons you think. A single web page read/write causes several esp_events to be sent, each one causing a malloc on its own and a contex switch to handle tasks.  And the worst part of it, is that we never listened on any of these events.

This PR adds a KConfig option to disable events on the webserver, this was a hug improvement for us in 5.4.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Kconfig switches to enable/disable HTTP(S) server events and gates event declarations/dispatches, with no-ops when disabled; examples updated accordingly.
> 
> - **Config**:
>   - Add `CONFIG_HTTPD_ENABLE_EVENTS` and `CONFIG_ESP_HTTPS_SERVER_EVENTS` to toggle `ESP_HTTP_SERVER_EVENT`/`ESP_HTTPS_SERVER_EVENT`.
>   - Event post timeouts now depend on these flags.
> - **esp_http_server**:
>   - Wrap `ESP_EVENT_DECLARE_BASE`, `esp_http_server_event_data`, and `ESP_EVENT_DEFINE_BASE` with `CONFIG_HTTPD_ENABLE_EVENTS`.
>   - Provide `esp_http_server_dispatch_event()` only when enabled; define as no-op otherwise.
>   - Guard event postings in `httpd_main.c`/`httpd_txrx.c` and maintain `http_server_state` updates.
> - **esp_https_server**:
>   - Wrap event base/dispatch and postings with `CONFIG_ESP_HTTPS_SERVER_EVENTS`; define no-op dispatcher when disabled.
>   - Update SPDX year.
> - **Examples**:
>   - Conditionally register HTTPS server event handlers only when events are enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd85dad2cf2e7436eca2d096b85bd5dcecc50875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->