### PR TITLE
Fix/jpeg p4 cache alignment for input buffers on P4 (IDFGH-17377)

### DIFF
--- a/components/esp_driver_jpeg/jpeg_decode.c
+++ b/components/esp_driver_jpeg/jpeg_decode.c
@@ -363,10 +363,20 @@ void *jpeg_alloc_decoder_mem(size_t size, const jpeg_decode_memory_alloc_cfg_t *
     /*
        Principle of buffer align.
        For output buffer(for decoder is 2DDMA write to PSRAM), both address and size should be aligned according to cache invalidate.
-       FOr input buffer(for decoder is PSRAM write to 2DDMA), no restriction for any align (both cache writeback and requirement from 2DDMA).
+       For input buffer(for decoder is PSRAM write to 2DDMA), no restriction for any align (both cache writeback and requirement from 2DDMA).
+       NOTE: If the chip uses write-back cache (like the ESP32-P4), the input buffer address and size must both be aligned; viz. the buffer_direction is insignificant.  (See also: jpeg_alloc_encoder_mem()).
     */
     size_t cache_align = 0;
     esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &cache_align);
+
+#if SOC_CACHE_WRITEBACK_SUPPORTED
+    /*
+      As noted above, mem_cfg->buffer_direction is ignored here; address and size must both be aligned regardless.
+    */ 
+    size = JPEG_ALIGN_UP(size, cache_align);
+    *allocated_size = size;
+    return heap_caps_aligned_calloc(cache_align, 1, size, MALLOC_CAP_SPIRAM);
+#else
     if (mem_cfg->buffer_direction == JPEG_DEC_ALLOC_OUTPUT_BUFFER) {
         size = JPEG_ALIGN_UP(size, cache_align);
         *allocated_size = size;
@@ -375,6 +385,7 @@ void *jpeg_alloc_decoder_mem(size_t size, const jpeg_decode_memory_alloc_cfg_t *
         *allocated_size = size;
         return heap_caps_calloc(1, size, MALLOC_CAP_SPIRAM);
     }
+#endif
 }
 
 /****************************************************************

--- a/components/esp_driver_jpeg/jpeg_encode.c
+++ b/components/esp_driver_jpeg/jpeg_encode.c
@@ -392,9 +392,19 @@ void *jpeg_alloc_encoder_mem(size_t size, const jpeg_encode_memory_alloc_cfg_t *
        Principle of buffer align.
        For output buffer(for decoder is 2DDMA write to PSRAM), both address and size should be aligned according to cache invalidate.
        For input buffer(for decoder is PSRAM write to 2DDMA), no restriction for any align (both cache writeback and requirement from 2DDMA).
+       NOTE: If the chip uses write-back cache (like the ESP32-P4), the input buffer address and size must both be aligned; viz. the buffer_direction is insignificant.  (See also: jpeg_alloc_decoder_mem()).
     */
     size_t cache_align = 0;
     esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &cache_align);
+
+#if SOC_CACHE_WRITEBACK_SUPPORTED
+    /*
+      As noted above, mem_cfg->buffer_direction is ignored here; address and size must both be aligned regardless.
+    */ 
+    size = JPEG_ALIGN_UP(size, cache_align);
+    *allocated_size = size;
+    return heap_caps_aligned_calloc(cache_align, 1, size, MALLOC_CAP_SPIRAM);
+#else
     if (mem_cfg->buffer_direction == JPEG_ENC_ALLOC_OUTPUT_BUFFER) {
         size = JPEG_ALIGN_UP(size, cache_align);
         *allocated_size = size;
@@ -403,6 +413,7 @@ void *jpeg_alloc_encoder_mem(size_t size, const jpeg_encode_memory_alloc_cfg_t *
         *allocated_size = size;
         return heap_caps_calloc(1, size, MALLOC_CAP_SPIRAM);
     }
+#endif
 }
 
 /****************************************************************


### PR DESCRIPTION
### **Problem**
On the **ESP32-P4**, the JPEG driver currently fails when using PSRAM-backed input buffers because it does not enforce cache-line alignment for the `JPEG_DEC_ALLOC_INPUT_BUFFER` (decoder) or `JPEG_ENC_ALLOC_INPUT_BUFFER` (encoder) directions.  Specifically, the allocation sizes are correctly aligned, but the start address of the allocations are incorrect.

Because the P4 utilizes a **write-back cache**, `esp_cache_msync` requires that both the **start address** and the **buffer size** be aligned to the cache line size (64 bytes). The existing allocation logic uses standard `heap_caps_calloc` for input buffers, which often results in a 4-byte offset, leading to a hard failure: `ESP_ERR_INVALID_ARG (0x102)` during cache synchronization.

### **Solution**
I have updated `jpeg_alloc_decoder_mem` and `jpeg_alloc_encoder_mem` to check for **`SOC_CACHE_WRITEBACK_SUPPORTED`**. 

* When this macro is true, the `buffer_direction` is ignored for alignment purposes.
* Both input and output buffers are now force-aligned using `JPEG_ALIGN_UP` for size and `heap_caps_aligned_calloc` for the address.
* This ensures full compatibility with the P4’s cache requirements while preserving the more optimized/relaxed allocation for write-through chips (like the original ESP32).

### **Testing performed**
* **Hardware:** ESP32-P4 (Waveshare 10.1-inch HMI All-in-One)
* **IDF Version:** v5.5
* **Result:** Confirmed that `esp_cache_msync` now returns `ESP_OK` (0x0). The previous alignment `LOGE` errors are resolved and JPEG decoding/encoding functions as expected.

### **Other Changes**
* Fixed a minor typo in the `jpeg_alloc_decoder_mem` and `jpeg_alloc_encoder_mem` header comments (corrected "FOr" to "For").
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [?] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes allocation behavior for JPEG encode/decode buffers on write-back-cache targets and could impact memory usage/alignment assumptions, but it is gated by `SOC_CACHE_WRITEBACK_SUPPORTED`.
> 
> **Overview**
> Ensures JPEG encode/decode PSRAM buffers are always cache-line aligned on write-back-cache targets (e.g., ESP32-P4) by ignoring `buffer_direction` and using `heap_caps_aligned_calloc` with size rounded up via `JPEG_ALIGN_UP`.
> 
> Keeps the prior behavior for non-write-back targets (only aligning decoder/encoder *output* buffers), and updates the allocation comments/typo to document the stricter alignment requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a0da9a8b9ee5dbf793f03a05555e7ce3432588b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->