### PR TITLE
esp_netif: retain RX pbuf free callback (IDFGH-17719)

### DIFF
--- a/components/esp_netif/include/lwip/esp_pbuf_ref.h
+++ b/components/esp_netif/include/lwip/esp_pbuf_ref.h
@@ -21,6 +21,8 @@ extern "C" {
  * @brief Allocate custom pbuf containing pointer to a private l2-free function
  *
  * @note pbuf_free() will deallocate this custom pbuf and call the driver assigned free function
+ * @note The returned pbuf may outlive esp_netif driver configuration updates. The driver handle
+ *       and RX-buffer free callback captured during allocation must remain valid until it is freed.
  */
 struct pbuf* esp_pbuf_allocate(esp_netif_t *esp_netif, void *buffer, size_t len, void *l2_buff);
 

--- a/components/esp_netif/include/lwip/esp_pbuf_ref.h
+++ b/components/esp_netif/include/lwip/esp_pbuf_ref.h
@@ -21,8 +21,9 @@ extern "C" {
  * @brief Allocate custom pbuf containing pointer to a private l2-free function
  *
  * @note pbuf_free() will deallocate this custom pbuf and call the driver assigned free function
- * @note The returned pbuf may outlive esp_netif driver configuration updates. The driver handle
- *       and RX-buffer free callback captured during allocation must remain valid until it is freed.
+ * @note The returned pbuf can outlive esp_netif driver configuration updates or esp_netif teardown.
+ *       The driver handle and RX-buffer free callback captured during allocation must remain valid
+ *       until the pbuf is freed.
  */
 struct pbuf* esp_pbuf_allocate(esp_netif_t *esp_netif, void *buffer, size_t len, void *l2_buff);
 

--- a/components/esp_netif/lwip/netif/esp_pbuf_ref.c
+++ b/components/esp_netif/lwip/netif/esp_pbuf_ref.c
@@ -6,12 +6,12 @@
 /**
  * @file esp_pbuf reference
  * This file handles lwip custom pbufs interfacing with esp_netif
- * and the L2 free function esp_netif_free_rx_buffer()
+ * and L2 driver RX buffer free callbacks
  */
 
 #include "lwip/mem.h"
 #include "lwip/esp_pbuf_ref.h"
-#include "esp_netif_net_stack.h"
+#include "esp_netif_lwip_internal.h"
 
 /**
  * @brief Specific pbuf structure for pbufs allocated by ESP netif
@@ -20,7 +20,8 @@
 typedef struct esp_custom_pbuf
 {
     struct pbuf_custom p;
-    esp_netif_t *esp_netif;
+    void* driver_handle;
+    void (*driver_free_rx_buffer)(void *h, void* buffer);
     void* l2_buf;
 } esp_custom_pbuf_t;
 
@@ -33,7 +34,7 @@ typedef struct esp_custom_pbuf
 static void esp_pbuf_free(struct pbuf *pbuf)
 {
     esp_custom_pbuf_t* esp_pbuf = (esp_custom_pbuf_t*)pbuf;
-    esp_netif_free_rx_buffer(esp_pbuf->esp_netif, esp_pbuf->l2_buf);
+    esp_pbuf->driver_free_rx_buffer(esp_pbuf->driver_handle, esp_pbuf->l2_buf);
     mem_free(pbuf);
 }
 
@@ -54,7 +55,9 @@ struct pbuf* esp_pbuf_allocate(esp_netif_t *esp_netif, void *buffer, size_t len,
         return NULL;
     }
     esp_pbuf->p.custom_free_function = esp_pbuf_free;
-    esp_pbuf->esp_netif = esp_netif;
+    /* The pbuf can outlive esp_netif driver config teardown. */
+    esp_pbuf->driver_handle = esp_netif->driver_handle;
+    esp_pbuf->driver_free_rx_buffer = esp_netif->driver_free_rx_buffer;
     esp_pbuf->l2_buf = l2_buff;
     p = pbuf_alloced_custom(PBUF_RAW, len, PBUF_REF, &esp_pbuf->p, buffer, len);
     if (p == NULL) {

--- a/components/esp_netif/lwip/netif/esp_pbuf_ref.c
+++ b/components/esp_netif/lwip/netif/esp_pbuf_ref.c
@@ -34,7 +34,9 @@ typedef struct esp_custom_pbuf
 static void esp_pbuf_free(struct pbuf *pbuf)
 {
     esp_custom_pbuf_t* esp_pbuf = (esp_custom_pbuf_t*)pbuf;
-    esp_pbuf->driver_free_rx_buffer(esp_pbuf->driver_handle, esp_pbuf->l2_buf);
+    if (esp_pbuf->driver_free_rx_buffer != NULL) {
+        esp_pbuf->driver_free_rx_buffer(esp_pbuf->driver_handle, esp_pbuf->l2_buf);
+    }
     mem_free(pbuf);
 }
 

--- a/components/esp_netif/test_apps/test_app_esp_netif/main/esp_netif_test_lwip.c
+++ b/components/esp_netif/test_apps/test_app_esp_netif/main/esp_netif_test_lwip.c
@@ -18,6 +18,7 @@
 #include "test_utils.h"
 #include "memory_checks.h"
 #include "lwip/netif.h"
+#include "lwip/esp_pbuf_ref.h"
 #include "esp_netif_test.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
@@ -740,6 +741,44 @@ TEST(esp_netif, initial_mtu_config_applied)
     esp_netif_destroy(n2);
 }
 
+static int s_l2_free_calls;
+static void test_l2_free(void *h, void *buffer)
+{
+    TEST_ASSERT_EQUAL_PTR((void *)0x1234, h);
+    TEST_ASSERT_EQUAL_PTR(&s_l2_free_calls, buffer);
+    ++s_l2_free_calls;
+}
+
+TEST(esp_netif, pbuf_uses_allocated_rx_free_callback)
+{
+    test_case_uses_tcpip();
+
+    esp_netif_driver_ifconfig_t driver_config = {
+        .handle = (void *)0x1234,
+        .driver_free_rx_buffer = test_l2_free,
+    };
+    esp_netif_config_t cfg = {
+        .base = ESP_NETIF_BASE_DEFAULT_WIFI_STA,
+        .driver = &driver_config,
+        .stack = ESP_NETIF_NETSTACK_DEFAULT_WIFI_STA,
+    };
+    esp_netif_t *esp_netif = esp_netif_new(&cfg);
+    TEST_ASSERT_NOT_NULL(esp_netif);
+
+    uint8_t payload = 0;
+    s_l2_free_calls = 0;
+    struct pbuf *pbuf = esp_pbuf_allocate(esp_netif, &payload, sizeof(payload), &s_l2_free_calls);
+    TEST_ASSERT_NOT_NULL(pbuf);
+
+    esp_netif_driver_ifconfig_t empty_driver_config = { };
+    TEST_ESP_OK(esp_netif_set_driver_config(esp_netif, &empty_driver_config));
+
+    TEST_ASSERT_EQUAL(1, pbuf_free(pbuf));
+    TEST_ASSERT_EQUAL(1, s_l2_free_calls);
+
+    esp_netif_destroy(esp_netif);
+}
+
 TEST_GROUP_RUNNER(esp_netif)
 {
     /**
@@ -770,6 +809,7 @@ TEST_GROUP_RUNNER(esp_netif)
     RUN_TEST_CASE(esp_netif, dhcp_server_state_transitions_mesh)
 #endif
     RUN_TEST_CASE(esp_netif, initial_mtu_config_applied)
+    RUN_TEST_CASE(esp_netif, pbuf_uses_allocated_rx_free_callback)
     RUN_TEST_CASE(esp_netif, route_priority)
     RUN_TEST_CASE(esp_netif, set_get_dnsserver)
     RUN_TEST_CASE(esp_netif, unified_netif_status_event)


### PR DESCRIPTION
## Summary
- Store the driver RX-buffer free callback and driver handle in each custom pbuf when it is allocated.
- Keep delayed `pbuf_free()` independent from later `esp_netif` driver config teardown.
- Add an `esp_netif` regression test that clears the driver config before freeing the custom pbuf.

## Root cause
`esp_pbuf_allocate()` kept an `esp_netif_t *` inside the custom pbuf. If the netif driver config was cleared before a queued pbuf was drained, `esp_pbuf_free()` could later call through the cleared/stale `esp_netif->driver_free_rx_buffer` path.

## Verification
- `git diff --check`
- `idf.py -C examples/wifi/getting_started/station -B /tmp/espnetif_pbuf_station_build -D SDKCONFIG=/tmp/espnetif_pbuf_station_sdkconfig set-target esp32 build`
- `idf.py -C components/esp_netif/test_apps/test_app_esp_netif -B /tmp/espnetif_test_app_build -D SDKCONFIG=/tmp/espnetif_test_app_sdkconfig set-target esp32 build`

Refs espressif/arduino-esp32#12517