### PR TITLE
docs(spi_flash): Fix redundant phrasing in esp_flash_get_size description (IDFGH-17305)

### DIFF
--- a/components/spi_flash/include/esp_flash.h
+++ b/components/spi_flash/include/esp_flash.h
@@ -71,7 +71,7 @@ esp_err_t esp_flash_read_id(esp_flash_t *chip, uint32_t *out_id);
  *
  * @note 1. Most flash chips use a common format for flash ID, where the lower 4 bits specify the size as a power of 2. If
  * the manufacturer doesn't follow this convention, the size may be incorrectly detected.
- *       2. The out_size returned only stands for The out_size stands for the size in the binary image header.
+ *       2. The out_size stands for the size in the binary image header.
  *  If you want to get the real size of the chip, please call `esp_flash_get_physical_size` instead.
  *
  * @return ESP_OK on success, or a flash error code if operation failed.


### PR DESCRIPTION
Fixed a redundant wording in the comments for the esp_flash_get_size function to improve documentation clarity.

## Description

This pull request fixes a redundant phrasing in the Doxygen comments for the `esp_flash_get_size` function within the `esp_flash.h` header file. 

The original text in line 74 contained a repetitive sentence fragment: "returned only stands for The out_size stands for". This change simplifies it to a single, clear statement to maintain the professional quality of the API documentation.

## Related

- Documentation quality improvement for the SPI Flash component.
- No specific issue was opened as this was a minor typographical discovery during code review.

## Testing

- **Manual Inspection:** Verified the text correction directly in `components/spi_flash/include/esp_flash.h`.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [] Tests are updated or added as necessary.
- [] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change in a header comment; no functional or API behavior changes.
> 
> **Overview**
> Removes redundant/garbled wording in the Doxygen `@note` for `esp_flash_get_size()` in `esp_flash.h`, clarifying that `out_size` refers to the size in the binary image header and pointing users to `esp_flash_get_physical_size()` for the real chip size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e09e5d658fcffe9feb226fc0aedf87985fa0f5a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->