### PR TITLE
Respect max_align_t (IDFGH-17761)

### DIFF
--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <sys/param.h>
 #include "esp_attr.h"
 #include "esp_heap_caps.h"
@@ -23,6 +24,9 @@ allocation possible, this code makes it possible to request memory that has cert
 its knowledge of how the memory is configured along with a priority scheme to allocate that memory in the most sane way
 possible. This should optimize the amount of RAM accessible to the code without hardwiring addresses.
 */
+
+//This is normally provided by the heap-memalign-hw component.
+extern void esp_heap_adjust_alignment_to_hw(size_t *p_alignment, size_t *p_size, uint32_t *p_caps);
 
 static esp_alloc_failed_hook_t alloc_failed_callback;
 
@@ -401,6 +405,28 @@ void heap_caps_get_info( multi_heap_info_t *info, uint32_t caps )
             info->allocated_blocks += hinfo.allocated_blocks;
             info->free_blocks += hinfo.free_blocks;
             info->total_blocks += hinfo.total_blocks;
+        }
+    }
+
+    if (info->largest_free_block > 0) {
+        /* heap_caps_malloc() uses aligned allocation (via heap_caps_malloc_base).
+         * tlsf_memalign_offs() inflates the block search by (alignment + sizeof(block_header_t))
+         * bytes regardless of whether a front-split is actually needed, so
+         * largest_free_block would overestimate the true malloc-able size without
+         * this adjustment.  Use esp_heap_adjust_alignment_to_hw() so that caps
+         * requiring stricter hardware alignment (e.g. MALLOC_CAP_DMA) are also
+         * handled correctly. */
+        size_t alignment = _Alignof(max_align_t);
+        size_t dummy_size = 1;
+        esp_heap_adjust_alignment_to_hw(&alignment, &dummy_size, &caps);
+        if (alignment > sizeof(size_t)) { //sizeof(size_t) is TLSF's natural alignment granularity
+            /* sizeof(block_header_t) = block_size_min + block_header_overhead
+             *                        = 2*sizeof(void*) + 2*sizeof(size_t) */
+            const size_t block_header = 2 * sizeof(void *) + 2 * sizeof(size_t);
+            const size_t overhead = alignment + block_header;
+            info->largest_free_block = info->largest_free_block > overhead
+                                       ? info->largest_free_block - overhead
+                                       : 0;
         }
     }
 }

--- a/components/heap/heap_caps_base.c
+++ b/components/heap/heap_caps_base.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <sys/param.h>
 #include "esp_attr.h"
 #include "multi_heap.h"
