### PR TITLE
feat(esp_hid): Enahcne esp_hid to support multiple BLE connections (IDFGH-16867)

### DIFF
--- a/components/esp_hid/include/esp_hidd.h
+++ b/components/esp_hid/include/esp_hidd.h
@@ -1,16 +1,8 @@
-// Copyright 2017-2019 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 
@@ -220,6 +212,63 @@ esp_err_t esp_hidd_dev_event_handler_register(esp_hidd_dev_t *dev, esp_event_han
  * @return: ESP_OK on success
  */
 esp_err_t esp_hidd_dev_event_handler_unregister(esp_hidd_dev_t *dev, esp_event_handler_t callback, esp_hidd_event_t event);
+
+/**
+ * @brief Connection information structure for querying connections
+ */
+typedef struct {
+    uint16_t conn_id;                           /*!< Connection ID */
+    uint8_t remote_bda[6];                      /*!< Remote device address */
+} esp_hidd_conn_info_t;
+
+/**
+ * @brief Set the active connection for unicast mode
+ * @param dev       : pointer to the device
+ * @param conn_id   : connection ID to set as active (sends to this connection only)
+ *
+ * @return: ESP_OK on success, ESP_ERR_NOT_FOUND if connection not found
+ * @note: This disables broadcast mode automatically
+ */
+esp_err_t esp_hidd_dev_set_active_conn(esp_hidd_dev_t *dev, uint16_t conn_id);
+
+/**
+ * @brief Query all active connections
+ * @param dev           : pointer to the device
+ * @param conn_list     : pointer to array to store connection info
+ * @param max_count     : maximum number of connections that can be stored
+ * @param[out] count    : actual number of connections returned
+ *
+ * @return: ESP_OK on success
+ */
+esp_err_t esp_hidd_dev_get_connections(esp_hidd_dev_t *dev, esp_hidd_conn_info_t *conn_list, size_t max_count, size_t *count);
+
+/**
+ * @brief Enable or disable broadcast mode
+ * @param dev       : pointer to the device
+ * @param enable    : true to broadcast to all connections, false for unicast to active connection
+ *
+ * @return: ESP_OK on success
+ * @note: In broadcast mode, all connected devices receive the events
+ */
+esp_err_t esp_hidd_dev_set_broadcast_mode(esp_hidd_dev_t *dev, bool enable);
+
+/**
+ * @brief Get the currently active connection (unicast) when not in broadcast mode
+ * @param dev       : pointer to the device
+ * @param[out] conn_id : connection ID of the active connection
+ *
+ * @return: ESP_OK on success, ESP_ERR_NOT_FOUND if no active connection, ESP_ERR_NOT_SUPPORTED if transport doesn't support multi-connection
+ */
+esp_err_t esp_hidd_dev_get_active_conn(esp_hidd_dev_t *dev, uint16_t *conn_id);
+
+/**
+ * @brief Query whether the device is in broadcast mode
+ * @param dev       : pointer to the device
+ * @param[out] enabled : true if broadcast mode is enabled, false otherwise
+ *
+ * @return: ESP_OK on success, ESP_ERR_NOT_SUPPORTED if transport doesn't support multi-connection
+ */
+esp_err_t esp_hidd_dev_is_broadcast_mode(esp_hidd_dev_t *dev, bool *enabled);
 
 #ifdef __cplusplus
 }

--- a/components/esp_hid/private/ble_hidd.h
+++ b/components/esp_hid/private/ble_hidd.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,13 @@ extern "C" {
 #if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
 
 esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev, const esp_hid_device_config_t *config, esp_event_handler_t callback);
+
+// Multi-connection management functions
+esp_err_t esp_ble_hidd_dev_set_active_conn(void *devp, uint16_t conn_id);
+esp_err_t esp_ble_hidd_dev_get_connections(void *devp, esp_hidd_conn_info_t *conn_list, size_t max_count, size_t *count);
+esp_err_t esp_ble_hidd_dev_set_broadcast_mode(void *devp, bool enable);
+esp_err_t esp_ble_hidd_dev_get_active_conn(void *devp, uint16_t *conn_id);
+esp_err_t esp_ble_hidd_dev_is_broadcast_mode(void *devp, bool *enabled);
 
 #endif /* CONFIG_GATTS_ENABLE */
 

--- a/components/esp_hid/src/esp_hidd.c
+++ b/components/esp_hid/src/esp_hidd.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -118,6 +118,101 @@ esp_err_t esp_hidd_dev_event_handler_unregister(esp_hidd_dev_t *dev, esp_event_h
         return ESP_FAIL;
     }
     return dev->event_handler_unregister(dev->dev, callback, event);
