### PR TITLE
fix(lwip): forward-declare struct dhcp before DHCP extra-option hook (IDFGH-17738)

### DIFF
--- a/components/lwip/port/include/lwip_default_hooks.h
+++ b/components/lwip/port/include/lwip_default_hooks.h
@@ -70,6 +70,7 @@ int lwip_hook_ip6_input(struct pbuf *p, struct netif *inp);
 #define LWIP_HOOK_IP6_INPUT lwip_hook_ip6_input
 #endif /* CONFIG_LWIP_HOOK_IP6_INPUT_CUSTIOM... */
 
+struct dhcp; /* forward declaration for the lwip_dhcp_on_extra_option() prototype below */
 #if defined(CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_CUSTOM) || defined(CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_DEFAULT)
 void lwip_dhcp_on_extra_option(struct dhcp *dhcp, uint8_t state, uint8_t option, uint8_t len, struct pbuf* p, uint16_t offset);
 #endif /* CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_CUSTOM (or DEFAULT) */


### PR DESCRIPTION
## Problem

When `CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_CUSTOM` (or `..._DEFAULT`) is
enabled, `components/lwip/port/include/lwip_default_hooks.h` declares:

```c
void lwip_dhcp_on_extra_option(struct dhcp *dhcp, ...);
```

but `struct dhcp` is only forward-declared further down, inside the
`#ifdef CONFIG_LWIP_IPV4` block — *after* this prototype. Every
translation unit that includes the header therefore declares `struct dhcp`
inside the parameter list, which GCC reports as:

```
error: 'struct dhcp' declared inside parameter list will not be visible
outside of this definition or declaration [-Werror]
```

The lwip component is built with `-Werror`, and this particular GCC
diagnostic has **no individual `-W` flag**, so it cannot be waived with
`-Wno-error=...`. The result: any project that enables the DHCP
extra-option hook fails to build.

## Reproduction

- ESP-IDF v6.0.1 and current `master` (GCC 13.2, xtensa-esp32s3)
- `CONFIG_LWIP_HOOK_DHCP_EXTRA_OPTION_CUSTOM=y` with an app-provided
  `lwip_dhcp_on_extra_option()` implementation

## Fix

Add a `struct dhcp;` forward declaration ahead of the prototype. A pointer
parameter only needs an incomplete type, so this is minimal and
sufficient. The redundant forward declaration inside `CONFIG_LWIP_IPV4`
is left untouched to keep the diff to a single added line.
