### PR TITLE
fix(bootloader_support): Fix app verification when split across multiple mmaps (IDFGH-17562)

### DIFF
--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -79,7 +79,7 @@ static esp_err_t process_segments(esp_image_metadata_t *data, bool silent, bool 
 static esp_err_t process_segment(int index, uint32_t flash_addr, esp_image_segment_header_t *header, bool silent, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum, esp_image_metadata_t *metadata);
 
 /* split segment and verify if data_len is too long */
-static esp_err_t process_segment_data(int segment, intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum, esp_image_metadata_t *metadata);
+static esp_err_t process_segment_data(int segment, intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum, esp_image_metadata_t *metadata, bool first_iteration);
 
 /* Verify the main image header */
 static esp_err_t verify_image_header(uint32_t src_addr, const esp_image_header_t *image, bool silent);
@@ -650,6 +650,7 @@ static esp_err_t process_segment(int index, uint32_t flash_addr, esp_image_segme
     uint32_t free_page_count = bootloader_mmap_get_free_pages();
     ESP_LOGD(TAG, "free data page_count 0x%08"PRIx32, free_page_count);
 
+    bool first_iteration = true;
     uint32_t data_len_remain = data_len;
     while (data_len_remain > 0) {
 #if (SECURE_BOOT_CHECK_SIGNATURE == 1) && defined(BOOTLOADER_BUILD)
@@ -668,9 +669,10 @@ static esp_err_t process_segment(int index, uint32_t flash_addr, esp_image_segme
             max_image_len = UINT32_MAX;
         }
         data_len = MIN(data_len_remain, max_image_len);
-        CHECK_ERR(process_segment_data(index, load_addr, data_addr, data_len, do_load, sha_handle, checksum, metadata));
+        CHECK_ERR(process_segment_data(index, load_addr, data_addr, data_len, do_load, sha_handle, checksum, metadata, first_iteration));
         data_addr += data_len;
         data_len_remain -= data_len;
+        first_iteration = false;
     }
 
     return ESP_OK;
@@ -718,7 +720,7 @@ static size_t process_esp_app_desc_data(const uint32_t *src, bootloader_sha256_h
 }
 #endif // CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
 
-static esp_err_t process_segment_data(int segment, intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum, esp_image_metadata_t *metadata)
+static esp_err_t process_segment_data(int segment, intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum, esp_image_metadata_t *metadata, bool first_iteration)
 {
     // If we are not loading, and the checksum is empty, skip processing this
     // segment for data
@@ -766,7 +768,7 @@ static esp_err_t process_segment_data(int segment, intptr_t load_addr, uint32_t 
     // Case II: Bootloader verifying bootloader
     // The esp_app_desc_t structure is located in DROM and is always in segment #0.
     // Anti-rollback check and efuse block version check should handle only Case I from above.
-    if (segment == 0 && !is_bootloader(metadata->start_addr)) {
+    if (segment == 0 && first_iteration && !is_bootloader(metadata->start_addr)) {
 /* ESP32 doesn't have more memory and more efuse bits for block major version. */
 #if !CONFIG_IDF_TARGET_ESP32
         const esp_app_desc_t *app_desc = (const esp_app_desc_t *)src;


### PR DESCRIPTION
## Description

When verifying an app image, [`process_segment()`](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L604) maps segments from flash into memory via MMU pages. If a segment is larger than the available MMU pages can map at once, the function [splits it into chunks and processes each chunk in a loop](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L653-L676).

Inside `process_segment_data()`, there's a [check on segment 0](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L771) that reads the `esp_app_desc_t` structure from the start of the DROM segment to perform:
1. [eFuse block version validation](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L773-L780)
2. [Anti-rollback checks](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L781-L787) (if enabled)

Previously, the condition was just `segment == 0`, meaning it would run on **every iteration** of the splitting loop. On the second and subsequent iterations, `data_addr` has advanced past the start of the segment, so `src` no longer points to `esp_app_desc_t` — it points to arbitrary segment data. The code would then interpret random bytes as an app descriptor, leading to incorrect validation results.

The fix adds a [`first_iteration`](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L653) boolean that is `true` only on the [first pass](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L672) through the while loop, and [set to `false` afterwards](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L675). The app descriptor check now requires [`segment == 0 && first_iteration`](https://github.com/nebkat/esp-idf/blob/2b5dc8d0674afc395a1556e62fae171f74f0c2de/components/bootloader_support/src/esp_image_format.c#L771), ensuring it only reads the descriptor when the mapped data actually starts at the beginning of the segment.

This only manifests when segment 0 (DROM) is large enough that it can't be mapped in a single mmap operation — i.e., when the segment exceeds `free_page_count * SPI_FLASH_MMU_PAGE_SIZE`.

## Testing

Internal testing conducted.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootloader image verification and anti-rollback/eFuse validation logic; although the change is small, mistakes here could cause false rejects or weaken verification for some images.
> 
> **Overview**
> Fixes a bootloader verification bug when a large segment is processed in multiple `bootloader_mmap()` chunks.
> 
> `process_segment()` now tracks a `first_iteration` flag and passes it into `process_segment_data()`, so segment-0 app descriptor parsing (eFuse block revision validation and anti-rollback `esp_app_desc_t` handling) only runs on the first chunk of the segment rather than on subsequent offsets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5dc8d0674afc395a1556e62fae171f74f0c2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->