### PR TITLE
feat(app_update): esp_ota_set_boot_partition_without_validate() (IDFGH-16972)

### DIFF
--- a/components/app_update/esp_ota_ops.c
+++ b/components/app_update/esp_ota_ops.c
@@ -682,6 +682,15 @@ esp_err_t esp_ota_set_boot_partition(const esp_partition_t *partition)
         return ESP_ERR_OTA_VALIDATE_FAILED;
     }
 
+    return esp_ota_set_boot_partition_without_validate(partition);
+}
+
+esp_err_t esp_ota_set_boot_partition_without_validate(const esp_partition_t* partition)
+{
+    if (partition == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
     // if set boot partition to factory bin ,just format ota info partition
     if (partition->type == ESP_PARTITION_TYPE_APP) {
         if (partition->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY) {

--- a/components/app_update/include/esp_ota_ops.h
+++ b/components/app_update/include/esp_ota_ops.h
@@ -209,6 +209,8 @@ esp_err_t esp_ota_abort(esp_ota_handle_t handle);
 /**
  * @brief Configure OTA data for a new boot partition
  *
+ * Equivalent to esp_image_verify() followed by esp_ota_set_boot_partition_without_validate().
+ *
  * @note If this function returns ESP_OK, calling esp_restart() will boot the newly configured app partition.
  *
  * @param partition Pointer to info for partition containing app image to boot.
@@ -221,6 +223,21 @@ esp_err_t esp_ota_abort(esp_ota_handle_t handle);
  *    - ESP_ERR_FLASH_OP_TIMEOUT or ESP_ERR_FLASH_OP_FAIL: Flash erase or write failed.
  */
 esp_err_t esp_ota_set_boot_partition(const esp_partition_t* partition);
+
+/**
+ * @brief Configure OTA data for a new boot partition without validating the image
+ *
+ * @note If this function returns ESP_OK, calling esp_restart() will boot the newly configured app partition.
+ *
+ * @param partition Pointer to info for partition containing app image to boot.
+ *
+ * @return
+ *    - ESP_OK: OTA data updated, next reboot will use specified partition.
+ *    - ESP_ERR_INVALID_ARG: partition argument was NULL or didn't point to a valid OTA partition of type "app".
+ *    - ESP_ERR_NOT_FOUND: OTA data partition not found.
+ *    - ESP_ERR_FLASH_OP_TIMEOUT or ESP_ERR_FLASH_OP_FAIL: Flash erase or write failed.
+ */
+esp_err_t esp_ota_set_boot_partition_without_validate(const esp_partition_t* partition);
 
 /**
  * @brief Get partition info of currently configured boot app


### PR DESCRIPTION
## Description

`esp_ota_end()` already performs `ota_verify_partition()` so there is no need for a second verification on `esp_ota_set_boot_partition_without_validate()`.

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a no-validate boot-partition setter and refactors `esp_ota_set_boot_partition()` to validate then delegate; updates public header/docs accordingly.
> 
> - **OTA boot selection**:
>   - Add `esp_ota_set_boot_partition_without_validate()` in `components/app_update/esp_ota_ops.c` and declare it in `include/esp_ota_ops.h`.
>   - Refactor `esp_ota_set_boot_partition()` to perform image validation then call `esp_ota_set_boot_partition_without_validate()`.
> - **API docs**:
>   - Document new function and note equivalence of `esp_ota_set_boot_partition()` to `esp_image_verify()` + `esp_ota_set_boot_partition_without_validate()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ab3735c2e6ae0c1bba8d30f2bc8dbe43437b4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->