### PR TITLE
fix(hal): Fix USB PHY selection logic in usb_wrap_ll.h (IDFGH-16746)

### DIFF
--- a/components/hal/esp32p4/include/hal/usb_wrap_ll.h
+++ b/components/hal/esp32p4/include/hal/usb_wrap_ll.h
@@ -59,8 +59,10 @@ FORCE_INLINE_ATTR void usb_wrap_ll_phy_select(usb_wrap_dev_t *hw, unsigned int p
     switch (phy_idx) {
     case 0:
         LP_SYS.usb_ctrl.sw_usb_phy_sel = true;
+        break;
     case 1:
         LP_SYS.usb_ctrl.sw_usb_phy_sel = false;
+        break;
     default:
         break;
     }


### PR DESCRIPTION
## Description

Fix: Unable to select a phy interface on ESP32P4

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing break statements in usb_wrap_ll_phy_select to correctly map PHY indices without fallthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43574a2a9276f56c7c2037b85ac6b0f2f4f1b222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->