### PR TITLE
Support BLE multiple connection in the BLE part of the esp_hid component. (IDFGH-16865)

### DIFF
--- a/components/esp_hid/include/esp_hidd.h
+++ b/components/esp_hid/include/esp_hidd.h
@@ -221,6 +221,45 @@ esp_err_t esp_hidd_dev_event_handler_register(esp_hidd_dev_t *dev, esp_event_han
  */
 esp_err_t esp_hidd_dev_event_handler_unregister(esp_hidd_dev_t *dev, esp_event_handler_t callback, esp_hidd_event_t event);
 
+/**
+ * @brief Connection information structure for querying connections
+ */
+typedef struct {
+    uint16_t conn_id;                           /*!< Connection ID */
+    uint8_t remote_bda[6];                      /*!< Remote device address */
+} esp_hidd_conn_info_t;
+
+/**
+ * @brief Set the active connection for unicast mode
+ * @param dev       : pointer to the device
+ * @param conn_id   : connection ID to set as active (sends to this connection only)
+ *
+ * @return: ESP_OK on success, ESP_ERR_NOT_FOUND if connection not found
+ * @note: This disables broadcast mode automatically
+ */
+esp_err_t esp_hidd_dev_set_active_conn(esp_hidd_dev_t *dev, uint16_t conn_id);
+
+/**
+ * @brief Query all active connections
+ * @param dev           : pointer to the device
+ * @param conn_list     : pointer to array to store connection info
+ * @param max_count     : maximum number of connections that can be stored
+ * @param[out] count    : actual number of connections returned
+ *
+ * @return: ESP_OK on success
+ */
+esp_err_t esp_hidd_dev_get_connections(esp_hidd_dev_t *dev, esp_hidd_conn_info_t *conn_list, size_t max_count, size_t *count);
+
+/**
+ * @brief Enable or disable broadcast mode
+ * @param dev       : pointer to the device
+ * @param enable    : true to broadcast to all connections, false for unicast to active connection
+ *
+ * @return: ESP_OK on success
+ * @note: In broadcast mode, all connected devices receive the events
+ */
+esp_err_t esp_hidd_dev_set_broadcast_mode(esp_hidd_dev_t *dev, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_hid/private/ble_hidd.h
+++ b/components/esp_hid/private/ble_hidd.h
@@ -18,6 +18,11 @@ extern "C" {
 
 esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev, const esp_hid_device_config_t *config, esp_event_handler_t callback);
 
+// Multi-connection management functions
+esp_err_t esp_ble_hidd_dev_set_active_conn(void *devp, uint16_t conn_id);
+esp_err_t esp_ble_hidd_dev_get_connections(void *devp, esp_hidd_conn_info_t *conn_list, size_t max_count, size_t *count);
+esp_err_t esp_ble_hidd_dev_set_broadcast_mode(void *devp, bool enable);
+
 #endif /* CONFIG_GATTS_ENABLE */
 
 #ifdef __cplusplus

--- a/components/esp_hid/src/ble_hidd.c
+++ b/components/esp_hid/src/ble_hidd.c
@@ -134,6 +134,15 @@ typedef struct {
     uint16_t                    hid_protocol_handle;
 } hidd_dev_map_t;
 
+// Connection info for tracking multiple connections
+#define ESP_HIDD_MAX_CONNECTIONS CONFIG_BT_ACL_CONNECTIONS
+typedef struct {
+    bool                        connected;
+    uint16_t                    conn_id;
+    esp_bd_addr_t               remote_bda;
+    hidd_le_ccc_value_t         bat_ccc;
+} hidd_connection_t;
+
 struct esp_ble_hidd_dev_s {
     esp_hidd_dev_t             *dev;
     SemaphoreHandle_t            sem;
@@ -141,11 +150,12 @@ struct esp_ble_hidd_dev_s {
     esp_hid_device_config_t     config;
     uint16_t                    appearance;
 
-    bool                        connected;
-    uint16_t                    conn_id;
-    esp_bd_addr_t               remote_bda;
+    // Multi-connection support
+    SemaphoreHandle_t            conn_mutex;        // Mutex for protecting connection state
+    hidd_connection_t           connections[ESP_HIDD_MAX_CONNECTIONS];
+    uint8_t                     active_conn_index;  // Index to active connection (0xFF = broadcast mode)
+    bool                        broadcast_mode;     // When true, send to all connections
 
-    hidd_le_ccc_value_t         bat_ccc;
     uint8_t                     bat_level;  // 0 - 100 - battery percentage
     uint8_t                     control;    // 0x00 suspend, 0x01 suspend off
     uint8_t                     protocol;   // 0x00 boot, 0x01 report
@@ -173,6 +183,8 @@ static const uint8_t hidInfo[4] = {
 
 #define WAIT_CB(d) xSemaphoreTake(d->sem, portMAX_DELAY)
 #define SEND_CB(d) xSemaphoreGive(d->sem)
+#define LOCK_CONN(d) xSemaphoreTake(d->conn_mutex, portMAX_DELAY)
+#define UNLOCK_CONN(d) xSemaphoreGive(d->conn_mutex)
 
 static const char *gatts_evt_names[25] = { "REG", "READ", "WRITE", "EXEC_WRITE", "MTU", "CONF", "UNREG", "CREATE", "ADD_INCL_SRVC", "ADD_CHAR", "ADD_CHAR_DESCR", "DELETE", "START", "STOP", "CONNECT", "DISCONNECT", "OPEN", "CANCEL_OPEN", "CLOSE", "LISTEN", "CONGEST", "RESPONSE", "CREAT_ATTR_TAB", "SET_ATTR_VAL", "SEND_SERVICE_CHANGE"};
 
@@ -182,6 +194,103 @@ static const char *gatts_evt_str(uint8_t event)
         return "UNKNOWN";
     }
     return gatts_evt_names[event];
+}
+
+/*
+ * Connection Management Helper Functions
+ */
+
+// Find connection by conn_id
+// NOTE: Caller must hold conn_mutex
+static int find_connection_by_id_with_lock(esp_ble_hidd_dev_t *dev, uint16_t conn_id)
+{
+    for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+        if (dev->connections[i].connected && dev->connections[i].conn_id == conn_id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Find first free connection slot
+// NOTE: Caller must hold conn_mutex
+static int find_free_connection_slot_with_lock(esp_ble_hidd_dev_t *dev)
+{
+    for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+        if (!dev->connections[i].connected) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Add a new connection
+// NOTE: Caller must hold conn_mutex
+static int add_connection_with_lock(esp_ble_hidd_dev_t *dev, uint16_t conn_id, esp_bd_addr_t remote_bda)
+{
+    int idx = find_free_connection_slot_with_lock(dev);
+    if (idx < 0) {
+        ESP_LOGE(TAG, "No free connection slots available");
+        return -1;
+    }
+    
+    dev->connections[idx].connected = true;
+    dev->connections[idx].conn_id = conn_id;
+    memcpy(dev->connections[idx].remote_bda, remote_bda, ESP_BD_ADDR_LEN);
+    dev->connections[idx].bat_ccc.value = 0;
+    
+    // Set as active if no active connection
+    if (dev->active_conn_index == 0xFF && !dev->broadcast_mode) {
+        dev->active_conn_index = idx;
+    }
+    
+    ESP_LOGI(TAG, "Added connection at index %d, conn_id=%d", idx, conn_id);
+    return idx;
+}
+
+// Remove a connection
+// NOTE: Caller must hold conn_mutex
+static void remove_connection_with_lock(esp_ble_hidd_dev_t *dev, uint16_t conn_id)
+{
+    int idx = find_connection_by_id_with_lock(dev, conn_id);
+    if (idx < 0) {
+        ESP_LOGW(TAG, "Connection not found for removal: conn_id=%d", conn_id);
+        return;
+    }
+    
+    dev->connections[idx].connected = false;
+    ESP_LOGI(TAG, "Removed connection at index %d, conn_id=%d", idx, conn_id);
+    
+    // Update active connection if removed
+    if (dev->active_conn_index == idx) {
+        // Find another active connection
+        dev->active_conn_index = 0xFF;
+        for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+            if (dev->connections[i].connected) {
+                dev->active_conn_index = i;
+                break;
+            }
+        }
+    }
+}
+
+// Count active connections
+// NOTE: Caller must hold conn_mutex
+static int count_active_connections_with_lock(esp_ble_hidd_dev_t *dev)
+{
+    int count = 0;
+    for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+        if (dev->connections[i].connected) {
+            count++;
+        }
+    }
+    return count;
+}
+
+// NOTE: Caller must hold conn_mutex
+static bool is_broadcast_enabled_with_lock(const esp_ble_hidd_dev_t *dev)
+{
+    return dev->active_conn_index == 0xFF && dev->broadcast_mode;
 }
 
 static void add_db_record(esp_gatts_attr_db_t *db, size_t index, uint8_t *uuid, uint8_t perm, uint16_t max_length, uint16_t length, uint8_t *value)
@@ -401,8 +510,17 @@ static void bat_event_handler(esp_ble_hidd_dev_t *dev, esp_gatts_cb_event_t even
         break;
     case ESP_GATTS_WRITE_EVT: {
         if (param->write.handle == dev->bat_ccc_handle) {
-            dev->bat_ccc.value = param->write.value[0];
-            ESP_LOGV(TAG, "Battery CCC: Notify: %s, Indicate: %s", dev->bat_ccc.notify_enable ? "On" : "Off", dev->bat_ccc.indicate_enable ? "On" : "Off");
+            // Update per-connection battery CCC
+            LOCK_CONN(dev);
+            int conn_idx = find_connection_by_id_with_lock(dev, param->write.conn_id);
+            if (conn_idx >= 0) {
+                dev->connections[conn_idx].bat_ccc.value = param->write.value[0];
+                ESP_LOGV(TAG, "Battery CCC conn[%d]: Notify: %s, Indicate: %s", 
+                    conn_idx,
+                    dev->connections[conn_idx].bat_ccc.notify_enable ? "On" : "Off", 
+                    dev->connections[conn_idx].bat_ccc.indicate_enable ? "On" : "Off");
+            }
+            UNLOCK_CONN(dev);
         }
         break;
     }
@@ -471,28 +589,46 @@ static void hid_event_handler(esp_ble_hidd_dev_t *dev, int device_index, esp_gat
     }
     case ESP_GATTS_CONNECT_EVT: {
         ESP_LOGD(TAG, "HID CONNECT[%d] conn_id = %x", device_index, param->connect.conn_id);
-        if (!dev->connected && device_index == (dev->devices_len - 1)) {
-            dev->connected = true;
-            dev->conn_id   = param->connect.conn_id;
-            memcpy(dev->remote_bda, param->connect.remote_bda, ESP_BD_ADDR_LEN);
+        // Only process connection on the last device interface to avoid duplicates
+        if (device_index == (dev->devices_len - 1)) {
+            LOCK_CONN(dev);
+            // Check if connection already exists
+            if (find_connection_by_id_with_lock(dev, param->connect.conn_id) < 0) {
+                int conn_idx = add_connection_with_lock(dev, param->connect.conn_id, param->connect.remote_bda);
+                UNLOCK_CONN(dev);
+                if (conn_idx >= 0) {
+                    esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT_NO_MITM);
 
-            esp_ble_set_encryption(param->connect.remote_bda, ESP_BLE_SEC_ENCRYPT_NO_MITM);
-
-            esp_hidd_event_data_t cb_param = {
-                .connect.dev = dev->dev,
-            };
-            esp_event_post_to(dev->event_loop_handle, ESP_HIDD_EVENTS, ESP_HIDD_CONNECT_EVENT, &cb_param, sizeof(esp_hidd_event_data_t), portMAX_DELAY);
+                    esp_hidd_event_data_t cb_param = {
+                        .connect.dev = dev->dev,
+                    };
+                    esp_event_post_to(dev->event_loop_handle, ESP_HIDD_EVENTS, ESP_HIDD_CONNECT_EVENT, &cb_param, sizeof(esp_hidd_event_data_t), portMAX_DELAY);
+                } else {
+                    ESP_LOGE(TAG, "Failed to add connection, max connections reached");
+                }
+            } else {
+                UNLOCK_CONN(dev);
+            }
         }
         break;
     }
     case ESP_GATTS_DISCONNECT_EVT: {
         ESP_LOGD(TAG, "HID DISCONNECT[%d] 0x%x", device_index, param->disconnect.reason);
-        if (dev->connected) {
-            dev->connected = false;
-            esp_hidd_event_data_t cb_param = {0};
-            cb_param.disconnect.dev = dev->dev;
-            cb_param.disconnect.reason = param->disconnect.reason;
-            esp_event_post_to(dev->event_loop_handle, ESP_HIDD_EVENTS, ESP_HIDD_DISCONNECT_EVENT, &cb_param, sizeof(esp_hidd_event_data_t), portMAX_DELAY);
+        // Only process disconnect on the last device interface to avoid duplicates
+        if (device_index == (dev->devices_len - 1)) {
+            LOCK_CONN(dev);
+            int conn_idx = find_connection_by_id_with_lock(dev, param->disconnect.conn_id);
+            if (conn_idx >= 0) {
+                remove_connection_with_lock(dev, param->disconnect.conn_id);
+                UNLOCK_CONN(dev);
+
+                esp_hidd_event_data_t cb_param = {0};
+                cb_param.disconnect.dev = dev->dev;
+                cb_param.disconnect.reason = param->disconnect.reason;
+                esp_event_post_to(dev->event_loop_handle, ESP_HIDD_EVENTS, ESP_HIDD_DISCONNECT_EVENT, &cb_param, sizeof(esp_hidd_event_data_t), portMAX_DELAY);
+            } else {
+                UNLOCK_CONN(dev);
+            }
         }
         break;
     }
@@ -730,6 +866,9 @@ static esp_err_t ble_hid_free_config(esp_ble_hidd_dev_t *dev)
     if (dev->sem != NULL) {
         vSemaphoreDelete(dev->sem);
     }
+    if (dev->conn_mutex != NULL) {
+        vSemaphoreDelete(dev->conn_mutex);
+    }
     if (dev->event_loop_handle != NULL) {
         esp_event_loop_delete(dev->event_loop_handle);
     }
@@ -810,30 +949,65 @@ static esp_err_t esp_ble_hidd_dev_deinit(void *devp)
 static bool esp_ble_hidd_dev_connected(void *devp)
 {
     esp_ble_hidd_dev_t *dev = (esp_ble_hidd_dev_t *)devp;
-    return (dev != NULL && s_dev == dev && dev->connected);
+    if (dev == NULL || s_dev != dev) {
+        return false;
+    }
+    LOCK_CONN(dev);
+    int count = count_active_connections_with_lock(dev);
+    UNLOCK_CONN(dev);
+    return count > 0;
 }
 
 static esp_err_t esp_ble_hidd_dev_battery_set(void *devp, uint8_t level)
 {
-    esp_err_t ret;
+    esp_err_t ret = ESP_OK;
     esp_ble_hidd_dev_t *dev = (esp_ble_hidd_dev_t *)devp;
     if (!dev || s_dev != dev) {
         return ESP_FAIL;
     }
     dev->bat_level = level;
 
-    if (!dev->connected || dev->bat_ccc.value == 0) {
+    LOCK_CONN(dev);
+    // Check if we have any connections
+    if (count_active_connections_with_lock(dev) == 0) {
         //if we are not yet connected, that is not an error
+        UNLOCK_CONN(dev);
         return ESP_OK;
     }
-
-    if (dev->bat_ccc.notify_enable) {
-        ret = esp_ble_gatts_send_indicate(dev->bat_svc.gatt_if, dev->conn_id, dev->bat_level_handle, 1, &dev->bat_level, false);
-        if (ret) {
-            ESP_LOGE(TAG, "esp_ble_gatts_send_notify failed: %d", ret);
-            return ESP_FAIL;
+    // Broadcast mode: send to all connections
+    if (is_broadcast_enabled_with_lock(dev)) {
+        bool any_sent = false;
+        for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+            if (dev->connections[i].connected && dev->connections[i].bat_ccc.notify_enable) {
+                ret = esp_ble_gatts_send_indicate(dev->bat_svc.gatt_if, dev->connections[i].conn_id, 
+                                                   dev->bat_level_handle, 1, &dev->bat_level, false);
+                if (ret != ESP_OK) {
+                    ESP_LOGE(TAG, "esp_ble_gatts_send_notify failed for conn[%d]: %d", i, ret);
+                } else {
+                    any_sent = true;
+                }
+            }
+        }
+        UNLOCK_CONN(dev);
+        return any_sent ? ESP_OK : ESP_FAIL;
+    }
+    
+    // Unicast mode: send to active connection only
+    uint8_t active_conn_index = dev->active_conn_index;
+    if (active_conn_index < ESP_HIDD_MAX_CONNECTIONS && 
+        dev->connections[active_conn_index].connected) {
+        if (dev->connections[active_conn_index].bat_ccc.notify_enable) {
+            ret = esp_ble_gatts_send_indicate(dev->bat_svc.gatt_if, 
+                                               dev->connections[active_conn_index].conn_id, 
+                                               dev->bat_level_handle, 1, &dev->bat_level, false);
+            if (ret != ESP_OK) {
+                ESP_LOGE(TAG, "esp_ble_gatts_send_notify failed: %d", ret);
+                UNLOCK_CONN(dev);
+                return ESP_FAIL;
+            }
         }
     }
+    UNLOCK_CONN(dev);
 
     return ESP_OK;
 }
@@ -846,10 +1020,13 @@ static esp_err_t esp_ble_hidd_dev_input_set(void *devp, size_t index, size_t id,
         return ESP_FAIL;
     }
 
-    if (!dev->connected) {
+    LOCK_CONN(dev);
+    if (count_active_connections_with_lock(dev) == 0) {
+        UNLOCK_CONN(dev);
         ESP_LOGE(TAG, "%s Device Not Connected", __func__);
         return ESP_FAIL;
     }
+    UNLOCK_CONN(dev);
 
     if (index >= dev->devices_len) {
         ESP_LOGE(TAG, "%s index out of range[0-%d]", __func__, dev->devices_len - 1);
@@ -857,12 +1034,51 @@ static esp_err_t esp_ble_hidd_dev_input_set(void *devp, size_t index, size_t id,
     }
 
     if ((p_rpt = get_report_by_id_and_type(dev, id, ESP_HID_REPORT_TYPE_INPUT)) != NULL && p_rpt->ccc.value) {
-        esp_err_t err = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, dev->conn_id, p_rpt->handle, length, data, p_rpt->ccc.indicate_enable);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Send Input Indicate Failed: %d", err);
+        esp_err_t err = ESP_OK;
+        
+        LOCK_CONN(dev);
+        // Broadcast mode: send to all connections
+        if (is_broadcast_enabled_with_lock(dev)) {
+            bool any_sent = false;
+            for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+                if (dev->connections[i].connected && p_rpt->ccc.value) {
+                    err = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, 
+                                                       dev->connections[i].conn_id, 
+                                                       p_rpt->handle, length, data, 
+                                                       p_rpt->ccc.indicate_enable);
+                    if (err == ESP_OK) {
+                        UNLOCK_CONN(dev);
+                        WAIT_CB(dev);
+                        LOCK_CONN(dev);
+                        any_sent = true;
+                    } else {
+                        ESP_LOGE(TAG, "Send Input Indicate Failed for conn[%d]: %d", i, err);
+                    }
+                }
+            }
+            UNLOCK_CONN(dev);
+            return any_sent ? ESP_OK : ESP_FAIL;
+        }
+        
+        // Unicast mode: send to active connection only
+        if (dev->active_conn_index < ESP_HIDD_MAX_CONNECTIONS && 
+            dev->connections[dev->active_conn_index].connected) {
+            err = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, 
+                                               dev->connections[dev->active_conn_index].conn_id, 
+                                               p_rpt->handle, length, data, 
+                                               p_rpt->ccc.indicate_enable);
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Send Input Indicate Failed: %d", err);
+                UNLOCK_CONN(dev);
+                return ESP_FAIL;
+            }
+            UNLOCK_CONN(dev);
+            WAIT_CB(dev);
+        } else {
+            ESP_LOGE(TAG, "No active connection");
+            UNLOCK_CONN(dev);
             return ESP_FAIL;
         }
-        WAIT_CB(dev);
     } else {
         ESP_LOGE(TAG, "Indicate Not Enabled: %d", 0);
         return ESP_FAIL;
@@ -878,10 +1094,13 @@ static esp_err_t esp_ble_hidd_dev_feature_set(void *devp, size_t index, size_t i
         return ESP_FAIL;
     }
 
-    if (!dev->connected) {
+    LOCK_CONN(dev);
+    if (count_active_connections_with_lock(dev) == 0) {
+        UNLOCK_CONN(dev);
         ESP_LOGE(TAG, "%s Device Not Connected", __func__);
         return ESP_FAIL;
     }
+    UNLOCK_CONN(dev);
 
     if (index >= dev->devices_len) {
         ESP_LOGE(TAG, "%s index out of range[0-%d]", __func__, dev->devices_len - 1);
@@ -896,13 +1115,46 @@ static esp_err_t esp_ble_hidd_dev_feature_set(void *devp, size_t index, size_t i
             return ESP_FAIL;
         }
         WAIT_CB(dev);
-        if (dev->connected && p_rpt->ccc.value) {
-            ret = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, dev->conn_id, p_rpt->handle, length, data, p_rpt->ccc.indicate_enable);
-            if (ret != ESP_OK) {
-                ESP_LOGE(TAG, "Send Feature Indicate Failed: %d", ret);
-                return ESP_FAIL;
+        LOCK_CONN(dev);
+        // Send feature report to connections if any are active and have CCC enabled
+        if (count_active_connections_with_lock(dev) > 0 && p_rpt->ccc.value) {
+            // Send to active connection or broadcast based on mode
+            if (is_broadcast_enabled_with_lock(dev)) {
+                // Broadcast to all connections
+                for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+                    if (dev->connections[i].connected && p_rpt->ccc.value) {
+                        ret = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, 
+                                                           dev->connections[i].conn_id, 
+                                                           p_rpt->handle, length, data, 
+                                                           p_rpt->ccc.indicate_enable);
+                        if (ret != ESP_OK) {
+                            ESP_LOGE(TAG, "Send Feature Indicate Failed for conn[%d]: %d", i, ret);
+                        } else {
+                            UNLOCK_CONN(dev);
+                            WAIT_CB(dev);
+                            LOCK_CONN(dev);
+                        }
+                    }
+                }
+            } else if (dev->active_conn_index < ESP_HIDD_MAX_CONNECTIONS && 
+                       dev->connections[dev->active_conn_index].connected) {
+                // Send to active connection only
+                ret = esp_ble_gatts_send_indicate(dev->devices[index].hid_svc.gatt_if, 
+                                                   dev->connections[dev->active_conn_index].conn_id, 
+                                                   p_rpt->handle, length, data, 
+                                                   p_rpt->ccc.indicate_enable);
+                if (ret != ESP_OK) {
+                    ESP_LOGE(TAG, "Send Feature Indicate Failed: %d", ret);
+                    UNLOCK_CONN(dev);
+                    return ESP_FAIL;
+                }
+                UNLOCK_CONN(dev);
+                WAIT_CB(dev);
+            } else {
+                UNLOCK_CONN(dev);
             }
-            WAIT_CB(dev);
+        } else {
+            UNLOCK_CONN(dev);
         }
     } else {
         ESP_LOGE(TAG, "FEATURE %d not found", id);
@@ -955,11 +1207,27 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
 
     // Reset the hid device target environment
     s_dev->bat_level = 100;
-    s_dev->bat_ccc.value = 0;
     s_dev->control = ESP_HID_CONTROL_EXIT_SUSPEND;
     s_dev->protocol = ESP_HID_PROTOCOL_MODE_REPORT;
     s_dev->event_loop_handle = NULL;
     s_dev->dev = dev_p;
+    
+    // Initialize multi-connection fields
+    for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++) {
+        s_dev->connections[i].connected = false;
+        s_dev->connections[i].conn_id = 0;
+        s_dev->connections[i].bat_ccc.value = 0;
+    }
+    s_dev->active_conn_index = 0xFF;  // No active connection initially
+    s_dev->broadcast_mode = false;     // Default to unicast mode
+
+    s_dev->conn_mutex = xSemaphoreCreateMutex();
+    if (s_dev->conn_mutex == NULL) {
+        ESP_LOGE(TAG, "HID device connection mutex could not be allocated");
+        ble_hidd_dev_free();
+        return ESP_FAIL;
+    }
+
     s_dev->sem = xSemaphoreCreateBinary();
     if (s_dev->sem == NULL) {
         ESP_LOGE(TAG, "HID device semaphore could not be allocated");
@@ -1017,6 +1285,88 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
     }
 
     return ret;
+}
+
+/*
+ * Multi-Connection Management API Functions
+ */
+
+esp_err_t esp_ble_hidd_dev_set_active_conn(void *devp, uint16_t conn_id)
+{
+    esp_ble_hidd_dev_t *dev = (esp_ble_hidd_dev_t *)devp;
+    if (!dev || s_dev != dev) {
+        return ESP_FAIL;
+    }
+
+    LOCK_CONN(dev);
+    int idx = find_connection_by_id_with_lock(dev, conn_id);
+    if (idx < 0) {
+        ESP_LOGE(TAG, "Connection not found: conn_id=%d", conn_id);
+        UNLOCK_CONN(dev);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    dev->active_conn_index = idx;
+    dev->broadcast_mode = false;  // Disable broadcast when setting active connection
+    ESP_LOGI(TAG, "Set active connection to index %d, conn_id=%d", idx, conn_id);
+    UNLOCK_CONN(dev);
+    return ESP_OK;
+}
+
+esp_err_t esp_ble_hidd_dev_get_connections(void *devp, esp_hidd_conn_info_t *conn_list, 
+                                           size_t max_count, size_t *count)
+{
+    esp_ble_hidd_dev_t *dev = (esp_ble_hidd_dev_t *)devp;
+    if (!dev || s_dev != dev) {
+        return ESP_FAIL;
+    }
+
+    if (!conn_list || !count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    LOCK_CONN(dev);
+    *count = 0;
+    for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS && *count < max_count; i++) {
+        if (dev->connections[i].connected) {
+            conn_list[*count].conn_id = dev->connections[i].conn_id;
+            memcpy(conn_list[*count].remote_bda, dev->connections[i].remote_bda, ESP_BD_ADDR_LEN);
+            (*count)++;
+        }
+    }
+    UNLOCK_CONN(dev);
+
+    return ESP_OK;
+}
+
+esp_err_t esp_ble_hidd_dev_set_broadcast_mode(void *devp, bool enable)
+{
+    esp_ble_hidd_dev_t *dev = (esp_ble_hidd_dev_t *)devp;
+    if (!dev || s_dev != dev) {
+        return ESP_FAIL;
+    }
+
+    LOCK_CONN(dev);
+    if (enable)
+    {
+        dev->active_conn_index = 0xFF;
+        dev->broadcast_mode = true;
+    } else {
+        dev->active_conn_index = 0xFF;
+        dev->broadcast_mode = false;
+        for (int i = 0; i < ESP_HIDD_MAX_CONNECTIONS; i++)
+        {
+            if (dev->connections[i].connected)
+            {
+                dev->active_conn_index = i;
+                break;
+            }
+        }
+    }
+
+    UNLOCK_CONN(dev);
+    ESP_LOGI(TAG, "Broadcast mode %s", enable ? "enabled" : "disabled");
+    return ESP_OK;
 }
 
 #endif /* CONFIG_GATTS_ENABLE */

--- a/components/esp_hid/src/esp_hidd.c
+++ b/components/esp_hid/src/esp_hidd.c
@@ -120,6 +120,65 @@ esp_err_t esp_hidd_dev_event_handler_unregister(esp_hidd_dev_t *dev, esp_event_h
     return dev->event_handler_unregister(dev->dev, callback, event);
 }
 
+/*
+ * Multi-Connection Management APIs
+ */
+
+esp_err_t esp_hidd_dev_set_active_conn(esp_hidd_dev_t *dev, uint16_t conn_id)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+    
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_set_active_conn(dev->dev, conn_id);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_get_connections(esp_hidd_dev_t *dev, esp_hidd_conn_info_t *conn_list, 
+                                       size_t max_count, size_t *count)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_get_connections(dev->dev, conn_list, max_count, count);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_set_broadcast_mode(esp_hidd_dev_t *dev, bool enable)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+    
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_set_broadcast_mode(dev->dev, enable);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
 /**
  * The deep copy data append the end of the esp_hidd_event_data_t, move the data pointer to the correct address. This is
  * a workaround way, it's better to use flexiable array in the interface.


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Since BLE supports multiple connections, it is not uncommon for a BLE hid host to support multiple connections. This PR address the need to support multiple connections in the BLE hid module. The core data struct is to add these memebers to esp_ble_hidd_dev_s. These fields help to track which connection currently is selected. I also update the handlers to use these members to respond to different events.
```
    // Multi-connection support
    SemaphoreHandle_t            conn_mutex;        // Mutex for protecting connection state
    hidd_connection_t           connections[ESP_HIDD_MAX_CONNECTIONS];
    uint8_t                     active_conn_index;  // Index to active connection (0xFF = broadcast mode)
    bool                        broadcast_mode;     // When true, send to all connections

```

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

I have tested this change using the esp_hid_device example. For single connection the behavior stays the same. I have a keyboard project which supports multiple BLE clients. I was able to switch between different BLE clients.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add BLE HID multi-connection support with per-connection CCC and APIs to set active connection, query connections, and toggle broadcast mode, updating send and event paths accordingly.
> 
> - **API (public `esp_hidd`)**:
>   - Add `esp_hidd_conn_info_t` and new APIs: `esp_hidd_dev_set_active_conn`, `esp_hidd_dev_get_connections`, `esp_hidd_dev_set_broadcast_mode`.
> - **BLE HID implementation (`ble_hidd`)**:
>   - Introduce multi-connection state: `connections[]`, `conn_mutex`, `active_conn_index`, `broadcast_mode`.
>   - Track per-connection CCC for Battery; update CCC handling.
>   - Update connect/disconnect to add/remove connections; adjust active connection.
>   - Modify `connected`, battery, input, and feature report paths to support unicast to active connection or broadcast to all.
>   - Initialize and free new mutex; add internal helper functions.
>   - Expose BLE-specific wrappers: `esp_ble_hidd_dev_set_active_conn`, `...get_connections`, `...set_broadcast_mode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7ab6483b3b80294ea4ef75ab6c86fd0c28d61c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->