### PR TITLE
Adding the required include in FreeRTOS if TraceRecorder is enabled (IDFGH-17579)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/FreeRTOS.h
@@ -62,6 +62,10 @@
 /* Application specific configuration options. */
 #include "FreeRTOSConfig.h"
 
+#ifdef CONFIG_PERCEPIO_TRACERECORDER_ENABLED
+	#include <trcRecorder.h>
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 


### PR DESCRIPTION
At present, when Percepio TraceRecorder is enabled in Kconfig the user must manually modify FreeRTOS.h with the code in this PR to ensure all of FreeRTOS is using the trace hooks from the TraceRecorder instead of the empty defines in FreeRTOS.

This PR allows for a more seamless user experience (no manual modification) and the TraceRecorder header will only be included when the user has enabled the TraceRecorder in Kconfig.

Would it be possible to also backport this to the 6.0 branch?

Erik Tamlin
Senior Software Engineer
Percepio

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single conditional include in `FreeRTOS.h` gated by `CONFIG_PERCEPIO_TRACERECORDER_ENABLED`, affecting builds only when TraceRecorder is enabled.
> 
> **Overview**
> When `CONFIG_PERCEPIO_TRACERECORDER_ENABLED` is set, `FreeRTOS.h` now includes `trcRecorder.h` so FreeRTOS trace hooks resolve to Percepio TraceRecorder definitions automatically (no manual header edits needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35049c61e8443d8edc6e67aa05fb2f314a5aec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->