### PR TITLE
doc: clarify NULL return value of esp_ota_get_last_invalid_partition (IDFGH-17099)

### DIFF
--- a/components/app_update/include/esp_ota_ops.h
+++ b/components/app_update/include/esp_ota_ops.h
@@ -362,7 +362,7 @@ esp_err_t esp_ota_mark_app_invalid_rollback_and_reboot(void);
 /**
  * @brief Returns last partition with invalid state (ESP_OTA_IMG_INVALID or ESP_OTA_IMG_ABORTED).
  *
- * @return partition.
+ * @return Pointer to the last invalid partition, or NULL if no invalid partition is recorded.
  */
 const esp_partition_t* esp_ota_get_last_invalid_partition(void);
 


### PR DESCRIPTION
docs(app_update): Clarify NULL return of esp_ota_get_last_invalid_partition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation in `components/app_update/include/esp_ota_ops.h` to explicitly state that `esp_ota_get_last_invalid_partition()` returns a pointer to the last invalid partition or `NULL` if none is recorded.
> 
> - No functional/code changes; header comment only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53d619a36f8f1e99b3a67d3186de70f4429a1a77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->