### PR TITLE
uart: fix threshold configuration loss when interrupts are disabled (IDFGH-17749)

### DIFF
--- a/components/esp_driver_uart/src/uart.c
+++ b/components/esp_driver_uart/src/uart.c
@@ -2219,9 +2219,7 @@ esp_err_t uart_set_rx_full_threshold(uart_port_t uart_num, int threshold)
         return ESP_ERR_INVALID_STATE;
     }
     UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
-    if (uart_hal_get_intr_ena_status(&(uart_context[uart_num].hal)) & UART_INTR_RXFIFO_FULL) {
-        uart_hal_set_rxfifo_full_thr(&(uart_context[uart_num].hal), threshold);
-    }
+    uart_hal_set_rxfifo_full_thr(&(uart_context[uart_num].hal), threshold);
     UART_EXIT_CRITICAL(&(uart_context[uart_num].spinlock));
     return ESP_OK;
 }
@@ -2236,9 +2234,7 @@ esp_err_t uart_set_tx_empty_threshold(uart_port_t uart_num, int threshold)
         return ESP_ERR_INVALID_STATE;
     }
     UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
-    if (uart_hal_get_intr_ena_status(&(uart_context[uart_num].hal)) & UART_INTR_TXFIFO_EMPTY) {
-        uart_hal_set_txfifo_empty_thr(&(uart_context[uart_num].hal), threshold);
-    }
+    uart_hal_set_txfifo_empty_thr(&(uart_context[uart_num].hal), threshold);
     UART_EXIT_CRITICAL(&(uart_context[uart_num].spinlock));
     return ESP_OK;
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Description: Fixes an asymmetric flaw in the UART driver where uart_set_rx_full_threshold and uart_set_tx_empty_threshold silently drop developer configuration updates and return ESP_OK if executed before the hardware interrupts are enabled.

Problem: Checking uart_hal_get_intr_ena_status inside setters prevents developer from setting-up initialization config. If a developer configures hardware thresholds before calling uart_driver_install or unmasking interrupts, the settings never reach HAL while the API reports ESP_OK. Meanwhile, uart_set_rx_timeout applies configurations unconditionally.

Solution: Refactored both functions to write directly to their respective HAL threshold registers unconditionally inside the critical section, aligning their architectural behavior with uart_set_rx_timeout.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
Fixes issue #13116
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
It compiles perfectly with v6.1-dev
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
