### PR TITLE
fix(wear_levelling): guard WL_Flash::write()/read() against size==0 underflow (IDFGH-17948)

### DIFF
--- a/components/wear_levelling/WL_Flash.cpp
+++ b/components/wear_levelling/WL_Flash.cpp
@@ -575,6 +575,13 @@ esp_err_t WL_Flash::write(size_t dest_addr, const void *src, size_t size)
     if (!this->initialized) {
         return ESP_ERR_INVALID_STATE;
     }
+    if (size == 0) {
+        // Nothing to do. Guard this explicitly: size is unsigned, so
+        // `size - 1` below would otherwise wrap around to SIZE_MAX and turn
+        // "count" into a huge page count, walking far past the caller's
+        // buffer (see components/wear_levelling/host_test).
+        return ESP_OK;
+    }
     ESP_LOGD(TAG, "%s - dest_addr= 0x%08" PRIx32 ", size= 0x%08" PRIx32 , __func__, (uint32_t) dest_addr, (uint32_t) size);
     uint32_t count = (size - 1) / this->cfg.wl_page_size;
     for (size_t i = 0; i < count; i++) {
@@ -593,6 +600,11 @@ esp_err_t WL_Flash::read(size_t src_addr, void *dest, size_t size)
     esp_err_t result = ESP_OK;
     if (!this->initialized) {
         return ESP_ERR_INVALID_STATE;
+    }
+    if (size == 0) {
+        // See the matching guard in WL_Flash::write() above: size==0 must
+        // not be allowed to reach the `size - 1` computation below.
+        return ESP_OK;
     }
     ESP_LOGD(TAG, "%s - src_addr= 0x%08" PRIx32 ", size= 0x%08" PRIx32 , __func__, (uint32_t) src_addr, (uint32_t) size);
     uint32_t count = (size - 1) / this->cfg.wl_page_size;

--- a/components/wear_levelling/host_test/main/test_wl.cpp
+++ b/components/wear_levelling/host_test/main/test_wl.cpp
@@ -99,6 +99,39 @@ TEST_CASE("write and read back data", "[wear_levelling]")
     free(read);
 }
 
