### PR TITLE
fix(lwip): prevent integer overflow in sys_arch_sem_wait timeout (IDFGH-17541)

### DIFF
--- a/components/lwip/port/freertos/sys_arch.c
+++ b/components/lwip/port/freertos/sys_arch.c
@@ -164,8 +164,12 @@ u32_t
 sys_arch_sem_wait(sys_sem_t *sem, u32_t timeout)
 {
   BaseType_t ret;
-
-  if (!timeout) {
+  /* * Protect against Integer Overflow: 
+   * If timeout is 0 (LwIP infinite wait), or if it's so large that adding 
+   * portTICK_PERIOD_MS would overflow the 32-bit unsigned integer,
+   * we force it to wait infinitely.
+   */
+  if (!timeout || timeout >= (UINT32_MAX - portTICK_PERIOD_MS)) {
     /* wait infinite */
     ret = xSemaphoreTake((QueueHandle_t)sem, portMAX_DELAY);
     LWIP_ASSERT("taking semaphore failed", ret == pdTRUE);


### PR DESCRIPTION
Description / Motivation:
This PR fixes a critical integer overflow vulnerability in sys_arch_sem_wait that causes an infinite spin-loop (starvation) when a maximum or near-maximum timeout value is passed, particularly when the RTOS tick rate is configured to 1000 Hz.

Root Cause Analysis:
When a third-party LwIP application (e.g., Barracuda App Server) attempts to wait infinitely by casting -1 to u32_t, the timeout argument becomes 0xFFFFFFFF.
The current macro used to round up ticks is:
TickType_t timeout_ticks = ((timeout + portTICK_PERIOD_MS - 1) / portTICK_PERIOD_MS) + 1;

If configTICK_RATE_HZ == 1000, portTICK_PERIOD_MS is 1.
The operation 0xFFFFFFFF + 1 overflows to 0. The math evaluates to exactly 0.
This passes 0 to xSemaphoreTake, resulting in an instant errQUEUE_EMPTY instead of blocking. The caller receives SYS_ARCH_TIMEOUT immediately, causing an infinite retry loop that hijacks the CPU (Starvation) and freezes the system.

(Note: At 100 Hz, the overflow results in a 1-tick delay, causing a silent performance drop rather than a hard freeze, which is likely why this went unnoticed).

The Fix:
Added a boundary check before the math operations:
if (!timeout || timeout >= (UINT32_MAX - portTICK_PERIOD_MS))
If the requested timeout is zero (standard LwIP infinite) or large enough to trigger an overflow when adding portTICK_PERIOD_MS, it is safely forced to portMAX_DELAY. This makes the function mathematically robust across all configTICK_RATE_HZ configurations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FreeRTOS/LwIP semaphore wait timing; while small, it changes blocking behavior for extreme timeout values and could affect edge-case timing in networking/concurrency paths.
> 
> **Overview**
> `sys_arch_sem_wait` now guards against 32-bit overflow when converting millisecond timeouts to FreeRTOS ticks by treating `timeout == 0` and near-`UINT32_MAX` values as an infinite wait (`portMAX_DELAY`). This prevents large/"-1 cast" timeouts from wrapping to a zero-tick wait and causing immediate `SYS_ARCH_TIMEOUT` returns (and potential busy-loop starvation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33feb7d6dd8fda16d2e5d51035e5040101dfb87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->