### PR TITLE
feat(esp-tls): support PSA key ID for TLS client credentials (IDFGH-17867)

### DIFF
--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -167,6 +167,13 @@ typedef struct esp_tls_cfg {
     unsigned int clientkey_pem_bytes;       /*!< Size of client key legacy name */
     };
 
+    uint32_t clientkey_psa_id;              /*!< PSA key ID for the client private key.
+                                                 When non-zero, this takes precedence over
+                                                 clientkey_buf/clientkey_pem_buf and the key
+                                                 is used via mbedtls_pk_wrap_psa() without
+                                                 exposing raw key material. The key must have
+                                                 been created with PSA_KEY_USAGE_SIGN_HASH. */
+
     const unsigned char *clientkey_password;/*!< Client key decryption password string */
 
     unsigned int clientkey_password_len;    /*!< String length of the password pointed to by

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -117,6 +117,7 @@ typedef struct esp_tls_pki_t {
     unsigned int privkey_pem_bytes;
     const unsigned char *privkey_password;
     unsigned int privkey_password_len;
+    psa_key_id_t psa_key_id;
 #ifdef CONFIG_ESP_TLS_USE_DS_PERIPHERAL
     void *esp_ds_data;
 #endif
@@ -630,18 +631,27 @@ static esp_err_t set_pki_context(esp_tls_t *tls, const esp_tls_pki_t *pki)
             }
         } else
 #endif
+        if (pki->psa_key_id != PSA_KEY_ID_NULL) {
+            mbedtls_pk_init(pki->pk_key);
+            ret = mbedtls_pk_wrap_psa(pki->pk_key, pki->psa_key_id);
+            if (ret != 0) {
+                ESP_LOGE(TAG, "Failed to wrap PSA key (id=%d): -0x%04X", (int)pki->psa_key_id, -ret);
+                mbedtls_print_error_msg(ret);
+                ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
+                return ESP_ERR_MBEDTLS_PK_PARSE_KEY_FAILED;
+            }
+        } else
         if (pki->privkey_pem_buf != NULL) {
             ret = mbedtls_pk_parse_key(pki->pk_key, pki->privkey_pem_buf, pki->privkey_pem_bytes,
                                        pki->privkey_password, pki->privkey_password_len);
+            if (ret < 0) {
+                ESP_LOGE(TAG, "mbedtls_pk_parse_key returned -0x%04X", -ret);
+                mbedtls_print_error_msg(ret);
+                ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
+                return ESP_ERR_MBEDTLS_PK_PARSE_KEY_FAILED;
+            }
         } else {
             return ESP_ERR_INVALID_ARG;
-        }
-
-        if (ret < 0) {
-            ESP_LOGE(TAG, "mbedtls_pk_parse_keyfile returned -0x%04X", -ret);
-            mbedtls_print_error_msg(ret);
-            ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
-            return ESP_ERR_MBEDTLS_PK_PARSE_KEY_FAILED;
         }
 
         ret = mbedtls_ssl_conf_own_cert(&tls->conf, pki->public_cert, pki->pk_key);
@@ -1109,6 +1119,23 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
         ESP_LOGE(TAG, "Please enable the support for signing using ECDSA peripheral in menuconfig.");
         return ESP_FAIL;
 #endif
+    } else if (cfg->clientcert_pem_buf != NULL && cfg->clientkey_psa_id != PSA_KEY_ID_NULL) {
+        esp_tls_pki_t pki = {
+            .public_cert = &tls->clientcert,
+            .pk_key = &tls->clientkey,
+            .publiccert_pem_buf = cfg->clientcert_buf,
+            .publiccert_pem_bytes = cfg->clientcert_bytes,
+            .privkey_pem_buf = NULL,
+            .privkey_pem_bytes = 0,
+            .privkey_password = NULL,
+            .privkey_password_len = 0,
+            .psa_key_id = cfg->clientkey_psa_id,
+        };
+        esp_err_t esp_ret = set_pki_context(tls, &pki);
+        if (esp_ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set client pki context (PSA key)");
+            return esp_ret;
+        }
     } else if (cfg->clientcert_pem_buf != NULL && cfg->clientkey_pem_buf != NULL) {
         esp_tls_pki_t pki = {
             .public_cert = &tls->clientcert,

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -498,11 +498,22 @@ void esp_mbedtls_cleanup(esp_tls_t *tls)
      * before calling mbedtls_pk_free(). mbedtls_pk_wrap_psa() sets the pk_info
      * to mbedtls_{rsa,ecdsa}_opaque_info, both of which have type
      * MBEDTLS_PK_OPAQUE — so a single check covers both DS and ECDSA paths.
-     * clientkey and serverkey share storage via union, so one branch suffices. */
+     * clientkey and serverkey share storage via union, so one branch suffices.
+     *
+     * Only destroy volatile keys created internally by the DS/ECDSA peripheral
+     * paths. Keys wrapped from an external clientkey_psa_id are caller-owned
+     * (typically persistent) and must not be destroyed here. */
 #if defined(CONFIG_ESP_TLS_USE_DS_PERIPHERAL) || defined(CONFIG_MBEDTLS_HARDWARE_ECDSA_SIGN)
     if (mbedtls_pk_get_type(&tls->clientkey) == MBEDTLS_PK_OPAQUE) {
         if (tls->clientkey.MBEDTLS_PRIVATE(priv_id) != PSA_KEY_ID_NULL) {
-            psa_destroy_key(tls->clientkey.MBEDTLS_PRIVATE(priv_id));
+            psa_key_attributes_t attrs = PSA_KEY_ATTRIBUTES_INIT;
+            if (psa_get_key_attributes(tls->clientkey.MBEDTLS_PRIVATE(priv_id),
+                                       &attrs) == PSA_SUCCESS) {
+                if (PSA_KEY_LIFETIME_IS_VOLATILE(psa_get_key_lifetime(&attrs))) {
+                    psa_destroy_key(tls->clientkey.MBEDTLS_PRIVATE(priv_id));
+                }
+                psa_reset_key_attributes(&attrs);
+            }
             tls->clientkey.MBEDTLS_PRIVATE(priv_id) = PSA_KEY_ID_NULL;
         }
     }

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -969,6 +969,10 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
             esp_transport_ssl_set_client_key_data_der(ssl, config->client_key_pem, config->client_key_len);
         }
     }
