### PR TITLE
docs: add Vale rules for more precise alternatives to animal-derived phrases (IDFGH-17293)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ XUNIT_RESULT*.xml
 
 # Vale
 .vale/styles/*
+!.vale/styles/Speciesism/

--- a/.vale.ini
+++ b/.vale.ini
@@ -73,7 +73,7 @@ https://dl.espressif.com/dl/esp-vale-config/Espressif-latest.zip
 
 # Enable styles to activate all rules included in them.
 # BasedOnStyles = Style1, Style2
-BasedOnStyles = Vale, Espressif-latest
+BasedOnStyles = Vale, Espressif-latest, Speciesism
 
 
 ### Deactivate individual rules ###

--- a/.vale/styles/Speciesism/AnimalIdioms.yml
+++ b/.vale/styles/Speciesism/AnimalIdioms.yml
@@ -1,0 +1,32 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'kill two birds with one stone': accomplish two things at once
+  'killing two birds with one stone': accomplishing two things at once
+  'killed two birds with one stone': accomplished two things at once
+  'beat a dead horse': belabor the point
+  'beating a dead horse': belaboring the point
+  'flog a dead horse': belabor the point
+  'flogging a dead horse': belaboring the point
+  'bring home the bacon': bring home the results
+  'bringing home the bacon': bringing home the results
+  'brought home the bacon': brought home the results
+  'more than one way to skin a cat': more than one way to solve this
+  'many ways to skin a cat': many ways to approach this
+  'let the cat out of the bag': reveal the secret
+  'letting the cat out of the bag': revealing the secret
+  'open a can of worms': create a complicated situation
+  'opening a can of worms': creating a complicated situation
+  'opened a can of worms': created a complicated situation
+  'wild goose chase': pointless pursuit
+  'take the bull by the horns': face the challenge head-on
+  'taking the bull by the horns': facing the challenge head-on
+  'took the bull by the horns': faced the challenge head-on
+  'like shooting fish in a barrel': extremely easy
+  'straight from the horse''s mouth': directly from the source
+  'from the horse''s mouth': from a reliable source
+  'whack-a-mole': recurring problem
+  'whack a mole': recurring problem

--- a/.vale/styles/Speciesism/AnimalMetaphors.yml
+++ b/.vale/styles/Speciesism/AnimalMetaphors.yml
@@ -1,0 +1,14 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This term references animals as objects or tools."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'guinea pig': test subject
+  'sacred cow': unquestioned belief
+  'sacred cows': unquestioned beliefs
+  'scapegoat(?:ed|ing)?': wrongly blamed
+  'dog-eat-dog': ruthlessly competitive
+  'dog eat dog': ruthlessly competitive
+  'rat race': competitive grind
+  'red herring': false lead

--- a/.vale/styles/Speciesism/TechTerminology.yml
+++ b/.vale/styles/Speciesism/TechTerminology.yml
@@ -1,0 +1,13 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This technical term has a more precise alternative."
+level: suggestion
+ignorecase: true
+swap:
+  'canary deployment': progressive rollout
+  'canary release': progressive rollout
+  'canary test(?:ing)?': incremental testing
+  'monkey[- ]?patch(?:ed|ing)?': runtime patch
+  'duck[- ]?typ(?:ed|ing)': structural typing
+  'dogfood(?:ing)?': self-hosting
+  'eat(?:ing)? (?:your|our|their) own dogfood': self-testing
+  'rubber duck(?:ing)? debugging': talk-through debugging


### PR DESCRIPTION
## Summary

Adds Vale substitution rules that suggest more precise alternatives to common animal-derived idioms and metaphors in ESP-IDF documentation.

Examples of suggested substitutions:
- "kill two birds with one stone" → "accomplish two things at once"
- "guinea pig" → "test subject"
- "monkey-patch" → "runtime patch" (suggestion level)

Three rule files under `.vale/styles/Speciesism/`:
- **AnimalIdioms.yml** — 26 patterns for common idioms (`warning` level)
- **AnimalMetaphors.yml** — 8 patterns for objectifying metaphors (`warning` level)
- **TechTerminology.yml** — 8 patterns for animal-derived tech jargon (`suggestion` level)

## Motivation

ESP-IDF's Vale config already enables `Google.Gender`, `Google.GenderBias`, and `Google.Slang`, showing attention to inclusive and clear documentation language. These speciesism rules extend that in the same direction — the suggested alternatives are often clearer for non-native English speakers while avoiding phrases that casually reference violence toward animals.

This follows a growing trend in open source documentation projects (webpack.js.org, Elastic, Datadog, OpenSearch, and others) adopting similar rules.

All suggestions reference [this peer-reviewed paper](https://doi.org/10.1007/s43681-023-00380-w).

## Changes

- Added `.vale/styles/Speciesism/` with three rule files
- Updated `.vale.ini` to include `Speciesism` in `BasedOnStyles`
- Updated `.gitignore` to un-ignore the committed Speciesism style (other styles are downloaded via `vale sync`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-lint configuration only; main impact is additional Vale warnings/suggestions that could affect CI if linting is enforced.
> 
> **Overview**
> Adds a new Vale style, `Speciesism`, with substitution rules that flag animal-derived idioms/metaphors and suggest alternative phrasing (warnings for idioms/metaphors; suggestions for a few tech terms).
> 
> Updates `.vale.ini` to enable the `Speciesism` style for `*.md`/`*.rst`, and adjusts `.gitignore` to commit `.vale/styles/Speciesism/` while continuing to ignore other synced Vale styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19928d105914fa40a5f7dd445ae439bf47bc8bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->