### PR TITLE
fix(uart): clear IOMUX function on RX pin when routed via GPIO matrix (IDFGH-17675)

### DIFF
--- a/components/esp_driver_uart/src/uart.c
+++ b/components/esp_driver_uart/src/uart.c
@@ -947,6 +947,9 @@ esp_err_t _uart_set_pin6(uart_port_t uart_num, int tx_io_num, int rx_io_num, int
         if (tx_rx_same_io || !uart_try_set_iomux_pin(uart_num, rx_io_num, SOC_UART_PERIPH_SIGNAL_RX)) {
             io_reserve_mask &= ~BIT64(rx_io_num); // input IO via GPIO matrix does not need to be reserved
             if (uart_num < SOC_UART_HP_NUM) {
+                // Clear any residual IOMUX function so the pin isn't simultaneously driven by IOMUX
+                // while we route it via the GPIO matrix. Symmetric with gpio_matrix_output().
+                gpio_func_sel(rx_io_num, PIN_FUNC_GPIO);
                 gpio_matrix_input(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_PERIPH_SIGNAL_RX), false);
             }
 #if SOC_LP_GPIO_MATRIX_SUPPORTED && (SOC_UART_LP_NUM >= 1)


### PR DESCRIPTION
## Summary

Fix `uart_set_pin()` so the RX pin's IOMUX function is reset to `PIN_FUNC_GPIO` when the pin is routed via the GPIO matrix. Without this, residual IOMUX function from boot keeps driving the pad in parallel with the matrix-routed RX signal, producing on-pin loopback when the default UART0 TX pin is reassigned as RX.

Closes #18363.

## Root cause

The matrix RX and matrix TX paths inside `_uart_set_pin6()` are asymmetric:

- **TX path** → `gpio_matrix_output()` → `gpio_hal_matrix_out()` first calls `gpio_ll_func_sel(..., PIN_FUNC_GPIO)` before connecting the output signal (`components/esp_hal_gpio/gpio_hal.c:60-69`).
- **RX path** → `gpio_matrix_input()` → `gpio_hal_matrix_in()` only enables the input; it never clears the IOMUX function (`components/esp_hal_gpio/gpio_hal.c:48-58`).

If the ROM bootloader (or any prior init code) had selected an IOMUX peripheral function on that pin — e.g. UART0 TX on GPIO21 (ESP32-C3) or GPIO16 (ESP32-C6) — that function keeps driving the pad after `uart_set_pin()` routes UART RX through the matrix. The pin is now simultaneously driven by IOMUX (as TX) and read by the matrix (as RX), so whatever UART TX writes is echoed back into the same UART's RX FIFO. This is the regression ESPHome has been carrying workarounds for across multiple ESP-IDF releases (see issue #18363 for the full ESPHome PR history).

## Fix

Call `gpio_func_sel(rx_io_num, PIN_FUNC_GPIO)` on the RX matrix path before `gpio_matrix_input()`. Matches what TX does implicitly and what `i2c_common.c`, `twai.c`, `i3c_master.c`, `i2s_common.c`, `esp_eth_mac_esp_gpio.c` already do before routing inputs via the GPIO matrix.

```diff
 if (uart_num < SOC_UART_HP_NUM) {
+    gpio_func_sel(rx_io_num, PIN_FUNC_GPIO);
     gpio_matrix_input(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_PERIPH_SIGNAL_RX), false);
 }
```

No build-system changes: `uart.c` already includes `esp_private/gpio.h` and `esp_driver_gpio` is already in `priv_requires`.

## Verification

Hardware: ESP32-C6 DevKit.

A small test program forces `IO_MUX[GPIO11].MCU_SEL` to a non-GPIO value, then calls `uart_set_pin(UART_NUM_1, tx=10, rx=11, -1, -1)`, then reads `MCU_SEL` back:

| Build | Pre | Post | Verdict |
|---|---|---|---|
| master (unpatched) | 0 | **0** (unchanged) | bug reproduced |
| master + this fix | 0 | **1** (`PIN_FUNC_GPIO`) | fixed |

Also: `components/esp_driver_uart/test_apps/uart` builds cleanly for esp32c6 with the patch (no new warnings).

## Alternative considered

The deeper asymmetry sits at the HAL: `gpio_hal_matrix_in()` could itself call `gpio_ll_func_sel(..., PIN_FUNC_GPIO)` so every peripheral driver routing input via the GPIO matrix gets the same hygiene as the output path. That would be a wider behavioural change touching every peripheral and is left as a follow-up if maintainers prefer it — happy to send a separate PR.

## Test plan

- [x] Builds cleanly for esp32c6 (`components/esp_driver_uart/test_apps/uart`, no new warnings)
- [x] Bug reproduced on ESP32-C6 hardware on unpatched master
- [x] Fix verified on ESP32-C6 hardware (MCU_SEL → PIN_FUNC_GPIO)
- [ ] Regression check: default-pin UART0 path (IOMUX, not matrix) still works on ESP32-C3 — recommended for reviewer / CI coverage