+
+    if (config->client_key_psa_id != 0) {
+        esp_transport_ssl_set_client_key_psa_id(ssl, config->client_key_psa_id);
+    }
 #ifdef CONFIG_MBEDTLS_HARDWARE_ECDSA_SIGN
     if (config->use_ecdsa_peripheral) {
 #if SOC_ECDSA_SUPPORT_CURVE_P384

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -200,6 +200,8 @@ typedef struct {
                                                      DER Certificate - Length of the buffer pointed to by client_cert_der. Should be the length of the certificate. */
     const char                  *client_key_pem;     /*!< SSL client key, PEM format as string, if the server requires to verify client */
     size_t                      client_key_len;      /*!< Length of the buffer pointed to by client_key_pem. May be 0 for null-terminated pem */
+    uint32_t                    client_key_psa_id;   /*!< PSA key ID for the client private key. When non-zero, takes precedence over client_key_pem.
+                                                          The key must have been created with PSA_KEY_USAGE_SIGN_HASH. */
     const char                  *client_key_password;      /*!< Client key decryption password string */
     size_t                      client_key_password_len;   /*!< String length of the password pointed to by client_key_password */
     esp_http_client_proto_ver_t tls_version;         /*!< TLS protocol version of the connection, e.g., TLS 1.2, TLS 1.3 (default - no preference) */

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -163,6 +163,16 @@ void esp_transport_ssl_set_client_key_password(esp_transport_handle_t t, const c
 void esp_transport_ssl_set_client_key_data_der(esp_transport_handle_t t, const char *data, int len);
 
 /**
+ * @brief      Set SSL client key via PSA key ID for mutual authentication.
+ *             The key must have been created with PSA_KEY_USAGE_SIGN_HASH.
+ *             This avoids exposing raw key material to the application.
+ *
+ * @param      t       ssl transport
+ * @param[in]  key_id  The PSA key ID (uint32_t, cast from psa_key_id_t)
+ */
+void esp_transport_ssl_set_client_key_psa_id(esp_transport_handle_t t, uint32_t key_id);
+
+/**
  * @brief      Set the list of supported application protocols to be used with ALPN.
  *             Note that, this function stores the pointer to data, rather than making a copy.
  *             So this data must remain valid until after the connection is cleaned up

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -476,6 +476,12 @@ void esp_transport_ssl_set_client_key_data_der(esp_transport_handle_t t, const c
     ssl->cfg.clientkey_bytes = len;
 }
 
+void esp_transport_ssl_set_client_key_psa_id(esp_transport_handle_t t, uint32_t key_id)
+{
+    GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);
+    ssl->cfg.clientkey_psa_id = key_id;
+}
+
 #if defined(CONFIG_MBEDTLS_SSL_ALPN) || defined(CONFIG_WOLFSSL_HAVE_ALPN)
 void esp_transport_ssl_set_alpn_protocol(esp_transport_handle_t t, const char **alpn_protos)
 {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Add client_key_psa_id to esp_http_client_config_t and connect it through tcp_transport and esp_http_client so that a client key stored in PSA may be used for mutual TLS authentication. This allows credentials generated on the device to be used without exposing the client secret. The client's public certificate must still be supplied using client_cert_der or client_cert_pem.

When clientkey_psa_id is non-zero the key is wrapped with mbedtls_pk_wrap_psa() and takes precedence over clientkey_*_buf. The caller-owned PSA key is not destroyed on TLS cleanup.

The key must have been created with PSA_KEY_USAGE_SIGN_HASH.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

I did not find any existing tests for client key/cert in the esp-tls so I have not added a unit test for this.

Testing locally I generated a PK on the device
```
    psa_status_t init_status = psa_crypto_init();
    if (init_status != PSA_SUCCESS)
    {
        ESP_LOGE(TAG, "psa_crypto_init failed: %d", (int) init_status);
        return -EIO;
    }

    psa_key_attributes_t attrs = PSA_KEY_ATTRIBUTES_INIT;
    psa_set_key_type(&attrs, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
    psa_set_key_bits(&attrs, 256);
    psa_set_key_usage_flags(&attrs, PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_SIGN_HASH);
    psa_set_key_algorithm(&attrs, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
    psa_set_key_enrollment_algorithm(&attrs, PSA_ALG_ECDH);
    psa_set_key_lifetime(&attrs, PSA_KEY_LIFETIME_PERSISTENT);
    psa_set_key_id(&attrs, DEVICE_PSA_KEY_ID);

    psa_status_t status = psa_generate_key(&attrs, &_device_key_id);
    psa_reset_key_attributes(&attrs);
```

I then generate a CSR:

```
    mbedtls_pk_context pk;
    mbedtls_pk_init(&pk);
    err = mbedtls_pk_wrap_psa(&pk, _device_key_id);
    if (0 != err)
    {
        ESP_LOGE(TAG, "Failed to wrap PSA key: -0x%04X", -err);
        return -EIO;
    }

    mbedtls_x509write_csr csr;
    mbedtls_x509write_csr_init(&csr);
    mbedtls_x509write_csr_set_key(&csr, &pk);
    mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);

    char subject[320];
    snprintf(subject, sizeof(subject), "O=%s,CN=%s", org, cn);

    err = mbedtls_x509write_csr_set_subject_name(&csr, subject);
    if (0 != err)
    {
        goto cleanup;
    }

    unsigned char der_buf[CSR_DER_BUF_SIZE];
    int der_len = mbedtls_x509write_csr_der(&csr, der_buf, sizeof(der_buf));
    if (der_len < 0)
    {
        err = der_len;
        goto cleanup;
    }

cleanup:
    mbedtls_x509write_csr_free(&csr);
    mbedtls_pk_free(&pk);
    return err;
```

The CSR is signed with the root CA key and the resulting client cert.der is stored back on the device. This is used along with the PSA key id for the client private key to configure the http_client:

```
    esp_http_client_config_t config = {
        .path = HTTP_PATH_POUCH,
        .host = CONFIG_POUCH_HTTP_GW_URI,
        .port = CONFIG_POUCH_HTTP_GW_PORT,
        .transport_type = HTTP_TRANSPORT_OVER_SSL,
        .event_handler = event_handler_proxy,
        .crt_bundle_attach = esp_crt_bundle_attach,
        .client_cert_der = sync->mtls_creds->client_cert_der,
        .client_cert_len = sync->mtls_creds->client_cert_der_len,
        .client_key_psa_id = sync->mtls_creds->client_key_id,
        .timeout_ms = HTTP_TIMEOUT_MS,
        .user_data = sync,
    };
```
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS client credential loading and PSA key lifecycle on disconnect; incorrect lifetime handling could delete caller keys or leak volatile ones, though the volatile-only destroy guard targets that risk.
> 
> **Overview**
> Adds **mutual TLS client authentication using a PSA key ID** instead of PEM/DER private key buffers, wired from `esp_http_client_config_t` through SSL transport into esp-tls.
> 
> When `client_key_psa_id` / `clientkey_psa_id` is non-zero, the stack uses `mbedtls_pk_wrap_psa()` and **takes precedence over** `client_key_pem`. The client certificate is still supplied as PEM or DER. Keys must be created with `PSA_KEY_USAGE_SIGN_HASH`.
> 
> **TLS teardown** now destroys opaque PSA keys only when their lifetime is **volatile** (DS/ECDSA internal keys). **Caller-owned persistent keys** from the new config field are not destroyed on connection cleanup.
> 
> New API: `esp_transport_ssl_set_client_key_psa_id()`. PKI setup also reports `mbedtls_pk_parse_key` failures immediately on the PEM path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a505ca5212e917623e1ce368c08aeef423b371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->