### PR TITLE
fix(vfs): use MAX_FDS instead of VFS_MAX_COUNT when clearing fd table on unregister (IDFGH-17954)

### DIFF
--- a/components/vfs/vfs.c
+++ b/components/vfs/vfs.c
@@ -589,7 +589,7 @@ esp_err_t esp_vfs_unregister_with_id(esp_vfs_id_t vfs_id)
 
     _lock_acquire(&s_fd_table_lock);
     // Delete all references from the FD lookup-table
-    for (int j = 0; j < VFS_MAX_COUNT; ++j) {
+    for (int j = 0; j < MAX_FDS; ++j) {
         if (s_fd_table[j].vfs_index == vfs_id) {
             s_fd_table[j] = FD_TABLE_ENTRY_UNUSED;
         }


### PR DESCRIPTION
### Bug

`esp_vfs_unregister_with_id()` in `components/vfs/vfs.c` clears stale
entries from the global fd lookup-table (`s_fd_table`) using the wrong
loop bound:

```c
esp_err_t esp_vfs_unregister_with_id(esp_vfs_id_t vfs_id)
{
    if (vfs_id < 0 || vfs_id >= VFS_MAX_COUNT || s_vfs[vfs_id] == NULL) {
        return ESP_ERR_INVALID_ARG;
    }
    vfs_entry_t* vfs = s_vfs[vfs_id];
    esp_vfs_free_entry(vfs);
    s_vfs[vfs_id] = NULL;

    _lock_acquire(&s_fd_table_lock);
    // Delete all references from the FD lookup-table
    for (int j = 0; j < VFS_MAX_COUNT; ++j) {   // <-- wrong bound
        if (s_fd_table[j].vfs_index == vfs_id) {
            s_fd_table[j] = FD_TABLE_ENTRY_UNUSED;
        }
    }
    _lock_release(&s_fd_table_lock);
    ...
```

`s_fd_table` is declared as `static fd_table_t s_fd_table[MAX_FDS]`
(`MAX_FDS` = `FD_SETSIZE`, which is 64 on non-Cygwin newlib targets, i.e.
every real ESP32 target), while `VFS_MAX_COUNT` is a small Kconfig value
(`CONFIG_VFS_MAX_COUNT`, default 8, range 1-20). So this loop only
scans the first 8-20 slots of a 64-slot table, missing every fd >=
`VFS_MAX_COUNT`.

Every other place in the VFS component that walks `s_fd_table` bounds
correctly on `MAX_FDS`: `vfs.c` lines ~646, ~697, ~760, ~794 (this PR's
base revision), and `vfs_calls.c` lines ~501, ~532, ~555. This one loop
is the only one that got the bound wrong.

### Impact

1. `esp_vfs_register("/fsA", &vfsA_ops, ctx)` returns some `vfs_id`.
2. With `VFS_MAX_COUNT` at its default of 8, and >=6 other fds already
   open (stdin/stdout/stderr occupy 0-2; eventfd, console, or other
   mounted filesystems commonly occupy the rest), a freshly opened file
   on `/fsA` can easily get a global fd >= 8, e.g. fd 10.
3. `esp_vfs_unregister("/fsA")` is called while that fd is still open.
   This is not a contrived misuse: shipping wrapper functions such as
   `esp_vfs_fat_unregister_path()` call `esp_vfs_unregister()`
   unconditionally, without checking for any fds still open against the
   mount. `s_fd_table[10]` (fd >= `VFS_MAX_COUNT`) is left untouched,
   still carrying `vfs_index == <fsA's old id>`.
4. A new filesystem B is registered. `esp_get_free_index()` returns the
   just-freed slot, so B gets the same `vfs_id` that A used to have.
5. Any operation on the stale fd (`read()`/`write()`/`close()`) is
   routed by `s_fd_table[fd].vfs_index` into filesystem B's context,
   using an `s_fd_table[fd].local_fd` that was never valid for B — a
   cross-filesystem fd/context confusion.

Even without steps 4-5, this is a deterministic fd-table slot leak:
repeated mount/unregister cycles (e.g. SD card hot-plug handling) can
exhaust all `MAX_FDS` slots over time, since a fd >= `VFS_MAX_COUNT`
that was left dangling can never be reclaimed by
`esp_vfs_unregister_with_id()` for any VFS afterwards.

### Fix

One-line change: bound the cleanup loop on `MAX_FDS` instead of
`VFS_MAX_COUNT`, matching every other `s_fd_table` loop in this file.

### Verification

This is host-testable logic (the fd-table bookkeeping does not touch
hardware), but rather than depend on standing up the full ESP-IDF Linux
host-test build, I wrote a small standalone C program that reproduces
the exact data layout and the exact before/after loop from `vfs.c`
using the real constants from this source tree:

- `fd_table_t` struct copied verbatim from
  `components/vfs/private_include/esp_vfs_private.h`
- `FD_TABLE_ENTRY_UNUSED` macro copied verbatim from `vfs.c`
- `VFS_MAX_COUNT = 8` (Kconfig default)
- `MAX_FDS = 64` (confirmed against this tree's actual toolchain
  `sys/select.h`, which defines `FD_SETSIZE` as 64 for non-Cygwin
  targets)
- The buggy loop (`j < VFS_MAX_COUNT`) and the fixed loop
  (`j < MAX_FDS`) reproduced verbatim from `esp_vfs_unregister_with_id()`

The program: registers VFS A, marks `s_fd_table[10]` as open against A
(fd 10 is >= `VFS_MAX_COUNT` but < `MAX_FDS`, matching the realistic
scenario above), unregisters A, registers VFS B (which reuses A's freed
slot), and checks whether `s_fd_table[10]` was cleared.

Result:
```
VFS_MAX_COUNT = 8, MAX_FDS = 64

[BUGGY  (j < VFS_MAX_COUNT)] s_fd_table[10].vfs_index after unregister = 0 (expected -1)
[BUGGY  (j < VFS_MAX_COUNT)] stale fd=10 now silently routes into VFS B's context: YES (cross-filesystem corruption)

[FIXED  (j < MAX_FDS)      ] s_fd_table[10].vfs_index after unregister = -1 (expected -1)
[FIXED  (j < MAX_FDS)      ] stale fd=10 now silently routes into VFS B's context: no

PASS: reproduced the leak with the current (buggy) bound, and confirmed the fix clears it.
```

i.e. with the current code, the stale fd survives unregister and gets
silently rerouted into the next filesystem registered in that slot;
with this fix applied, it is correctly cleared.

I also searched for existing reports/PRs about this before opening
this one (`gh pr list`/`gh search prs`/`gh issue list`/`gh search
issues` on `espressif/esp-idf` for `esp_vfs_unregister`,
`VFS_MAX_COUNT`, `s_fd_table`, `fd_table_t`, "vfs unregister leak",
"stale file descriptor VFS", etc.) and found nothing describing this
specific bound bug.

### Disclosure

I used Claude (Anthropic) to help investigate this bug and prepare this
fix and verification. I've reviewed the change and the verification
methodology myself before submitting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-loop bound correction in fd bookkeeping; aligns with existing patterns and reduces corruption risk without changing public API behavior.
> 
> **Overview**
> **`esp_vfs_unregister_with_id()`** now scans the full global fd lookup table when unregistering a VFS. The cleanup loop bound changes from **`VFS_MAX_COUNT`** (typically 8) to **`MAX_FDS`** (64), matching every other `s_fd_table` walk in the component.
> 
> Previously, fds at indices ≥ `VFS_MAX_COUNT` were not cleared on unregister, which could leave stale `vfs_index` entries and route I/O to a later filesystem that reused the same VFS slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03822bb5a65eebacf06bc2172d3bf50a14a7e5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->