### PR TITLE
fix(ppa): bypass SRM macro block order for P4 rotation (IDFGH-17870)

### DIFF
--- a/components/esp_driver_ppa/src/ppa_srm.c
+++ b/components/esp_driver_ppa/src/ppa_srm.c
@@ -156,18 +156,35 @@ bool ppa_srm_transaction_on_picked(uint32_t num_chans, const dma2d_trans_channel
 
 #if CONFIG_IDF_TARGET_ESP32P4
     // Hardware bug workaround (DIG-734)
-    uint32_t w_out = srm_trans_desc->in.block_w * srm_trans_desc->scale_x_int + srm_trans_desc->in.block_w * srm_trans_desc->scale_x_frag / PPA_LL_SRM_SCALING_FRAG_MAX;
+    uint32_t in_block_w, in_block_h;
+    uint32_t scale_x_int, scale_x_frag, scale_y_int, scale_y_frag;
+    if (srm_trans_desc->rotation_angle == PPA_SRM_ROTATION_ANGLE_90 || srm_trans_desc->rotation_angle == PPA_SRM_ROTATION_ANGLE_270) {
+        in_block_w = srm_trans_desc->in.block_h;
+        in_block_h = srm_trans_desc->in.block_w;
+        scale_x_int = srm_trans_desc->scale_y_int;
+        scale_x_frag = srm_trans_desc->scale_y_frag;
+        scale_y_int = srm_trans_desc->scale_x_int;
+        scale_y_frag = srm_trans_desc->scale_x_frag;
+    } else {
+        in_block_w = srm_trans_desc->in.block_w;
+        in_block_h = srm_trans_desc->in.block_h;
+        scale_x_int = srm_trans_desc->scale_x_int;
+        scale_x_frag = srm_trans_desc->scale_x_frag;
+        scale_y_int = srm_trans_desc->scale_y_int;
+        scale_y_frag = srm_trans_desc->scale_y_frag;
+    }
+    uint32_t w_out = in_block_w * scale_x_int + in_block_w * scale_x_frag / PPA_LL_SRM_SCALING_FRAG_MAX;
     uint32_t w_divisor = (ppa_out_color_mode == PPA_SRM_COLOR_MODE_ARGB8888 || ppa_out_color_mode == PPA_SRM_COLOR_MODE_RGB888) ? 32 : 64;
     uint32_t w_left = w_out % w_divisor;
     w_left = (w_left == 0) ? w_divisor : w_left;
     uint32_t h_mb = (ppa_ll_srm_get_mb_size(platform->hal.dev) == PPA_LL_SRM_MB_SIZE_16_16) ? 16 : 32;
-    uint32_t h_in_left = srm_trans_desc->in.block_h % h_mb;
+    uint32_t h_in_left = in_block_h % h_mb;
     h_in_left = (h_in_left == 0) ? h_mb : h_in_left;
-    uint32_t h_left = h_in_left * srm_trans_desc->scale_y_int + h_in_left * srm_trans_desc->scale_y_frag / PPA_LL_SRM_SCALING_FRAG_MAX;
+    uint32_t h_left = h_in_left * scale_y_int + h_in_left * scale_y_frag / PPA_LL_SRM_SCALING_FRAG_MAX;
     const uint32_t dma2d_fifo_depth_bits = 12 * 128;
     uint32_t out_pixel_depth = color_hal_pixel_format_fourcc_get_bit_depth((esp_color_fourcc_t)ppa_out_color_mode);
     bool bypass_mb_order = false;
-    if (((w_out > w_divisor) || (srm_trans_desc->in.block_h > h_mb)) && // will be cut into more than one trans unit
+    if (((w_out > w_divisor) || (in_block_h > h_mb)) && // will be cut into more than one trans unit
             ((w_left * h_left * out_pixel_depth) < dma2d_fifo_depth_bits)
        ) {
         bypass_mb_order = true;


### PR DESCRIPTION
## Description

This extends the existing ESP32-P4 SRM macro block order workaround so 90/270-degree rotation also enables macro block order bypass before starting the SRM engine.

`esp_lvgl_adapter` currently documents a downstream patch for ESP32-P4 display freezes when `ESP_LV_ADAPTER_TEAR_AVOID_MODE_TRIPLE_PARTIAL` is used with screen rotation and PPA acceleration. ESP-IDF already has a `DIG-734` workaround in this area using `ppa_ll_srm_bypass_mb_order()`, so this change keeps the existing LL path instead of adding a direct register write.

## Testing

- Compared this branch against `espressif:master`: 1 file changed, +2/-1.
- Checked the touched file for trailing whitespace.

Not run:

- ESP-IDF build.
- ESP-IDF pre-commit hooks.
- ESP32-P4 hardware reproduction test.

The local environment used for preparing this PR could not clone from `github.com` with `git` and does not have `idf.py` available, so this is opened as a draft for maintainer review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ESP32-P4-only display DMA/PPA workaround logic; wrong dimension mapping could mis-set bypass and affect stability under rotation, but scope is a single guarded code path aligned with existing rotation math in the same file.
> 
> **Overview**
> **ESP32-P4 DIG-734 workaround:** the logic that decides when to call `ppa_ll_srm_bypass_mb_order()` now uses **post-rotation** block size and scale factors, matching how output geometry is already computed elsewhere in SRM.
> 
> For **90° and 270°** rotation, effective width/height and X/Y scale integers/fragments are swapped before computing `w_out`, `h_left`, and the multi–macro-block split condition. **0°/180°** paths keep the previous direct use of `in.block_w/h` and `scale_x/y_*`.
> 
> This should let the existing hardware workaround trigger correctly under rotation (e.g. LVGL partial tear-avoid + PPA), instead of underestimating output size and skipping bypass when it was needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8513a3d1528bcea1365d0f39012d870c0edd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->