### PR TITLE
Improve logging for VFS start_select function (IDFGH-17441)

### DIFF
--- a/components/vfs/vfs_calls.c
+++ b/components/vfs/vfs_calls.c
@@ -656,8 +656,13 @@ int esp_vfs_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds
         const vfs_entry_t *vfs = get_vfs_for_index(i);
         fds_triple_t *item = &vfs_fds_triple[i];
 
-        if (vfs == NULL || vfs->vfs->select == NULL || vfs->vfs->select->start_select == NULL) {
-            ESP_LOGD(TAG, "start_select function callback for this vfs (s_vfs[%d]) is not defined", vfs->offset);
+        if (vfs == NULL) {
+            ESP_LOGD(TAG, "start_select callback not defined: vfs is NULL at index %u", (unsigned)i);
+            continue;
+        }
+
+        if (vfs->vfs == NULL || vfs->vfs->select == NULL || vfs->vfs->select->start_select == NULL) {
+            ESP_LOGD(TAG, "start_select callback not defined for VFS offset %d", vfs->offset);
             continue;
         }
 


### PR DESCRIPTION
Resolves issue identified in https://github.com/espressif/esp-idf/issues/18398 by seperating logging when `vfs == NULL`

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk logging/control-flow change that avoids dereferencing a NULL `vfs` entry during `select()` setup and only affects debug output and early-continue behavior.
> 
> **Overview**
> Improves `esp_vfs_select()` diagnostics by splitting the `start_select`-missing log into two cases: **NULL VFS table entry** vs **VFS present but `start_select` not implemented**. This also avoids accessing `vfs->offset` when `vfs` is NULL, preventing misleading logs and potential NULL dereference in that path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a5d1af3de15fa291169652a9e8068f660715000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->