### PR TITLE
fix(bootloader): prevent unsigned overflow in partition table validation (IDFGH-17230)

### DIFF
--- a/components/bootloader_support/src/flash_partitions.c
+++ b/components/bootloader_support/src/flash_partitions.c
@@ -23,7 +23,7 @@ esp_err_t esp_partition_table_verify(const esp_partition_info_t *partition_table
 
         if (part->magic == ESP_PARTITION_MAGIC) {
             const esp_partition_pos_t *pos = &part->pos;
-            if (pos->offset > chip_size || pos->offset + pos->size > chip_size) {
+            if (pos->offset > chip_size || pos->size > chip_size - pos->offset) {
                 if (log_errors) {
                     ESP_LOGE(TAG, "partition %d invalid - offset 0x%"PRIx32" size 0x%"PRIx32" exceeds flash chip size 0x%"PRIx32,
                              num_parts, pos->offset, pos->size, chip_size);


### PR DESCRIPTION
## Summary

The bounds check in `esp_partition_table_verify()` uses:
```c
if (pos->offset > chip_size || pos->offset + pos->size > chip_size)
```

When both `pos->offset` and `pos->size` are large `uint32_t` values, their addition can silently wrap around to a small value, bypassing the validation and allowing an invalid partition entry to pass.

**Fix:** Replace with `pos->size > chip_size - pos->offset`, which is safe because the first condition already guarantees `pos->offset <= chip_size`.

## How it was found

Found via [esp-fuzzer](https://github.com/Eun0us/esp-fuzzer) with `-fsanitize=integer`.

## Test plan

- [x] Verified with crafted partition table where `offset + size` wraps `UINT32_MAX`
- [x] Normal partition tables still validate correctly (subtraction produces same result when no overflow)