### PR TITLE
mbedtls: Add missing MBEDTLS_PK_RSA_ALT_SUPPORT Kconfig option (IDFGH-17174)

### DIFF
--- a/components/mbedtls/Kconfig
+++ b/components/mbedtls/Kconfig
@@ -999,6 +999,18 @@ menu "mbedTLS"
             help
                 Enable RSA. Needed to use RSA-xxx TLS ciphersuites.
 
+        config MBEDTLS_PK_RSA_ALT_SUPPORT
+            bool "Support external private RSA keys (eg from a HSM) in the PK layer"
+            default y
+            depends on MBEDTLS_RSA_C && SOC_DIG_SIGN_SUPPORTED
+            help
+                Support external private RSA keys (eg from a HSM) in the PK layer.
+
+                When enabled, the application can use mbedtls_pk_setup_rsa_alt() to
+                register a custom RSA signature callback.
+
+                See ESP-TLS documentation for more details about using DS peripheral.
+
         config MBEDTLS_ECP_C
             bool  "Enable Elliptic Curve Ciphers(ECC) support"
             default y


### PR DESCRIPTION
This pull request may fix #18181 .

The ESP-TLS component's ESP_TLS_USE_DS_PERIPHERAL config option depends on MBEDTLS_PK_RSA_ALT_SUPPORT, but this symbol was never defined in the Kconfig system. It only existed as a preprocessor macro in esp_config.h.

This caused the DS peripheral option to be unavailable in menuconfig, even on chips that support it (ESP32-S2, ESP32-S3, ESP32-C3, etc.), resulting in build errors when using ds_data in esp_http_client_config_t.

Add the missing Kconfig option with proper dependencies on MBEDTLS_RSA_C and SOC_DIG_SIGN_SUPPORTED.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ *] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a missing Kconfig symbol with conservative dependencies, affecting menuconfig visibility/build config rather than runtime crypto behavior.
> 
> **Overview**
> Adds the previously-missing `MBEDTLS_PK_RSA_ALT_SUPPORT` Kconfig option to the mbedTLS `Asymmetric Ciphers` menu.
> 
> The new option defaults to enabled and is gated by `MBEDTLS_RSA_C` and `SOC_DIG_SIGN_SUPPORTED`, allowing features (e.g., DS-peripheral-backed RSA signing via `mbedtls_pk_setup_rsa_alt()`) to be selected via menuconfig instead of relying on an undefined symbol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54020973a4af11b32252aaff39fc650bdb5c31d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->