### PR TITLE
esp_wifi: require SHA1 for SoftAP (IDFGH-17711)

### DIFF
--- a/components/esp_wifi/Kconfig
+++ b/components/esp_wifi/Kconfig
@@ -447,6 +447,7 @@ menu "Wi-Fi"
 
         config ESP_WIFI_SOFTAP_SUPPORT
             bool "WiFi SoftAP Support"
+            select MBEDTLS_SHA1_C
             default y
             help
                 WiFi module can be compiled without SoftAP to save code size.

--- a/components/esp_wifi/remote/Kconfig.wifi.in
+++ b/components/esp_wifi/remote/Kconfig.wifi.in
@@ -426,6 +426,7 @@ config WIFI_RMT_GMAC_SUPPORT
 
 config WIFI_RMT_SOFTAP_SUPPORT
     bool "WiFi SoftAP Support"
+    select MBEDTLS_SHA1_C
     default y
     help
         WiFi module can be compiled without SoftAP to save code size.


### PR DESCRIPTION
## Summary
- Select `MBEDTLS_SHA1_C` when regular SoftAP support is enabled.
- Mirror the same dependency for the remote Wi-Fi SoftAP Kconfig option.

## Verification
- `git diff --check`
- `python tools/ci/check_kconfigs.py components/esp_wifi/Kconfig components/esp_wifi/remote/Kconfig.wifi.in`
- `idf.py -C examples/wifi/getting_started/softAP -B /tmp/softap_sha1_build -D SDKCONFIG=/tmp/softap_sha1_sdkconfig -D SDKCONFIG_DEFAULTS=/tmp/softap-sha1-off.defaults set-target esp32 build`
- `rg "CONFIG_(ESP_WIFI_SOFTAP_SUPPORT|MBEDTLS_SHA1_C)" /tmp/softap_sha1_sdkconfig /tmp/softap_sha1_build/config/sdkconfig.h`

Closes #18508