### PR TITLE
feat(fatfs): add multi-sector readahead for move_window()    (IDFGH-17499)

### DIFF
--- a/components/fatfs/Kconfig
+++ b/components/fatfs/Kconfig
@@ -354,4 +354,18 @@ menu "FAT Filesystem support"
                 If 1, the file system will not trust the last allocated cluster number in the FSINFO (in FATFS struct).
                 This may result in more accurate output from `f_getfree()` function but increased overhead.
     endmenu
+
+    config FATFS_WINDOW_SECTORS
+        int "move_window sector buffer size"
+        default 1
+        range 1 16
+        help
+            Number of consecutive sectors buffered by move_window().
+            When a cache miss occurs, this many sectors are read in
+            a single disk operation (CMD18), amortizing per-transaction
+            SPI overhead. Default 1 preserves original single-sector
+            behavior. 8 is recommended for SD cards over SPI (~43%
+            faster directory listing at the cost of FF_MIN_SS * (N-1)
+            bytes of additional RAM in the FATFS struct).
+
 endmenu

--- a/components/fatfs/src/ff.c
+++ b/components/fatfs/src/ff.c
@@ -1066,6 +1066,9 @@ static FRESULT sync_window (	/* Returns FR_OK or FR_DISK_ERR */
 	if (fs->wflag) {	/* Is the disk access window dirty? */
 		if (disk_write(fs->pdrv, fs->win, fs->winsect, 1) == RES_OK) {	/* Write it back into the volume */
 			fs->wflag = 0;	/* Clear window dirty flag */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+			fs->ra_base = (LBA_t)0 - 1; fs->ra_count = 0;	/* Invalidate readahead on write */
+#endif
 			if (fs->winsect - fs->fatbase < fs->fsize) {	/* Is it in the 1st FAT? */
 				if (fs->n_fats == 2) disk_write(fs->pdrv, fs->win, fs->winsect + fs->fsize, 1);	/* Reflect it to 2nd FAT if needed */
 			}
@@ -1091,10 +1094,36 @@ static FRESULT move_window (	/* Returns FR_OK or FR_DISK_ERR */
 		res = sync_window(fs);		/* Flush the window */
 #endif
 		if (res == FR_OK) {			/* Fill sector window with new data */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+			/* Check readahead buffer first */
+			if (sect >= fs->ra_base && sect < fs->ra_base + fs->ra_count) {
+				/* Readahead hit */
+				memcpy(fs->win, fs->ra_buf + (UINT)(sect - fs->ra_base) * SS(fs), SS(fs));
+			} else {
+				/* Readahead miss — read multiple consecutive sectors */
+				UINT n = CONFIG_FATFS_WINDOW_SECTORS;
+				if (disk_read(fs->pdrv, fs->ra_buf, sect, n) != RES_OK) {
+					/* Fall back to single-sector read */
+					n = 1;
+					if (disk_read(fs->pdrv, fs->ra_buf, sect, 1) != RES_OK) {
+						sect = (LBA_t)0 - 1;
+						fs->ra_base = (LBA_t)0 - 1;
+						fs->ra_count = 0;
+						res = FR_DISK_ERR;
+						fs->winsect = sect;
+						return res;
+					}
+				}
+				fs->ra_base = sect;
+				fs->ra_count = n;
+				memcpy(fs->win, fs->ra_buf, SS(fs));
+			}
+#else
 			if (disk_read(fs->pdrv, fs->win, sect, 1) != RES_OK) {
 				sect = (LBA_t)0 - 1;	/* Invalidate window if read data is not valid */
 				res = FR_DISK_ERR;
 			}
+#endif
 			fs->winsect = sect;
 		}
 	}
@@ -1687,6 +1716,9 @@ static FRESULT dir_clear (	/* Returns FR_OK or FR_DISK_ERR */
 	if (sync_window(fs) != FR_OK) return FR_DISK_ERR;	/* Flush disk access window */
 	sect = clst2sect(fs, clst);		/* Top of the cluster */
 	fs->winsect = sect;				/* Set window to top of the cluster */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+	fs->ra_base = (LBA_t)0 - 1; fs->ra_count = 0;	/* Invalidate readahead (direct disk_write below) */
+#endif
 	memset(fs->win, 0, SS(fs));	/* Clear window buffer */
 #if FF_USE_LFN == 3		/* Quick table clear by using multi-secter write */
 	/* Allocate a temporary buffer */
@@ -3376,6 +3408,9 @@ static UINT check_fs (	/* 0:FAT/FAT32 VBR, 1:exFAT VBR, 2:Not FAT and valid BS, 
 
 
 	fs->wflag = 0; fs->winsect = (LBA_t)0 - 1;		/* Invaidate window */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+	fs->ra_base = (LBA_t)0 - 1; fs->ra_count = 0;
+#endif
 	if (move_window(fs, sect) != FR_OK) return 4;	/* Load the boot sector */
 	sign = ld_16(fs->win + BS_55AA);
 #if FF_FS_EXFAT
@@ -3515,6 +3550,10 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 #if FF_USE_DYN_BUFFER
     fs->win = ff_memalloc(SS(fs));		/* Allocate memory for sector buffer */
     if (!fs->win) return FR_NOT_ENOUGH_CORE;
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+    fs->ra_buf = ff_memalloc(SS(fs) * CONFIG_FATFS_WINDOW_SECTORS);
+    if (!fs->ra_buf) { ff_memfree(fs->win); fs->win = 0; return FR_NOT_ENOUGH_CORE; }
+#endif
 #endif
 
 	/* Find an FAT volume on the hosting drive */
@@ -3768,8 +3807,12 @@ FRESULT f_mount (
 		ff_mutex_delete(vol);
 #endif
 #if FF_USE_DYN_BUFFER
-        if (cfs->fs_type)           /* Check if the buffer was ever allocated */
+        if (cfs->fs_type) {         /* Check if the buffer was ever allocated */
             ff_memfree(cfs->win);   /* Deallocate buffer allocated for the filesystem object */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+            ff_memfree(cfs->ra_buf);
+#endif
+        }
 #endif
 		cfs->fs_type = 0;		/* Invalidate the filesystem object to be unregistered */
 	}

--- a/components/fatfs/src/ff.c
+++ b/components/fatfs/src/ff.c
@@ -1095,35 +1095,43 @@ static FRESULT move_window (	/* Returns FR_OK or FR_DISK_ERR */
 #endif
 		if (res == FR_OK) {			/* Fill sector window with new data */
 #if CONFIG_FATFS_WINDOW_SECTORS > 1
-			/* Check readahead buffer first */
-			if (sect >= fs->ra_base && sect < fs->ra_base + fs->ra_count) {
-				/* Readahead hit */
-				memcpy(fs->win, fs->ra_buf + (UINT)(sect - fs->ra_base) * SS(fs), SS(fs));
-			} else {
-				/* Readahead miss — read multiple consecutive sectors */
-				UINT n = CONFIG_FATFS_WINDOW_SECTORS;
-				if (disk_read(fs->pdrv, fs->ra_buf, sect, n) != RES_OK) {
-					/* Fall back to single-sector read */
-					n = 1;
-					if (disk_read(fs->pdrv, fs->ra_buf, sect, 1) != RES_OK) {
-						sect = (LBA_t)0 - 1;
-						fs->ra_base = (LBA_t)0 - 1;
-						fs->ra_count = 0;
-						res = FR_DISK_ERR;
-						fs->winsect = sect;
-						return res;
+			/* Readahead only for small-sector drives (SD cards over SPI, not WL flash).
+			   WL drives don't benefit from readahead (no SPI per-transaction overhead),
+			   and the static ra_buf is sized at FF_MIN_SS * N — a WL drive with
+			   SS(fs) > FF_MIN_SS would overflow it.  When FF_MIN_SS == FF_MAX_SS this
+			   comparison is compile-time true and the else branch is optimized out. */
+			if (SS(fs) == FF_MIN_SS) {
+				/* Check readahead buffer first */
+				if (sect >= fs->ra_base && sect < fs->ra_base + fs->ra_count) {
+					/* Readahead hit */
+					memcpy(fs->win, fs->ra_buf + (UINT)(sect - fs->ra_base) * SS(fs), SS(fs));
+				} else {
+					/* Readahead miss — read multiple consecutive sectors */
+					UINT n = CONFIG_FATFS_WINDOW_SECTORS;
+					if (disk_read(fs->pdrv, fs->ra_buf, sect, n) != RES_OK) {
+						/* Fall back to single-sector read */
+						n = 1;
+						if (disk_read(fs->pdrv, fs->ra_buf, sect, 1) != RES_OK) {
+							sect = (LBA_t)0 - 1;
+							fs->ra_base = (LBA_t)0 - 1;
+							fs->ra_count = 0;
+							res = FR_DISK_ERR;
+							fs->winsect = sect;
+							return res;
+						}
 					}
+					fs->ra_base = sect;
+					fs->ra_count = n;
+					memcpy(fs->win, fs->ra_buf, SS(fs));
 				}
-				fs->ra_base = sect;
-				fs->ra_count = n;
-				memcpy(fs->win, fs->ra_buf, SS(fs));
-			}
-#else
-			if (disk_read(fs->pdrv, fs->win, sect, 1) != RES_OK) {
-				sect = (LBA_t)0 - 1;	/* Invalidate window if read data is not valid */
-				res = FR_DISK_ERR;
-			}
+			} else
 #endif
+			{
+				if (disk_read(fs->pdrv, fs->win, sect, 1) != RES_OK) {
+					sect = (LBA_t)0 - 1;	/* Invalidate window if read data is not valid */
+					res = FR_DISK_ERR;
+				}
+			}
 			fs->winsect = sect;
 		}
 	}
@@ -3551,8 +3559,10 @@ static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
     fs->win = ff_memalloc(SS(fs));		/* Allocate memory for sector buffer */
     if (!fs->win) return FR_NOT_ENOUGH_CORE;
 #if CONFIG_FATFS_WINDOW_SECTORS > 1
-    fs->ra_buf = ff_memalloc(SS(fs) * CONFIG_FATFS_WINDOW_SECTORS);
-    if (!fs->ra_buf) { ff_memfree(fs->win); fs->win = 0; return FR_NOT_ENOUGH_CORE; }
+    if (SS(fs) == FF_MIN_SS) {
+        fs->ra_buf = ff_memalloc(FF_MIN_SS * CONFIG_FATFS_WINDOW_SECTORS);
+        if (!fs->ra_buf) { ff_memfree(fs->win); fs->win = 0; return FR_NOT_ENOUGH_CORE; }
+    }
 #endif
 #endif
 

--- a/components/fatfs/src/ff.h
+++ b/components/fatfs/src/ff.h
@@ -190,6 +190,17 @@ typedef struct {
 #else
 	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
 #endif
+							/* Note: when CONFIG_FATFS_WINDOW_SECTORS > 1, win[] is populated from
+							   ra_buf (readahead cache) rather than directly from disk_read(). */
+#if CONFIG_FATFS_WINDOW_SECTORS > 1
+	LBA_t	ra_base;		/* First sector in readahead buffer ((LBA_t)-1 = invalid) */
+	UINT	ra_count;		/* Number of valid sectors in readahead buffer */
+#if FF_USE_DYN_BUFFER
+	BYTE*	ra_buf;			/* Readahead sector buffer (dynamically allocated) */
+#else
+	BYTE	ra_buf[FF_MIN_SS * CONFIG_FATFS_WINDOW_SECTORS];	/* Readahead sector buffer */
+#endif
+#endif
 } FATFS;
 
 


### PR DESCRIPTION
Adds a configurable readahead buffer (FATFS_WINDOW_SECTORS) that reads                                                                                
  multiple consecutive sectors on a cache miss, amortizing per-transaction                                                                              
  SPI overhead. Default of 1 preserves existing single-sector behavior.                                                                                 
                                                                                                                                                        
  The readahead buffer is dynamically allocated via ff_memalloc() when                                                                                  
  FF_USE_DYN_BUFFER is enabled, ensuring DMA-capable/cache-aligned                                                                                      
  placement consistent with the win[] buffer.                                                                                                           
                                                                                                                                                        
  ## Description                                                                                                                                        
                                                                                                                                                        
  Each `move_window()` call currently issues a single-sector `disk_read()`. On SD cards over SPI,                                                       
  per-transaction protocol overhead (CMD, R1 response, data token wait, CRC16, CS toggle)
  dominates — measured at 661μs overhead vs 205μs actual data transfer per 512-byte sector                                                              
  (76% overhead). Sequential metadata access patterns (directory scanning, FAT chain traversal)                                                         
  issue hundreds of these back-to-back.                                                                                                                 
                                                                                                                                                        
  This PR adds a new Kconfig option `CONFIG_FATFS_WINDOW_SECTORS` (default 1, range 1–16) that                                                          
  controls how many consecutive sectors `move_window()` reads per cache miss. On a miss, sectors
  are read in a single multi-sector `disk_read()` call (CMD18) into a readahead buffer; subsequent                                                      
  `move_window()` calls for adjacent sectors are served from the buffer via `memcpy` with no disk I/O.                                                  
                                                                                                                                                        
  Benchmarked on an ESP32-S3 with SPI SD card at 20 MHz, listing 2249 files:                                                                            
                                                                                                                                                        
  | Metric | Before (1 sector) | After (8 sectors) | Delta |                                                                                            
  |--------|---:|---:|---:|                                 
  | disk_read calls | 640 | 89 | -86% |                                                                                                                 
  | disk_read time | 554ms | 289ms | -48% |                                                                                                             
  | readdir total | 793ms | 419ms | -47% |                                                                                                              
  | **Listing total** | **870ms** | **585ms** | **-33%** |                                                                                              
                                                                                                                                                        
  Cost: `FF_MIN_SS * (N-1)` bytes of additional RAM (e.g. 3.5KB at `WINDOW_SECTORS=8`).                                                                 
                                                                                                                                                        
  Key implementation details:                                                                                                                           
  - Default of 1 compiles to identical code (all readahead code is behind `#if CONFIG_FATFS_WINDOW_SECTORS > 1`)
  - Multi-sector read falls back to single-sector on failure                                                                                            
  - When `FF_USE_DYN_BUFFER` is enabled (default on master), `ra_buf` is allocated/freed via `ff_memalloc()`/`ff_memfree()` alongside `win`, ensuring   
  proper DMA/cache alignment                                                                                                                            
  - Readahead buffer is invalidated on dirty window writeback (`sync_window`), volume mount (`check_fs`), and directory cluster clearing (`dir_clear`)  
                                                                                                                                                        
  ## Related                                                                                                                                            
                                                                                                                                                        
  None — standalone enhancement to the FatFS component. Applies to both `master` and `release/v5.5`.                                                    
                                                            
  ## Testing                                                                                                                                            
                                                            
  - Existing fatfs test suite (`host_test`, `test_apps/dyn_buffers`, `test_apps/flash_wl`) passes unchanged — default `WINDOW_SECTORS=1` compiles out   
  all readahead code
  - The `dyn_buffers` allocation count test (expects exactly 2 allocations of `FF_MAX_SS`) is unaffected: `ra_buf` is a different size and only         
  allocated when `WINDOW_SECTORS > 1`                                                                                                                   
  - Functional testing with `WINDOW_SECTORS=8` on SPI SD card (ESP32-S3): mount, create files/directories, list 2249 files, read, write, unmount — no
  data corruption                                                                                                                                       
  - Performance benchmarked with `esp_timer_get_time()` instrumentation and FatFS source-level tracing
  - No dedicated CI test for `WINDOW_SECTORS > 1` yet — existing tests only exercise the default (no-op) path. Happy to add a `test_apps` variant if desired                                                                                                                                               
                                                                                                                                                        
  ---                                                                                                                                                   
                                                            
  ## Checklist                                                                                                                                          
                                                            
  - [x] 🚨 This PR does not introduce breaking changes.                                                                                                 
  - [ ] All CI checks (GH Actions) pass.
  - [ ] Documentation is updated as needed.                                                                                                             
  - [ ] Tests are updated or added as necessary.            
  - [x] Code is well-commented, especially in complex areas.                                                                                            
  - [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FatFS sector caching/mount code paths and adds new buffering/allocation logic, which could affect data integrity or memory usage on constrained targets when enabled. Default config keeps behavior unchanged, reducing blast radius.
> 
> **Overview**
> Adds new Kconfig `FATFS_WINDOW_SECTORS` (default `1`, range `1–16`) to let `move_window()` read and cache multiple consecutive sectors per miss to reduce SPI SD overhead.
> 
> When `CONFIG_FATFS_WINDOW_SECTORS > 1`, `FATFS` gains a readahead cache (`ra_base`/`ra_count`/`ra_buf`), `move_window()` serves hits via `memcpy` and fills the cache via multi-sector `disk_read()` with a single-sector fallback on failure; the cache is invalidated on writes (`sync_window`), mount/boot-sector checks (`check_fs`), and cluster clearing (`dir_clear`), and `ra_buf` is allocated/freed alongside `win` under `FF_USE_DYN_BUFFER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b9c1704c9b6de15d0770c24cf10da14b9b5cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->