### PR TITLE
fix(esp_https_server): SSL context leak when HTTPS server fails to start (IDFGH-17248)

### DIFF
--- a/components/esp_https_server/src/https_server.c
+++ b/components/esp_https_server/src/https_server.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2018-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -448,8 +448,9 @@ esp_err_t httpd_ssl_start(httpd_handle_t *pHandle, struct httpd_ssl_config *conf
 
     ret = httpd_start(&handle, &config->httpd);
     if (ret != ESP_OK) {
-        free(ssl_ctx);
-        ssl_ctx = NULL;
+        if (ssl_ctx) {
+            free_secure_context(ssl_ctx);
+        }
         return ret;
     }
 


### PR DESCRIPTION

## Description

Fixes SSL context memory leak when an HTTPS server fails to start. Frees dynamic memory that may have been allocated when starting the HTTPS server.

## Related

Fixes #18230 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized cleanup change on an error path; minimal behavior impact aside from preventing a memory leak.
> 
> **Overview**
> Fixes a resource leak when `httpd_ssl_start()` fails: on `httpd_start()` error, the code now tears down the HTTPS global SSL context via `free_secure_context()` (including TLS config/cert/key buffers) instead of only freeing the top-level pointer.
> 
> Also updates the SPDX copyright year to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5f58a14470e101eda0a19d5f773c07846974026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->