### PR TITLE
fix(tools): add UTF-8 encoding and Windows short path support for Unicode paths (IDFGH-17822)

### DIFF
--- a/tools/kconfig_new/prepare_kconfig_files.py
+++ b/tools/kconfig_new/prepare_kconfig_files.py
@@ -87,7 +87,7 @@ def main() -> None:
 
     parser.add_argument(
         '--env-file',
-        type=argparse.FileType('r'),
+        type=argparse.FileType('r', encoding='utf-8'),
         help='Optional file to load environment variables from. Contents '
         'should be a JSON object where each key/value pair is a variable.',
     )

--- a/tools/ldgen/ldgen.py
+++ b/tools/ldgen/ldgen.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 #
+import ctypes
 import errno
 import hashlib
 import json
@@ -17,7 +18,6 @@ from io import StringIO
 import rich_click as click
 from esp_pylib.cli_options import MutuallyExclusiveOption
 from esp_pylib.cli_options import OptionEatAll
-import ctypes
 
 def get_short_path_name(long_name):
     if os.name != 'nt':

--- a/tools/ldgen/ldgen.py
+++ b/tools/ldgen/ldgen.py
@@ -17,6 +17,31 @@ from io import StringIO
 import rich_click as click
 from esp_pylib.cli_options import MutuallyExclusiveOption
 from esp_pylib.cli_options import OptionEatAll
+import ctypes
+
+def get_short_path_name(long_name):
+    if os.name != 'nt':
+        return long_name
+    try:
+        dirname, filename = os.path.split(long_name)
+        normalized_dir = os.path.normpath(dirname)
+        buf_size = ctypes.windll.kernel32.GetShortPathNameW(normalized_dir, None, 0)
+        if buf_size == 0:
+            normalized_name = os.path.normpath(long_name)
+            buf_size = ctypes.windll.kernel32.GetShortPathNameW(normalized_name, None, 0)
+            if buf_size == 0:
+                return long_name
+            output_buf = ctypes.create_unicode_buffer(buf_size)
+            ctypes.windll.kernel32.GetShortPathNameW(normalized_name, output_buf, buf_size)
+            return output_buf.value.replace('\\', '/')
+        
+        output_buf = ctypes.create_unicode_buffer(buf_size)
+        ctypes.windll.kernel32.GetShortPathNameW(normalized_dir, output_buf, buf_size)
+        short_dir = output_buf.value.replace('\\', '/')
+        return short_dir + '/' + filename
+    except Exception:
+        return long_name
+
 from esp_pylib.excepthook import install_exception_reporting
 from esp_pylib.logger import Verbosity
 from esp_pylib.logger import log
@@ -183,7 +208,7 @@ def _run(
             if library:
                 new_env = os.environ.copy()
                 new_env['LC_ALL'] = 'C'
-                dump = StringIO(subprocess.check_output([objdump, '-h', library], env=new_env).decode())
+                dump = StringIO(subprocess.check_output([objdump, '-h', get_short_path_name(library)], env=new_env).decode('utf-8', errors='replace'))
                 dump.name = library
                 sections_infos.add_sections_info(dump)
 
@@ -269,12 +294,12 @@ def _run(
     context_settings={'help_option_names': ['-h', '--help']},
     help='ESP-IDF linker script generator',
 )
-@click.option('--input', '-i', 'input_file', type=click.File('r'), help='Linker template file')
+@click.option('--input', '-i', 'input_file', type=click.File('r', encoding='utf-8'), help='Linker template file')
 @click.option(
     '--fragments',
     '-f',
     multiple=True,
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     cls=MutuallyExclusiveEatAllOption,
     exclusive_with=['fragments_list', 'fragments_list_file'],
     help='Input fragment files',
@@ -287,19 +312,19 @@ def _run(
 )
 @click.option(
     '--fragments-list-file',
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     cls=MutuallyExclusiveOption,
     exclusive_with=['fragments', 'fragments_list'],
     help='File containing fragment file paths, one per line',
 )
 @click.option(
     '--libraries-file',
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     help='File that contains the list of libraries in the build',
 )
 @click.option(
     '--mutable-libraries-file',
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     help='File that contains the list of mutable libraries in the build',
 )
 @click.option('--output', '-o', help='Output linker script')
@@ -312,7 +337,7 @@ def _run(
 )
 @click.option(
     '--check-mapping-exceptions',
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     help='Mappings exempted from check',
 )
 @click.option(
@@ -325,7 +350,7 @@ def _run(
 )
 @click.option(
     '--env-file',
-    type=click.File('r'),
+    type=click.File('r', encoding='utf-8'),
     help='Optional file to load environment variables from. Contents '
     'should be a JSON object where each key/value pair is a variable.',
 )


### PR DESCRIPTION
## Description

On Windows, when the user's home directory contains non-ASCII characters (e.g. Turkish `Ö`, Chinese, Japanese, Korean characters), several ESP-IDF build tools fail because they read UTF-8 encoded build files using the system's default ANSI code page (e.g. `cp1254` for Turkish locale).

### Root Cause

CMake generates build configuration files (`config.env`, `ldgen_libraries`) encoded in UTF-8. However, the Python scripts that consume these files use `argparse.FileType('r')` **without** specifying an encoding, causing Python to open them with the system's default ANSI code page.

For example, on a Turkish Windows system (code page `cp1254`), the UTF-8 bytes for `Ö` (`0xC3 0x96`) are incorrectly decoded as `Ã–` (U+00C3 U+2013). This corrupts all file paths containing the user's home directory, leading to `FileNotFoundError` during the build.

Additionally, the GCC cross-compiler toolchain's `objdump` does not support Unicode characters in file paths on Windows, even when the paths are correctly decoded by Python.

### Affected Tools

- `tools/kconfig_new/prepare_kconfig_files.py` — fails to write `kconfigs.in` because the output path is corrupted
- `tools/ldgen/ldgen.py` — fails when calling `objdump` on library files because paths contain non-ASCII characters

### Fix

1. **Explicit UTF-8 encoding**: Changed `argparse.FileType('r')` to `argparse.FileType('r', encoding='utf-8')` for `--env-file` and `--libraries-file` arguments, ensuring build configuration files are read with the correct encoding regardless of the system locale.

2. **Windows 8.3 short path resolution**: Added a `get_short_path_name()` helper in `ldgen.py` that converts long Unicode paths to DOS 8.3 short paths (e.g. `C:\Users\MERYIL~1\...`) before passing them to `objdump`. This works around the GCC toolchain's lack of Unicode path support on Windows.

3. **Robust output decoding**: Changed `.decode()` to `.decode('utf-8', errors='replace')` for `objdump` output to prevent decoding crashes.

### Testing

Tested on Windows 11 with:
- User path: `C:\Users\Ömer YILDIZ\workspace\scan`
- System locale: Turkish (cp1254)
- ESP-IDF v6.0.1
- Both clean and incremental builds succeed after the fix

### Related

This fix also requires a corresponding change in the `esp-idf-kconfig` package (`kconfgen/core.py`) which uses the same `argparse.FileType('r')` pattern for `--env-file`. A separate PR will be submitted to that repository.