### PR TITLE
fix(esp_libc): add missing stdint include (IDFGH-17572)

### DIFF
--- a/components/esp_libc/priv_include/esp_time_impl.h
+++ b/components/esp_libc/priv_include/esp_time_impl.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 uint64_t esp_time_impl_get_time(void);
 
 uint64_t esp_time_impl_get_time_since_boot(void);


### PR DESCRIPTION
## Motivation

```
In file included from /esp-idf/components/esp_libc/src/timekeeping.c:20:
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:8:1: error: unknown type name 'uint64_t'
    8 | uint64_t esp_time_impl_get_time(void);
      | ^~~~~~~~
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:1:1: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
  +++ |+#include <stdint.h>
    1 | /*
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:10:1: error: unknown type name 'uint64_t'
   10 | uint64_t esp_time_impl_get_time_since_boot(void);
      | ^~~~~~~~
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:10:1: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:12:1: error: unknown type name 'uint32_t'
   12 | uint32_t esp_time_impl_get_time_resolution(void);
      | ^~~~~~~~
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:12:1: note: 'uint32_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:14:34: error: unknown type name 'uint64_t'
   14 | void esp_time_impl_set_boot_time(uint64_t t);
      |                                  ^~~~~~~~
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:14:34: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:16:1: error: unknown type name 'uint64_t'
   16 | uint64_t esp_time_impl_get_boot_time(void);
      | ^~~~~~~~
/esp-idf/components/esp_libc/priv_include/esp_time_impl.h:16:1: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
/esp-idf/components/esp_libc/src/timekeeping.c: In function 'esp_libc_timekeeping_adjust_boot_time':
/esp-idf/components/esp_libc/src/timekeeping.c:62:13: error: implicit declaration of function 'esp_time_impl_set_boot_time'; did you mean 'esp_time_impl_get_boot_time'? [-Wimplicit-function-declaration]
   62 |             esp_time_impl_set_boot_time(boot_time);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             esp_time_impl_get_boot_time
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing standard header include to fix build errors for `uint32_t`/`uint64_t` declarations, with no behavioral changes.
> 
> **Overview**
> Fixes a compile failure in `esp_time_impl.h` by adding `#include <stdint.h>` so the `uint32_t`/`uint64_t` timekeeping function declarations are properly typed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0772f0be58d0095b1310d354b401a51ea24ef1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->