### PR TITLE
fix(bt/osi): stop timer before re-arming in alarm_set (IDFGH-17864)

### DIFF
--- a/components/bt/common/osi/alarm.c
+++ b/components/bt/common/osi/alarm.c
@@ -247,6 +247,11 @@ static osi_alarm_err_t alarm_set(osi_alarm_t *alarm, period_ms_t timeout, bool i
     }
 
     int64_t timeout_us = 1000 * (int64_t)timeout;
+    /* Stop the timer first in case it is already running. Calling
+     * esp_timer_start_once/periodic on an active timer returns
+     * ESP_ERR_INVALID_STATE, silently dropping the alarm. This mirrors the
+     * pattern used in alarm_free(). */
+    esp_timer_stop(alarm->alarm_hdl);
     esp_err_t stat;
     if (is_periodic) {
         stat = esp_timer_start_periodic(alarm->alarm_hdl, (uint64_t)timeout_us);


### PR DESCRIPTION
## Summary

`alarm_set()` calls `esp_timer_start_once` / `esp_timer_start_periodic` without first stopping the timer handle. If the Bluedroid stack re arms an alarm that is already running (e.g. a scheduling alarm fired before the previous instance was cancelled), `esp_timer_start_*` returns `ESP_ERR_INVALID_STATE` and the alarm is silently dropped, producing the log error:

```
E (xxxx) BT_OSI: alarm_set failed to start timer, err 0x103
```

`alarm_free()` already uses the correct pattern it calls `esp_timer_stop` before `esp_timer_delete`. This fix applies the same stop before start in `alarm_set` so that a double-set reschedules the alarm rather than failing.

## Change

Add `esp_timer_stop(alarm->alarm_hdl)` before the `esp_timer_start_once` / `esp_timer_start_periodic` call inside the static `alarm_set()` helper in `components/bt/common/osi/alarm.c`.

`esp_timer_stop` returns `ESP_ERR_INVALID_STATE` when the timer is already stopped, which is expected and harmless; the subsequent start call then proceeds normally.

## Reproduction

Observed on ESP32 S3 with `CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST=y`. PSRAM allocation latency shifts task scheduling enough that `osi_alarm_set` is called on a running timer handle during BLE GAP advertising setup, triggering the error on every boot.

## Test

Build with Bluedroid enabled (`CONFIG_BT_BLUEDROID_ENABLED=y`, `CONFIG_BT_BLE_ENABLED=y`) and start BLE advertising  the `alarm_set failed` error no longer appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in BT timer scheduling aligned with existing `alarm_free()` usage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes Bluedroid alarms being **silently dropped** when `osi_alarm_set` / `osi_alarm_set_periodic` runs on a handle that is still active. `esp_timer_start_once` and `esp_timer_start_periodic` return `ESP_ERR_INVALID_STATE` in that case, which surfaced as `alarm_set failed to start timer, err 0x103` during BLE GAP advertising on ESP32-S3 with SPIRAM-first BT allocation.
> 
> **`alarm_set()`** in `alarm.c` now calls **`esp_timer_stop`** on the handle before starting the timer, matching the stop-then-operate pattern already used in **`alarm_free()`**. Re-arming reschedules the alarm instead of failing; stopping an already-idle timer is harmless (`ESP_ERR_INVALID_STATE` is ignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7af0d4506f8545a96d07c73143a196ab0a7b99b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->