### PR TITLE
fix(eth): use stored base_increment when computing PTP addend (IDFGH-17700)

### DIFF
--- a/components/esp_hal_emac/emac_hal.c
+++ b/components/esp_hal_emac/emac_hal.c
@@ -404,12 +404,25 @@ esp_err_t emac_hal_ptp_start(emac_hal_context_t *hal, const emac_hal_ptp_config_
     int32_t to = 0;
     /* If you are using the Fine correction method */
     if (config->upd_method == ETH_PTP_UPDATE_METHOD_FINE) {
-        /**
-         *           2^32                 2^32                      TsysClk(ns)
-         * Addend = ——————— = —————————————————————————— = 2^32 * ——————————————
-         *           ratio     SysClk(MHz)/PTPaccur(MHz)            Taccur(ns)
+        /*
+         * Compute the addend from the actual integer base_increment written
+         * to hardware, not from the ideal ptp_req_accuracy_ns. Because
+         * base_increment is a uint8_t, the cast truncates the fractional
+         * part, making the real sub-second step differ from the requested
+         * accuracy. This is especially required for IEEE 802.1AS where the
+         * uncorrected rate must already be within 200 ppm (neighborRateRatio)
+         * before Sync messages arrive, so we derive the addend from
+         * the truncated value directly.
          */
-        uint32_t base_addend = (1ll << 32) * config->ptp_clk_src_period_ns / config->ptp_req_accuracy_ns;
+        double increment_ns;
+        if (emac_ll_is_ts_digital_roll_set(hal->ptp_regs)) {
+            increment_ns = (double)base_increment;
+        } else {
+            increment_ns = (double)base_increment * 1.0e9 / (double)(1ULL << 31);
+        }
+        uint32_t base_addend = (uint32_t)((double)(1ULL << 32) *
+                                          config->ptp_clk_src_period_ns /
+                                          increment_ns);
         emac_ll_set_ts_addend_val(hal->ptp_regs, base_addend);
         emac_ll_ts_addend_do_update(hal->ptp_regs);
         while (!emac_ll_is_ts_addend_update_done(hal->ptp_regs) && to < EMAC_PTP_INIT_TIMEOUT_US) {


### PR DESCRIPTION
# fix(eth): use stored `base_increment` when computing PTP addend

## Summary

`emac_hal_ptp_start()` in `components/esp_hal_emac/emac_hal.c` was computing the PTP fine-correction addend from the floating-point `config->ptp_req_accuracy_ns` rather than from the integer `base_increment` value that actually drives the EMAC sub-second update register. For binary rollover, `base_increment` is `req_accuracy_ns / 0.465` cast to `uint8_t`, which loses the fractional part — and the addend formula didn't compensate. Net effect: the PTP clock runs at a constant rate offset relative to real time.

## Reproduction

With ESP32-P4 default config:
```c
eth_mac_ptp_config_t ptp_config = ETH_MAC_ESP_PTP_DEFAULT_CONFIG();
// clk_src      = EMAC_PTP_CLK_SRC_XTAL    (40 MHz)
// clk_src_period_ns = 25
// required_accuracy_ns = 40
// roll_type    = ETH_PTP_BINARY_ROLLOVER
esp_eth_mac_ptp_enable(mac, &ptp_config);
```

The driver computes:
- `base_increment = 40 / 0.465 = 86.022 → uint8_t = 86` (true value 85.899 rounded up)
- `base_addend   = 2^32 * 25 / 40 = 2,684,354,560`

Then PTP rate becomes:
```
rate = (ref_clk * addend / 2^32) * (base_increment / 2^31)
     = (40e6 * 2,684,354,560 / 2^32) * (86 / 2^31)
     = 25e6 * 4.0047e-8 s
     = 1.001172 s/s   →  +1172 ppm
```

That's far outside the IEEE 802.1AS `neighborRateRatio` window of ±200 ppm, so strict 802.1AS bridges (we hit this on a PreSonus SW5E gPTP-aware switch) refuse to mark the port `asCapable` and gPTP never converges.

## Fix

Compute the addend from the actually-stored `base_increment` (i.e. AFTER the uint8_t truncation/rounding), for both rollover modes. The unified formula is:

```
addend = 2^32 * clk_period_ns / increment_ns
```

where `increment_ns` is `base_increment` for digital rollover, or `base_increment * 1e9 / 2^31` for binary rollover.

## Measured impact

Same physical hardware (ESP32-P4 Waveshare ETH dev board) on a PreSonus SW5E AVB switch:

| Metric | Before fix | After fix |
|---|---|---|
| `neighborRateRatio` (measured wire-side over 14 cycles) | **+1147.5 ppm** (σ 6.9 ppm) | **+4.2 ppm** (σ 6.8 ppm) |
| 802.1AS spec window | exceeds ±200 ppm | well inside |
| `asCapable` granted by switch | No | Yes (within ~3 s of boot) |
| Sync messages received | 0 in 30 s | 190 in 30 s (8 Hz) |
| `Switching to better PTP time source` event | 0 | 1 (at t ≈ 5.2 s) |

For comparison, a known-good MOTU 8D audio endpoint on the same switch measures `neighborRateRatio = +4.6 ppm` — so the ESP32-P4 with this fix is now indistinguishable from the reference implementation.

## Notes

- The residual +4 ppm matches the crystal tolerance of typical ±10–50 ppm parts, well within spec. The runtime `emac_hal_ptp_adj_freq()` / `emac_hal_ptp_adj_inc()` mechanisms can take it from there for full nanosecond-class servo lock.
- Digital rollover wasn't directly observed but is fixed by the same change (the original formula was correct only when `base_increment = req_accuracy_ns` exactly, which is only guaranteed if `req_accuracy_ns` was already an integer).
- This bug likely affects all ESP32 family chips that share this HAL code path with `SOC_EMAC_IEEE1588V2_SUPPORTED` and binary rollover.

## How tested

- Bench setup: ESP32-P4-ETH dev board ↔ PreSonus SW5E AVB switch, traffic tapped to a Linux capture host running tshark.
- Measured `neighborRateRatio` directly from wire timestamps of successive Pdelay_Req/Pdelay_Resp pairs over a 14-cycle window.
- Verified `asCapable` promotion by observing PreSonus's Sync / Follow_Up / Announce emissions on the ESP-facing port, which were entirely absent before the fix and continuous at 8 Hz after.
- Confirmed device-side via `ptpd` serial log: `Switching to better PTP time source` followed by sustained `Got sync packet` / `Got follow-up packet` events.
- ESP32-P4 build target with `ETH_MAC_ESP_PTP_DEFAULT_CONFIG()` and IEEE 802.1AS-compliant endpoint firmware.

## Checklist

- [x] The change addresses a real bug (constant +1170 ppm PTP rate offset)
- [x] Fix is minimal and contained to the calculation
- [x] Updated comment explains the math and the failure mode
- [x] Verified empirically with wire-level measurements
- [ ] CI green (will be checked on push)
