### PR TITLE
fix(heap_task_info): Fix incorrect current_usage subtraction on realloc() (IDFGH-17818)

### DIFF
--- a/components/heap/heap_task_info.c
+++ b/components/heap/heap_task_info.c
@@ -338,11 +338,8 @@ HEAP_IRAM_ATTR void heap_caps_update_per_task_info_realloc(heap_t *heap, void *o
     SLIST_FOREACH(task_info, &task_stats, next_task_info) {
         if (task_info->task_stat.handle == old_task) {
             heap_stats_t *heap_stats = NULL;
-            task_info->task_stat.overall_current_usage -= old_size;
             STAILQ_FOREACH(heap_stats, &task_info->heaps_stats, next_heap_stat) {
                 if (heap_stats->heap == heap->heap) {
-                    heap_stats->heap_stat.current_usage -= old_size;
-                    heap_stats->heap_stat.alloc_count--;
 
                     /* remove the alloc from the list. The updated alloc stats are added later
                      * in the function */
@@ -354,6 +351,13 @@ HEAP_IRAM_ATTR void heap_caps_update_per_task_info_realloc(heap_t *heap, void *o
                             break;
                         }
                     }
+
+                    if (alloc_stat != NULL) {
+                        heap_stats->heap_stat.current_usage -= old_size;
+                        heap_stats->heap_stat.alloc_count--;
+                        task_info->task_stat.overall_current_usage -= old_size;
+                    }
+
                     break;
                 }
             }
@@ -430,6 +434,8 @@ HEAP_IRAM_ATTR void heap_caps_update_per_task_info_free(heap_t *heap, void *ptr)
                         heap_stats->heap_stat.current_usage -= alloc_stat->alloc_stat.size;
                         task_info->task_stat.overall_current_usage -= alloc_stat->alloc_stat.size;
                     }
+
+                    break;
                 }
             }
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This fixes CONFIG_HEAP_TASK_TRACKING=1 sometimes counting negative heap usage when using realloc().

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

Fixes #18723. 
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Tested by rebasing onto the reproducer example [here](https://github.com/GoeBachmann/esp-idf/tree/heap-tracking-bug/examples/system/heap_task_tracking/basic): New log: [fixed_heap_usage.log](https://github.com/user-attachments/files/28957036/fixed_heap_usage.log)


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
