### PR TITLE
fix(bootloader): sync IDF_TARGET env in subproject (IDFGH-17847)

### DIFF
--- a/components/bootloader/subproject/CMakeLists.txt
+++ b/components/bootloader/subproject/CMakeLists.txt
@@ -14,6 +14,7 @@ if(NOT IDF_TARGET)
     message(FATAL_ERROR "Bootloader subproject expects the IDF_TARGET variable to be passed "
         "in by the parent build process.")
 endif()
+set(ENV{IDF_TARGET} "${IDF_TARGET}")
 
 if(IDF_BUILD_V2)
     include(CMakeLists_v2.txt)


### PR DESCRIPTION
## Description

The bootloader subproject receives `IDF_TARGET` from the parent build via `-DIDF_TARGET=...`, and it already treats a missing `IDF_TARGET` CMake variable as fatal.

However, the ESP-IDF target initialization code can still observe `$ENV{IDF_TARGET}`. In environments where the parent process has a stale target, the bootloader subproject can fail with a target mismatch even though the generated bootloader CMake command passes the correct `-DIDF_TARGET`.

One practical case is a Windows VS Code ESP-IDF multi-root workspace containing several independent ESP-IDF project folders, where each folder targets a different chip. For example:

```text
workspace
├── p4/  -> esp32p4
├── c5/  -> esp32c5
├── c2/  -> esp32c2
└── s3/  -> esp32s3
```

After configuring/building one folder, switching the ESP-IDF extension context to another folder can leave the task/process environment with the previous folder's `IDF_TARGET`. The new folder's main project is configured with the requested target, but the bootloader subproject can inherit the stale environment value and fail during target initialization.

For example, when switching from an `esp32p4` folder to an `esp32c5` folder, the generated bootloader configure command can correctly contain:

```text
-DIDF_TARGET=esp32c5
```

but bootloader configuration still fails if the inherited environment contains:

```text
IDF_TARGET=esp32p4
```

This change synchronizes the bootloader subproject environment with the explicitly passed `IDF_TARGET` before including the ESP-IDF project machinery:

```cmake
set(ENV{IDF_TARGET} "${IDF_TARGET}")
```

That keeps the CMake variable/cache value and the environment value consistent inside the bootloader subproject.

## Related issue

Fixes espressif/vscode-esp-idf-extension#1883

## Testing

Verified locally on Windows with ESP-IDF v6.0.1.

Reproduced the failure in a VS Code multi-root workspace with multiple independent ESP-IDF firmware folders configured for different targets (`esp32p4`, `esp32c5`, `esp32c2`, and `esp32s3`). After switching from the `esp32p4` folder to the `esp32c5` folder, the `esp32c5` bootloader configure step failed because the inherited environment still selected `esp32p4`.

Also reduced the issue to a direct stale-environment reproduction by setting:

```powershell
$env:IDF_TARGET = "esp32p4"
```

Then configured/built an `esp32c5` project whose generated bootloader configure command passed:

```text
-DIDF_TARGET=esp32c5
```

Before this change, the bootloader configure step failed with:

```text
IDF_TARGET 'esp32c5' in CMake cache does not match currently selected IDF_TARGET 'esp32p4'
```

After this change, the bootloader configured successfully and generated an ESP32-C5 bootloader image.

## Notes

This is intentionally limited to the bootloader subproject. The parent build still owns target selection; the subproject only mirrors the explicitly passed target into its own process environment so ESP-IDF target initialization sees a consistent value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CMake env sync in the bootloader subproject only; no auth, data, or application runtime behavior changes.
> 
> **Overview**
> Fixes bootloader configure failures when the process still has a **stale `IDF_TARGET` in the environment** (e.g. switching chip targets in a VS Code multi-root ESP-IDF workspace) even though the parent passes the correct `-DIDF_TARGET=...`.
> 
> After the existing fatal check that `IDF_TARGET` is defined, the bootloader subproject now runs **`set(ENV{IDF_TARGET} "${IDF_TARGET}")`** so ESP-IDF target initialization sees the same target in CMake and in `$ENV{IDF_TARGET}`, avoiding cache-vs-environment mismatch errors. Scope is limited to the bootloader subproject; the parent build still selects the target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd12709ab9214d630446cd66e4a8af273f057e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->