### PR TITLE
fix(ppa): validate scaled YUV SRM output blocks (IDFGH-17886)

### DIFF
--- a/components/esp_driver_ppa/src/ppa_srm.c
+++ b/components/esp_driver_ppa/src/ppa_srm.c
@@ -223,6 +223,15 @@ esp_err_t ppa_do_scale_rotate_mirror(ppa_client_handle_t ppa_client, const ppa_s
     uint32_t scale_x_frag = (uint32_t)(config->scale_x * PPA_LL_SRM_SCALING_FRAG_MAX) & (PPA_LL_SRM_SCALING_FRAG_MAX - 1);
     uint32_t scale_y_int = (uint32_t)config->scale_y;
     uint32_t scale_y_frag = (uint32_t)(config->scale_y * PPA_LL_SRM_SCALING_FRAG_MAX) & (PPA_LL_SRM_SCALING_FRAG_MAX - 1);
+    // SRM processes in blocks. Block x/(y) cannot be scaled to odd number when YUV422/YUV420 is the output color mode
+    // When block size is 16x16, odd number is possible, so needs to make them even
+    // When block size is 32x32, calculated frag values are always even
+    if (config->out.srm_cm == PPA_SRM_COLOR_MODE_YUV420) {
+        scale_x_frag = scale_x_frag & ~1;
+        scale_y_frag = scale_y_frag & ~1;
+    } else if (PPA_IS_CM_YUV422(config->out.srm_cm)) {
+        scale_x_frag = scale_x_frag & ~1;
+    }
     uint32_t new_block_w = 0;
     uint32_t new_block_h = 0;
     if (config->rotation_angle == PPA_SRM_ROTATION_ANGLE_0 || config->rotation_angle == PPA_SRM_ROTATION_ANGLE_180) {
@@ -235,6 +244,13 @@ esp_err_t ppa_do_scale_rotate_mirror(ppa_client_handle_t ppa_client, const ppa_s
     ESP_RETURN_ON_FALSE(new_block_w <= (config->out.pic_w - config->out.block_offset_x) &&
                         new_block_h <= (config->out.pic_h - config->out.block_offset_y),
                         ESP_ERR_INVALID_ARG, TAG, "scale does not fit in the out pic");
+    if (config->out.srm_cm == PPA_SRM_COLOR_MODE_YUV420) {
+        ESP_RETURN_ON_FALSE(new_block_w % 2 == 0 && new_block_h % 2 == 0,
+                            ESP_ERR_INVALID_ARG, TAG, "YUV420 output block does not support odd width or height after scaling");
+    } else if (PPA_IS_CM_YUV422(config->out.srm_cm)) {
+        ESP_RETURN_ON_FALSE(new_block_w % 2 == 0,
+                            ESP_ERR_INVALID_ARG, TAG, "YUV422 output block does not support odd width after scaling");
+    }
 
     if (!ppa_check_buffer_alignment(ppa_client, &config->in, true, config->in.block_w) ||
             !ppa_check_buffer_alignment(ppa_client, &config->out, false, new_block_w)) {
@@ -290,15 +306,6 @@ esp_err_t ppa_do_scale_rotate_mirror(ppa_client_handle_t ppa_client, const ppa_s
         srm_trans_desc->scale_x_frag = scale_x_frag;
         srm_trans_desc->scale_y_int = scale_y_int;
         srm_trans_desc->scale_y_frag = scale_y_frag;
-        // SRM processes in blocks. Block x/(y) cannot be scaled to odd number when YUV422/YUV420 is the output color mode
-        // When block size is 16x16, odd number is possible, so needs to make them even
-        // When block size is 32x32, calculated frag values are always even
-        if (config->out.srm_cm == PPA_SRM_COLOR_MODE_YUV420) {
-            srm_trans_desc->scale_x_frag = srm_trans_desc->scale_x_frag & ~1;
-            srm_trans_desc->scale_y_frag = srm_trans_desc->scale_y_frag & ~1;
-        } else if (PPA_IS_CM_YUV422(config->out.srm_cm)) {
-            srm_trans_desc->scale_x_frag = srm_trans_desc->scale_x_frag & ~1;
-        }
         srm_trans_desc->alpha_value = new_alpha_value;
         srm_trans_desc->data_burst_length = ppa_client->data_burst_length;
 

--- a/components/esp_driver_ppa/test_apps/main/test_ppa.cpp
+++ b/components/esp_driver_ppa/test_apps/main/test_ppa.cpp
@@ -426,6 +426,64 @@ TEST_CASE("ppa_srm_basic_data_correctness_check", "[PPA]")
 #endif
 }
 
+TEST_CASE("ppa_srm_yuv420_scaled_output_validation", "[PPA]")
+{
+    const uint32_t in_pic_w = 96;
+    const uint32_t in_pic_h = 96;
+    const uint32_t out_pic_w = 52;
+    const uint32_t out_pic_h = 18;
+    const uint32_t in_block_w = 18;
+    const uint32_t in_block_h = 34;
+    const ppa_srm_color_mode_t cm = PPA_SRM_COLOR_MODE_YUV420;
+
+    uint32_t in_buf_size = ALIGN_UP(in_pic_w * in_pic_h * color_hal_pixel_format_fourcc_get_bit_depth((esp_color_fourcc_t)cm) / 8, 64);
+    uint32_t out_buf_size = ALIGN_UP(out_pic_w * out_pic_h * color_hal_pixel_format_fourcc_get_bit_depth((esp_color_fourcc_t)cm) / 8, 64);
+    uint8_t *in_buf = static_cast<uint8_t *>(heap_caps_aligned_calloc(4, in_buf_size, sizeof(uint8_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT | MALLOC_CAP_DMA));
+    TEST_ASSERT_NOT_NULL(in_buf);
+    uint8_t *out_buf = static_cast<uint8_t *>(heap_caps_aligned_calloc(4, out_buf_size, sizeof(uint8_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT | MALLOC_CAP_DMA));
+    if (!out_buf) {
+        free(in_buf);
+    }
+    TEST_ASSERT_NOT_NULL(out_buf);
+
+    ppa_client_handle_t ppa_client_handle;
+    ppa_client_config_t ppa_client_config = {};
+    ppa_client_config.oper_type = PPA_OPERATION_SRM;
+    ppa_client_config.max_pending_trans_num = 1;
+    TEST_ESP_OK(ppa_register_client(&ppa_client_config, &ppa_client_handle));
+
+    ppa_srm_oper_config_t oper_config = {};
+    oper_config.in.buffer = in_buf;
+    oper_config.in.pic_w = in_pic_w;
+    oper_config.in.pic_h = in_pic_h;
+    oper_config.in.block_w = in_block_w;
+    oper_config.in.block_h = in_block_h;
+    oper_config.in.block_offset_x = 0;
+    oper_config.in.block_offset_y = 0;
+    oper_config.in.srm_cm = cm;
+    oper_config.out.buffer = out_buf;
+    oper_config.out.buffer_size = out_buf_size;
+    oper_config.out.pic_w = out_pic_w;
+    oper_config.out.pic_h = out_pic_h;
+    oper_config.out.block_offset_x = 0;
+    oper_config.out.block_offset_y = 0;
+    oper_config.out.srm_cm = cm;
+    oper_config.rotation_angle = PPA_SRM_ROTATION_ANGLE_90;
+    oper_config.scale_x = 1.0;
+    oper_config.scale_y = 1.5;
+    oper_config.mode = PPA_TRANS_MODE_BLOCKING;
+    TEST_ESP_ERR(ESP_ERR_INVALID_ARG, ppa_do_scale_rotate_mirror(ppa_client_handle, &oper_config));
+
+    oper_config.out.pic_w = 34;
+    oper_config.out.pic_h = 18;
+    oper_config.scale_y = 1.0;
+    TEST_ESP_OK(ppa_do_scale_rotate_mirror(ppa_client_handle, &oper_config));
+
+    TEST_ESP_OK(ppa_unregister_client(ppa_client_handle));
+    free(in_buf);
+    free(out_buf);
+}
+
 static void ppa_blend_basic_data_correctness_check(bool auto_light_sleep)
 {
     const uint32_t w = 2;


### PR DESCRIPTION
## Summary

- Move the YUV422/YUV420 SRM scale-fragment adjustment before scaled output block size calculation.
- Reject scaled YUV output blocks that would produce unsupported odd dimensions before starting the PPA SRM transaction.
- Add a YUV420 regression test that rejects a rotated/scaled 51x18 output block and then verifies a nearby valid 34x18 case still succeeds.

## Why

For YUV420 output, the final scaled block width and height must remain even. The existing API validation checks output picture dimensions and offsets, but the effective SRM output block size can become odd after rotation and scaling.

Observed case:

```text
cm=YUV420, rotation=90, in block=18x34, scale_x=1.0, scale_y=1.5
scaled output block=51x18, output picture=52x18
```

Without early validation, the operation can enter the hardware path and time out. On the tested board, that also left subsequent SRM operations blocked until the validation fix was applied.

## Validation

- Patch application checked against ESP-IDF master file contents at fa8039b5cadb6e85dd830ff8c2c4bd73b6538aee.
- `git diff --check` passed for the generated master patch.
- Equivalent v5.5.3-based ESP-IDF test app build passed for esp32p4:
  - app: `components/esp_driver_ppa/test_apps`
  - build dir: `build_codex_yuv420_validation`
  - `ppa_srm.c` and `test_ppa.c` compiled
  - `ppa_test.bin` generated
- Board validation was done with an application-level SRM diagnostic on ESP32-P4 using an equivalent fix:
  - invalid YUV420 case returned `ESP_ERR_INVALID_ARG`
  - subsequent RGB565 SRM returned `ESP_OK`
  - `SRMSTRESS 2000` completed 8000 cases with `result=ESP_OK`
  - `SRMSTRESS 10000` completed 40000 cases with `result=ESP_OK` in an earlier run

## Notes

- I could not run the official master test app on the board in this environment. The local product board uses a 32 MB OTA layout, while the official test app build is a 2 MB single factory-app layout.
- I could not fetch the full ESP-IDF master worktree locally due repeated network connection resets, so master validation here is patch-level plus v5.5.3 build/board validation of the same logic.
- YUV422 hardware behavior was not board-verified on this setup because the current target config selects ESP32-P4 rev < 3, where YUV422 SRM is not supported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SRM API validation on the hardware transaction path; incorrect checks could reject valid configs or still allow bad ones, but scope is limited to YUV scaled-block dimension rules.
> 
> **Overview**
> **PPA SRM** now validates YUV output constraints using the same scale fragments and block dimensions that will be programmed, instead of adjusting fragments only when a transaction is queued.
> 
> For **YUV420/YUV422** outputs, scale fractional parts are forced even **before** computing the post-rotate/scaled output block size (`new_block_w` / `new_block_h`). The driver then returns **`ESP_ERR_INVALID_ARG`** if that effective block would be odd (YUV420: width and height; YUV422: width), so invalid configs never reach the hardware path that could hang or block later SRM work.
> 
> The duplicate fragment masking in the DMA transaction setup path is removed. A **YUV420** regression test covers 90° rotation with scaling: it expects failure for an odd-sized scaled block and success for a nearby valid configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a94ca7d44319d891da2d8fe3e94f84f8640420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->