### PR TITLE
fix(hw_support): Fix crash when reconfiguring flash from 40 to 80 MHz (IDFGH-16831)

### DIFF
--- a/components/esp_system/port/cpu_start.c
+++ b/components/esp_system/port/cpu_start.c
@@ -634,6 +634,22 @@ MSPI_INIT_ATTR void mspi_init(void)
     }
 #endif
 }
+
+#if CONFIG_IDF_TARGET_ESP32
+#if !CONFIG_SPIRAM_BOOT_HW_INIT
+/*
+ * Adjust flash configuration. This must be placed in IRAM because running from flash,
+ * while it is being reconfigured, will result in corrupt data being read.
+ */
+NOINLINE_ATTR IRAM_ATTR static void configure_flash(esp_image_header_t *fhdr)
+{
+    bootloader_flash_gpio_config(fhdr);
+    bootloader_flash_dummy_config(fhdr);
+    bootloader_flash_clock_config(fhdr);
+    bootloader_flash_cs_timing_config();
+}
+#endif // !CONFIG_SPIRAM_BOOT_HW_INIT
+#endif // CONFIG_IDF_TARGET_ESP32
 #endif // !CONFIG_APP_BUILD_TYPE_PURE_RAM_APP
 
 /*
@@ -874,10 +890,7 @@ NOINLINE_ATTR static void system_early_init(const soc_reset_reason_t *rst_reas)
 #if CONFIG_IDF_TARGET_ESP32
 #if !CONFIG_SPIRAM_BOOT_HW_INIT
     // If psram is uninitialized, we need to improve some flash configuration.
-    bootloader_flash_clock_config(&fhdr);
-    bootloader_flash_gpio_config(&fhdr);
-    bootloader_flash_dummy_config(&fhdr);
-    bootloader_flash_cs_timing_config();
+    configure_flash(&fhdr);
 #endif //!CONFIG_SPIRAM_BOOT_HW_INIT
 #endif //CONFIG_IDF_TARGET_ESP32
 


### PR DESCRIPTION
7549d08 moved `call_start_cpu0` from IRAM to flash. Unfortunately, this included code that reconfigures the flash if the application’s flash speed differs from the bootloader’s flash speed.

When an application with a flash speed of 80 MHz is started from a bootloader with a flash speed of 40 MHz, it will crash shortly after `bootloader_flash_cs_timing_config()` returns. This is caused by reading instructions from flash while the flash is being reconfigured to the higher speed, which results in corrupt instruction data being read.

Possible crashes to encounter:

- IllegalInstruction at an address between two assembly instructions, possibly from a corrupt previous instruction that was shorter or longer than what should have been there.
- IllegalInstruction at an address that should contain a valid instruction.
- LoadProhibited at an address that should contain an instruction that cannot cause that exception, such as `movi.n  a8, 1`.

As this code runs early during start-up, the device will be stuck in an infinite reboot loop. This means that loading an application built from the 5.5.1 release via OTA onto a device that contains an older bootloader with a slower flash speed will brick the device.

This PR fixes the problem by moving the flash configuration calls into a helper function that is placed in IRAM. The call to increase the flash clock has also been moved so that the GPIO settings and SPI dummy cycles are set to safe values before the clock is increased.

The commit that introduces the problem has already been backported to 5.5.1 as e1faf67, so this fix will also have to be backported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves ESP32 flash config sequence into IRAM helper `configure_flash()` and invokes it during early init (when PSRAM HW init is disabled) to avoid executing from flash while reconfiguring.
> 
> - **ESP32 boot/flash init**:
>   - Add IRAM-only helper `configure_flash()` to adjust flash GPIO, dummy cycles, clock, and CS timing safely.
>   - Replace inline `bootloader_flash_*` calls with `configure_flash(&fhdr)` in early init when `!CONFIG_SPIRAM_BOOT_HW_INIT`.
>   - Guard with `CONFIG_IDF_TARGET_ESP32`; no behavior change for other targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7565d53868b994b1928de9e4bf236b6d99472cef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->