### PR TITLE
(Components/esp_lcd) Adds the function of setting contrast for the SSD1306 display (IDFGH-17186)

### DIFF
--- a/components/esp_lcd/include/esp_lcd_panel_ssd1306.h
+++ b/components/esp_lcd/include/esp_lcd_panel_ssd1306.h
@@ -24,6 +24,10 @@ typedef struct {
      * @brief Display's height in pixels (64(default) or 32)
      */
     uint8_t height;
+    /**
+     * @brief Display's contrast (128(default) or 0~255)
+     */
+    uint8_t contrast;
 } esp_lcd_panel_ssd1306_config_t;
 
 /**

--- a/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
+++ b/components/esp_lcd/src/esp_lcd_panel_ssd1306.c
@@ -41,6 +41,7 @@ static const char *TAG = "lcd_panel.ssd1306";
 #define SSD1306_CMD_MIRROR_Y_OFF          0xC0
 #define SSD1306_CMD_MIRROR_Y_ON           0xC8
 #define SSD1306_CMD_SET_COMPINS           0xDA
+#define SSD1306_CMD_SET_CONTRAST          0x81
 
 static esp_err_t panel_ssd1306_del(esp_lcd_panel_t *panel);
 static esp_err_t panel_ssd1306_reset(esp_lcd_panel_t *panel);
@@ -91,7 +92,8 @@ esp_err_t esp_lcd_new_panel_ssd1306(const esp_lcd_panel_io_handle_t io, const es
     ssd1306->bits_per_pixel = panel_dev_config->bits_per_pixel;
     ssd1306->reset_gpio_num = panel_dev_config->reset_gpio_num;
     ssd1306->reset_level = panel_dev_config->flags.reset_active_high;
-    ssd1306->height = ssd1306_spec_config ? ssd1306_spec_config->height : 64;
+    ssd1306->height = (ssd1306_spec_config != NULL && ssd1306_spec_config->height != 0) ? ssd1306_spec_config->height : 64;
+    ssd1306->contrast = (ssd1306_spec_config != NULL && ssd1306_spec_config->contrast != 0) ? ssd1306_spec_config->contrast : 128;
     ssd1306->base.del = panel_ssd1306_del;
     ssd1306->base.reset = panel_ssd1306_reset;
     ssd1306->base.init = panel_ssd1306_init;
@@ -166,6 +168,10 @@ static esp_err_t panel_ssd1306_init(esp_lcd_panel_t *panel)
                         "io tx param SSD1306_CMD_MIRROR_X_OFF failed");
     ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_MIRROR_Y_OFF, NULL, 0), TAG,
                         "io tx param SSD1306_CMD_MIRROR_Y_OFF failed");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_io_tx_param(io, SSD1306_CMD_SET_CONTRAST, (uint8_t[]){
+        ssd1306->contrast  // set display contrast
+    }, 1), TAG, "io tx param SSD1306_CMD_SET_CONTRAST failed");
+    
     return ESP_OK;
 }
 


### PR DESCRIPTION
I found that the structure ssd1306_panel_t of SSD1306 does not have any parameters related to contrast, and there are no corresponding instructions in the macro definitions.
This submission adds the function of setting contrast to SSD1306.