### PR TITLE
esp_gdbstub: build without task support (IDFGH-17710)

### DIFF
--- a/components/esp_gdbstub/src/gdbstub.c
+++ b/components/esp_gdbstub/src/gdbstub.c
@@ -45,10 +45,7 @@ static void esp_gdbstub_send_str_as_hex(const char *str);
 #endif
 
 static void handle_qSupported_command(const unsigned char *cmd, int len);
-
-#if (CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME || CONFIG_ESP_GDBSTUB_SUPPORT_TASKS)
 static bool command_name_matches(const char *pattern, const unsigned char *ucmd, int len);
-#endif // (CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME || CONFIG_ESP_GDBSTUB_SUPPORT_TASKS)
 
 static void send_reason(void);
 
@@ -992,9 +989,6 @@ int gdbstub__swrite(struct _reent *data1, void *data2, const char *buff, int len
 // TODO IDF-11287
 #endif // CONFIG_LIBC_NEWLIB
 
-/* Everything below is related to the support for listing FreeRTOS tasks as threads in GDB */
-
-#if (CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME || CONFIG_ESP_GDBSTUB_SUPPORT_TASKS)
 static bool command_name_matches(const char *pattern, const unsigned char *ucmd, int len)
 {
     const char *cmd = (const char *) ucmd;
@@ -1009,7 +1003,8 @@ static bool command_name_matches(const char *pattern, const unsigned char *ucmd,
     }
     return *pattern == 0 && (cmd == end || *cmd == ',');
 }
-#endif // (CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME || CONFIG_ESP_GDBSTUB_SUPPORT_TASKS)
+
+/* Everything below is related to the support for listing FreeRTOS tasks as threads in GDB */
 
 #ifdef CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 

--- a/components/esp_gdbstub/src/port/riscv/gdbstub_riscv.c
+++ b/components/esp_gdbstub/src/port/riscv/gdbstub_riscv.c
@@ -99,7 +99,7 @@ static void esp_gdbstub_pie_regs_to_regfile (esp_gdbstub_gdb_regfile_t *dst)
 }
 #endif
 
-#if SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE
+#if (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 static void *esp_gdbstub_coproc_saved_area(const StaticTask_t *tcb, int coproc, bool is_read) {
     /*
      * Coprocessors have lazy register saving mechanism:
@@ -181,7 +181,7 @@ static void esp_gdbstub_coproc_regs_to_regfile(const esp_gdbstub_frame_t *frame,
     }
 #endif
 }
-#endif /* SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE */
+#endif /* (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS */
 
 void esp_gdbstub_frame_to_regfile(const esp_gdbstub_frame_t *frame, esp_gdbstub_gdb_regfile_t *dst)
 {
@@ -192,7 +192,7 @@ void esp_gdbstub_frame_to_regfile(const esp_gdbstub_frame_t *frame, esp_gdbstub_
     // See The RISC-V Instruction Set Manual Volume I: Unprivileged ISA Document Version 20191213 for more details.
     memcpy(&(dst->x[1]), &frame->ra, sizeof(uint32_t) * 31);
 
-#if SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE
+#if (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
     esp_gdbstub_coproc_regs_to_regfile(frame, dst);
 #endif
 }
@@ -444,7 +444,7 @@ void esp_gdbstub_set_pie_register(uint32_t reg_index, uint32_t *value_ptr)
 }
 #endif /* SOC_CPU_HAS_PIE */
 
-#if SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE
+#if (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 void esp_gdbstub_set_coproc_register(esp_gdbstub_frame_t *frame, uint32_t reg_index, uint32_t *value_ptr) {
     const StaticTask_t *tcb = esp_gdbstub_find_tcb_by_frame(frame);
     uint32_t *csa; /* points to coprocessor registers data. */
@@ -479,7 +479,7 @@ void esp_gdbstub_set_coproc_register(esp_gdbstub_frame_t *frame, uint32_t reg_in
     }
 #endif
 }
-#endif /* SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE */
+#endif /* (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS */
 
 void esp_gdbstub_set_register(esp_gdbstub_frame_t *frame, uint32_t reg_index, uint32_t *value_ptr)
 {
@@ -493,7 +493,7 @@ void esp_gdbstub_set_register(esp_gdbstub_frame_t *frame, uint32_t reg_index, ui
     } else if (reg_index == 32) { /* register 32 is PC  */
         frame->mepc = value;
     }
-#if SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE
+#if (SOC_CPU_HAS_FPU || SOC_CPU_HAS_PIE) && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
     esp_gdbstub_set_coproc_register(frame, reg_index, value_ptr);
 #endif
 }

--- a/components/esp_gdbstub/src/port/xtensa/gdbstub_xtensa.c
+++ b/components/esp_gdbstub/src/port/xtensa/gdbstub_xtensa.c
@@ -39,7 +39,7 @@ static void update_regfile_common(esp_gdbstub_gdb_regfile_t *dst)
     RSR(XT_REG_CONFIGID1, dst->configid1);
 }
 
