### PR TITLE
fix(spi_flash): add #if check for s_mxic_set_required_regs() (IDFGH-17953)

### DIFF
--- a/components/spi_flash/esp32s3/spi_flash_oct_flash_init.c
+++ b/components/spi_flash/esp32s3/spi_flash_oct_flash_init.c
@@ -219,6 +219,7 @@ static void s_flash_init_mxic(esp_rom_spiflash_read_mode_t mode)
 }
 #endif   // #if CONFIG_SPI_FLASH_SUPPORT_MXIC_OPI_CHIP
 
+#if CONFIG_SPI_FLASH_SUPPORT_MXIC_OPI_CHIP
 static void s_mxic_set_required_regs(uint32_t chip_id)
 {
     bool is_swap = false;
@@ -230,6 +231,7 @@ static void s_mxic_set_required_regs(uint32_t chip_id)
     esp_rom_spi_set_dtr_swap_mode(0, is_swap, is_swap);
     esp_rom_spi_set_dtr_swap_mode(1, is_swap, is_swap);
 }
+#endif
 
 
 /*----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Currently, s_mxic_set_required_regs() lacks checking for CONFIG_SPI_FLASH_SUPPORT_MXIC_OPI_CHIP. And this causes a defined but not used warning when MXIC flash driver is disabled in project config. So add a #if check for this to supress warning.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time `#if` only; no runtime behavior change when MXIC OPI is enabled.
> 
> **Overview**
> Wraps **`s_mxic_set_required_regs()`** in `#if CONFIG_SPI_FLASH_SUPPORT_MXIC_OPI_CHIP` so it is only compiled when MXIC OPI flash support is enabled in menuconfig.
> 
> This matches how other MXIC helpers and **`opi_flash_func_mxic`** are gated and removes the **defined but not used** compiler warning when the MXIC OPI driver is turned off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062c948c1885222c2ee7c7fe5daa21d1a5e32f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->