### PR TITLE
fix(usb_serial_jtag_driver): tx_ring_buf not checked for successful allocation (IDFGH-16876)

### DIFF
--- a/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag.c
+++ b/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag.c
@@ -183,7 +183,7 @@ esp_err_t usb_serial_jtag_driver_install(usb_serial_jtag_driver_config_t *usb_se
     }
 
     p_usb_serial_jtag_obj->tx_ring_buf = xRingbufferCreate(usb_serial_jtag_config->tx_buffer_size, RINGBUF_TYPE_BYTEBUF);
-    if (p_usb_serial_jtag_obj->rx_ring_buf == NULL) {
+    if (p_usb_serial_jtag_obj->tx_ring_buf == NULL) {
         ESP_LOGE(USB_SERIAL_JTAG_TAG, "ringbuffer create error");
         err = ESP_ERR_NO_MEM;
         goto _exit;


### PR DESCRIPTION
The NULL check for `rx_ring_buf` looks to have been copied+pasted for `tx_ring_buf` but the name was not updated in both places.

This means if the `tx_ring_buf` allocation fails, an error is not returned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the NULL check to validate `tx_ring_buf` allocation (instead of `rx_ring_buf`) and properly error on failure in `usb_serial_jtag_driver_install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1297790591d76cdddc13d98c578b457dc24ae410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->