### PR TITLE
fix(debugging): fix ROM ELF file path used in gdbinit/symbols (IDFGH-17715)

### DIFF
--- a/components/esp_rom/gen_gdbinit.py
+++ b/components/esp_rom/gen_gdbinit.py
@@ -49,7 +49,7 @@ def generate_gdbinit_rom_add_symbols(target: str) -> str:
         build_date_addr = int(k['build_date_str_addr'], base=16)
         r.append(indent(f'# if $_streq((char *) {hex(build_date_addr)}, "{k["build_date_str"]}")', indent_str))
         r.append(indent(get_rom_if_condition_str(build_date_addr, k['build_date_str']), indent_str))
-        r.append(indent(f'add-symbol-file {rom_elfs_dir}{rom_file}', indent_str + base_ident))
+        r.append(indent(f'add-symbol-file {os.path.join(rom_elfs_dir, rom_file)}', indent_str + base_ident))
         r.append(indent('else', indent_str))
         if i == len(roms[target]):
             # In case no one known ROM ELF fits - print warning


### PR DESCRIPTION
Add a missing separator to the ELF file path in the generated `gdbinit/symbols` file. Without this change, `gdbinit/symbols` specifies an incorrect path to target ROM ELFs.

## Description

I just installed ESP-IDF and I'm trying to get GDB to work with my ESP32S3-based board. I'm making the assumption that what I was trying to do should succeed with the default `ESP_ROM_ELF_DIR` given by the setup script.

First I installed ESP-IDF with `eim`:
```javascript
eim install -i v6.0.1
```
Sourcing the setup script assigns `ESP_ROM_ELF_DIR` to this:
```javascript
[olew@um580 ~] $ source "/home/olew/.espressif/tools/activate_idf_v6.0.1.sh"
Added environment variable ESP_IDF_VERSION = 6.0
Added environment variable IDF_TOOLS_PATH = /home/olew/.espressif/tools
Added environment variable IDF_COMPONENT_LOCAL_STORAGE_URL = file:///home/olew/.espressif/tools
Added environment variable IDF_PATH = /home/olew/.espressif/v6.0.1/esp-idf
Added environment variable ESP_ROM_ELF_DIR = /home/olew/.espressif/tools/esp-rom-elfs/20241011
Added environment variable OPENOCD_SCRIPTS = /home/olew/.espressif/tools/openocd-esp32/v0.12.0-esp32-20260304/openocd-esp32/share/openocd/scripts
Added environment variable IDF_PYTHON_ENV_PATH = /home/olew/.espressif/tools/python/v6.0.1/venv
Added proper directory to PATH
Activated virtual environment at /home/olew/.espressif/tools/python/v6.0.1/venv
Environment setup complete for the current shell session.
These changes will be lost when you close this terminal.
You are now using IDF version 6.0.
eim select v6.0.1
```
Building `hello-world`:
```javascript
cd $IDF_PATH/examples/get-started/hello_world/
idf.py set-target esp32s3
idf.py build
```
This is the resulting `build/gdbinit/symbols`:
```javascript
# Load esp32s3 ROM ELF symbols
define target hookpost-remote
set confirm off
  # if $_streq((char *) 0x3ff194ad, "Mar  1 2021")
  if (*(int*) 0x3ff194ad) == 0x2072614d && (*(int*) 0x3ff194b1) == 0x32203120 && (*(int*) 0x3ff194b5) == 0x313230
    add-symbol-file /home/olew/.espressif/tools/esp-rom-elfs/20241011esp32s3_rev0_rom.elf
  else
    echo Warning: Unknown esp32s3 ROM revision.\n
  end
set confirm on
end


# Load bootloader symbols
set confirm off
    add-symbol-file /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/bootloader/bootloader.elf
set confirm on

# Load application symbols
file /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/hello_world.elf

```
As you can see, the end of `/home/olew/.espressif/tools/esp-rom-elfs/20241011esp32s3_rev0_rom.elf` is missing a forward slash. 
This gave me problems when running `idf.py openocd gdb`:
```javascript
(venv) [olew@um580 hello_world ((v6.0.1))] $ idf.py openocd gdb
Executing action: openocd
Note: OpenOCD cfg not found (via env variable OPENOCD_COMMANDS nor as a --openocd-commands argument)
OpenOCD arguments default to: "-f board/esp32s3-builtin.cfg"
OpenOCD started as a background task 34005
Executing action: gdb
GNU gdb (esp-gdb) 16.3_20250913
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=xtensa-esp-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
add symbol table from file "/home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/bootloader/bootloader.elf"
0x40000400 in ?? ()
add symbol table from file "/home/olew/.espressif/tools/esp-rom-elfs/20241011esp32s3_rev0_rom.elf"
/home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/gdbinit/connect:3: Error in sourced command file:
/home/olew/.espressif/tools/esp-rom-elfs/20241011esp32s3_rev0_rom.elf: No such file or directory.
(gdb)
```

