### PR TITLE
Declutter log from overly verbose SPI DMA logging (IDFGH-16940)

### DIFF
--- a/components/esp_driver_spi/src/gpspi/spi_master.c
+++ b/components/esp_driver_spi/src/gpspi/spi_master.c
@@ -1197,7 +1197,7 @@ static SPI_MASTER_ISR_ATTR esp_err_t setup_dma_priv_buffer(spi_host_t *host, uin
         }
     }
     need_malloc |= (((uint32_t)buffer | len) & (alignment - 1));
-    ESP_EARLY_LOGD(SPI_TAG, "%s %p, len %d, is_ptr_ext %d, use_psram: %d, alignment: %d, need_malloc: %d from %s", is_tx ? "TX" : "RX", buffer, len, is_ptr_ext, use_psram, alignment, need_malloc, (mem_cap & MALLOC_CAP_SPIRAM) ? "psram" : "internal");
+    ESP_EARLY_LOGV(SPI_TAG, "%s %p, len %d, is_ptr_ext %d, use_psram: %d, alignment: %d, need_malloc: %d from %s", is_tx ? "TX" : "RX", buffer, len, is_ptr_ext, use_psram, alignment, need_malloc, (mem_cap & MALLOC_CAP_SPIRAM) ? "psram" : "internal");
     if (need_malloc) {
         ESP_RETURN_ON_FALSE_ISR(!(flags & SPI_TRANS_DMA_BUFFER_ALIGN_MANUAL), ESP_ERR_INVALID_ARG, SPI_TAG, "Set flag SPI_TRANS_DMA_BUFFER_ALIGN_MANUAL but %s addr&len not align to %d, or not dma_capable", is_tx ? "TX" : "RX", alignment);
         len = (len + alignment - 1) & (~(alignment - 1));   // up align alignment

--- a/components/esp_mm/esp_cache_msync.c
+++ b/components/esp_mm/esp_cache_msync.c
@@ -102,7 +102,7 @@ esp_err_t esp_cache_msync(void *addr, size_t size, int flags)
     uint32_t cache_id = 0;
     valid = cache_hal_vaddr_to_cache_level_id(vaddr, size, &cache_level, &cache_id);
     if (!valid) {
-        ESP_EARLY_LOGD(TAG, "vaddr is not in cacheable range, do nothing");
+        ESP_EARLY_LOGV(TAG, "vaddr is not in cacheable range, do nothing");
         return ESP_ERR_NOT_SUPPORTED;
     }
 


### PR DESCRIPTION
SPI component is overly verbose about its
handling of pre-DMA cache<->memory
synchronization. This commit moves the logs to
verbose level, as [it seems to fit the criteria
for it](https://github.com/espressif/esp-idf/blob/487551888a46971a07e33caef3312fe3a6f5cf68/docs/en/api-reference/system/log.rst?plain=1#L53).
Also
<img width="807" height="1376" alt="Screenshot From 2025-12-09 20-58-34" src="https://github.com/user-attachments/assets/21d3cf3c-a806-4cbb-b4cd-c2dba6288368" />

Yeah!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Demotes specific SPI DMA and cache msync logs from DEBUG to VERBOSE to reduce log noise.
> 
> - **Logging**:
>   - Demote SPI DMA buffer alignment message in `components/esp_driver_spi/src/gpspi/spi_master.c` from `ESP_EARLY_LOGD` to `ESP_EARLY_LOGV`.
>   - Demote cache range validity message in `components/esp_mm/esp_cache_msync.c` from `ESP_EARLY_LOGD` to `ESP_EARLY_LOGV`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59933e16b5db033c1b0e892047c28ff65070c9d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->