+}
+
+/*
+ * Multi-Connection Management APIs
+ */
+
+esp_err_t esp_hidd_dev_set_active_conn(esp_hidd_dev_t *dev, uint16_t conn_id)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_set_active_conn(dev->dev, conn_id);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_get_connections(esp_hidd_dev_t *dev, esp_hidd_conn_info_t *conn_list,
+                                       size_t max_count, size_t *count)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_get_connections(dev->dev, conn_list, max_count, count);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_set_broadcast_mode(esp_hidd_dev_t *dev, bool enable)
+{
+    if (dev == NULL) {
+        return ESP_FAIL;
+    }
+
+    // Currently only BLE transport supports multi-connection
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_set_broadcast_mode(dev->dev, enable);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_get_active_conn(esp_hidd_dev_t *dev, uint16_t *conn_id)
+{
+    if (dev == NULL || conn_id == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Currently only BLE transport supports multi-connection */
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_get_active_conn(dev->dev, conn_id);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t esp_hidd_dev_is_broadcast_mode(esp_hidd_dev_t *dev, bool *enabled)
+{
+    if (dev == NULL || enabled == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Currently only BLE transport supports multi-connection */
+    if (dev->transport != ESP_HID_TRANSPORT_BLE) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+#if CONFIG_GATTS_ENABLE || CONFIG_BT_NIMBLE_ENABLED
+    return esp_ble_hidd_dev_is_broadcast_mode(dev->dev, enabled);
+#else
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
 }
 
 /**

--- a/tools/ci/check_copyright_ignore.txt
+++ b/tools/ci/check_copyright_ignore.txt
@@ -400,7 +400,6 @@ components/console/linenoise/linenoise.c
 components/console/linenoise/linenoise.h
 components/esp_event/host_test/esp_event_unit_test/main/esp_event_test.cpp
 components/esp_event/host_test/fixtures.hpp
-components/esp_hid/include/esp_hidd.h
 components/esp_hid/include/esp_hidd_gatts.h
 components/esp_hid/include/esp_hidd_transport.h
 components/esp_hid/include/esp_hidh_bluedroid.h

--- a/tools/ci/check_public_headers_exceptions.txt
+++ b/tools/ci/check_public_headers_exceptions.txt
@@ -19,12 +19,7 @@ components/freertos/FreeRTOS-Kernel-SMP/portable/xtensa/include/freertos/
 
 # LWIP: sockets.h uses #include_next<>, which doesn't work correctly with the checker
 # memp_std.h is supposed to be included multiple times with different settings
-components/lwip/lwip/src/include/lwip/priv/memp_std.h
 components/lwip/include/lwip/sockets.h
-components/lwip/lwip/src/include/lwip/prot/nd6.h
-components/lwip/lwip/src/include/netif/ppp/
-components/lwip/lwip/src/include/lwip/apps/tftp_server.h
-components/lwip/lwip/src/include/lwip/apps/tftp_client.h
 
 components/spi_flash/include/spi_flash_chip_issi.h
 components/spi_flash/include/spi_flash_chip_mxic.h
@@ -57,20 +52,15 @@ components/idf_test/include/idf_performance.h
 
 components/spiffs/include/spiffs_config.h
 
-components/unity/unity/src/unity_internals.h
 components/unity/include/unity_config.h
 components/unity/include/unity_test_runner.h
 
-components/cmock/CMock/src/cmock.h
-components/cmock/CMock/src/cmock_internals.h
 
 
 components/openthread/openthread/
 
 # The following TLSF headers contain object definitions but have to be
 # made public to be used in esp_rom to help patching the TLSF in ROM.
-components/heap/tlsf/tlsf_block_functions.h
-components/heap/tlsf/tlsf_control_functions.h
 
 ### Here are the files that do not compile for some reason
 #


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Since BLE supports multiple connections, it is not uncommon for a BLE HID host device to support multiple connections. This PR addresses the need to support multiple connections in the BLE HID layer.

1. Add neccessary data structures to manage multiple connections in the HID layer of BLE protocol.
2. Add interfaces to allow users to select a connection out of multiple connections or boradcast to all connections.
3. This change keep the single connection behavior the same.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Tests done so far:

1. I have tested this change using the esp_hid_device example. For single connection the behavior stays the same. 
2. I have a keyboard project which supports multiple BLE clients. I am able to switch between different BLE clients and enable broadcast mode.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds BLE HID multi-connection support with APIs to select an active connection or broadcast to all, and updates report sending and event handling accordingly.
> 
> - **API (public `components/esp_hid/include/esp_hidd.h`)**:
>   - Add `esp_hidd_conn_info_t`.
>   - New multi-connection APIs: `esp_hidd_dev_set_active_conn`, `esp_hidd_dev_get_connections`, `esp_hidd_dev_set_broadcast_mode`, `esp_hidd_dev_get_active_conn`, `esp_hidd_dev_is_broadcast_mode`.
> - **BLE HID implementation (`components/esp_hid/src/ble_hidd.c`, `private/ble_hidd.h`)**:
>   - Introduce connection table with mutex, active-connection index, and broadcast mode; helper functions to add/remove/query connections.
>   - Update GATT event handling to manage multiple connections and per-connection Battery CCC.
>   - Modify `connected`, battery, INPUT, and FEATURE report paths to send to active connection (unicast) or all (broadcast), with proper synchronization and callbacks.
>   - Expose BLE-specific multi-connection functions for use by the public wrapper.
> - **Wrapper (`components/esp_hid/src/esp_hidd.c`)**:
>   - Route new multi-connection APIs to BLE transport (return `ESP_ERR_NOT_SUPPORTED` for others).
> - **CI**:
>   - Update header check exception lists related to public headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94e721cec9bb65874d3b343e6665b451ccab47c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->