### PR TITLE
fix(openeth): fix cache-off panic in IRAM ISR handler (IDFGH-17705)

### DIFF
--- a/components/esp_eth/src/openeth/esp_eth_mac_openeth.c
+++ b/components/esp_eth/src/openeth/esp_eth_mac_openeth.c
@@ -28,7 +28,8 @@
 #include "esp_mac.h"
 #include "esp_eth_mac_openeth.h"
 
-static const char *TAG = "opencores.emac";
+// TAG must reside in DRAM so it is accessible when flash cache is disabled (IRAM ISR context)
+static const DRAM_ATTR char TAG[] = "opencores.emac";
 
 // Driver state structure
 typedef struct {
@@ -63,7 +64,8 @@ static IRAM_ATTR void emac_opencores_isr_handler(void *args)
     }
 
     if (status & OPENETH_INT_BUSY) {
-        ESP_EARLY_LOGW(TAG, "%s: RX frame dropped (0x%" PRIx32 ")", __func__, status);
+        // Use ESP_DRAM_LOGW: TAG and format string must be in DRAM when cache is off
+        ESP_DRAM_LOGW(TAG, "RX frame dropped (0x%" PRIx32 ")", status);
     }
 
     // Clear interrupt


### PR DESCRIPTION
Description
emac_opencores_isr_handler is registered with ESP_INTR_FLAG_IRAM and marked IRAM_ATTR, meaning it must not access flash-backed memory while the cache is disabled. However, the handler contained:

ESP_EARLY_LOGW(TAG, "%s: RX frame dropped (0x%" PRIx32 ")", __func__, status);
This is not cache-off-safe:

TAG (static const char *TAG = "opencores.emac") sits in .rodata → flash
__func__ is also a flash-resident string
ESP_EARLY_LOGW eventually calls uart_hal_write_txfifo, which lives in flash (IROM) unless CONFIG_UART_ISR_IN_IRAM=y
When OPENETH_INT_BUSY fires while another task has the cache disabled (e.g. during esp_partition_read), the firmware panics:

Guru Meditation Error: Core 0 panic'ed (Cache disabled but cached memory region accessed).
EXCCAUSE: 0x00000007
Fix:

Declare TAG as static const DRAM_ATTR char TAG[] to place the string in DRAM
Replace ESP_EARLY_LOGW with ESP_DRAM_LOGW (the correct macro for cache-off ISR context)
Remove the __func__ argument (flash string) from the log call

Related
Reproducer (synthetic, no networking, deterministic): openeth_repro/ — registers an ESP_INTR_FLAG_IRAM SW interrupt mirroring the openeth ISR body, and concurrently hammers esp_partition_read to disable the cache. Crashes within seconds on unpatched code; runs indefinitely with this fix.

Measurements (ESP32, IDF v5.4, qemu-system-xtensa):

Build	Crashes / 30 s	ISR fires before crash
Upstream (buggy)	6	~191
This patch	0	27 636+

Issue: https://github.com/espressif/esp-idf/issues/18644