### PR TITLE
Bump up log_v2's max arg count (IDFGH-16764)

### DIFF
--- a/components/log/include/esp_log_args.h
+++ b/components/log/include/esp_log_args.h
@@ -143,6 +143,18 @@ typedef struct {
 #define ESP_LOG_INIT_ARG_TYPE_46(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_42(__VA_ARGS__)
 #define ESP_LOG_INIT_ARG_TYPE_47(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_43(__VA_ARGS__)
 #define ESP_LOG_INIT_ARG_TYPE_48(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_44(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_49(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_45(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_50(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_46(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_51(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_47(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_52(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_48(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_53(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_49(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_54(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_50(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_55(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_51(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_56(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_52(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_57(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_53(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_58(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_54(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_59(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_55(__VA_ARGS__)
+#define ESP_LOG_INIT_ARG_TYPE_60(a, b, c, d, ...) ESP_LOG_INIT_ARG_TYPE_4(a, b, c, d), ESP_LOG_INIT_ARG_TYPE_56(__VA_ARGS__)
 
 // Pack 4 types into a single byte (8 bits)
 #define ESP_LOG_PACK_4_TYPES(a, b, c, d) (char) ( \


### PR DESCRIPTION
## Description

Bump esp_log v2 max argc. The abstract reasoning for it is that there's no completely objective way of determining a cap on how many arguments the logging functions should take, hence the ad-hoc approach. The concrete reasoning is so that I can migrate the main project I'm working on to log v2, which log elements of a couple of configuration structs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends `ESP_LOG_INIT_ARG_TYPE_*` macros from 48 to 60 to support up to 60 logging arguments.
> 
> - **Logging (binary args typing)**:
>   - Extend `ESP_LOG_INIT_ARG_TYPE_*` definitions from `..._48` to `..._60`, increasing supported logging arguments to 60.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9c3524ae07e65aa0a915eb252bfc24487d26d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->