### PR TITLE
fix(sd): Disable warning about input line delay not supported (IDFGH-17561)

### DIFF
--- a/components/esp_driver_sdmmc/src/sd_host_sdmmc.c
+++ b/components/esp_driver_sdmmc/src/sd_host_sdmmc.c
@@ -201,7 +201,9 @@ static esp_err_t sd_host_slot_sdmmc_configure(sd_host_slot_handle_t slot, const 
 #if SOC_SDMMC_UHS_I_SUPPORTED
     ESP_RETURN_ON_FALSE(config->delayline < (SOC_SDMMC_DELAY_PHASE_NUM + 1), ESP_ERR_INVALID_ARG, TAG, "invalid delay line");
 #else
-    ESP_LOGW(TAG, "input line delay not supported, fallback to 0 delay");
+    if (config->delayline != SDMMC_DELAY_LINE_DISABLED) {
+        ESP_LOGW(TAG, "input line delay not supported, fallback to 0 delay");
+    }
 #endif
 
 #if CONFIG_IDF_TARGET_ESP32P4
@@ -235,7 +237,7 @@ static esp_err_t sd_host_slot_sdmmc_configure(sd_host_slot_handle_t slot, const 
 #endif
         slot_ctx->delay_phase.delay_phase_state = SD_HOST_SLOT_STATE_READY;
     }
-    if (config->delayline != 0) {
+    if (config->delayline != SDMMC_DELAY_LINE_DISABLED) {
 #if SOC_SDMMC_UHS_I_SUPPORTED
         slot_ctx->delay_line.delayline = config->delayline;
 #else

--- a/components/esp_hal_sd/include/hal/sd_types.h
+++ b/components/esp_hal_sd/include/hal/sd_types.h
@@ -64,6 +64,7 @@ typedef enum {
  * @brief SD/MMC Host clock timing delay lines
  */
 typedef enum {
+    SDMMC_DELAY_LINE_DISABLED = 0,  /*!< Delay line disabled */
     SDMMC_DELAY_LINE_0 = 1,         /*!< Delay line 0 */
     SDMMC_DELAY_LINE_1,             /*!< Delay line 1 */
     SDMMC_DELAY_LINE_2,             /*!< Delay line 2 */


### PR DESCRIPTION
## Description

Remove confusing log message introduced in ESP-IDF v6.0.

Alternatively it should only be printed if value is anything other than 0, in which case an `SDMMC_DELAY_LINE_DISABLED = 0` or similar should be introduced.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to SDMMC configuration defaults/logging and introduce a clearer sentinel value for a disabled delay line, with minimal behavioral impact beyond when warnings are emitted and when delay-line config is applied.
> 
> **Overview**
> Reduces noisy SDMMC init logging by only warning about unsupported input delay lines when the caller explicitly requests a delay line.
> 
> Introduces `SDMMC_DELAY_LINE_DISABLED = 0` and updates slot configuration to treat this as the “do not configure delay line” sentinel (replacing `!= 0` checks), keeping delay-line state untouched unless enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b621c3496f33bd0e2162d65dafb21c601fcf46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->