### PR TITLE
ci: fix DangerJS workflow permissions

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   pull-request-style-linter:


### PR DESCRIPTION
Security update: Modifies DangerJS workflow permissions from `contents: write` to `contents: read`.

**Enable workflow `.github/workflows/dangerjs.yml` when this merged - currently disabled!**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts GitHub Actions permissions, but it could cause the DangerJS job to fail if it previously relied on `contents: write`.
> 
> **Overview**
> Updates the DangerJS PR review workflow to use **read-only** repository `contents` permissions (from `write` to `read`) while keeping `pull-requests: write` for commenting on PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e3993cc4e9eb300fc560c1da23c5ceff731d0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->