### PR TITLE
fix(esp_eth): recover EMAC RX from descriptor exhaustion under bursts (IDFGH-17916)

### DIFF
--- a/components/esp_eth/src/mac/esp_eth_mac_esp.c
+++ b/components/esp_eth/src/mac/esp_eth_mac_esp.c
@@ -776,7 +776,10 @@ IRAM_ATTR void emac_isr_default_handler(void *args)
 #endif // SOC_EMAC_IEEE1588V2_SUPPORTED
 
 #if EMAC_LL_CONFIG_ENABLE_INTR_MASK & EMAC_LL_INTR_RECEIVE_ENABLE
-    if (intr_stat & EMAC_LL_DMA_RECEIVE_FINISH_INTR) {
+    /* RBU must also wake the RX task: with the ring full the DMA suspends
+     * and raises no further RECEIVE interrupts, so RBU is the only drain trigger. */
+    if (intr_stat & (EMAC_LL_DMA_RECEIVE_FINISH_INTR |
+                     EMAC_LL_DMA_RECEIVE_BUFF_UNAVAILABLE_INTR)) {
         BaseType_t rx_high_task_woken = pdFALSE;
         /* notify receive task */
         vTaskNotifyGiveFromISR(emac->rx_task_hdl, &rx_high_task_woken);

--- a/components/esp_eth/src/mac/esp_eth_mac_esp_dma.c
+++ b/components/esp_eth/src/mac/esp_eth_mac_esp_dma.c
@@ -337,6 +337,17 @@ static esp_err_t emac_esp_dma_get_valid_recv_len(emac_esp_dma_handle_t emac_esp_
         }
         /* First segment in frame */
         if (desc_iter->RDES0.FirstDescriptor) {
+            /* Return to DMA any first-without-last segments left by overflow-truncated
+             * frames; skipping them would leak the descriptors permanently. */
+            if (emac_esp_dma->rx_desc != desc_iter) {
+                eth_dma_rx_descriptor_t *orphan = emac_esp_dma->rx_desc;
+                while (orphan != desc_iter) {
+                    orphan->RDES0.Own = EMAC_LL_DMADESC_OWNER_DMA;
+                    DMA_CACHE_WB(orphan, EMAC_HAL_DMA_DESC_SIZE);
+                    orphan = (eth_dma_rx_descriptor_t *)(orphan->Buffer2NextDescAddr);
+                }
+                emac_hal_receive_poll_demand(&emac_esp_dma->hal);
+            }
             emac_esp_dma->rx_desc = desc_iter;
         }
         /* point to next descriptor */

--- a/components/esp_hal_emac/esp32p4/include/hal/emac_ll.h
+++ b/components/esp_hal_emac/esp32p4/include/hal/emac_ll.h
@@ -142,8 +142,10 @@ extern "C" {
 #define EMAC_LL_MAC_INTR_TIME_STAMP_ENABLE             0x00000200U
 #define EMAC_LL_MAC_INTR_POWER_MANAGEMENT_MOD_ENABLE   0x00000008U
 
-/* Enable needed DMA interrupts (recv/recv_buf_unavailabal/normal must be enabled to make eth work) */
-#define EMAC_LL_CONFIG_ENABLE_INTR_MASK    (EMAC_LL_INTR_RECEIVE_ENABLE | EMAC_LL_INTR_NORMAL_SUMMARY_ENABLE)
+/* Enable needed DMA interrupts (recv/recv_buf_unavailabal/normal must be enabled to make eth work).
+ * RBU is abnormal-class, so the abnormal summary enable is required with it. */
+#define EMAC_LL_CONFIG_ENABLE_INTR_MASK    (EMAC_LL_INTR_RECEIVE_ENABLE | EMAC_LL_INTR_RECEIVE_BUFF_UNAVAILABLE_ENABLE | \
+                                            EMAC_LL_INTR_ABNORMAL_SUMMARY_ENABLE | EMAC_LL_INTR_NORMAL_SUMMARY_ENABLE)
 
 /* Enable needed MAC interrupts */
 #define EMAC_LL_CONFIG_ENABLE_MAC_INTR_MASK  (EMAC_LL_MAC_INTR_TIME_STAMP_ENABLE)


### PR DESCRIPTION
### Summary

Two related EMAC RX defects that leave reception stalled after traffic bursts exhaust the RX descriptor ring, found on ESP32-P4 under sustained ~16k pkt/s bidirectional AVB traffic:

1. **RX task is never woken on RBU.** With the ring completely full, no RECEIVE_FINISH interrupt can occur, and `RECEIVE_BUFF_UNAVAILABLE` is neither in `EMAC_LL_CONFIG_ENABLE_INTR_MASK` (whose comment already lists it as required) nor handled by the ISR. The ring is never drained and reception stalls with the DMA missed-frame counter climbing.
2. **Descriptors of overflow-truncated frames leak.** A frame whose tail is cut by an RX FIFO overflow leaves first-without-last CPU-owned descriptors; the receive-length walk skips them without returning them to the DMA. Each event permanently shrinks the ring until reception stops entirely (remaining frames = 0, free descriptors = 0, DMA suspended, no interrupts possible).

### Testing

Validated on ESP32-P4 (chip rev 1.3) at v6.1-dev-4859 and rebased onto master (the touched code is identical). Repro: a boot burst combining AVDECC controller enumeration with bidirectional 8000 pkt/s Class A streams wedged RX on ~50% of boots; with both fixes, 10/10 boot cycles ran clean, DMA overflow counters stayed at zero throughout, and no RX stalls occurred in extended runs.

### Related

On ESP32-P4 the 256 B RX FIFO forces threshold mode (`emac_hal_init_dma_default` disables receive store-forward for this reason), and an RX FIFO overflow can additionally latch the MTL FIFO itself — unrecoverable by poll demand or receiver toggle; only a DMA software reset clears it. That is filed as #18800 since the proper fix likely needs silicon-errata knowledge; the two fixes here make the trigger rare and keep the descriptor state always recoverable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches EMAC DMA interrupt handling and RX descriptor ownership in the ISR and receive path; incorrect behavior could affect all Ethernet RX on targets using this driver, though the change is narrowly scoped to stall recovery.
> 
> **Overview**
> Fixes **EMAC RX stalls** when the RX descriptor ring is exhausted under heavy traffic (notably ESP32-P4 AVB bursts).
> 
> **Receive buffer unavailable (RBU):** On ESP32-P4, `EMAC_LL_CONFIG_ENABLE_INTR_MASK` now enables **receive-buffer-unavailable** and **abnormal summary** DMA interrupts (RBU is abnormal-class). The default EMAC ISR also notifies `emac_rx` on **RBU** as well as receive-finish, so the ring can drain when the DMA is suspended and no further receive-complete IRQs fire.
> 
> **Descriptor leaks:** In `emac_esp_dma_get_valid_recv_len`, when a new frame’s first segment appears ahead of the current `rx_desc`, any **orphaned first-without-last** descriptors from overflow-truncated frames are returned to the DMA and receive poll demand is issued, instead of being skipped forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84df26c895f44a72baad9dac4c9c71a15558c6f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->