### PR TITLE
Improve error logging in _node_queue_tx function (IDFGH-16811)

### DIFF
--- a/components/esp_driver_twai/esp_twai_onchip.c
+++ b/components/esp_driver_twai/esp_twai_onchip.c
@@ -1,4 +1,4 @@
-unm/*
+/*
  * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Enhanced error message for unmatched dlc and buffer_len.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances _node_queue_tx error logging by printing DLC and computed buffer_len DLC when they mismatch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeb27515fc5d3438c666edbe7faa4618f7047d08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->