### PR TITLE
fix:Report the full buffer length to the UAC stack by setting bytes_r… (IDFGH-16855)

### DIFF
--- a/examples/peripherals/i2s/i2s_advance/i2s_usb/main/i2s_usb_example_main.c
+++ b/examples/peripherals/i2s/i2s_advance/i2s_usb/main/i2s_usb_example_main.c
@@ -236,6 +236,11 @@ static esp_err_t usb_uac_device_input_cb(uint8_t *buf, size_t len, size_t *bytes
         return ESP_FAIL;
     }
 
+    /* Report full-length data for UAC */
+    if (bytes_read) {
+        *bytes_read = len;
+    }
+
     return ESP_OK;
 }
 


### PR DESCRIPTION
Description
Set bytes_read to len in usb_uac_device_input_cb() after a successful esp_codec_dev_read().
This ensures the UAC stack receives the correct number of bytes and no longer interprets the callback as producing zero-length audio data.
<img width="1021" height="602" alt="image" src="https://github.com/user-attachments/assets/177cab0c-ccdc-4d05-afa1-ed0c31426e9f" />
Related
N/A (found while testing the USB UAC device input callback).
Testing
Built the USB UAC example.
Ran on an ESP32-S4 board and verified that audio input is correctly received by the host (no more zero-length data reported).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `bytes_read = len` in `usb_uac_device_input_cb` so the UAC stack receives full-length audio data instead of zero-length.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d11f8bd73a44d5dd5b718ae86790daca2fdfa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->