### PR TITLE
fix(tools): idf_tools.py uninstall: initialize archive_version before use (IDFGH-17632)

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -3126,6 +3126,7 @@ def action_uninstall(args: Any) -> None:
             else:
                 tool_name, tool_version = tool_spec.split('@', 1)
             tool_obj = tools_info_for_platform[tool_name]
+            archive_version = None
             if tool_version is None:
                 tool_version = tool_obj.get_preferred_installed_version()
             # mypy-checks
@@ -3133,9 +3134,8 @@ def action_uninstall(args: Any) -> None:
                 archive_version = tool_obj.versions[tool_version].get_download_for_platform(CURRENT_PLATFORM)
             if archive_version is not None:
                 archive_version_url = archive_version.url
-
-            archive = os.path.basename(archive_version_url)
-            used_archives.append(archive)
+                archive = os.path.basename(archive_version_url)
+                used_archives.append(archive)
 
         downloaded_archives = os.listdir(dist_path)
         for archive in downloaded_archives:


### PR DESCRIPTION
## Description

`idf_tools.py uninstall --remove-archives` throws `UnboundLocalError` when
`tool_version` is `None`, because `archive_version` and `archive_version_url`
are referenced before being assigned.

**Fixes:**
1. Initialize `archive_version = None` before the `if tool_version is not None`
   conditional.
2. Indent the `archive_version_url` / `archive` / `used_archives.append` lines
   inside the `if archive_version is not None:` guard.

**Before fix:**
```
UnboundLocalError: cannot access local variable 'archive_version'
                 where it is not associated with a value
```

**After fix:** all unused archives removed successfully.

Introduced by commit `52badb9186` ("fix(tools): idf_tools.py uninstall decide
based on preferred tool version", 2025-06-20).


## Testing

Verified manually on Linux:
```bash
python tools/idf_tools.py uninstall --remove-archives
```


## Related

None — no linked issue.


## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.