### PR TITLE
Fix minor issues in sdmmc

### DIFF
--- a/components/sdmmc/sdmmc_cmd.c
+++ b/components/sdmmc/sdmmc_cmd.c
@@ -408,7 +408,7 @@ esp_err_t sdmmc_send_cmd_send_scr(sdmmc_card_t* card, sdmmc_scr_t *out_scr)
     if (err == ESP_OK) {
         err = sdmmc_decode_scr(buf, out_scr);
     }
-    free(buf);
+    heap_caps_free(buf);
     return err;
 }
 
@@ -478,16 +478,15 @@ esp_err_t sdmmc_send_cmd_num_of_written_blocks(sdmmc_card_t* card, size_t* out_n
 
     err = sdmmc_send_app_cmd(card, &cmd);
     if (err != ESP_OK) {
-        free(buf);
+        heap_caps_free(buf);
         ESP_LOGE(TAG, "%s: sdmmc_send_app_cmd returned 0x%x, failed to get number of written write blocks", __func__, err);
         return err;
     }
 
-    size_t result = __builtin_bswap32(*(uint32_t*)buf);
     if (out_num_blocks) {
-        *out_num_blocks = result;
+        *out_num_blocks = __builtin_bswap32(*(uint32_t*)buf);
     }
-    free(buf);
+    heap_caps_free(buf);
     return err;
 }
 
@@ -550,7 +549,7 @@ esp_err_t sdmmc_write_sectors(sdmmc_card_t* card, const void* src,
             }
         }
         if (!use_dma_aligned_buffer) {
-            free(buf);
+            heap_caps_free(buf);
         }
     }
     return err;
@@ -707,7 +706,7 @@ esp_err_t sdmmc_read_sectors(sdmmc_card_t* card, void* dst,
             cur_dst += block_size * blocks_per_read;
         }
         if (!use_dma_aligned_buffer) {
-            free(buf);
+            heap_caps_free(buf);
         }
     }
     return err;

--- a/components/sdmmc/sdmmc_mmc.c
+++ b/components/sdmmc/sdmmc_mmc.c
@@ -98,7 +98,7 @@ esp_err_t sdmmc_init_mmc_read_ext_csd(sdmmc_card_t* card)
     card->ext_csd.sec_feature = ext_csd[EXT_CSD_SEC_FEATURE_SUPPORT];
 
 out:
-    free(ext_csd);
+    heap_caps_free(ext_csd);
     return err;
 }
 
@@ -194,7 +194,7 @@ esp_err_t sdmmc_mmc_decode_csd(sdmmc_response_t response, sdmmc_csd_t* out_csd)
         out_csd->read_block_len = MMC_CSD_READ_BL_LEN(response);
     } else {
         ESP_LOGE(TAG, "unknown MMC CSD structure version 0x%x", out_csd->csd_ver);
-        return 1;
+        return ESP_ERR_NOT_SUPPORTED;
     }
     int read_bl_size = 1 << out_csd->read_block_len;
     out_csd->sector_size = MIN(read_bl_size, 512);
@@ -292,7 +292,7 @@ esp_err_t sdmmc_init_mmc_check_ext_csd(sdmmc_card_t* card)
     }
 
 out:
-    free(ext_csd);
+    heap_caps_free(ext_csd);
     return err;
 }
 

--- a/components/sdmmc/sdmmc_sd.c
+++ b/components/sdmmc/sdmmc_sd.c
@@ -120,7 +120,7 @@ esp_err_t sdmmc_init_sd_ssr(sdmmc_card_t* card)
     // read SD status register
     err = sdmmc_send_app_cmd(card, &cmd);
     if (err != ESP_OK) {
-        free(sd_ssr);
+        heap_caps_free(sd_ssr);
         ESP_LOGE(TAG, "%s: sdmmc_send_cmd returned 0x%x", __func__, err);
         return err;
     }
@@ -129,7 +129,7 @@ esp_err_t sdmmc_init_sd_ssr(sdmmc_card_t* card)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "%s: error sdmmc_decode_ssr returned 0x%x", __func__, err);
     }
-    free(sd_ssr);
+    heap_caps_free(sd_ssr);
     return err;
 }
 
@@ -320,7 +320,7 @@ esp_err_t sdmmc_enter_higher_speed_mode(sdmmc_card_t* card)
     }
 
 out:
-    free(response);
+    heap_caps_free(response);
     return err;
 }
 
@@ -515,7 +515,7 @@ esp_err_t sdmmc_select_driver_strength(sdmmc_card_t *card, sdmmc_driver_strength
     ESP_GOTO_ON_FALSE(supported_mask == driver_strength, ESP_ERR_INVALID_ARG, out, TAG, "fail to switch to type 0x%x", driver_strength);
 
 out:
-    free(response);
+    heap_caps_free(response);
     return ret;
 }
 
@@ -622,7 +622,7 @@ esp_err_t sdmmc_select_current_limit(sdmmc_card_t *card, sdmmc_current_limit_t c
     ESP_GOTO_ON_FALSE(supported_mask == current_limit, ESP_ERR_INVALID_ARG, out, TAG, "fail to switch to type 0x%x", current_limit);
 
 out:
-    free(response);
+    heap_caps_free(response);
     return ret;
 }
 


### PR DESCRIPTION
## Description

- return correct error code if csd_ver is unrecognized  
- alloc/free primitives used in `sdmmc` component are harmonized

## Related

Issues were discovered while working on #18805 (IDFGH-17929)

## Testing

Steps described in #18805

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized allocator pairing and one error-code fix in MMC CSD decode; no API or protocol behavior changes beyond correct buffer lifetime.
> 
> **Overview**
> Replaces **`free()`** with **`heap_caps_free()`** everywhere the SD/MMC stack releases buffers allocated via **`heap_caps_malloc(..., MALLOC_CAP_DMA)`** (command helpers, sector read/write staging buffers, EXT_CSD, SSR, and SWITCH_FUNC response buffers). That pairing fixes leaks and undefined behavior when DDR/higher-speed init fails on error paths such as **`sdmmc_enter_higher_speed_mode`**.
> 
> In **`sdmmc_mmc_decode_csd`**, an unknown MMC CSD structure version now returns **`ESP_ERR_NOT_SUPPORTED`** instead of the integer **`1`**. **`sdmmc_send_cmd_num_of_written_blocks`** inlines the byte-swap into the optional output assignment (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e9adb403dbc8edf6264567f377e46667220aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->