### PR TITLE
Fix typos in NimBLE example comments (IDFGH-16737)

### DIFF
--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_Beacon/main/src/gap.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_Beacon/main/src/gap.c
@@ -51,7 +51,7 @@ static void start_advertising(void) {
     adv_fields.le_role = BLE_GAP_LE_ROLE_PERIPHERAL;
     adv_fields.le_role_is_present = 1;
 
-    /* Set advertiement fields */
+    /* Set advertisement fields */
     rc = ble_gap_adv_set_fields(&adv_fields);
     if (rc != 0) {
         ESP_LOGE(TAG, "failed to set advertising data, error code: %d", rc);
@@ -74,7 +74,7 @@ static void start_advertising(void) {
         return;
     }
 
-    /* Set non-connetable and general discoverable mode to be a beacon */
+    /* Set non-connectable and general discoverable mode to be a beacon */
     adv_params.conn_mode = BLE_GAP_CONN_MODE_NON;
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 

--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_Connection/main/src/gap.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_Connection/main/src/gap.c
@@ -80,7 +80,7 @@ static void start_advertising(void) {
     adv_fields.le_role = BLE_GAP_LE_ROLE_PERIPHERAL;
     adv_fields.le_role_is_present = 1;
 
-    /* Set advertiement fields */
+    /* Set advertisement fields */
     rc = ble_gap_adv_set_fields(&adv_fields);
     if (rc != 0) {
         ESP_LOGE(TAG, "failed to set advertising data, error code: %d", rc);
@@ -107,7 +107,7 @@ static void start_advertising(void) {
         return;
     }
 
-    /* Set non-connetable and general discoverable mode to be a beacon */
+    /* Set undirected connectable and general discoverable mode */
     adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 

--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/main/src/gap.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/main/src/gap.c
@@ -80,7 +80,7 @@ static void start_advertising(void) {
     adv_fields.le_role = BLE_GAP_LE_ROLE_PERIPHERAL;
     adv_fields.le_role_is_present = 1;
 
-    /* Set advertiement fields */
+    /* Set advertisement fields */
     rc = ble_gap_adv_set_fields(&adv_fields);
     if (rc != 0) {
         ESP_LOGE(TAG, "failed to set advertising data, error code: %d", rc);
@@ -107,7 +107,7 @@ static void start_advertising(void) {
         return;
     }
 
-    /* Set non-connetable and general discoverable mode to be a beacon */
+    /* Set undirected connectable and general discoverable mode */
     adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 

--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_Security/main/src/gap.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_Security/main/src/gap.c
@@ -95,7 +95,7 @@ static void start_advertising(void) {
     adv_fields.le_role = BLE_GAP_LE_ROLE_PERIPHERAL;
     adv_fields.le_role_is_present = 1;
 
-    /* Set advertiement fields */
+    /* Set advertisement fields */
     rc = ble_gap_adv_set_fields(&adv_fields);
     if (rc != 0) {
         ESP_LOGE(TAG, "failed to set advertising data, error code: %d", rc);
@@ -122,7 +122,7 @@ static void start_advertising(void) {
         return;
     }
 
-    /* Set non-connetable and general discoverable mode to be a beacon */
+    /* Set undirected connectable and general discoverable mode */
     adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Hi, while working through the NimBLE "get started" examples, I noticed a few typos and copy-paste mistakes.
I hope this helps. :)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects misspellings and clarifies advertising mode comments across NimBLE example GAP files.
> 
> - **NimBLE examples (GAP `gap.c`)**:
>   - Correct spelling of "advertiement" to "advertisement" in advertising setup comments in:
>     - `NimBLE_Beacon/main/src/gap.c`
>     - `NimBLE_Connection/main/src/gap.c`
>     - `NimBLE_GATT_Server/main/src/gap.c`
>     - `NimBLE_Security/main/src/gap.c`
>   - Clarify advertising mode comments:
>     - Beacon: "non-connectable" general discoverable mode.
>     - Connection/GATT Server/Security: "undirected connectable" general discoverable mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1868714b973d26fb803779f6024032408fef307e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->