### PR TITLE
fix(nimble): initialize return value in LED characteristic access cal… (IDFGH-17862)

### DIFF
--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/README.md
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/README.md
@@ -169,9 +169,6 @@ The characteristic is binded with `led_chr_access` callback function, in which t
 ``` C
 static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
                           struct ble_gatt_access_ctxt *ctxt, void *arg) {
-    /* Local variables */
-    int rc;
-
     /* Handle access events */
     /* Note: LED characteristic is write only */
     switch (ctxt->op) {
@@ -203,7 +200,7 @@ static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
             } else {
                 goto error;
             }
-            return rc;
+            return 0;
         }
         goto error;
 

--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/main/src/gatt_svc.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_GATT_Server/main/src/gatt_svc.c
@@ -114,9 +114,6 @@ error:
 
 static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
                           struct ble_gatt_access_ctxt *ctxt, void *arg) {
-    /* Local variables */
-    int rc = 0;
-
     /* Handle access events */
     /* Note: LED characteristic is write only */
     switch (ctxt->op) {
@@ -148,7 +145,7 @@ static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
             } else {
                 goto error;
             }
-            return rc;
+            return 0;
         }
         goto error;
 

--- a/examples/bluetooth/ble_get_started/nimble/NimBLE_Security/main/src/gatt_svc.c
+++ b/examples/bluetooth/ble_get_started/nimble/NimBLE_Security/main/src/gatt_svc.c
@@ -117,9 +117,6 @@ error:
 
 static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
                           struct ble_gatt_access_ctxt *ctxt, void *arg) {
-    /* Local variables */
-    int rc = 0;
-
     /* Handle access events */
     /* Note: LED characteristic is write only */
     switch (ctxt->op) {
@@ -151,7 +148,7 @@ static int led_chr_access(uint16_t conn_handle, uint16_t attr_handle,
             } else {
                 goto error;
             }
-            return rc;
+            return 0;
         }
         goto error;
 


### PR DESCRIPTION
When the NimBLE stack called this callback for a GATT Write Request, the uninitialized stack value was interpreted as a non-zero GATT error code, causing the stack to send BLE_ATT_ERR_UNLIKELY (0x0E) back to the client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix in example BLE GATT callbacks with no auth or data-model changes.
> 
> **Overview**
> Fixes **LED characteristic write handling** in the NimBLE get-started examples so successful GATT writes report **0** to the stack instead of an undefined return value.
> 
> In `led_chr_access` (NimBLE_GATT_Server and NimBLE_Security `gatt_svc.c`, plus the matching README snippet), the success path no longer returns an unused `rc` variable. That value was never set on the write path, so NimBLE could treat it as a non-zero ATT error and respond to clients with **`BLE_ATT_ERR_UNLIKELY` (0x0E)** even when the LED logic ran correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afd05e6ba6b16241b79c0a5e923bb783f2a6250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->