### PR TITLE
esp_psram: Set missing PSRAM errors to warnings if "ignore not found" is configured. (IDFGH-17789)

### DIFF
--- a/components/esp_psram/device/esp_psram_impl_ap_hex.c
+++ b/components/esp_psram/device/esp_psram_impl_ap_hex.c
@@ -462,7 +462,7 @@ esp_err_t esp_psram_impl_enable(void)
     s_init_psram_mode_reg(PSRAM_CTRLR_LL_MSPI_ID_3, &mode_reg);
 
     if (s_check_psram_connected(PSRAM_CTRLR_LL_MSPI_ID_3) != ESP_OK) {
-        ESP_EARLY_LOGE(TAG, "PSRAM chip is not connected");
+        PSRAM_LOG_NOTFOUND(TAG, "PSRAM chip is not connected");
         return ESP_ERR_NOT_SUPPORTED;
     }
 

--- a/components/esp_psram/device/esp_psram_impl_ap_quad.c
+++ b/components/esp_psram/device/esp_psram_impl_ap_quad.c
@@ -356,7 +356,7 @@ esp_err_t esp_psram_impl_enable(void)
     psram_disable_qio_mode(PSRAM_CTRLR_LL_MSPI_ID_1);
 
     if (s_check_psram_connected(PSRAM_CTRLR_LL_MSPI_ID_1) != ESP_OK) {
-        ESP_EARLY_LOGE(TAG, "PSRAM chip is not connected, or wrong PSRAM line mode");
+        PSRAM_LOG_NOTFOUND(TAG, "PSRAM chip is not connected, or wrong PSRAM line mode");
         return ESP_ERR_NOT_SUPPORTED;
     }
 

--- a/components/esp_psram/device/include/esp_private/esp_psram_impl.h
+++ b/components/esp_psram/device/include/esp_private/esp_psram_impl.h
@@ -36,6 +36,13 @@ extern "C" {
 #define PSRAM_HALFSLEEP_RESUME_CODE_ATTR
 #endif
 
+// Downgrade "PSRAM not found" errors to warning if ignoring missing SPIRAM
+#if CONFIG_SPIRAM_IGNORE_NOTFOUND
+#define PSRAM_LOG_NOTFOUND ESP_EARLY_LOGW
+#else
+#define PSRAM_LOG_NOTFOUND ESP_EARLY_LOGE
+#endif
+
 /**
  * @brief To get the physical psram size in bytes.
  *

--- a/components/esp_psram/esp32/esp_psram_impl_quad.c
+++ b/components/esp_psram/esp32/esp_psram_impl_quad.c
@@ -988,7 +988,7 @@ esp_err_t IRAM_ATTR esp_psram_impl_enable(void)   //psram init
          */
         psram_read_id(spi_num, &s_psram_id);
         if (!PSRAM_IS_VALID(s_psram_id)) {
-            ESP_EARLY_LOGE(TAG, "PSRAM ID read error: 0x%08" PRIx32 ", PSRAM chip not found or not supported", (uint32_t)s_psram_id);
+            PSRAM_LOG_NOTFOUND(TAG, "PSRAM ID read error: 0x%08" PRIx32 ", PSRAM chip not found or not supported", (uint32_t)s_psram_id);
             return ESP_ERR_NOT_SUPPORTED;
         }
     }

--- a/components/esp_psram/esp32s3/esp_psram_impl_octal.c
+++ b/components/esp_psram/esp32s3/esp_psram_impl_octal.c
@@ -359,7 +359,7 @@ esp_err_t esp_psram_impl_enable(void)
     s_init_psram_mode_reg(1, &mode_reg);
 
     if (s_check_psram_connected(1) != ESP_OK) {
-        ESP_EARLY_LOGE(TAG, "PSRAM chip is not connected, or wrong PSRAM line mode");
+        PSRAM_LOG_NOTFOUND(TAG, "PSRAM chip is not connected, or wrong PSRAM line mode");
         return ESP_ERR_NOT_SUPPORTED;
     }
 

