### PR TITLE
fix(build): Correct the usage example for function (IDFGH-17161)

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -75,8 +75,8 @@ endfunction()
 # @param[in] new_option the option to replace with (if empty, the old option will be removed)
 #
 # Example usage:
-#   idf_build_replace_options_from_property(COMPILE_OPTIONS "-Werror" "-Werror=all")
-#   idf_build_replace_options_from_property(COMPILE_OPTIONS "-Wno-error=extra" "")
+#   idf_build_replace_option_from_property(COMPILE_OPTIONS "-Werror" "-Werror=all")
+#   idf_build_replace_option_from_property(COMPILE_OPTIONS "-Wno-error=extra" "")
 #
 function(idf_build_replace_option_from_property property_name option_to_remove new_option)
     idf_build_get_property(current_list_of_options ${property_name})


### PR DESCRIPTION
fix(build): Correct the usage example for function idf_build_replace_option_from_property

## Description

Correct the spelling of the function name in the example usage.

## Testing

Copy/pasted the new example into my project and it worked.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x ] All CI checks (GH Actions) pass.
- [x ] Documentation is updated as needed.
- [x ] Tests are updated or added as necessary.
- [x ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation comment in `tools/cmake/build.cmake` to use the correct function name in the example (`idf_build_replace_option_from_property`), replacing the incorrect pluralized variant. No functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d25272d0de2be138678fa43234a45bc3d5eeb474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->