### PR TITLE
fix(examples): fix types on 64-bit cpu support(linux) (IDFGH-17869)

### DIFF
--- a/examples/system/freertos/basic_freertos_smp_usage/main/create_task_example.c
+++ b/examples/system/freertos/basic_freertos_smp_usage/main/create_task_example.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
+#include <stdint.h>
 #include "freertos/FreeRTOS.h"
 #include "esp_log.h"
 #include "basic_freertos_smp_usage.h"
@@ -27,7 +28,7 @@ static void spin_iteration(int spin_iter_num)
 static void spin_task(void *arg)
 {
     // convert arg pointer from void type to int type then dereference it
-    int task_id = (int)arg;
+    int task_id = (intptr_t)arg;
     ESP_LOGI(TAG, "created task#%d", task_id);
     while (!timed_out) {
         int core_id = esp_cpu_get_core_id();
@@ -46,7 +47,7 @@ int comp_creating_task_entry_func(int argc, char **argv)
     timed_out = false;
     // pin 2 tasks on same core and observe in-turn execution,
     // and pin another task on the other core to observe "simultaneous" execution
-    int task_id0 = 0, task_id1 = 1, task_id2 = 2, task_id3 = 3;
+    intptr_t task_id0 = 0, task_id1 = 1, task_id2 = 2, task_id3 = 3;
     xTaskCreatePinnedToCore(spin_task, "pinned_task0_core0", 4096, (void*)task_id0, TASK_PRIO_3, NULL, CORE0);
     xTaskCreatePinnedToCore(spin_task, "pinned_task1_core0", 4096, (void*)task_id1, TASK_PRIO_3, NULL, CORE0);
     xTaskCreatePinnedToCore(spin_task, "pinned_task2_core1", 4096, (void*)task_id2, TASK_PRIO_3, NULL, CORE1);

--- a/examples/system/freertos/basic_freertos_smp_usage/main/lock_example.c
+++ b/examples/system/freertos/basic_freertos_smp_usage/main/lock_example.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
 #include <stdatomic.h>
+#include <stdint.h>
 #include "freertos/FreeRTOS.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -78,7 +79,7 @@ static void inc_num_atomic_iter(void *arg)
 
 static void inc_num_mutex(void *arg)
 {
-    int task_index = (int)arg;
+    int task_index = (intptr_t)arg;
     ESP_LOGI(TAG, "mutex task %d created", task_index);
 
     while (!timed_out) {
@@ -122,7 +123,7 @@ and in turn accessed by multiple tasks. */
 int comp_lock_entry_func(int argc, char **argv)
 {
     s_global_num = 0;
-    int thread_id;
+    intptr_t thread_id;
     int core_id;
 
     timed_out = false;


### PR DESCRIPTION
## Description

Address a pair of compiler errors in the examples when building on Linux target.

## Testing

Built for ESP32-S3 as well.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only type fixes with no production logic changes; behavior on 32-bit targets stays the same.
> 
> **Overview**
> Fixes **Linux / 64-bit build failures** in the basic FreeRTOS SMP examples by passing small integer task IDs through `void*` using **`intptr_t`** instead of **`int`**.
> 
> In **`create_task_example.c`** and **`lock_example.c`**, task parameters are now stored as `intptr_t`, cast to `(void*)` for `xTaskCreatePinnedToCore`, and recovered in task entry with `(intptr_t)arg` before narrowing to `int` for logging. **`stdint.h`** is included where needed.
> 
> Runtime behavior on typical 32-bit MCU targets is unchanged; this only aligns pointer↔integer conversions with platforms where pointers are wider than `int`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75b7daa3c6d8fbdc5db6ac2513bb0333c1b524d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->