### PR TITLE
Set CMake CACHE variables for mbedtls correctly (IDFGH-17095)

### DIFF
--- a/components/mbedtls/CMakeLists.txt
+++ b/components/mbedtls/CMakeLists.txt
@@ -124,11 +124,11 @@ if(CONFIG_MBEDTLS_CERTIFICATE_BUNDLE)
 endif()
 
 # Only build mbedtls libraries
-set(ENABLE_TESTING CACHE BOOL OFF)
-set(ENABLE_PROGRAMS CACHE BOOL OFF)
+set(ENABLE_TESTING OFF CACHE BOOL "mbedtls: enable testing")
+set(ENABLE_PROGRAMS OFF CACHE BOOL "mbedtls: enable programs")
 
 # Use pre-generated source files in mbedtls repository
-set(GEN_FILES CACHE BOOL OFF)
+set(GEN_FILES OFF CACHE BOOL "mbedtls: use pre-generated source files")
 
 # Make sure mbedtls finds the same Python interpreter as IDF uses
 idf_build_get_property(python PYTHON)

--- a/components/mbedtls/esp_tee/esp_tee_mbedtls.cmake
+++ b/components/mbedtls/esp_tee/esp_tee_mbedtls.cmake
@@ -19,11 +19,11 @@ idf_component_register(SRCS "${srcs}"
                        PRIV_REQUIRES "${priv_requires}")
 
 # Only build mbedtls libraries
-set(ENABLE_TESTING CACHE BOOL OFF)
-set(ENABLE_PROGRAMS CACHE BOOL OFF)
+set(ENABLE_TESTING OFF CACHE BOOL "mbedtls: enable testing")
+set(ENABLE_PROGRAMS OFF CACHE BOOL "mbedtls: enable programs")
 
 # Use pre-generated source files in mbedtls repository
-set(GEN_FILES CACHE BOOL OFF)
+set(GEN_FILES OFF CACHE BOOL "mbedtls: use pre-generated source files")
 
 # Needed to for include_next includes to work from within mbedtls
 include_directories("${COMPONENT_DIR}/port/include")


### PR DESCRIPTION


<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

In `components/mbedtls/CMakeLists.txt` and `components/mbedtls/esp_tee/esp_tee_mbedtls.cmake`, the CACHE variables `ENABLE_TESTING`, `ENABLE_PROGRAMS`, and `GEN_FILES` were set incorrectly.

The syntax for setting cache variables is actually `set(<variable> <value> CACHE <type> <docstring>)` and not `set(<variable> CACHE <type> <value>)`.

The previous code silently set the variables to the empty string.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Before the change:

- Build an example esp-idf project
- See the empty `ENABLE_TESTING:BOOL=` in `build/CMakeCache.txt`

After the change:

- Build an example esp-idf project
- See the correct `ENABLE_TESTING:BOOL=OFF` in `build/CMakeCache.txt`

Building before and after the change also results in the same binaries except for build time and esp-idf version string.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct CMake cache configuration for mbedtls.
> 
> - In `components/mbedtls/CMakeLists.txt` and `components/mbedtls/esp_tee/esp_tee_mbedtls.cmake`, replace incorrect cache `set()` usage with `set(<var> OFF CACHE BOOL "...")` for `ENABLE_TESTING`, `ENABLE_PROGRAMS`, and `GEN_FILES`.
> - Guarantees only mbedtls libraries build and that pre-generated sources are used by properly populating cache values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c3be2604e790275c47a077c4b84a4fb3d75746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->