### PR TITLE
Fixes TWAI arbitration lost event handling (IDFGH-17068)

### DIFF
--- a/components/esp_hal_twai/twai_hal_v1.c
+++ b/components/esp_hal_twai/twai_hal_v1.c
@@ -288,6 +288,7 @@ uint32_t twai_hal_get_events(twai_hal_context_t *hal_ctx)
             .form_err = (type == TWAI_LL_ERR_FORM),
             .stuff_err = (type == TWAI_LL_ERR_STUFF),
             .ack_err = (type == TWAI_LL_ERR_OTHER) && (seg == TWAI_LL_ERR_SEG_ACK_SLOT),
+            .arb_lost = 0,
         };
         hal_ctx->errors = errors;
 #if TWAI_LL_HAS_RX_FRAME_ISSUE
@@ -301,6 +302,7 @@ uint32_t twai_hal_get_events(twai_hal_context_t *hal_ctx)
 #endif
     }
     if (events & TWAI_HAL_EVENT_ARB_LOST) {
+        hal_ctx->errors.arb_lost = 1;
         twai_ll_clear_arb_lost_cap(hal_ctx->dev);
     }
 #if TWAI_LL_HAS_RX_FIFO_ISSUE


### PR DESCRIPTION
Ensures the arbitration lost flag is correctly set when the
TWAI_HAL_EVENT_ARB_LOST event is detected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix arbitration-lost handling**
> 
> - Initializes `errors.arb_lost` to `0` during bus-error (`BEI`) decode in `twai_hal_get_events`
> - Sets `hal_ctx->errors.arb_lost = 1` and clears arb-lost capture when `TWAI_HAL_EVENT_ARB_LOST` (ALI) is raised
> 
> Improves correctness of `twai_error_flags_t` reporting for arbitration loss.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d7d682d1919326226bb80ecef4452dddc66e7be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->