### PR TITLE
Added the function of setting contrast for SSD1306. (IDFGH-17184)

### DIFF
--- a/components/esp_lcd/include/esp_lcd_panel_ssd1306.h
+++ b/components/esp_lcd/include/esp_lcd_panel_ssd1306.h
@@ -22,8 +22,10 @@ extern "C" {
 typedef struct {
     /**
      * @brief Display's height in pixels (64(default) or 32)
+     * @brief Display's contrast (128(default) or 0~255)
      */
     uint8_t height;
+    uint8_t contrast;
 } esp_lcd_panel_ssd1306_config_t;
 
 /**

--- a/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
+++ b/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
@@ -41,6 +41,7 @@ static const char *TAG = "lcd_panel.ssd1306";
 #define SSD1306_CMD_MIRROR_Y_OFF          0xC0
 #define SSD1306_CMD_MIRROR_Y_ON           0xC8
 #define SSD1306_CMD_SET_COMPINS           0xDA
+#define SSD1306_CMD_SET_CONTRAST          0x81
 
 static esp_err_t panel_ssd1306_del(esp_lcd_panel_t *panel);
 static esp_err_t panel_ssd1306_reset(esp_lcd_panel_t *panel);
@@ -56,6 +57,7 @@ typedef struct {
     esp_lcd_panel_t base;
     esp_lcd_panel_io_handle_t io;
     uint8_t height;
+    uint8_t contrast;
     gpio_num_t reset_gpio_num;
     int x_gap;
     int y_gap;
@@ -92,6 +94,7 @@ esp_err_t esp_lcd_new_panel_ssd1306(const esp_lcd_panel_io_handle_t io, const es
     ssd1306->reset_gpio_num = panel_dev_config->reset_gpio_num;
     ssd1306->reset_level = panel_dev_config->flags.reset_active_high;
     ssd1306->height = ssd1306_spec_config ? ssd1306_spec_config->height : 64;
+    ssd1306->contrast = ssd1306_spec_config ? ssd1306_spec_config->contrast : 128;
     ssd1306->base.del = panel_ssd1306_del;
     ssd1306->base.reset = panel_ssd1306_reset;
     ssd1306->base.init = panel_ssd1306_init;
@@ -166,6 +169,10 @@ static esp_err_t panel_ssd1306_init(esp_lcd_panel_t *panel)
                         "io tx param SSD1306_CMD_MIRROR_X_OFF failed");
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_MIRROR_Y_OFF, NULL, 0), TAG,
                         "io tx param SSD1306_CMD_MIRROR_Y_OFF failed");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_SET_CONTRAST, (uint8_t[]){
+        ssd1306->contrast  // set display contrast
+    }, 1), TAG, "io tx param SSD1306_CMD_SET_CONTRAST failed");
+    
     return ESP_OK;
 }
 


### PR DESCRIPTION
I found that the structure ssd1306_panel_t of SSD1306 does not have any parameters related to contrast, and there are no corresponding instructions in the macro definitions.
This time, the function for setting contrast has been added for SSD1306.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional config field and sends one additional init command; behavior is unchanged unless a custom contrast is provided (or relies on the new default of 128).
> 
> **Overview**
> Adds a new `contrast` field to `esp_lcd_panel_ssd1306_config_t` and stores it in the internal SSD1306 panel state (default `128`).
> 
> During `panel_ssd1306_init`, the driver now issues `SSD1306_CMD_SET_CONTRAST` (0x81) to apply the configured contrast when initializing the display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42425c1c7a65af98dade7761e883fe347b4a3878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->