### PR TITLE
docs(nvs): remove unused return code (IDFGH-17878)

### DIFF
--- a/components/nvs_flash/include/nvs.h
+++ b/components/nvs_flash/include/nvs.h
@@ -383,7 +383,6 @@ esp_err_t nvs_set_blob(nvs_handle_t handle, const char* key, const void* value, 
  *             - ESP_ERR_NVS_NOT_FOUND if the requested key doesn't exist
  *             - ESP_ERR_NVS_INVALID_HANDLE if handle has been closed or is NULL
  *             - ESP_ERR_NVS_INVALID_NAME if key name doesn't satisfy constraints
- *             - ESP_ERR_NVS_INVALID_LENGTH if length is not sufficient to store data
  */
 esp_err_t nvs_get_i8 (nvs_handle_t handle, const char* key, int8_t* out_value);
 


### PR DESCRIPTION
## Description

nvs_get_i8() cannot return ESP_ERR_NVS_INVALID_LENGTH, as a length argument is not present.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header comment change only; no runtime or API behavior change.
> 
> **Overview**
> Removes **`ESP_ERR_NVS_INVALID_LENGTH`** from the `@return` list on the shared Doxygen block for **`nvs_get_i8`** and the other fixed-size scalar getters that inherit that documentation.
> 
> That error applies only to length-based APIs such as **`nvs_get_str`** and **`nvs_get_blob`**; scalar getters have no length argument, so documenting it there was misleading for callers checking return codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1efc077ed9051f3f611cc41d90dda08ca1f49e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->