### PR TITLE
Update serial-studio-dashboard.json to comply with new formatting (IDFGH-17341)

### DIFF
--- a/examples/peripherals/mcpwm/mcpwm_bdc_speed_control/serial-studio-dashboard.json
+++ b/examples/peripherals/mcpwm/mcpwm_bdc_speed_control/serial-studio-dashboard.json
@@ -1,6 +1,12 @@
 {
+    "actions": [
+    ],
+    "decoder": 0,
+    "frameDetection": 1,
     "frameEnd": "*/",
+    "frameParser": "/**\n * Automatically migrated frame parser function.\n */\nfunction parse(frame) {\n    return frame.split(',');\n}",
     "frameStart": "/*",
+    
     "groups": [
         {
             "datasets": [


### PR DESCRIPTION
## Description

serial studio has updated the required format for the json file



## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema/format update to an example `serial-studio-dashboard.json` file; no firmware/runtime code paths change, but the dashboard may parse frames differently if the new `frameParser` behavior is incorrect.
> 
> **Overview**
> Updates the example `serial-studio-dashboard.json` to comply with the newer Serial Studio dashboard schema by adding required top-level fields (e.g., `actions`, `decoder`, `frameDetection`) and embedding a `frameParser` function that splits incoming frames on commas.
> 
> This is a formatting/config migration only; the dataset/group definitions are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41dab13688a4e9724ca23b4a15df05b5f4a9dd21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->