## Testing

This is the `build/gdbinit/symbols` I get with my suggested change:
```javascript
# Load esp32s3 ROM ELF symbols
define target hookpost-remote
set confirm off
  # if $_streq((char *) 0x3ff194ad, "Mar  1 2021")
  if (*(int*) 0x3ff194ad) == 0x2072614d && (*(int*) 0x3ff194b1) == 0x32203120 && (*(int*) 0x3ff194b5) == 0x313230
    add-symbol-file /home/olew/.espressif/tools/esp-rom-elfs/20241011/esp32s3_rev0_rom.elf
  else
    echo Warning: Unknown esp32s3 ROM revision.\n
  end
set confirm on
end


# Load bootloader symbols
set confirm off
    add-symbol-file /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/bootloader/bootloader.elf
set confirm on

# Load application symbols
file /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/hello_world.elf
```
And now GDB finds the file:
```javascript
(venv) [olew@um580 hello_world ((v6.0.1))] $ idf.py openocd gdb
Executing action: openocd
Note: OpenOCD cfg not found (via env variable OPENOCD_COMMANDS nor as a --openocd-commands argument)
OpenOCD arguments default to: "-f board/esp32s3-builtin.cfg"
OpenOCD started as a background task 39055
Executing action: gdb
GNU gdb (esp-gdb) 16.3_20250913
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=xtensa-esp-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
add symbol table from file "/home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/build/bootloader/bootloader.elf"
0x40000400 in ?? ()
add symbol table from file "/home/olew/.espressif/tools/esp-rom-elfs/20241011/esp32s3_rev0_rom.elf"
JTAG tap: esp32s3.tap0 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
JTAG tap: esp32s3.tap1 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
[esp32s3.cpu0] requesting target halt and executing a soft reset
[esp32s3.cpu0] Debug controller was reset.
[esp32s3.cpu0] Core was reset.
[esp32s3.cpu0] Target halted, PC=0x500000EF, debug_reason=00000000
[esp32s3.cpu0] Reset cause (3) - (Software core reset)
[esp32s3.cpu0] Core was reset.
[esp32s3.cpu0] Target halted, PC=0x40000400, debug_reason=00000000
[esp32s3.cpu1] Debug controller was reset.
[esp32s3.cpu1] Core was reset.
[esp32s3.cpu1] Target halted, PC=0x40000400, debug_reason=00000000
[esp32s3.cpu1] Reset cause (3) - (Software core reset)
[esp32s3.cpu0] Reset cause (3) - (Software core reset)
Hardware assisted breakpoint 1 at 0x420066cc: file /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/main/hello_world_main.c, line 17.
[esp32s3.cpu0] Target halted, PC=0x420066CC, debug_reason=00000001
Set GDB target to 'esp32s3.cpu0'
[esp32s3.cpu1] Target halted, PC=0x4037897E, debug_reason=00000000
[New Thread 1070160300]
[Remote target exited]
[New Thread 1070163588]
[New Thread 1070161944]
[New Thread 1070154440]
[New Thread 1070153052]
[Switching to Thread 1070160300]

Thread 2 "main" hit Temporary breakpoint 1, app_main () at /home/olew/.espressif/v6.0.1/esp-idf/examples/get-started/hello_world/main/hello_world_main.c:17
17	{
(gdb)
```