### PR TITLE
Kampi/feature 18282 (IDFGH-17297)

### DIFF
--- a/components/esp_lcd/include/esp_lcd_io_spi.h
+++ b/components/esp_lcd/include/esp_lcd_io_spi.h
@@ -41,6 +41,7 @@ typedef struct {
         unsigned int sio_mode: 1;        /*!< Read and write through a single data line (MOSI) */
         unsigned int lsb_first: 1;       /*!< Transmit LSB bit first */
         unsigned int cs_high_active: 1;  /*!< CS line is high active */
+        unsigned int psram_mode: 1;      /*!< Enable direct transmissions from the PSRAM */
     } flags;                            /*!< Extra flags to fine-tune the SPI device */
 } esp_lcd_panel_io_spi_config_t;
 

--- a/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
+++ b/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
@@ -63,6 +63,7 @@ typedef struct {
         unsigned int dc_param_level: 1;  // Indicates the level of DC line when transferring parameters
         unsigned int octal_mode: 1;      // Indicates whether the transmitting is enabled with octal mode (8 data lines)
         unsigned int quad_mode: 1;       // Indicates whether the transmitting is enabled with quad mode (4 data lines)
+        unsigned int psram_mode: 1;       // Indicates whether the transmitting is done from PSRAM
     } flags;
     lcd_spi_trans_descriptor_t trans_pool[]; // Transaction pool
 } esp_lcd_panel_io_spi_t;
@@ -106,6 +107,7 @@ esp_err_t esp_lcd_new_panel_io_spi(esp_lcd_spi_bus_handle_t bus, const esp_lcd_p
     spi_panel_io->flags.dc_param_level = !io_config->flags.dc_low_on_param;
     spi_panel_io->flags.octal_mode = io_config->flags.octal_mode;
     spi_panel_io->flags.quad_mode = io_config->flags.quad_mode;
+    spi_panel_io->flags.psram_mode = io_config->flags.psram_mode;
     spi_panel_io->on_color_trans_done = io_config->on_color_trans_done;
     spi_panel_io->user_ctx = io_config->user_ctx;
     spi_panel_io->lcd_cmd_bits = io_config->lcd_cmd_bits;
@@ -232,6 +234,10 @@ static esp_err_t panel_io_spi_tx_param(esp_lcd_panel_io_t *io, int lcd_cmd, cons
         lcd_trans->base.flags |= (SPI_TRANS_MULTILINE_CMD | SPI_TRANS_MULTILINE_ADDR | SPI_TRANS_MODE_OCT);
     }
 
+    if (spi_panel_io->flags.psram_mode) {
+        lcd_trans->base.flags |= SPI_TRANS_DMA_USE_PSRAM;
+    }
+
     if (send_cmd) {
         spi_lcd_prepare_cmd_buffer(spi_panel_io, &lcd_cmd);
         lcd_trans->flags.dc_gpio_level = spi_panel_io->flags.dc_cmd_level; // set D/C level in command phase
@@ -284,6 +290,10 @@ static esp_err_t panel_io_spi_rx_param(esp_lcd_panel_io_t *io, int lcd_cmd, void
     if (spi_panel_io->flags.octal_mode) {
         // use 8 lines for transmitting command, address and data
         lcd_trans->base.flags |= (SPI_TRANS_MULTILINE_CMD | SPI_TRANS_MULTILINE_ADDR | SPI_TRANS_MODE_OCT);
+    }
+
+    if (spi_panel_io->flags.psram_mode) {
+        lcd_trans->base.flags |= SPI_TRANS_DMA_USE_PSRAM;
     }
 
     if (send_cmd) {
@@ -347,6 +357,11 @@ static esp_err_t panel_io_spi_tx_color(esp_lcd_panel_io_t *io, int lcd_cmd, cons
             // use 8 lines for transmitting command, address and data
             lcd_trans->base.flags |= (SPI_TRANS_MULTILINE_CMD | SPI_TRANS_MULTILINE_ADDR | SPI_TRANS_MODE_OCT);
         }
+
+        if (spi_panel_io->flags.psram_mode) {
+            lcd_trans->base.flags |= SPI_TRANS_DMA_USE_PSRAM;
+        }
+
         // command is short, using polling mode
         ret = spi_device_polling_transmit(spi_panel_io->spi_dev, &lcd_trans->base);
         ESP_GOTO_ON_ERROR(ret, err, TAG, "spi transmit (polling) command failed");
@@ -389,6 +404,10 @@ static esp_err_t panel_io_spi_tx_color(esp_lcd_panel_io_t *io, int lcd_cmd, cons
         } else if (spi_panel_io->flags.quad_mode) {
             // use 4 lines only for transmitting data
             lcd_trans->base.flags |= SPI_TRANS_MODE_QIO;
+        }
+
+        if (spi_panel_io->flags.psram_mode) {
+            lcd_trans->base.flags |= SPI_TRANS_DMA_USE_PSRAM;
         }
 
         // color data is usually large, using queue+blocking mode


### PR DESCRIPTION
## Description

Add `SPI_TRANS_DMA_USE_PSRAM` to SPI LCD component.

## Related

See feature request #18282 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged unless the new `psram_mode` flag is enabled; when enabled it affects low-level SPI DMA flags and could expose PSRAM/DMA compatibility issues on some targets.
> 
> **Overview**
> Adds a new `psram_mode` bit to `esp_lcd_panel_io_spi_config_t.flags` and stores it in the SPI panel IO instance.
> 
> When enabled, all SPI LCD transactions (command/param read+write and queued color chunks) set `SPI_TRANS_DMA_USE_PSRAM`, allowing direct DMA transmissions from PSRAM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c87755f74b4379079ae46dbcd736c5f03d3091f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->