### PR TITLE
esp_eth: make OpenETH ISR logging DRAM-safe (IDFGH-17708)

### DIFF
--- a/components/esp_eth/src/openeth/esp_eth_mac_openeth.c
+++ b/components/esp_eth/src/openeth/esp_eth_mac_openeth.c
@@ -28,7 +28,7 @@
 #include "esp_mac.h"
 #include "esp_eth_mac_openeth.h"
 
-static const char *TAG = "opencores.emac";
+ESP_LOG_ATTR_TAG_DRAM(TAG, "opencores.emac");
 
 // Driver state structure
 typedef struct {
@@ -63,7 +63,7 @@ static IRAM_ATTR void emac_opencores_isr_handler(void *args)
     }
 
     if (status & OPENETH_INT_BUSY) {
-        ESP_EARLY_LOGW(TAG, "%s: RX frame dropped (0x%" PRIx32 ")", __func__, status);
+        ESP_DRAM_LOGW(TAG, "RX frame dropped (0x%" PRIx32 ")", status);
     }
 
     // Clear interrupt


### PR DESCRIPTION
## Summary
- Move the OpenETH log tag into DRAM.
- Replace the IRAM ISR's `ESP_EARLY_LOGW` plus `__func__` with `ESP_DRAM_LOGW`.
- Avoid touching flash-resident log strings when the MAC interrupt fires while cache is disabled.

## Verification
- `git diff --check`
- `idf.py -C components/esp_eth/test_apps -B /tmp/esp_eth_openeth_build -D SDKCONFIG=/tmp/openeth_sdkconfig -D "SDKCONFIG_DEFAULTS=sdkconfig.defaults;/tmp/openeth.defaults" set-target esp32 build`

Closes #18644