-#if XCHAL_HAVE_FP
+#if XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 /** @brief Read FPU registers to memory
 */
 static void gdbstub_read_fpu_regs(xtensa_fpu_regs_t *fpu)
@@ -168,7 +168,7 @@ static void write_fpu_regs_to_regfile(void *tcb, esp_gdbstub_gdb_regfile_t *dst)
         memcpy (&dst->fpu, fpu_save_area, sizeof(dst->fpu));
     }
 }
-#endif // XCHAL_HAVE_FP
+#endif // XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 
 
 void esp_gdbstub_frame_to_regfile(const esp_gdbstub_frame_t *frame, esp_gdbstub_gdb_regfile_t *dst)
@@ -193,10 +193,10 @@ void esp_gdbstub_frame_to_regfile(const esp_gdbstub_frame_t *frame, esp_gdbstub_
         dst->a[i] = 0xDEADBEEF;
     }
 
-#if XCHAL_HAVE_FP
+#if XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
     extern void *pxCurrentTCBs[portNUM_PROCESSORS];
     write_fpu_regs_to_regfile(pxCurrentTCBs[esp_cpu_get_core_id()], dst);
-#endif //XCHAL_HAVE_FP
+#endif // XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 #if XCHAL_HAVE_LOOPS
     dst->lbeg = frame->lbeg;
     dst->lend = frame->lend;
@@ -240,9 +240,9 @@ void esp_gdbstub_tcb_frame_to_regfile(dummy_tcb_t *tcb, esp_gdbstub_gdb_regfile_
         dst->a[i] = 0xDEADBEEF;
     }
 
-#if XCHAL_HAVE_FP
+#if XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
     write_fpu_regs_to_regfile(tcb, dst);
-#endif // XCHAL_HAVE_FP
+#endif // XCHAL_HAVE_FP && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 
 #if XCHAL_HAVE_LOOPS
     dst->lbeg = frame->lbeg;
@@ -394,7 +394,7 @@ void esp_gdbstub_trigger_cpu(void)
 #endif
 }
 
-#if XCHAL_HAVE_FP
+#if XCHAL_HAVE_FP && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 static void gdbstub_set_fpu_register(uint32_t fpu_reg_index, float *value_ptr)
 {
     if (fpu_reg_index == 0) {
@@ -466,7 +466,7 @@ static void gdbstub_write_fpu_regs(esp_gdbstub_frame_t *frame, uint32_t reg_inde
         fpu_save_area[fpu_reg_index] = *value_ptr;
     }
 }
-#endif // XCHAL_HAVE_FP
+#endif // XCHAL_HAVE_FP && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 
 /** @brief GDB set register in frame
  * Set register in frame with address to value
@@ -481,7 +481,7 @@ void esp_gdbstub_set_register(esp_gdbstub_frame_t *frame, uint32_t reg_index, ui
     } else if (reg_index > 0 && (reg_index <= 27)) {
         (&frame->a0)[reg_index - 1] = value;
     }
-#if XCHAL_HAVE_FP
+#if XCHAL_HAVE_FP && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
     gdbstub_write_fpu_regs(frame, reg_index, value_ptr);
-#endif // XCHAL_HAVE_FP
+#endif // XCHAL_HAVE_FP && CONFIG_ESP_SYSTEM_GDBSTUB_RUNTIME && CONFIG_ESP_GDBSTUB_SUPPORT_TASKS
 }


### PR DESCRIPTION
## Summary
- Keep `command_name_matches()` available for always-on `qSupported` handling.
- Skip task-TCB FPU/coprocessor register paths when GDBStub task support is disabled.
- Preserve the existing task/runtime paths when support is enabled.

## Verification
- `git diff --check`
- `idf.py -C examples/system/gdbstub -B /tmp/gdbstub_disabled_build2 -D SDKCONFIG=/tmp/gdbstub_disabled_sdkconfig2 -D "SDKCONFIG_DEFAULTS=sdkconfig.defaults;/tmp/gdbstub-disabled.defaults" set-target esp32s3 build`
- `idf.py -C examples/system/gdbstub -B /tmp/gdbstub_default_build -D SDKCONFIG=/tmp/gdbstub_default_sdkconfig set-target esp32s3 build`
- `PATH=/home/dhimasardinata/.espressif/tools/riscv32-esp-elf/esp-15.2.0_20251204/riscv32-esp-elf/bin:$PATH idf.py -C examples/system/gdbstub -B /tmp/gdbstub_disabled_c6_build2 -D SDKCONFIG=/tmp/gdbstub_disabled_c6_sdkconfig2 -D "SDKCONFIG_DEFAULTS=sdkconfig.defaults;/tmp/gdbstub-disabled.defaults" set-target esp32c6 build`

Closes #18466