### PR TITLE
fix(esp_http_client): reset response buffer and raw length before new… (IDFGH-17389)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -188,6 +188,7 @@ static const char *HTTP_METHOD_MAPPING[] = {
     "REPORT"
 };
 
+static void esp_http_client_cached_buf_cleanup(esp_http_buffer_t *res_buffer);
 esp_err_t esp_http_client_request_send(esp_http_client_handle_t client, int write_len);
 static esp_err_t esp_http_client_connect(esp_http_client_handle_t client);
 static esp_err_t esp_http_client_send_post_data(esp_http_client_handle_t client);
@@ -742,6 +743,12 @@ esp_err_t esp_http_client_prepare(esp_http_client_handle_t client)
     client->process_again = 0;
     client->response->data_process = 0;
     client->first_line_prepared = false;
+
+    // Reset the response buffer before each new request to ensure raw_data == orig_raw_data.
+    esp_http_client_cached_buf_cleanup(client->response->buffer);
+    // Also unconditionally reset raw_len.
+    client->response->buffer->raw_len = 0;
+
     /**
      * Clear location field before making a new HTTP request. Location
      * field should not be cleared in http_on_header* callbacks because


### PR DESCRIPTION
… HTTP requests

When making multiple requests using the same client connection, if the response isn't read or flushed before the next request it can cause the following crash.

```
assert failed: http_on_body esp_http_client.c:316 (res_buffer->orig_raw_data == res_buffer->raw_data)
```

## Testing

Applying this patch resolved the issue with manual testing in my project.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTTP client request lifecycle; while small, it changes how response buffering state is reset between requests and could affect applications relying on cached unread data across calls.
> 
> **Overview**
> Prevents crashes when reusing an `esp_http_client` handle for multiple requests by **clearing any cached response body buffer and resetting `raw_len`** at the start of `esp_http_client_prepare()`.
> 
> This ensures `res_buffer->raw_data` and `orig_raw_data` are consistent before parsing a new response, avoiding assertion failures if a previous response wasn’t fully read or flushed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f36127a5f89716ac46e26255db2c9f545e28056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->