### PR TITLE
fix(fatfs): correct preprocessor guard for fail label when FF_FS_TINY=1 and FF_USE_DYN_BUFFER=1 (IDFGH-17355)

### DIFF
--- a/components/fatfs/src/ff.c
+++ b/components/fatfs/src/ff.c
@@ -4013,7 +4013,7 @@ FRESULT f_open (
 #endif
     }
 
-#if FF_USE_DYN_BUFFER
+#if !FF_FS_TINY && FF_USE_DYN_BUFFER
 fail:
 #endif
 


### PR DESCRIPTION

## Description

Fixes compiler error when enabling `CONFIG_FATFS_USE_DYN_BUFFERS=y` with `CONFIG_FATFS_FS_TINY=y`.

The `fail:` label was guarded by `#if FF_USE_DYN_BUFFER`, but the `goto fail` statement was guarded by `#if !FF_FS_READONLY && !FF_FS_TINY && FF_USE_DYN_BUFFER`.

When `FF_FS_TINY=1` and `FF_USE_DYN_BUFFER=1`:
- `goto fail` compiles to nothing (condition false)
- `fail:` label still exists (condition true)
- Result: `error: label 'fail' defined but not used [-Werror=unused-label]`

Changed the label guard to `#if !FF_FS_TINY && FF_USE_DYN_BUFFER` to match the `goto fail` condition.

## Related

## Testing

Built with `CONFIG_FATFS_USE_DYN_BUFFERS=y` and `CONFIG_FATFS_FS_TINY=y` and no longer produces unused label error.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single preprocessor-guard tweak to fix a compiler warning/error; no runtime behavior changes unless the code previously failed to compile under specific config combinations.
> 
> **Overview**
> Fixes a build failure when `FF_FS_TINY=1` with `FF_USE_DYN_BUFFER=1` by changing the preprocessor guard around the `fail:` label in `components/fatfs/src/ff.c`.
> 
> The `fail:` label is now only emitted when `!FF_FS_TINY && FF_USE_DYN_BUFFER`, matching the `goto fail` path and avoiding `-Werror=unused-label` in tiny-FS builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 043470174070aee1101a67b09a49a42b84bd5708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->