### PR TITLE
fix(protocomm): free response buffers on 2nd psa_cipher_update failure (IDFGH-17940)

### DIFF
--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -198,6 +198,7 @@ static esp_err_t handle_session_command1(session_t *cur_session,
         ESP_LOGE(TAG, "Failed at psa_cipher_update with error code : %d", status);
         psa_cipher_abort(&cur_session->ctx_aes);
         psa_destroy_key(key_id);
+        cur_session->key_id_sym = PSA_KEY_ID_NULL;
         free(outbuf);
         free(out_resp);
         free(out);

--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -196,7 +196,11 @@ static esp_err_t handle_session_command1(session_t *cur_session,
     status = psa_cipher_update(&cur_session->ctx_aes, cur_session->client_pubkey, sizeof(cur_session->client_pubkey), outbuf, PUBLIC_KEY_LEN, &outlen);
     if (status != PSA_SUCCESS) {
         ESP_LOGE(TAG, "Failed at psa_cipher_update with error code : %d", status);
+        psa_cipher_abort(&cur_session->ctx_aes);
+        psa_destroy_key(key_id);
         free(outbuf);
+        free(out_resp);
+        free(out);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
## Summary

Fixes #18804. In `handle_session_command1()` (`components/protocomm/src/security/security1.c`), if the second `psa_cipher_update()` call (encrypting the device verify data to send back to the client) fails, the error path only frees the `outbuf` ciphertext buffer:

```c
status = psa_cipher_update(&cur_session->ctx_aes, cur_session->client_pubkey, sizeof(cur_session->client_pubkey), outbuf, PUBLIC_KEY_LEN, &outlen);
if (status != PSA_SUCCESS) {
    ESP_LOGE(TAG, "Failed at psa_cipher_update with error code : %d", status);
    free(outbuf);
    return ESP_FAIL;
}
```

`out` (`Sec1Payload`) and `out_resp` (`SessionResp1`) — allocated a few lines above this — are never freed on this path, and neither the in-progress cipher operation (`cur_session->ctx_aes`) nor the imported key (`key_id`) are released either.

The caller chain (`sec1_req_handler()` → `sec1_session_setup()`) returns immediately on a non-`ESP_OK` result without any cleanup of its own: `sec1_session_setup_cleanup()` only runs on the success path, after `resp->sec1` has actually been assigned to `out` — which never happens here since the assignment (`resp->sec1 = out;`) is further down, past this failure point. So nothing else ever reaches these allocations on this path.

## Fix

Add `psa_cipher_abort()`, `psa_destroy_key()`, and `free()` for `out`/`out_resp` to this branch, matching the cleanup pattern already used by every other failure branch earlier in this same function (e.g. the first `psa_cipher_update()` call a few lines up does exactly this on failure).

## Testing

I don't have a working ESP-IDF build/QEMU environment fully set up for this component right now, so I can't provide a real on-target or `test_apps` run. What I did instead: traced the full call chain (`sec1_req_handler` → `sec1_session_setup` → `handle_session_command1`) to confirm there's genuinely no cleanup path reaching this branch's allocations, and wrote a standalone host-C reproduction mirroring just the alloc/free/cipher-abort/destroy-key call counts on this exact control-flow path (mocked `psa_*` calls, since the real PSA crypto init is more involved to stand up outside the full build):

- **Before fix**: 3 mocked allocations, only 1 freed, cipher-abort/destroy-key never called.
- **After fix**: 3 allocations, 3 frees, both cleanup calls made.

Happy to add a case to `components/protocomm/test_apps/main/test_security1.c` forcing this specific `psa_cipher_update` call to fail, if that's preferred over the standalone repro for confirming this before merge.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-path fix in session setup; no change to successful handshake or crypto logic, only resource cleanup on an already-failing path.
> 
> **Overview**
> Fixes a leak on the **Session Command1** error path in `handle_session_command1()` when the second `psa_cipher_update()` (device verify ciphertext) fails.
> 
> That branch previously freed only `outbuf` and returned `ESP_FAIL`. **`Sec1Payload` / `SessionResp1`**, the in-flight **`psa_cipher_abort`**, and **`psa_destroy_key`** for the imported AES key were left unreleased. **`sec1_req_handler`** returns immediately on setup failure and never runs **`sec1_session_setup_cleanup`** (success-only, and `resp->sec1` is not assigned on this path).
> 
> The change adds the same cleanup used by earlier failure branches in this function: abort cipher, destroy key, clear **`key_id_sym`**, and free **`outbuf`**, **`out_resp`**, and **`out`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa38c2f25aba07b3eadbd244e8d0fb971188a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->