### PR TITLE
Fixed typo of word switch (was spelled swtich) in pmu_struct.h (IDFGH-17500)

### DIFF
--- a/components/soc/esp32c5/register/soc/pmu_struct.h
+++ b/components/soc/esp32c5/register/soc/pmu_struct.h
@@ -617,7 +617,7 @@ typedef union {
         uint32_t sleep_switch_active_end  : 1;
         uint32_t sleep_switch_modem_end   : 1;
         uint32_t modem_switch_sleep_end   : 1;
-        uint32_t active_swtich_sleep_end  : 1;
+        uint32_t active_switch_sleep_end  : 1;
         uint32_t modem_switch_active_start: 1;
         uint32_t sleep_switch_active_start: 1;
         uint32_t sleep_switch_modem_start : 1;

--- a/components/soc/esp32c6/register/soc/pmu_struct.h
+++ b/components/soc/esp32c6/register/soc/pmu_struct.h
@@ -605,7 +605,7 @@ typedef union {
         uint32_t sleep_switch_active_end  : 1;
         uint32_t sleep_switch_modem_end   : 1;
         uint32_t modem_switch_sleep_end   : 1;
-        uint32_t active_swtich_sleep_end  : 1;
+        uint32_t active_switch_sleep_end  : 1;
         uint32_t modem_switch_active_start: 1;
         uint32_t sleep_switch_active_start: 1;
         uint32_t sleep_switch_modem_start : 1;

--- a/components/soc/esp32c61/register/soc/pmu_struct.h
+++ b/components/soc/esp32c61/register/soc/pmu_struct.h
@@ -635,7 +635,7 @@ typedef union {
         uint32_t sleep_switch_active_end  : 1;
         uint32_t sleep_switch_modem_end   : 1;
         uint32_t modem_switch_sleep_end   : 1;
-        uint32_t active_swtich_sleep_end  : 1;
+        uint32_t active_switch_sleep_end  : 1;
         uint32_t modem_switch_active_start: 1;
         uint32_t sleep_switch_active_start: 1;
         uint32_t sleep_switch_modem_start : 1;

--- a/components/soc/esp32h21/register/soc/pmu_struct.h
+++ b/components/soc/esp32h21/register/soc/pmu_struct.h
@@ -805,7 +805,7 @@ typedef union
         uint32_t sleep_switch_active_end  : 1;
         uint32_t sleep_switch_modem_end   : 1;
         uint32_t modem_switch_sleep_end   : 1;
-        uint32_t active_swtich_sleep_end  : 1;
+        uint32_t active_switch_sleep_end  : 1;
         uint32_t modem_switch_active_start: 1;
         uint32_t sleep_switch_active_start: 1;
         uint32_t sleep_switch_modem_start : 1;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Fixed a typo in the word switch (was spelled swtich) in a number of pmu_struct.h files

The pmu_struct.h files are for the following chips:
- esp32c5
- esp32c6
- esp32c61
- esp32h21
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Not needed or possible. The misspelled register is not used anywhere in ESP-IDF, nor any of the  examples or tests, so testing is not possible.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: header-only rename of a misspelled bitfield name in PMU register structs; no logic changes, but any out-of-tree code referencing the old identifier will need updating.
> 
> **Overview**
> Fixes a typo in the `pmu_lp_intr_reg_t` bitfield name across several SoC PMU register headers (`esp32c5`, `esp32c6`, `esp32c61`, `esp32h21`), renaming `active_swtich_sleep_end` to `active_switch_sleep_end` for consistency and correct spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41681eba2978c948c2b0ef8fe601ca78a5a96e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->