### PR TITLE
fix(esp_eth): fix compile error due to wrong order of fields (IDFGH-17358)

### DIFF
--- a/components/esp_eth/include/esp_eth_mac_esp.h
+++ b/components/esp_eth/include/esp_eth_mac_esp.h
@@ -225,7 +225,6 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
         },                                                                    \
         .dma_burst_len = ETH_DMA_BURST_LEN_32,                                \
         .intr_priority = 0,                                                   \
-        .mdc_freq_hz = 0,                                                     \
         .emac_dataif_gpio =                                                   \
         {                                                                     \
             .rmii =                                                           \
@@ -246,6 +245,7 @@ typedef bool (*ts_target_exceed_cb_from_isr_t)(esp_eth_mediator_t *eth, void *us
                 .clock_gpio = -1                                              \
             }                                                                 \
         },                                                                    \
+        .mdc_freq_hz = 0,                                                     \
     }
 #endif // CONFIG_IDF_TARGET_ESP32P4
 


### PR DESCRIPTION
## Description

In ESP-IDF version 5.5.3 there was a compile error when building a C++ project. Calling ETH_ESP32_EMAC_DEFAULT_CONFIG resulted in an error due to wrong order of struct fields:
```
/usr/share/esp-idf/components/esp_eth/include/esp_eth_mac_esp.h:303:5: error: designator order for field 'eth_esp32_emac_config_t::emac_dataif_gpio' does not match declaration order in 'eth_esp32_emac_config_t'
```

## Related

I could not find any open issue related with this. 

## Testing

Applying the patch locally allows to build the project.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reorders a single designated initializer field in a default config macro; no logic changes and minimal runtime impact.
> 
> **Overview**
> Fixes a C++ compilation error in `ETH_ESP32_EMAC_DEFAULT_CONFIG()` for ESP32-P4 by reordering the designated initializer so `.mdc_freq_hz` matches the field declaration order (after `clock_config_out_in`).
> 
> No functional behavior changes are intended; this is an initializer-order fix to satisfy stricter C++ designated-initializer rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac90297f64f160c15aedea6be60786677e54296. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->