### PR TITLE
docs: encoder's 'symbols' parameter may be a hw buffer (IDFGH-16932)

### DIFF
--- a/components/esp_driver_rmt/include/driver/rmt_encoder.h
+++ b/components/esp_driver_rmt/include/driver/rmt_encoder.h
@@ -109,7 +109,7 @@ struct rmt_encoder_t {
  * @param[in] data_size Size of the data, as passed to rmt_transmit()
  * @param[in] symbols_written Current position in encoded stream, in symbols
  * @param[in] symbols_free The maximum amount of symbols that can be written into the `symbols` buffer
- * @param[out] symbols Symbols to be sent to the RMT hardware
+ * @param[out] symbols Symbols to be sent to the RMT hardware. This may be a hardware buffer and can't be used with 'memcpy'
  * @param[out] done Setting this to true marks this transaction as finished
  * @param arg Opaque argument
  * @return Amount of symbols encoded in this callback round. 0 if more space is needed.


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The `symbols` parameter given to the RMT encoder's callback function may be a hardware buffer which can't be used as target for memcpy.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

https://esp32.com/viewtopic.php?t=47324
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies in `rmt_encoder.h` that the `symbols` buffer in the simple encoder callback may be a hardware buffer and must not be used with memcpy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eb0f81517681712006bd3bbf3dbdb2f42f4ff71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->