### PR TITLE
fix(esp_http_server): Dispatch PONG frames to WebSocket handler (IDFGH-17331)

### DIFF
--- a/components/esp_http_server/src/httpd_parse.c
+++ b/components/esp_http_server/src/httpd_parse.c
@@ -809,9 +809,16 @@ esp_err_t httpd_req_new(struct httpd_data *hd, struct sock_db *sd)
             ESP_LOGD(TAG, LOG_FMT("Received PONG frame"));
         }
 
-        /* Call handler if it's a non-control frame (or if handler requests control frames, as well) */
+        /* Call handler if it's a non-control frame, a PONG frame,
+         * or if handler requests control frames as well.
+         * PONG must be dispatched so that:
+         *  1. User code that sends PINGs can track responses (heartbeat)
+         *  2. The PONG frame bytes are consumed from the socket via
+         *     httpd_ws_recv_frame(), preventing TCP stream misalignment */
         if (ret == ESP_OK &&
-            (ra->ws_type < HTTPD_WS_TYPE_CLOSE || sd->ws_control_frames)) {
+            (ra->ws_type < HTTPD_WS_TYPE_CLOSE ||
+             ra->ws_type == HTTPD_WS_TYPE_PONG ||
+             sd->ws_control_frames)) {
             ret = sd->ws_handler(r);
         }
 


### PR DESCRIPTION
## Description

PONG frames (opcode `0xA`) are never dispatched to the user's WebSocket handler despite an existing comment at `httpd_parse.c:808` stating they should be ("Pass the PONG frames to the handler as well, as user app might send PINGs").

The dispatch condition `ra->ws_type < HTTPD_WS_TYPE_CLOSE` excludes PONG (`0xA`) since `HTTPD_WS_TYPE_CLOSE` is `0x8`.

This causes a **critical secondary bug**: when the server sends PING frames and the client responds with PONG, `httpd_ws_recv_frame()` is never called for the PONG, leaving the remaining frame bytes (second_byte plus 4-byte mask_key) unconsumed in the TCP buffer. On the next WebSocket read, these orphaned bytes are misinterpreted as a new frame header, causing either:
- "WS frame is not properly masked" errors
- EAGAIN timeouts with garbage length values

This effectively destroys the connection every time a PONG arrives.

## Fix

Add `ra->ws_type == HTTPD_WS_TYPE_PONG` to the dispatch condition in `httpd_parse.c` so PONG frames reach the user handler, which calls `httpd_ws_recv_frame()` to properly consume the frame bytes from the socket.

```c
if (ret == ESP_OK &&
    (ra->ws_type < HTTPD_WS_TYPE_CLOSE ||
     ra->ws_type == HTTPD_WS_TYPE_PONG ||
     sd->ws_control_frames)) {
    ret = sd->ws_handler(r);
}
```

Closes https://github.com/espressif/esp-idf/issues/18227

## Testing

Tested on ESP32-S3 (Seeed XIAO ESP32S3 Sense) with a WebSocket server sending PING frames every 10 seconds to browser clients. Before the fix, connections would fail with masking errors after the first PONG. After the fix, PONG frames are correctly dispatched and connections remain stable indefinitely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the WebSocket request dispatch path in `httpd_parse.c`; while the change is small, it alters which frames reach user handlers and affects on-the-wire stream consumption.
> 
> **Overview**
> Ensures WebSocket `PONG` frames are dispatched to the user `ws_handler` (even when `ws_control_frames` is disabled), aligning behavior with the existing intent and allowing user code to call `httpd_ws_recv_frame()` to consume the frame bytes.
> 
> Updates the dispatch condition and clarifies the comment to document why `PONG` must be handled (heartbeat support and preventing TCP/WebSocket stream misalignment).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89b921ff04b80b9b2a2b31a302a1d4767c77bf0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->