### PR TITLE
fix(esp_eth): Fixed designated initializer order in ETH_ESP32_EMAC_DEFAULT_CONFIG (IDFGH-17286)

### DIFF
--- a/components/esp_eth/include/esp_eth_mac_esp.h
+++ b/components/esp_eth/include/esp_eth_mac_esp.h
@@ -225,7 +225,6 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
         },                                                                    \
         .dma_burst_len = ETH_DMA_BURST_LEN_32,                                \
         .intr_priority = 0,                                                   \
-        .mdc_freq_hz = 0,                                                     \
         .emac_dataif_gpio =                                                   \
         {                                                                     \
             .rmii =                                                           \
@@ -246,6 +245,7 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
                 .clock_gpio = -1                                              \
             }                                                                 \
         },                                                                    \
+        .mdc_freq_hz = 0,                                                     \
     }
 #endif // CONFIG_IDF_TARGET_ESP32P4
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Compilation fails with the following error:
`components/esp_eth/include/esp_eth_mac_esp.h:303:5: error: designator order for field 'eth_esp32_emac_config_t::emac_dataif_gpio' does not match declaration order in 'eth_esp32_emac_config_t'`

Designated initializers must appear in the same order as the members are declared in the struct. The current initialization of eth_esp32_emac_config_t does not follow the declaration order, which results in a build error.

This PR moves .mdc_freq_hz to the correct position so that it matches the declaration order. This bug affects only ESP32-P4.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: reorders a single designated initializer in a default config macro to fix a compile-time struct member order error on ESP32-P4, with no functional logic changes expected.
> 
> **Overview**
> Fixes an ESP32-P4 build failure by reordering the `.mdc_freq_hz` designated initializer in `ETH_ESP32_EMAC_DEFAULT_CONFIG()` to match `eth_esp32_emac_config_t`’s member declaration order.
> 
> This is a *compile-time-only* change to the default EMAC configuration macro; runtime values remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56e1d95fc9ae810b8d4c674f8deaf9c2601a0b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->