### PR TITLE
fix(ulp): disable unsupported LP_IO_NUM7 for ESP32-C5 (IDFGH-17287)

### DIFF
--- a/components/ulp/lp_core/lp_core/include/ulp_lp_core_gpio.h
+++ b/components/ulp/lp_core/lp_core/include/ulp_lp_core_gpio.h
@@ -25,6 +25,7 @@ typedef enum {
     LP_IO_NUM_4 = 4,     /*!< GPIO4, input and output */
     LP_IO_NUM_5 = 5,     /*!< GPIO5, input and output */
     LP_IO_NUM_6 = 6,     /*!< GPIO6, input and output */
+#if SOC_RTCIO_PIN_COUNT > 7
     LP_IO_NUM_7 = 7,     /*!< GPIO7, input and output */
 #if SOC_RTCIO_PIN_COUNT > 8
     LP_IO_NUM_8 = 8,     /*!< GPIO8, input and output */
@@ -35,6 +36,7 @@ typedef enum {
     LP_IO_NUM_13 = 13,   /*!< GPIO13, input and output */
     LP_IO_NUM_14 = 14,   /*!< GPIO14, input and output */
     LP_IO_NUM_15 = 15,   /*!< GPIO15, input and output */
+#endif
 #endif
 } lp_io_num_t;
 


### PR DESCRIPTION
## Description
This PR disables `LP_IO_NUM7` for ESP32-C5 because GPIO7 does not support LP GPIO functionality on ESP32-C5.

## Related
The Technical Reference Manual for the ESP32-C5 states that LP GPIO only supports GPIO0 - GPIO6.  
https://documentation.espressif.com/api/resource/doc/file/XYbNDLY0/FILE/esp32-c5_technical_reference_manual_en.pdf#subsection.8.2.2

## Testing
I confirmed that GPIO7 configured as LP GPIO does not function on the ESP32-C5.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, compile-time-only change to an enum that reduces supported pins on certain targets; risk is limited to potential build/API compatibility issues for code referencing `LP_IO_NUM_7` on those SoCs.
> 
> **Overview**
> Updates `ulp_lp_core_gpio.h` so `LP_IO_NUM_7` is only defined when `SOC_RTCIO_PIN_COUNT > 7`, preventing builds from exposing an unsupported LP GPIO number on targets like ESP32-C5.
> 
> This effectively limits LP GPIO enumeration to `GPIO0`–`GPIO6` on affected chips while preserving `LP_IO_NUM_8+` behind the existing `SOC_RTCIO_PIN_COUNT > 8` guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 480974b4c2e75754c4347ddb206446c1b84d395a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->