--- a/components/esp_psram/system_layer/esp_psram.c
+++ b/components/esp_psram/system_layer/esp_psram.c
@@ -219,7 +219,7 @@ static esp_err_t s_psram_chip_init(void)
     ret = esp_psram_impl_enable();
     if (ret != ESP_OK) {
 #if CONFIG_SPIRAM_IGNORE_NOTFOUND
-        ESP_EARLY_LOGE(TAG, "PSRAM enabled but initialization failed. Bailing out.");
+        ESP_EARLY_LOGW(TAG, "PSRAM enabled but initialization failed. Bailing out.");
 #endif
         return ret;
     }

--- a/components/esp_system/port/cpu_start.c
+++ b/components/esp_system/port/cpu_start.c
@@ -657,7 +657,7 @@ MSPI_INIT_ATTR void mspi_init(void)
 #if CONFIG_SPIRAM_BOOT_HW_INIT
     if (esp_psram_chip_init() != ESP_OK) {
 #if CONFIG_SPIRAM_IGNORE_NOTFOUND
-        ESP_DRAM_LOGE(TAG, "Failed to init external RAM; continuing without it.");
+        ESP_DRAM_LOGW(TAG, "Failed to init external RAM; continuing without it.");
 #else
         ESP_DRAM_LOGE(TAG, "Failed to init external RAM!");
         abort();


### PR DESCRIPTION
Hi folks!

## Description

A little PR for your consideration: This avoids ~5 errors being logged during boot if the board has no PSRAM but is configured to boot anyway.

It solves a minor annoyance for us in MicroPython - we try to ship a set of generic binaries that run on as many boards as possible, but if a board with `CONFIG_SPIRAM=y` and `CONFIG_SPIRAM_IGNORE_NOTFOUND=y` doesn't have SPIRAM then it logs 5 errors on boot. For example, ESP32-C5:

```
E (433) quad_psram: PSRAM chip is not connected, or wrong PSRAM line mode
E (434) esp_psram: PSRAM enabled but initialization failed. Bailing out.
E cpu_start: Failed to init external RAM; continuing without it.
E (441) quad_psram: PSRAM chip is not connected, or wrong PSRAM line mode
E (447) esp_psram: PSRAM enabled but initialization failed. Bailing out.
```

MicroPython tries to log as little as possible during boot, so this is a lot for us.

This PR downgrades these log lines to warnings if `CONFIG_SPIRAM_IGNORE_NOTFOUND` is set (which removes them on MicroPython as we set the default log level to Error.)

## Related

* Reported against MicroPython here (but closed by the reporter): https://github.com/micropython/micropython/issues/15537
* Noted (by me!) when enabling PSRAM support for C5 here: https://github.com/micropython/micropython/pull/19303#issuecomment-4665285093

## Testing

I tested on original ESP32 and ESP32-S3 boards I have here with no PSRAM, verified the log lines are now Warnings. i.e.:

```
W (159) quad_psram: PSRAM ID read error: 0xffffffff, PSRAM chip not found or not supported
W (162) esp_psram: PSRAM enabled but initialization failed. Bailing out.
W cpu_start: Failed to init external RAM; continuing without it.
I (174) quad_psram: This chip is ESP32-U4WDH
W (178) quad_psram: PSRAM ID read error: 0xffffffff, PSRAM chip not found or not supported
W (186) esp_psram: PSRAM enabled but initialization failed. Bailing out.
```

and

```
W (165) quad_psram: PSRAM chip is not connected, or wrong PSRAM line mode
W (165) esp_psram: PSRAM enabled but initialization failed. Bailing out.
W cpu_start: Failed to init external RAM; continuing without it.
W (173) quad_psram: PSRAM chip is not connected, or wrong PSRAM line mode
W (179) esp_psram: PSRAM enabled but initialization failed. Bailing out.
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
