### PR TITLE
fix(protocomm): prevent out-of-bounds write in console line buffer (IDFGH-17699)

### DIFF
--- a/components/protocomm/src/transports/protocomm_console.c
+++ b/components/protocomm/src/transports/protocomm_console.c
@@ -94,7 +94,7 @@ static void protocomm_console_task(void *arg)
                 }
             }
             if (event.type == UART_DATA) {
-                while (uart_read_bytes(uart_num, (uint8_t *) &linebuf[i], 1, 0) && (i < LINE_BUF_SIZE)) {
+                while ((i < LINE_BUF_SIZE - 1) && uart_read_bytes(uart_num, (uint8_t *) &linebuf[i], 1, 0)) {
                     if (linebuf[i] == '\r') {
                         uart_write_bytes(uart_num, "\r\n", 2);
                     } else {
@@ -106,7 +106,7 @@ static void protocomm_console_task(void *arg)
             if ((i > 0) && (linebuf[i-1] == '\r')) {
                 break;
             }
-        } while (i < LINE_BUF_SIZE);
+        } while (i < LINE_BUF_SIZE - 1);
         if (stopped()) {
             break;
         }


### PR DESCRIPTION
## Summary

Fixes a one-byte stack buffer overflow in the protocomm console transport (`protocomm_console.c`), reported in #18638 (IDFGH-17695).

## Root cause

The line-reading loop evaluated the byte read before the bounds check:

```c
while (uart_read_bytes(uart_num, (uint8_t *) &linebuf[i], 1, 0) && (i < LINE_BUF_SIZE)) {
```

`&&` is evaluated left-to-right, so `uart_read_bytes()` writes into `&linebuf[i]` *before* `i < LINE_BUF_SIZE` is tested. `linebuf` is a 256-byte stack array (`LINE_BUF_SIZE == 256`). A line of `LINE_BUF_SIZE` or more bytes with no `\r` lets `i` reach 256, and `uart_read_bytes()` writes `linebuf[256]` — one byte past the array — before the loop exits.

## Fix

```c
while ((i < LINE_BUF_SIZE - 1) && uart_read_bytes(uart_num, (uint8_t *) &linebuf[i], 1, 0)) {
```

- **Gate the read on the bounds check** so no write happens once the buffer is full.
- **Bound at `LINE_BUF_SIZE - 1`** (in both the inner read loop and the outer `do…while`) so the final byte stays as the zero written by the `memset()` at the top of the loop. This guarantees `esp_console_run((char *)linebuf, …)` always receives a NUL-terminated string — otherwise a fully-filled buffer would terminate the *write* overflow but leave a *read* overflow downstream.

Overlong input is now truncated to 255 bytes and dispatched, which is one of the behaviors the reporter listed as acceptable. Normal (sub-buffer) input is unaffected.

## Testing

- `components/protocomm/test_apps` builds clean for `esp32c3` (`idf.py build`, exit 0) with the existing `CONFIG_COMPILER_STACK_CHECK*` / `CONFIG_HEAP_POISONING_COMPREHENSIVE` options the test app enables.
- The fix is verifiable by inspection: the write index is now bounded before every access, and `linebuf[LINE_BUF_SIZE - 1]` is never written, so it remains the `memset`-zeroed terminator.

Closes #18638
