### PR TITLE
Fix header value truncation detection in httpd_req_get_hdr_value_str (IDFGH-17829)

### DIFF
--- a/components/esp_http_server/src/httpd_parse.c
+++ b/components/esp_http_server/src/httpd_parse.c
@@ -1121,12 +1121,13 @@ esp_err_t httpd_req_get_hdr_value_str(httpd_req_t *r, const char *field, char *v
         }
 
         /* Get the NULL terminated value and copy it to the caller's buffer.
-         * Note `strlcpy()` will always return the size of the source string
-         * including terminimating null.*/
+         * strlcpy() returns strlen() of the source string (the terminating
+         * null is NOT counted), so only val_size - 1 characters fit. */
         size_t full_size = strlcpy(val, val_ptr, val_size);
 
-        /* If buffer length is smaller than needed, return truncation error */
-        if (val_size < full_size) {
+        /* If the value did not fit in the buffer it was truncated, i.e. its
+         * length reached or exceeded val_size. Return truncation error. */
+        if (val_size <= full_size) {
             return ESP_ERR_HTTPD_RESULT_TRUNC;
         }
         return ESP_OK;


### PR DESCRIPTION
## Description

This PR fixes truncation reporting in `httpd_req_get_hdr_value_str()`.

The function detected truncation with `val_size < full_size`, where `full_size` is the return value of `strlcpy()`. However, `strlcpy()` returns `strlen(src)`, excluding the terminating null byte. Therefore truncation occurs when `strlen(src) >= val_size`.

At the boundary case where `strlen(src) == val_size`, the value is copied as `val_size - 1` characters followed by NUL, so the returned header value is truncated. However, the function previously returned `ESP_OK`, so the caller was not informed that truncation occurred.

This PR changes the check to `val_size <= full_size` and corrects the misleading comment about `strlcpy()`'s return value.

No memory-safety impact is intended: for `val_size > 0`, `strlcpy()` still writes a NUL-terminated destination buffer. The issue is that truncation was not reported to the caller at the exact-size boundary.

## Related

Related to #16202, which fixed the same truncation-reporting class for `httpd_cookie_key_value()`. `httpd_req_get_hdr_value_str()` still had the old boundary check.

## Testing

Tested locally with a header value whose length exactly matches `val_size`.

Verified that:

- before the fix, `httpd_req_get_hdr_value_str()` returned `ESP_OK` even though the copied value was truncated to `val_size - 1` characters plus NUL;
- after the fix, the same boundary case returns `ESP_ERR_HTTPD_RESULT_TRUNC`;
- non-truncated header values still return `ESP_OK`;
- the destination buffer remains NUL-terminated when `val_size > 0`.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.