+TEST_CASE("write and read with zero size are safe no-ops", "[wear_levelling]")
+{
+    esp_err_t result;
+    wl_handle_t wl_handle;
+
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+
+    // Mount wear-levelled partition
+    result = wl_mount(partition, &wl_handle);
+    REQUIRE(result == ESP_OK);
+
+    // wl_write()/wl_read() do not document size==0 as invalid (analogous to
+    // POSIX write()/read() with count==0), so it must not be treated as an
+    // out-of-bounds request. Previously, WL_Flash::write()/read() computed
+    // `(size - 1) / wl_page_size` without checking for size==0 first; since
+    // size is unsigned, size==0 wrapped this to a huge page count and walked
+    // far past the caller-provided buffer.
+    uint8_t dummy = 0xAA;
+    result = wl_write(wl_handle, 0, &dummy, 0);
+    REQUIRE(result == ESP_OK);
+
+    uint8_t read_back = 0x55;
+    result = wl_read(wl_handle, 0, &read_back, 0);
+    REQUIRE(result == ESP_OK);
+
+    // Untouched by a genuine zero-length read.
+    REQUIRE(read_back == 0x55);
+
+    // Unmount
+    result = wl_unmount(wl_handle);
+    REQUIRE(result == ESP_OK);
+}
+
 TEST_CASE("power down test", "[wear_levelling]")
 {
     esp_err_t result;


### PR DESCRIPTION
## Summary

`WL_Flash::write()` and `WL_Flash::read()` (`components/wear_levelling/WL_Flash.cpp`) both compute:

```cpp
uint32_t count = (size - 1) / this->cfg.wl_page_size;
```

`size` is `size_t` (unsigned). Neither the public `wl_write()`/`wl_read()` API (`components/wear_levelling/wear_levelling.cpp`) nor the block-device path (`wl_bdl_write()`/`wl_bdl_read()` in `components/wear_levelling/wl_blockdev.cpp`) reject `size == 0` before calling into `WL_Flash`, and `wear_levelling.h` does not document `size == 0` as invalid input — a 0-byte write/read is a reasonable no-op, the same way POSIX `write()`/`read()` with `count == 0` is.

When `size == 0`, `size - 1` wraps around to `SIZE_MAX` (unsigned underflow), so `count` becomes an enormous page count instead of `0`. The loop that follows then performs `count` flash-partition accesses of `wl_page_size` bytes each, walking straight past the caller-supplied buffer starting on the very first iteration:

- `write()`: `partition->write(..., &((uint8_t*)src)[i * wl_page_size], wl_page_size)` — **out-of-bounds read** from the caller's `src` buffer.
- `read()`: `partition->read(..., &((uint8_t*)dest)[i * wl_page_size], wl_page_size)` — **out-of-bounds write** into the caller's `dest` buffer (the more severe case: it corrupts caller memory with flash content instead of merely over-reading).

Neither `wear_levelling`'s own `host_test/main/test_wl.cpp` nor any other caller in-tree exercises `size == 0`, so this was previously untested.

## Fix

Add an explicit `size == 0` early return (`return ESP_OK;`, mirroring the existing `!initialized` guard already at the top of both functions) to both `WL_Flash::write()` and `WL_Flash::read()`, before the `size - 1` computation. This matches the sibling function `erase_range()`, which already naturally handles `size == 0` safely because its own formula is `(size + sector_size - 1) / sector_size` rather than `(size - 1) / ...`.

Also added a `host_test` regression case (`"write and read with zero size are safe no-ops"` in `components/wear_levelling/host_test/main/test_wl.cpp`) that calls `wl_write()`/`wl_read()` through the public API with `size == 0` and checks the caller's buffer is left untouched.

## Testing

I verified this with a standalone, host-side reproduction that compiles the **unmodified** `WL_Flash.cpp` from this tree (only `esp_err.h`/`esp_log.h`/`esp_random.h` are swapped for minimal stand-ins, and `crc32::crc32_le` is stubbed since the repro sets up the instance directly rather than going through `config()`/`init()`, which are irrelevant to this bug), against a mock `Flash_Access` partition:

- **Raw arithmetic**, `size=0`, `wl_page_size=4096`: `count = (size - 1) / wl_page_size` evaluates to `4294967295` (`0xFFFFFFFF`) instead of the expected `0`.
- **Before fix, unmitigated**: calling the real `WL_Flash::write(dest_addr=0, src=<8-byte buffer>, size=0)` **segfaults** (confirmed, exit code from SIGSEGV) — the runaway loop walks `src` off the end of the process address space.
- **Before fix, instrumented** (harness stops early once a few out-of-bounds touches are confirmed, so it can report cleanly instead of crashing):
  - `write(..., size=0)` → out-of-bounds **read** starting exactly at the end of an 8-byte buffer, attempting to read 4096 bytes there.
  - `read(..., size=0)` → out-of-bounds **write** into the same 8-byte buffer, attempting to write 4096 bytes there.
- **After fix**: both calls return `ESP_OK` immediately with no out-of-bounds access; a non-zero-size write+read round-trip sanity check still passes unchanged (no regression).

I don't have the full `idf.py --preview set-target linux` + component-manager (`espressif/catch2`) environment set up to build/run `components/wear_levelling/host_test` itself in my current setup, so I can't attach a CI-equivalent run of the added test case — I verified its logic against the same standalone harness instead, and mirrored the existing test file's conventions (`wl_mount`/`wl_write`/`wl_read`/`wl_unmount`, `esp_partition_find_first(..., "storage")`) as closely as possible. Happy to adjust if it doesn't build as-is.

## Generative AI

I used generative AI tools (Claude) when creating this PR, but a human has checked the code and is responsible for the code and the description above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes out-of-bounds memory access in core flash I/O paths; the change is small but the prior bug could corrupt memory or crash on any zero-length transfer.
> 
> **Overview**
> Fixes a **memory safety bug** when `wl_write()` / `wl_read()` (and block-device paths into `WL_Flash`) are called with **`size == 0`**.
> 
> `WL_Flash::write()` and `WL_Flash::read()` now return **`ESP_OK` immediately** if `size == 0`, before computing `(size - 1) / wl_page_size`. Without that guard, unsigned `size - 1` becomes `SIZE_MAX`, the page loop runs billions of times, and the driver **reads past `src` or writes past `dest`**.
> 
> A **host_test** case (`write and read with zero size are safe no-ops`) exercises zero-length `wl_write`/`wl_read` and asserts the caller buffer is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7461a9f900025c728702948c6b2811e36e814b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->