### PR TITLE
fix(esp_partition): prevent size_t overflow bypassing bounds checks on linux target (IDFGH-17957)

### DIFF
--- a/components/esp_partition/partition_linux.c
+++ b/components/esp_partition/partition_linux.c
@@ -554,7 +554,7 @@ esp_err_t esp_partition_write(const esp_partition_t *partition, size_t dst_offse
     if (dst_offset > partition->size) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (dst_offset + size > partition->size) {
+    if (size > partition->size - dst_offset) {
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -610,7 +610,7 @@ esp_err_t esp_partition_read(const esp_partition_t *partition, size_t src_offset
     if (src_offset > partition->size) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (src_offset + size > partition->size) {
+    if (size > partition->size - src_offset) {
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -655,7 +655,7 @@ esp_err_t esp_partition_erase_range(const esp_partition_t *partition, size_t off
     if (offset > partition->size || offset % partition->erase_size != 0) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (offset + size > partition->size || size % partition->erase_size != 0) {
+    if (size > partition->size - offset || size % partition->erase_size != 0) {
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -707,7 +707,7 @@ esp_err_t esp_partition_mmap(const esp_partition_t *partition, size_t offset, si
     if (offset > partition->size) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (offset + size > partition->size) {
+    if (size > partition->size - offset) {
         return ESP_ERR_INVALID_SIZE;
     }
     if (partition->flash_chip != NULL) {


### PR DESCRIPTION
## Summary

`components/esp_partition/partition_linux.c` is the `esp_partition` backend used by the `linux` target (`idf.py --preview set-target linux`, used for host-based unit tests and pure software simulation). Four of its bounds checks use the additive form:

```c
if (offset > partition->size) {
    return ESP_ERR_INVALID_ARG;
}
if (offset + size > partition->size) {   // <-- can overflow size_t
    return ESP_ERR_INVALID_SIZE;
}
```

in `esp_partition_write()`, `esp_partition_read()`, `esp_partition_erase_range()`, and `esp_partition_mmap()`.

When `size` is large enough that `offset + size` wraps around `size_t`, the addition can evaluate to a small value, so the second check silently passes even though the request is far outside the partition. For example:

```c
esp_partition_write(partition, /*dst_offset=*/1, src, /*size=*/SIZE_MAX);
```

`dst_offset(1) > partition->size` is false, and `dst_offset + size` = `1 + SIZE_MAX` wraps to `0` on a 64-bit `size_t`, so `0 > partition->size` is also false — the bounds check is bypassed entirely. Execution then reaches the byte-copy loop with `new_size == SIZE_MAX`, producing an out-of-bounds read from the caller-supplied `src` buffer and an out-of-bounds write into the mmap'd emulated-flash file (far past the mapped region). The same pattern makes `esp_partition_read()` perform an out-of-bounds `memcpy`, and `esp_partition_erase_range()` perform an out-of-bounds `memset` (the `size % partition->erase_size == 0` guard is trivially satisfiable by values close to `SIZE_MAX`).

Note this is specific to the `linux`-target backend. The other `esp_partition` backends already use the overflow-safe subtractive form:

- `components/esp_partition/partition_target.c` (real hardware)
- `components/esp_partition/partition_bootloader.c`
- `components/esp_partition/partition_tee.c`

```c
if (offset > partition->size) {
    return ESP_ERR_INVALID_ARG;
}
if (size > partition->size - offset) {   // safe: offset <= partition->size already established
    return ESP_ERR_INVALID_SIZE;
}
```

This PR brings `partition_linux.c` in line with that existing, overflow-safe pattern used everywhere else in the same component, for all four affected functions.

A related but distinct instance of the exact same overflow-check pattern was already fixed for the bootloader's partition-table validation in #18229 (`components/bootloader_support/src/flash_partitions.c`, merged). That PR did not touch `partition_linux.c`; this PR addresses the separate occurrence in the `linux` target backend.

## Fix

For each of the four functions, replaced:
```c
if (X + size > partition->size) {
    return ESP_ERR_INVALID_SIZE;
}
```
with the overflow-safe equivalent:
```c
if (size > partition->size - X) {
    return ESP_ERR_INVALID_SIZE;
}
```
(`X` being `dst_offset` / `src_offset` / `offset` as appropriate). This is safe because the immediately preceding check already guarantees `X <= partition->size`, so `partition->size - X` cannot underflow.

## Verification

Since this is purely an integer-comparison fix, I wrote a standalone, dependency-free C program that copies the exact boundary-check logic (both the original and the fixed form) out of `partition_linux.c`, using a minimal stub of `esp_partition_t` (just the `size` field the check touches):

```c
#include <stdio.h>
#include <stdint.h>
#include <stddef.h>
#include <limits.h>

typedef struct { size_t size; } stub_partition_t;
typedef enum { STUB_ESP_OK = 0, STUB_ESP_ERR_INVALID_ARG, STUB_ESP_ERR_INVALID_SIZE } stub_esp_err_t;

/* verbatim copy of the ORIGINAL check */
static stub_esp_err_t bounds_check_buggy(const stub_partition_t *partition, size_t dst_offset, size_t size)
{
    if (dst_offset > partition->size)       return STUB_ESP_ERR_INVALID_ARG;
    if (dst_offset + size > partition->size) return STUB_ESP_ERR_INVALID_SIZE; /* can overflow */
    return STUB_ESP_OK;
}

/* verbatim copy of the FIXED check, as applied in this PR */
static stub_esp_err_t bounds_check_fixed(const stub_partition_t *partition, size_t dst_offset, size_t size)
{
    if (dst_offset > partition->size)        return STUB_ESP_ERR_INVALID_ARG;
    if (size > partition->size - dst_offset) return STUB_ESP_ERR_INVALID_SIZE; /* overflow-safe */
    return STUB_ESP_OK;
}

int main(void)
{
    stub_partition_t partition = { .size = 4096 };
    size_t offset = 1, size = SIZE_MAX;

    printf("buggy : %d (0 = ESP_OK, i.e. bypassed)\n", bounds_check_buggy(&partition, offset, size));
    printf("fixed : %d (2 = ESP_ERR_INVALID_SIZE, i.e. correctly rejected)\n", bounds_check_fixed(&partition, offset, size));
    return 0;
}
```

Result, compiled with `gcc -Wall -Wextra -O2`:

- **Before the fix**: `bounds_check_buggy(partition{size=4096}, offset=1, size=SIZE_MAX)` returns `ESP_OK` — the vulnerable check is bypassed (`1 + SIZE_MAX` wraps to `0` on 64-bit `size_t`).
- **After the fix**: `bounds_check_fixed(...)` with the same input returns `ESP_ERR_INVALID_SIZE` — correctly rejected.
- **No regression**: I additionally swept a matrix of inputs through both the buggy and fixed check —
  - Every combination of `offset ∈ {0,1,100,4095,4096}` with `size` near `SIZE_MAX` is now rejected by the fixed check (all previously bypassed by the buggy check for `offset != 0`).
  - Legitimate in-bounds requests (`offset=0,size=4096` full partition; `offset=100,size=100`; `offset=4095,size=1` last byte; `offset=2048,size=2048` exact fit to end; zero-length ops) are accepted identically by both the old and new check — no behavior change for valid usage.
  - Legitimate out-of-bounds requests that don't involve wraparound (e.g. `offset=0,size=4097`; `offset=4097,size=1`) are still rejected identically by both.

All checks passed (0 failures). Happy to fold this repro into `components/esp_partition/host_test/partition_api_test` as an actual test case if maintainers would like it committed as a regression test — I kept it out-of-tree here since it doesn't need any esp-idf headers to demonstrate the logic bug/fix.

## Disclosure

This bug was found and this fix was implemented with the assistance of Claude (Anthropic AI). I (the PR author) reviewed the diagnosis, the diff, and the verification results myself before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation change on the linux simulation target only; no behavior change for normal in-bounds partition I/O.
> 
> **Overview**
> Fixes a **bounds-check bypass** in the Linux host `esp_partition` backend (`partition_linux.c`) where `offset + size` could wrap on `size_t` overflow and let out-of-range read/write/erase/mmap proceed.
> 
> **`esp_partition_write`**, **`esp_partition_read`**, **`esp_partition_erase_range`**, and **`esp_partition_mmap`** now use `size > partition->size - offset` (after `offset <= partition->size` is already validated), matching **`partition_target.c`**, **`partition_bootloader.c`**, and **`partition_tee.c`**. Valid in-bounds calls behave the same; oversized `size` values (e.g. near `SIZE_MAX`) are rejected with `ESP_ERR_INVALID_SIZE` instead of passing the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daae1fb403b36fc0f9fc57ccdfc20fad458f13e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->