@@ -33,6 +34,11 @@ extern void esp_heap_adjust_alignment_to_hw(size_t *p_alignment, size_t *p_size,
 
 //Default alignment the multiheap allocator / tlsf will align 'unaligned' memory to, in bytes
 #define UNALIGNED_MEM_ALIGNMENT_BYTES 4
+
+// Default malloc must be at least as strict as TLSF's natural alignment for the routing
+// in aligned_or_unaligned_alloc to be correct.
+_Static_assert(_Alignof(max_align_t) >= UNALIGNED_MEM_ALIGNMENT_BYTES,
+               "malloc alignment must be >= TLSF natural alignment (UNALIGNED_MEM_ALIGNMENT_BYTES)");
 
 /*
   This takes a memory chunk in a region that can be addressed as both DRAM as well as IRAM. It will convert it to
@@ -89,7 +95,7 @@ HEAP_IRAM_ATTR void heap_caps_free( void *ptr)
 }
 
 HEAP_IRAM_ATTR static inline void *aligned_or_unaligned_alloc(multi_heap_handle_t heap, size_t size, size_t alignment, size_t offset) {
-    if (alignment<=UNALIGNED_MEM_ALIGNMENT_BYTES) { //alloc and friends align to 32-bit by default
+    if (alignment<=UNALIGNED_MEM_ALIGNMENT_BYTES) { //use TLSF's natural (4-byte) alloc path
         return multi_heap_malloc(heap, size);
     } else {
         return multi_heap_aligned_alloc_offs(heap, size, alignment, offset);
@@ -98,8 +104,9 @@ HEAP_IRAM_ATTR static inline void *aligned_or_unaligned_alloc(multi_heap_handle_
 
 /*
 This function should not be called directly as it does not check for failure / call heap_caps_alloc_failed()
-Note that this function does 'unaligned' alloc calls if alignment <= UNALIGNED_MEM_ALIGNMENT_BYTES (=4) as the
-allocator will align to that value by default.
+Note that this function uses TLSF's natural (4-byte) alloc path when alignment <= UNALIGNED_MEM_ALIGNMENT_BYTES,
+and the aligned-alloc path otherwise. Default malloc requests alignof(max_align_t), which on 32-bit targets
+is 8 and so always takes the aligned path.
 */
 HEAP_IRAM_ATTR NOINLINE_ATTR void *heap_caps_aligned_alloc_base(size_t alignment, size_t size, uint32_t caps)
 {
@@ -204,7 +211,7 @@ HEAP_IRAM_ATTR NOINLINE_ATTR void *heap_caps_aligned_alloc_base(size_t alignment
 
 //Wrapper for heap_caps_aligned_alloc_base as that can also do unaligned allocs.
 HEAP_IRAM_ATTR NOINLINE_ATTR void *heap_caps_malloc_base( size_t size, uint32_t caps) {
-    return heap_caps_aligned_alloc_base(UNALIGNED_MEM_ALIGNMENT_BYTES, size, caps);
+    return heap_caps_aligned_alloc_base(_Alignof(max_align_t), size, caps);
 }
 
 /*
@@ -218,7 +225,7 @@ HEAP_IRAM_ATTR NOINLINE_ATTR void *heap_caps_realloc_base( void *ptr, size_t siz
     void *dram_ptr = NULL;
 
     //See if memory needs alignment because of hardware reasons.
-    size_t alignment = UNALIGNED_MEM_ALIGNMENT_BYTES;
+    size_t alignment = _Alignof(max_align_t);
     esp_heap_adjust_alignment_to_hw(&alignment, &size, &caps);
 
     if (ptr == NULL) {
@@ -267,8 +274,24 @@ HEAP_IRAM_ATTR NOINLINE_ATTR void *heap_caps_realloc_base( void *ptr, size_t siz
     bool compatible_caps = (caps & get_all_caps(heap)) == caps;
 
     //Note we don't try realloc() on memory that needs to be aligned, that is handled
-    //by the fallthrough code.
-    if (compatible_caps && !ptr_in_diram_case && alignment<=UNALIGNED_MEM_ALIGNMENT_BYTES) {
+    //by the fallthrough code. multi_heap_realloc uses TLSF's natural 4-byte alignment
+    //for any internal alloc+copy fallback, so skip this fast path for stricter alignments.
+    //Exception: a shrink always returns the same pointer (TLSF trims in-place without a
+    //new alloc), so the existing alignment is preserved and the fast path is safe.
+    //Under CONFIG_HEAP_POISONING_COMPREHENSIVE however, multi_heap_realloc always allocates
+    //a new block via multi_heap_malloc_impl (4-byte aligned) even for shrinks, so the
+    //same-pointer invariant does not hold and is_shrink must be disabled to preserve alignment.
+    //For ptr_in_diram_case, heap is set to the DRAM heap while ptr is still the IRAM address,
+    //so multi_heap_get_allocated_size cannot be called with this heap/ptr combination.
+#if defined(CONFIG_HEAP_POISONING_COMPREHENSIVE)
+    const bool is_shrink = false;
+#else
+    const bool is_shrink = !ptr_in_diram_case &&
+                           (MULTI_HEAP_ADD_BLOCK_OWNER_SIZE(size) <=
+                            multi_heap_get_allocated_size(heap->heap, ptr));
+#endif
+    if (compatible_caps && !ptr_in_diram_case &&
+            (alignment <= UNALIGNED_MEM_ALIGNMENT_BYTES || is_shrink)) {
         // try to reallocate this memory within the same heap
         // (which will resize the block if it can)
 

--- a/components/heap/test_apps/heap_tests/main/test_malloc.c
+++ b/components/heap/test_apps/heap_tests/main/test_malloc.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -9,6 +9,7 @@
 
 #include <esp_types.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -208,8 +209,8 @@ TEST_CASE("test get allocated size", "[heap]")
         ptr_array[i] = heap_caps_malloc(alloc_sizes[i], MALLOC_CAP_INTERNAL);
         TEST_ASSERT_NOT_NULL(ptr_array[i]);
 
-        // test that the heap_caps_get_allocated_size() returns the right number of bytes (aligned to 4 bytes
-        // since the heap component aligns to 4 bytes)
+        // test that the heap_caps_get_allocated_size() returns at least the requested size
+        // rounded up to the TLSF block granularity (4 bytes)
         const size_t aligned_size = (alloc_sizes[i] + 3) & ~3;
         const size_t real_size = heap_caps_get_allocated_size(ptr_array[i]);
         TEST_ASSERT(aligned_size <= real_size);
@@ -292,3 +293,53 @@ TEST_CASE("test allocation and free function hooks", "[heap]")
     TEST_ASSERT_TRUE(test_success);
 }
 #endif
+
+TEST_CASE("malloc/calloc/realloc return memory aligned to alignof(max_align_t)", "[heap]")
+{
+    /* Keep all pointers live so successive calls get different blocks.
+     * Freeing immediately would recycle the same block and hide misalignment. */
+    const int N = 32;
+    void *ptrs[N];
+
+    for (int i = 0; i < N; i++) {
+        ptrs[i] = malloc(256 + i);
+        TEST_ASSERT_NOT_NULL(ptrs[i]);
+        TEST_ASSERT_MESSAGE(
+            ((uintptr_t)ptrs[i] % _Alignof(max_align_t)) == 0,
+            "malloc() returned memory not aligned to alignof(max_align_t)");
+    }
+    for (int i = 0; i < N; i++) {
+        free(ptrs[i]);
+    }
+
+    for (int i = 0; i < N; i++) {
+        ptrs[i] = calloc(1, 256 + i);
+        TEST_ASSERT_NOT_NULL(ptrs[i]);
+        TEST_ASSERT_MESSAGE(
+            ((uintptr_t)ptrs[i] % _Alignof(max_align_t)) == 0,
+            "calloc() returned memory not aligned to alignof(max_align_t)");
+    }
+    for (int i = 0; i < N; i++) {
+        free(ptrs[i]);
+    }
+
+    /* realloc: check both the fresh allocation and the grown pointer */
+    for (int i = 0; i < N; i++) {
+        ptrs[i] = realloc(NULL, 256 + i);
+        TEST_ASSERT_NOT_NULL(ptrs[i]);
+        TEST_ASSERT_MESSAGE(
+            ((uintptr_t)ptrs[i] % _Alignof(max_align_t)) == 0,
+            "realloc(NULL) returned memory not aligned to alignof(max_align_t)");
+    }
+    for (int i = 0; i < N; i++) {
+        void *grown = realloc(ptrs[i], 512 + i);
+        TEST_ASSERT_NOT_NULL(grown);
+        TEST_ASSERT_MESSAGE(
+            ((uintptr_t)grown % _Alignof(max_align_t)) == 0,
+            "realloc(grow) returned memory not aligned to alignof(max_align_t)");
+        ptrs[i] = grown;
+    }
+    for (int i = 0; i < N; i++) {
+        free(ptrs[i]);
+    }
+}

--- a/components/heap/test_apps/heap_tests/main/test_malloc_caps.c
+++ b/components/heap/test_apps/heap_tests/main/test_malloc_caps.c
@@ -149,7 +149,7 @@ TEST_CASE("heap_caps metadata test", "[heap]")
     void *b = heap_caps_malloc(original.largest_free_block, MALLOC_CAP_8BIT);
     TEST_ASSERT_NOT_NULL(b);
 
-    printf("After allocating %d bytes:\n", original.largest_free_block);
+    printf("After allocating %zu bytes:\n", original.largest_free_block);
     heap_caps_print_heap_info(MALLOC_CAP_8BIT);
 
     multi_heap_info_t after;


### PR DESCRIPTION
## Description

Align all pointers with [max_align_t](https://cppreference.com/c/types/max_align_t) to match C/C++ specification.

## Related

Fixes #18685

## Testing

* https://github.com/ltowarek/esp-opentelemetry-cpp/blob/main/test/heap_align_idf/
* https://github.com/ltowarek/esp-opentelemetry-cpp/tree/main/test/heap_align_protobuf
* components/heap/test_apps/heap_tests/main/test_malloc.c

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
