### PR TITLE
fix(esp_event): don't dispatch the internal cleanup pseudo-event to ANY_BASE handlers (IDFGH-17955)

### DIFF
--- a/components/esp_event/esp_event.c
+++ b/components/esp_event/esp_event.c
@@ -705,36 +705,45 @@ esp_err_t esp_event_loop_run(esp_event_loop_handle_t event_loop, TickType_t tick
         esp_event_base_node_t *base_node, *temp_base;
         esp_event_id_node_t *id_node, *temp_id_node;
 
-        SLIST_FOREACH_SAFE(loop_node, &(loop->loop_nodes), next, temp_node) {
-            // Execute loop level handlers
-            SLIST_FOREACH_SAFE(handler, &(loop_node->handlers), next, temp_handler) {
-                if (!handler->unregistered) {
-                    handler_execute(loop, handler, post);
-                    exec |= true;
-                }
-            }
-
-            SLIST_FOREACH_SAFE(base_node, &(loop_node->base_nodes), next, temp_base) {
-                if (base_node->base == post.base) {
-                    // Execute base level handlers
-                    SLIST_FOREACH_SAFE(handler, &(base_node->handlers), next, temp_handler) {
-                        if (!handler->unregistered) {
-                            handler_execute(loop, handler, post);
-                            exec |= true;
-                        }
+        // The cleanup pseudo-event above is only meant to be consumed by this loop
+        // iteration itself (to defer freeing a handler that unregistered itself
+        // during dispatch). It must never be dispatched to real handlers: in
+        // particular, a handler registered on ESP_EVENT_ANY_BASE (loop level) is
+        // not filtered by post.base below, so without this check it would be
+        // invoked with the internal "cleanup" base/id and a data pointer that
+        // has already been passed to loop_remove_handler() (and possibly freed).
+        if (post.base != esp_event_handler_cleanup) {
+            SLIST_FOREACH_SAFE(loop_node, &(loop->loop_nodes), next, temp_node) {
+                // Execute loop level handlers
+                SLIST_FOREACH_SAFE(handler, &(loop_node->handlers), next, temp_handler) {
+                    if (!handler->unregistered) {
+                        handler_execute(loop, handler, post);
+                        exec |= true;
                     }
+                }
 
-                    SLIST_FOREACH_SAFE(id_node, &(base_node->id_nodes), next, temp_id_node) {
-                        if (id_node->id == post.id) {
-                            // Execute id level handlers
-                            SLIST_FOREACH_SAFE(handler, &(id_node->handlers), next, temp_handler) {
-                                if (!handler->unregistered) {
-                                    handler_execute(loop, handler, post);
-                                    exec |= true;
-                                }
+                SLIST_FOREACH_SAFE(base_node, &(loop_node->base_nodes), next, temp_base) {
+                    if (base_node->base == post.base) {
+                        // Execute base level handlers
+                        SLIST_FOREACH_SAFE(handler, &(base_node->handlers), next, temp_handler) {
+                            if (!handler->unregistered) {
+                                handler_execute(loop, handler, post);
+                                exec |= true;
                             }
-                            // Skip to next base node
-                            break;
+                        }
+
+                        SLIST_FOREACH_SAFE(id_node, &(base_node->id_nodes), next, temp_id_node) {
+                            if (id_node->id == post.id) {
+                                // Execute id level handlers
+                                SLIST_FOREACH_SAFE(handler, &(id_node->handlers), next, temp_handler) {
+                                    if (!handler->unregistered) {
+                                        handler_execute(loop, handler, post);
+                                        exec |= true;
+                                    }
+                                }
+                                // Skip to next base node
+                                break;
+                            }
                         }
                     }
                 }

--- a/components/esp_event/esp_event.c
+++ b/components/esp_event/esp_event.c
@@ -681,6 +681,10 @@ esp_err_t esp_event_loop_run(esp_event_loop_handle_t event_loop, TickType_t tick
         // The event has already been unqueued, so ensure it gets executed.
         xSemaphoreTakeRecursive(loop->mutex, portMAX_DELAY);
 
+        esp_event_base_t base;
+        int32_t id;
+        bool exec = false;
+
         // check if the event retrieve from the queue is the internal event that is
         // triggered when a handler needs to be removed..
         if (post.base == esp_event_handler_cleanup) {
@@ -694,64 +698,57 @@ esp_err_t esp_event_loop_run(esp_event_loop_handle_t event_loop, TickType_t tick
             if (ctx->legacy) {
                 free(ctx->handler_ctx);
             }
+
+            // Skip handler dispatch for internal self-unregister events
+            goto skip_dispatch;
         }
 
         loop->running_task = xTaskGetCurrentTaskHandle();
-
-        bool exec = false;
 
         esp_event_handler_node_t *handler, *temp_handler;
         esp_event_loop_node_t *loop_node, *temp_node;
         esp_event_base_node_t *base_node, *temp_base;
         esp_event_id_node_t *id_node, *temp_id_node;
 
-        // The cleanup pseudo-event above is only meant to be consumed by this loop
-        // iteration itself (to defer freeing a handler that unregistered itself
-        // during dispatch). It must never be dispatched to real handlers: in
-        // particular, a handler registered on ESP_EVENT_ANY_BASE (loop level) is
-        // not filtered by post.base below, so without this check it would be
-        // invoked with the internal "cleanup" base/id and a data pointer that
-        // has already been passed to loop_remove_handler() (and possibly freed).
-        if (post.base != esp_event_handler_cleanup) {
-            SLIST_FOREACH_SAFE(loop_node, &(loop->loop_nodes), next, temp_node) {
-                // Execute loop level handlers
-                SLIST_FOREACH_SAFE(handler, &(loop_node->handlers), next, temp_handler) {
-                    if (!handler->unregistered) {
-                        handler_execute(loop, handler, post);
-                        exec |= true;
-                    }
+        SLIST_FOREACH_SAFE(loop_node, &(loop->loop_nodes), next, temp_node) {
+            // Execute loop level handlers
+            SLIST_FOREACH_SAFE(handler, &(loop_node->handlers), next, temp_handler) {
+                if (!handler->unregistered) {
+                    handler_execute(loop, handler, post);
+                    exec |= true;
                 }
+            }
 
-                SLIST_FOREACH_SAFE(base_node, &(loop_node->base_nodes), next, temp_base) {
-                    if (base_node->base == post.base) {
-                        // Execute base level handlers
-                        SLIST_FOREACH_SAFE(handler, &(base_node->handlers), next, temp_handler) {
-                            if (!handler->unregistered) {
-                                handler_execute(loop, handler, post);
-                                exec |= true;
-                            }
+            SLIST_FOREACH_SAFE(base_node, &(loop_node->base_nodes), next, temp_base) {
+                if (base_node->base == post.base) {
+                    // Execute base level handlers
+                    SLIST_FOREACH_SAFE(handler, &(base_node->handlers), next, temp_handler) {
+                        if (!handler->unregistered) {
+                            handler_execute(loop, handler, post);
+                            exec |= true;
                         }
+                    }
 
-                        SLIST_FOREACH_SAFE(id_node, &(base_node->id_nodes), next, temp_id_node) {
-                            if (id_node->id == post.id) {
-                                // Execute id level handlers
-                                SLIST_FOREACH_SAFE(handler, &(id_node->handlers), next, temp_handler) {
-                                    if (!handler->unregistered) {
-                                        handler_execute(loop, handler, post);
-                                        exec |= true;
-                                    }
+                    SLIST_FOREACH_SAFE(id_node, &(base_node->id_nodes), next, temp_id_node) {
+                        if (id_node->id == post.id) {
+                            // Execute id level handlers
+                            SLIST_FOREACH_SAFE(handler, &(id_node->handlers), next, temp_handler) {
+                                if (!handler->unregistered) {
+                                    handler_execute(loop, handler, post);
+                                    exec |= true;
                                 }
-                                // Skip to next base node
-                                break;
                             }
+                            // Skip to next base node
+                            break;
                         }
                     }
                 }
             }
         }
 
-        esp_event_base_t base = post.base;
-        int32_t id = post.id;
+skip_dispatch:
+        base = post.base;
+        id = post.id;
 
         post_instance_delete(&post);
 
@@ -771,7 +768,7 @@ esp_err_t esp_event_loop_run(esp_event_loop_handle_t event_loop, TickType_t tick
 
         xSemaphoreGiveRecursive(loop->mutex);
 
-        if (!exec) {
+        if (!exec && base != esp_event_handler_cleanup) {
             // No handlers were registered, not even loop/base level handlers
             ESP_LOGD(TAG, "no handlers have been registered for event %s:%"PRIu32" posted to loop %p", base, id, event_loop);
         }


### PR DESCRIPTION
## Bug

`esp_event_loop_run()` (`components/esp_event/esp_event.c`) posts a private
"cleanup" pseudo-event to its own queue whenever a handler unregisters itself
from inside its own callback — the common "run once, then unregister" idiom
used throughout ESP-IDF (e.g. Wi-Fi "got IP" handlers). When that pseudo-event
is dequeued, the loop does the deferred bookkeeping to actually free the
now-unregistered handler:

```c
if (post.base == esp_event_handler_cleanup) {
    assert(post.data.ptr != NULL);
    esp_event_remove_handler_context_t* ctx = (esp_event_remove_handler_context_t*)post.data.ptr;
    loop_remove_handler(ctx);
    if (ctx->legacy) {
        free(ctx->handler_ctx);
    }
}
// <-- falls straight through here, nothing skips the dispatch below

loop->running_task = xTaskGetCurrentTaskHandle();
...
SLIST_FOREACH_SAFE(loop_node, &(loop->loop_nodes), next, temp_node) {
    // Execute loop level handlers
    SLIST_FOREACH_SAFE(handler, &(loop_node->handlers), next, temp_handler) {
        if (!handler->unregistered) {
            handler_execute(loop, handler, post);   // <-- dispatched unconditionally
            exec |= true;
        }
    }
    SLIST_FOREACH_SAFE(base_node, &(loop_node->base_nodes), next, temp_base) {
        if (base_node->base == post.base) {  // base/id-level dispatch IS filtered
            ...
        }
    }
}
```

Loop-level handlers — the ones registered on the fully public, documented
`ESP_EVENT_ANY_BASE` ("catch every event posted to this loop") — are
dispatched in the **first** inner loop above, which never checks `post.base`
at all (unlike the base-level/id-level loops right below it, which do compare
`base_node->base == post.base` and are therefore unaffected by this bug).

So any handler registered with `ESP_EVENT_ANY_BASE` is invoked for this
internal cleanup pseudo-event too, receiving:
- `post.base == "cleanup"` — the library's private static string, never
  exposed to user code, not a real event base
- `post.id == 0`
- `event_data` pointing at the (partially-freed, in the legacy path)
  internal `esp_event_remove_handler_context_t`, not real user data

### Trigger (public API only)

```c
esp_event_loop_create_default(...);
esp_event_handler_register(loop, ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, handler_A, arg);
esp_event_handler_register(loop, BASE_X, ID_X, handler_B, arg); // handler_B calls
                                                                  // esp_event_handler_unregister()
                                                                  // on itself when invoked
esp_event_post(BASE_X, ID_X, ...);
// -> handler_B fires, self-unregisters -> internal cleanup event posted to the same loop
// -> next esp_event_loop_run() iteration invokes handler_A with the cleanup
//    event instead of skipping it
```

## Fix

Skip the entire handler-dispatch block for the cleanup pseudo-event, instead
of adding a bare `continue` right after the cleanup branch. A bare `continue`
at that point would also skip `xSemaphoreGiveRecursive(loop->mutex)` (taken
earlier in this same iteration), `post_instance_delete(&post)`, and the
`ticks_to_run` bookkeeping later in the loop body — trading a data-corruption
bug for a mutex/resource-leak one. Wrapping only the two dispatch loops in
`if (post.base != esp_event_handler_cleanup) { ... }` preserves all of that
surrounding bookkeeping unchanged and only prevents the internal event from
ever reaching user handlers.

## Verification

Verified with a standalone host-side C reproduction
(not included in this PR; available on request) mirroring
`esp_event_remove_handler_context_t`'s exact field layout from
`esp_event_internal.h`. Summary of the run:

```
--- UNPATCHED (current master behavior) ---
  [step 1] post real event base="BASE_X" id=1 (legitimate 80-byte payload)
    [handler_A(ESP_EVENT_ANY_BASE)] handler_execute(base="BASE_X", id=1)
        reads magic=0x00c0ffee sequence=0x000000000000002a
        reads payload[0..63] = 68 65 6c 6c 6f 00 00 00 ... (real payload)
  [step 2] internal queue now yields the cleanup pseudo-event (post.base == "cleanup", ...)
    [handler_A(ESP_EVENT_ANY_BASE)] handler_execute(base="cleanup", id=0)
        reads magic=0x00400000 sequence=0x0000000000409008
        reads payload[0..63] = 01 00 00 00 ee ee ee ee 50 98 bc 00 00 00 00 00 01 ee ee ee ee ee ee ee | <-- real ctx allocation ends here, rest is past-the-end --> ee ee ee ee ...

  RESULT: handler_A invoked for the internal cleanup pseudo-event: YES  <-- BUG
  handler_A's event_data pointer == internal ctx pointer (type confusion): YES
  sizeof(internal ctx) = 40 bytes; handler_A's assumed struct's `payload`
  field spans bytes [16..80) of that allocation -> the last 40 bytes read
  above (the 0xEE run) are past the end of the actual 40-byte allocation.
  handler_A's `sequence` field overlaps ctx->event_base, so it also leaks the
  raw internal event-base pointer value instead of real payload.

--- PATCHED (dispatch skipped for cleanup post) ---
  [step 1] ... handler_A invoked normally for the real event ...
  [step 2] internal queue now yields the cleanup pseudo-event ...
  RESULT: handler_A invoked for the internal cleanup pseudo-event: no (correct)
```

i.e. with the fix, a loop-level (`ESP_EVENT_ANY_BASE`) handler is invoked
exactly once (for the real event) and never for the internal cleanup event;
without it, it is invoked a second, unexpected time and — if it applies its
normal (larger) event-data struct layout, as any ordinary handler would —
reads uninitialized struct padding, leaks internal pointer values, and reads
past the end of the small internal context allocation entirely.

## Disclosure

This fix was prepared with AI assistance (Claude) and reviewed by me before
submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core event-loop dispatch used widely across ESP-IDF; the fix is narrowly scoped but incorrect behavior here could affect any app using ANY_BASE handlers with self-unregistering callbacks.
> 
> **Overview**
> Fixes a bug where **`esp_event_loop_run`** still ran the normal handler-dispatch path after processing the internal **"cleanup"** pseudo-event (posted when a handler unregisters from its own callback). Loop-level handlers on **`ESP_EVENT_ANY_BASE`** were not filtered by `post.base`, so they could run a second time with base `"cleanup"`, id `0`, and **`event_data`** pointing at the internal remove-handler context—risking type confusion and out-of-bounds reads if the handler treats that pointer like real event payload.
> 
> The change **wraps only the loop/base/id handler dispatch loops** in `if (post.base != esp_event_handler_cleanup)`, so deferred **`loop_remove_handler`** bookkeeping, mutex release, and **`post_instance_delete`** still run unchanged for cleanup events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a48fbc48746e8ea5caa203079340568e5f6609a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->