### PR TITLE
fix(mbedtls): Add missing MBEDTLS_PK_RSA_ALT_SUPPORT Kconfig option (IDFGH-17188)

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -25,7 +25,7 @@ menu "ESP-TLS"
 
     config ESP_TLS_USE_DS_PERIPHERAL
         bool "Use Digital Signature (DS) Peripheral with ESP-TLS"
-        depends on ESP_TLS_USING_MBEDTLS && SOC_DIG_SIGN_SUPPORTED && MBEDTLS_PK_RSA_ALT_SUPPORT
+        depends on ESP_TLS_USING_MBEDTLS && SOC_DIG_SIGN_SUPPORTED
         default y
         help
             Enable use of the Digital Signature Peripheral for ESP-TLS.The DS peripheral


### PR DESCRIPTION
This pull request may fix #18181 . Because #18182 was submitted to the wrong branch (it should have been submitted to release/v5.5 instead of the master branch), a new submission has been created.

The ESP_TLS_USE_DS_PERIPHERAL option in esp-tls/Kconfig depends on MBEDTLS_PK_RSA_ALT_SUPPORT (added in commit 30f93c0516), but this Kconfig option was never defined in mbedtls/Kconfig.

Without this definition, the MBEDTLS_PK_RSA_ALT_SUPPORT symbol evaluates to 'n', making ESP_TLS_USE_DS_PERIPHERAL invisible in menuconfig and effectively disabling DS peripheral support.

This commit adds the missing Kconfig option to restore DS peripheral functionality.

Note: In v5.5.x, MBEDTLS_RSA_C is hardcoded in esp_config.h rather than being a Kconfig option, so this option only depends on SOC_DIG_SIGN_SUPPORTED.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Kconfig-only change that broadens when `ESP_TLS_USE_DS_PERIPHERAL` is selectable; behavior changes only via configuration.
> 
> **Overview**
> **Kconfig gating change:** Updates `components/esp-tls/Kconfig` so `ESP_TLS_USE_DS_PERIPHERAL` no longer depends on `MBEDTLS_PK_RSA_ALT_SUPPORT`, and is now controlled only by `ESP_TLS_USING_MBEDTLS && SOC_DIG_SIGN_SUPPORTED`.
> 
> This makes the DS peripheral option visible/selectable in `menuconfig` whenever digital signature hardware support is present, instead of being implicitly disabled by an unmet/undefined mbedTLS symbol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692d47b6b788a47a7ff2f9fa41e09b7cbc008c42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->