### PR TITLE
Kampi/issue 18542 (IDFGH-17619)

### DIFF
--- a/components/esp_lcd/i2c/esp_lcd_panel_io_i2c.c
+++ b/components/esp_lcd/i2c/esp_lcd_panel_io_i2c.c
@@ -29,6 +29,9 @@ static const char *TAG = "lcd_panel.io.i2c";
 #define CONTROL_PHASE_LENGTH  (1)
 #define CMD_LENGTH            (4)
 
+/** Default I2C transaction timeout when the caller leaves transaction_timeout_ms = 0. */
+#define LCD_I2C_DEFAULT_TIMEOUT_MS  200
+
 static esp_err_t panel_io_i2c_del(esp_lcd_panel_io_t *io);
 static esp_err_t panel_io_i2c_rx_param(esp_lcd_panel_io_t *io, int lcd_cmd, void *param, size_t param_size);
 static esp_err_t panel_io_i2c_tx_param(esp_lcd_panel_io_t *io, int lcd_cmd, const void *param, size_t param_size);
@@ -45,6 +48,7 @@ typedef struct {
     uint32_t control_phase_cmd;  // control byte when transferring command
     uint32_t control_phase_data; // control byte when transferring data
     esp_lcd_panel_io_color_trans_done_cb_t on_color_trans_done; // User register's callback, invoked when color data trans done
+    int transaction_timeout_ms; // I2C transaction timeout in ms (0 = default, -1 = portMAX_DELAY)
     void *user_ctx;             // User's private data, passed directly to callback on_color_trans_done()
 } lcd_panel_io_i2c_t;
 
@@ -68,6 +72,23 @@ esp_err_t esp_lcd_new_panel_io_i2c(i2c_master_bus_handle_t bus, const esp_lcd_pa
         .scl_speed_hz = io_config->scl_speed_hz,
     };
     ESP_GOTO_ON_ERROR(i2c_master_bus_add_device(bus, &i2c_lcd_cfg, &i2c_handle), err, TAG, "i2c add device fail");
+
+    i2c_panel_io->transaction_timeout_ms = io_config->transaction_timeout_ms;
+
+    // Check transaction_timeout_ms is within valid range
+    if (io_config->transaction_timeout_ms > 10000) {
+        ESP_LOGW(TAG, "transaction_timeout_ms is set to %d, which exceeds the maximum value 10000. Set to maximum value.", io_config->transaction_timeout_ms);
+        i2c_panel_io->transaction_timeout_ms = 10000;
+    } else if (io_config->transaction_timeout_ms == 0) {
+        ESP_LOGW(TAG, "transaction_timeout_ms is set to 0, which means use default timeout. Set to default value %d ms.", LCD_I2C_DEFAULT_TIMEOUT_MS);
+        i2c_panel_io->transaction_timeout_ms = LCD_I2C_DEFAULT_TIMEOUT_MS;
+    } else if (io_config->transaction_timeout_ms == -1) {
+        ESP_LOGW(TAG, "transaction_timeout_ms is set to -1, which means wait indefinitely. Ensure this is intended.");
+        i2c_panel_io->transaction_timeout_ms = portMAX_DELAY;
+    } else {
+        ESP_LOGE(TAG, "transaction_timeout_ms is set to %d, which is invalid. It should be either 0 (use default) or -1 (wait indefinitely).", io_config->transaction_timeout_ms);
+        i2c_panel_io->transaction_timeout_ms = LCD_I2C_DEFAULT_TIMEOUT_MS;
+    }
 
     i2c_panel_io->i2c_handle = i2c_handle;
     i2c_panel_io->lcd_cmd_bits = io_config->lcd_cmd_bits;
@@ -142,9 +163,9 @@ static esp_err_t panel_io_i2c_rx_buffer(esp_lcd_panel_io_t *io, int lcd_cmd, voi
             write_size += cmds_size;
         }
 
-        ESP_GOTO_ON_ERROR(i2c_master_transmit_receive(i2c_panel_io->i2c_handle, write_buffer, write_size, buffer, buffer_size, -1), err, TAG, "i2c transaction failed");
+        ESP_GOTO_ON_ERROR(i2c_master_transmit_receive(i2c_panel_io->i2c_handle, write_buffer, write_size, buffer, buffer_size, i2c_panel_io->transaction_timeout_ms), err, TAG, "i2c transaction failed");
     } else {
-        ESP_GOTO_ON_ERROR(i2c_master_receive(i2c_panel_io->i2c_handle, buffer, buffer_size, -1), err, TAG, "i2c transaction failed");
+        ESP_GOTO_ON_ERROR(i2c_master_receive(i2c_panel_io->i2c_handle, buffer, buffer_size, i2c_panel_io->transaction_timeout_ms), err, TAG, "i2c transaction failed");
     }
 
     return ESP_OK;
@@ -190,7 +211,7 @@ static esp_err_t panel_io_i2c_tx_buffer(esp_lcd_panel_io_t *io, int lcd_cmd, con
         {.write_buffer = lcd_buffer, .buffer_size = lcd_buffer_size},
     };
 
-    ESP_GOTO_ON_ERROR(i2c_master_multi_buffer_transmit(i2c_panel_io->i2c_handle, lcd_i2c_buffer, sizeof(lcd_i2c_buffer) / sizeof(i2c_master_transmit_multi_buffer_info_t), -1), err, TAG, "i2c transaction failed");
+    ESP_GOTO_ON_ERROR(i2c_master_multi_buffer_transmit(i2c_panel_io->i2c_handle, lcd_i2c_buffer, sizeof(lcd_i2c_buffer) / sizeof(i2c_master_transmit_multi_buffer_info_t), i2c_panel_io->transaction_timeout_ms), err, TAG, "i2c transaction failed");
     if (!is_param) {
         // trans done callback
         if (i2c_panel_io->on_color_trans_done) {

--- a/components/esp_lcd/include/esp_lcd_io_i2c.h
+++ b/components/esp_lcd/include/esp_lcd_io_i2c.h
@@ -31,6 +31,10 @@ typedef struct {
         unsigned int dc_low_on_data: 1;  /*!< If this flag is enabled, DC line = 0 means transfer data, DC line = 1 means transfer command; vice versa */
         unsigned int disable_control_phase: 1; /*!< If this flag is enabled, the control phase isn't used */
     } flags; /*!< Extra flags to fine-tune the I2C device */
+    int transaction_timeout_ms; /*!< Timeout in milliseconds for each I2C transaction.
+                                     0 means use the default (200 ms).
+                                     Set to -1 to wait indefinitely (portMAX_DELAY).
+                                     Must not exceed 10000. */
 } esp_lcd_panel_io_i2c_config_t;
 
 /**


### PR DESCRIPTION
## Description

A new field transaction_timeout_ms is added to esp_lcd_panel_io_i2c_config_t.  When set to 0 (or not initialised) the driver defaults to 200 ms, which is well above the worst-case transfer time of a GT911 read at 400 kHz (< 1 ms) while still
allowing the caller to detect and recover from a bus fault without hanging the whole system.  Setting the value to -1 restores the original infinite-wait (portMAX_DELAY) behaviour.

## Related

Fixes https://github.com/espressif/esp-idf/issues/18542

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
