### PR TITLE
(fix/examples): Fix memory allocation checks for rssi and scanned_name (IDFGH-17024)

### DIFF
--- a/examples/bluetooth/hci/ble_adv_scan_combined/main/app_bt.c
+++ b/examples/bluetooth/hci/ble_adv_scan_combined/main/app_bt.c
@@ -309,7 +309,7 @@ void hci_evt_process(void *pvParameters)
 
                     /* Counts of advertisements done. This count is set in advertising data every time before advertising. */
                     rssi = (short int *)malloc(sizeof(short int) * num_responses);
-                    if (data_len == NULL) {
+                    if (rssi == NULL) {
                         ESP_LOGE(TAG, "Malloc rssi failed!");
                         goto reset;
                     }
@@ -320,7 +320,7 @@ void hci_evt_process(void *pvParameters)
                     /* Extracting advertiser's name. */
                     data_msg_ptr = 0;
                     scanned_name = (ble_scan_local_name_t *)malloc(num_responses * sizeof(ble_scan_local_name_t));
-                    if (data_len == NULL) {
+                    if (scanned_name == NULL) {
                         ESP_LOGE(TAG, "Malloc scanned_name failed!");
                         goto reset;
                     }


### PR DESCRIPTION
## Description
Updated memory allocation checks to correctly verify pointer validity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures proper pointer validation during BLE advertising report parsing to avoid potential crashes.
> 
> - In `app_bt.c` (`hci_evt_process`), replace mistaken `data_len == NULL` checks with correct checks for `rssi` and `scanned_name` after their respective `malloc` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de7f311233415640447a1012d7552d0fd3ace797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->