### PR TITLE
fix: add missing esp_eth dependency for examples/wifi/getting_started/station/main/CMakeLists.txt (IDFGH-17650)

### DIFF
--- a/examples/wifi/getting_started/station/main/CMakeLists.txt
+++ b/examples/wifi/getting_started/station/main/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "station_example_main.c"
                     PRIV_REQUIRES esp_wifi nvs_flash
+                    PRIV_REQUIRES esp_eth
                     INCLUDE_DIRS ".")


### PR DESCRIPTION
The wifi/getting_started/station example fails to build on ESP-IDF v5.5.4 because it uses esp_netif_create_default_wifi_pseudo, which requires the esp_eth component, but it was missing in CMakeLists.txt.

## Description

<!--
- Without explicitly adding `esp_eth` to `PRIV_REQUIRES` in `main/CMakeLists.txt`, the build fails with the following error:

```text
D:/ESP-IDF/components/esp_netif/lwip/esp_netif_br_glue.c:9:10: fatal error: esp_eth_driver.h: No such file or directory
    9 | #include "esp_eth_driver.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
-->


## Testing

<!--
- Verified that the example builds successfully after adding `PRIV_REQUIRES esp_eth`.
-->


