### PR TITLE
Adjust bus timing configuration in TWAI HAL (IDFGH-17543)

### DIFF
--- a/components/esp_hal_twai/twai_hal_v1.c
+++ b/components/esp_hal_twai/twai_hal_v1.c
@@ -86,7 +86,7 @@ void twai_hal_configure(twai_hal_context_t *hal_ctx, const twai_timing_config_t 
     }
 
     //Configure bus timing, acceptance filter, CLKOUT, and interrupts
-    twai_ll_set_bus_timing(hal_ctx->dev, brp, t_config->sjw, t_config->tseg_1, t_config->tseg_2, t_config->triple_sampling);
+    twai_ll_set_bus_timing(hal_ctx->dev, brp, t_config->sjw, t_config->tseg_1 + t_config->prop_seg, t_config->tseg_2, t_config->triple_sampling);
     twai_ll_set_acc_filter(hal_ctx->dev, f_config->acceptance_code, f_config->acceptance_mask, f_config->single_filter);
     twai_ll_set_clkout(hal_ctx->dev, clkout_divider);
 }


### PR DESCRIPTION
fixes https://github.com/espressif/esp-idf/issues/18477

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level TWAI/CAN timing parameters, which can affect baud rate/sample point and potentially break communication on existing setups if they relied on the previous (incorrect) segment calculation.
> 
> **Overview**
> Fixes TWAI v1 HAL bus timing setup by **including `prop_seg` in the configured phase segment 1**. In `twai_hal_configure()`, the value passed to `twai_ll_set_bus_timing()` now uses `tseg_1 + prop_seg` (matching the advanced timing path) so propagation delay is accounted for in the nominal bit timing configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88add4c174bbb4d3b0b06c03d28fbad5f05d86b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->