### PR TITLE
fix(freertos): Correct misleading error messages for vPortEnter/ExitCritical (IDFGH-17077)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/portable/riscv/port.c
+++ b/components/freertos/FreeRTOS-Kernel/portable/riscv/port.c
@@ -600,7 +600,7 @@ void vPortExitCriticalCompliance(portMUX_TYPE *mux)
 void vPortEnterCritical(void)
 {
 #if (configNUM_CORES > 1)
-        esp_rom_printf("vPortEnterCritical(void) is not supported on single-core targets. Please use vPortEnterCriticalMultiCore(portMUX_TYPE *mux) instead.\n");
+        esp_rom_printf("vPortEnterCritical(void) is not supported on multi-core targets. Please use vPortEnterCriticalMultiCore(portMUX_TYPE *mux) instead.\n");
         abort();
 #endif /* (configNUM_CORES > 1) */
     BaseType_t state = portSET_INTERRUPT_MASK_FROM_ISR();
@@ -614,7 +614,7 @@ void vPortEnterCritical(void)
 void vPortExitCritical(void)
 {
 #if (configNUM_CORES > 1)
-        esp_rom_printf("vPortExitCritical(void) is not supported on single-core targets. Please use vPortExitCriticalMultiCore(portMUX_TYPE *mux) instead.\n");
+        esp_rom_printf("vPortExitCritical(void) is not supported on multi-core targets. Please use vPortExitCriticalMultiCore(portMUX_TYPE *mux) instead.\n");
         abort();
 #endif /* (configNUM_CORES > 1) */
 


### PR DESCRIPTION
## Description

The error messages for vPortEnterCritical and vPortExitCritical are misleading when they're called on a multi-core target, as they seem to imply that the call is NOT supported on a single-core target. In fact, they are, these functions are, however, not supported on multi-core targets, so the error message has been updated to reflect this.

## Related

None

## Testing

None, this is just a string change.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates misleading runtime error strings under `#if (configNUM_CORES > 1)` in `components/freertos/FreeRTOS-Kernel/portable/riscv/port.c`.
> 
> - Corrects messages in `vPortEnterCritical` and `vPortExitCritical` to state they are not supported on multi-core targets and to use `vPortEnterCriticalMultiCore(portMUX_TYPE *mux)` / `vPortExitCriticalMultiCore(portMUX_TYPE *mux)` instead
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc8c73696369093a056911a07f631390708a92a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->