### PR TITLE
bt/ble_log: release fallback mutex on host write errors (IDFGH-17872)

### DIFF
--- a/components/bt/common/ble_log/deprecated/ble_log_spi_out.c
+++ b/components/bt/common/ble_log/deprecated/ble_log_spi_out.c
@@ -1336,6 +1336,7 @@ int ble_log_spi_out_host_write(uint8_t source, const char *prefix, const char *f
     spi_out_log_cb_t *log_cb;
     uint8_t *str_buf;
     bool fallback = false;
+    int ret = -1;
     if (!spi_out_get_task_mapping(LOG_MODULE_TASK_MAP(host),
                                   LOG_MODULE_CB_CNT(host), &log_cb, &str_buf)) {
         // NimBLE workaround
@@ -1348,7 +1349,7 @@ int ble_log_spi_out_host_write(uint8_t source, const char *prefix, const char *f
     // Copy prefix to string buffer
     int prefix_len = strlen(prefix);
     if (prefix_len >= SPI_OUT_LOG_STR_BUF_SIZE) {
-        return -1;
+        goto exit;
     }
     memcpy(str_buf, prefix, prefix_len);
 
@@ -1358,16 +1359,19 @@ int ble_log_spi_out_host_write(uint8_t source, const char *prefix, const char *f
     int total_len = spi_out_write_str(str_buf, format, args, prefix_len);
     va_end(args);
     if (total_len == 0) {
-        return -1;
+        goto exit;
     }
 
     // Write log control block buffer
     spi_out_write_hex(log_cb, source, str_buf, (uint16_t)total_len, true);
 
+    ret = 0;
+
+exit:
     if (fallback) {
         xSemaphoreGive(LOG_MODULE_MUTEX(ul));
     }
-    return 0;
+    return ret;
 }
 #endif // SPI_OUT_HOST_ENABLED
 


### PR DESCRIPTION
﻿## Summary

This fixes the fallback path in `ble_log_spi_out_host_write()` so that `LOG_MODULE_MUTEX(ul)` is released on host write errors.

When no host task mapping is available, the function falls back to the `ul` log buffer and takes `LOG_MODULE_MUTEX(ul)`. Two error paths after that point returned `-1` directly, leaving the fallback mutex locked.

## Changes

- Use a single local exit path for `ble_log_spi_out_host_write()` after fallback lock ownership can exist.
- Preserve the existing successful write behavior.
- Keep the change limited to the deprecated BLE log SPI output implementation.

## Testing

- `git diff --check origin/master..HEAD`
- `rg -n "ble_log_spi_out_host_write|fallback|LOG_MODULE_MUTEX\\(ul\\)|return -1|goto exit|ret =" components/bt/common/ble_log/deprecated/ble_log_spi_out.c`
- `git diff --stat origin/master..HEAD`

Build not run locally: `idf.py` is not available in this Windows environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix in deprecated BLE log SPI code; behavior on success is unchanged and only error cleanup is corrected.
> 
> **Overview**
> Fixes a **mutex leak** in deprecated `ble_log_spi_out_host_write()` when the NimBLE **fallback** path is used (no host task mapping → takes `LOG_MODULE_MUTEX(ul)` and uses the `ul` log buffer).
> 
> Previously, **oversized prefix** and **failed string formatting** (`total_len == 0`) returned `-1` immediately and never called `xSemaphoreGive`, which could deadlock other BLE log SPI output on `ul`.
> 
> The change routes those failures through a shared **`exit`** label, sets **`ret`** to `0` only on success, and always releases the fallback mutex before returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e349ca37cf90805e3554929d34d89f51e7819c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->