### PR TITLE
Fix "IMPORTED_LOCATION not set for imported target" CMake errors during codemodel-v2 api queries with CMake 4.2 (IDFGH-17071)

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -286,6 +286,8 @@ function(__build_init idf_path)
     # Create the build target, to which the ESP-IDF build properties, dependencies are attached to.
     # Must be global so as to be accessible from any subdirectory in custom projects.
     add_library(__idf_build_target STATIC IMPORTED GLOBAL)
+    # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+    set_property(TARGET __idf_build_target PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
 
     # Set the Python path (which may be passed in via -DPYTHON=) and store in a build property
     set_default(PYTHON "python")

--- a/tools/cmake/component.cmake
+++ b/tools/cmake/component.cmake
@@ -167,6 +167,8 @@ function(__component_add component_dir prefix component_source)
     if(NOT component_target IN_LIST component_targets)
         if(NOT TARGET ${component_target})
             add_library(${component_target} STATIC IMPORTED)
+            # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+            set_property(TARGET ${component_target} PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
         endif()
         idf_build_set_property(__COMPONENT_TARGETS ${component_target} APPEND)
     else()


### PR DESCRIPTION
esp-idf uses imported targets as dummy targets that are never linked. Previous CMake versions would ignore these and not error on unset IMPORTED_LOCATION if they are never actually linked. CMake 4.2 and newer errors during codemodel-v2 api queries when imported targets are missing IMPORTED_LOCATION, so set a dummy location that would error when actually linked, which fixes the error during api queries.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

esp-idf uses `IMPORTED` targets extensively for internal bookkeeping, but most of these are never linked into a binary, so esp-idf never sets the `IMPORTED_LOCATION` property.

CMake 4.2 and later now include `IMPORTED` target information in codemodel-v2 api queries (which are often used by IDEs to gather information about a CMake project), which causes CMake to print a non-fatal error for every `IMPORTED` target without an `IMPORTED_LOCATION` property.

## Testing

- Create an esp-idf example application
- Build it with `idf.py build` (works)
- Run `install -D /dev/null build/.cmake/api/v1/query/codemodel-v2` to trigger a codemodel-v2 api query on next build
- Run `idf.py reconfigure` (breaks)
- Observe the following errors:

```
-- Configuring done (2.9s)
-- Generating done (0.2s)
CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_trace".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_trace".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_update".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_update".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader_support".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader_support".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bt".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bt".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cmock".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cmock".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_console".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_console".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cxx".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cxx".

...

CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_xtensa".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_xtensa".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "__idf_build_target".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "__idf_build_target".


-- Build files have been written to: /tmp/tmp.GWBrOKTmsz/build
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures IDE codemodel queries with CMake 4.2+ don't error on `IMPORTED` targets lacking `IMPORTED_LOCATION`.
> 
> - In `build.cmake`, set `IMPORTED_LOCATION` for `__idf_build_target` to `${CMAKE_CURRENT_BINARY_DIR}/dummy.a`
> - In `component.cmake`, set `IMPORTED_LOCATION` for each imported component target (`___<prefix>_<name>`) to the same dummy archive
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da756f43a2f0c7907ba1dc603ac2eece07ff290c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->