### PR TITLE
Fix typo in cmake docs for EXTRA_COMPONENT_DIRS (IDFGH-16884)

### DIFF
--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -567,9 +567,9 @@ endfunction()
 
 macro(project project_name)
     # Initialize project, preparing COMPONENTS argument for idf_build_process()
-    # call later using external COMPONENT_DIRS, COMPONENTS_DIRS, EXTRA_COMPONENTS_DIR,
-    # EXTRA_COMPONENTS_DIRS, COMPONENTS, EXLUDE_COMPONENTS, TEST_COMPONENTS,
-    # TEST_EXLUDE_COMPONENTS, TESTS_ALL, BUILD_TESTS
+    # call later using external COMPONENT_DIRS, COMPONENTS_DIRS, EXTRA_COMPONENT_DIRS,
+    # COMPONENTS, EXLUDE_COMPONENTS, TEST_COMPONENTS, TEST_EXLUDE_COMPONENTS,
+    # TESTS_ALL, BUILD_TESTS
     __project_init(components test_components)
 
     __target_set_toolchain()


### PR DESCRIPTION
I noticed a typo in the comments of `tools/cmake/project.cmake` referencing `EXTRA_COMPONENT_DIRS`, this fixes it. 

It's nothing critical at all but it threw me off while digging through the code so here it is :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects comment in `tools/cmake/project.cmake` to reference `EXTRA_COMPONENT_DIRS` consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a6e26224dc1cda2e10981b13a3ddd8c7b94af63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->