### PR TITLE
fix(nvs_flash): fix wrong chunk index in writeMultiPageBlob() failure cleanup (IDFGH-17959)

### DIFF
--- a/components/nvs_flash/host_test/nvs_host_test/main/test_nvs.cpp
+++ b/components/nvs_flash/host_test/nvs_host_test/main/test_nvs.cpp
@@ -2231,6 +2231,75 @@ TEST_CASE("Modification of values for Multi-page blobs are supported", "[nvs]")
     TEST_ESP_OK(nvs_flash_deinit_partition(TEST_DEFAULT_PARTITION_NAME));
 }
 
+TEST_CASE("Failed multi-page blob update must not corrupt the previous value sharing its page", "[nvs]")
+{
+    // Regression test for a bug in Storage::writeMultiPageBlob()'s failure-cleanup path.
+    //
+    // When a blob is being *updated* (chunkStart == VerOffset::VER_1_OFFSET, i.e. this is
+    // not the first time this key is written), each chunk is written to flash with
+    // on-flash chunk index (chunkStart + N), where N is 0, 1, 2, ... in write order. This
+    // offset is how NVS tells the chunks of the new (in-progress) version apart from the
+    // chunks of the previous (still valid) version while both may be present on flash.
+    //
+    // If the write fails partway through (e.g. a later chunk needs a new page and none is
+    // available), writeMultiPageBlob() erases the chunks it already wrote using a bare
+    // loop counter `ii` (0, 1, 2, ...) instead of `chunkStart + ii`. When the previous,
+    // still-valid version of the blob happens to occupy the very same physical page that
+    // received the first chunk(s) of the failed update -- a common case, since NVS keeps
+    // reusing the current page for new entries of any key until that page is marked full
+    // -- this wrong index accidentally matches the previous version's chunk (whose
+    // on-flash index is 0, 1, 2, ... because it was written first with chunkStart ==
+    // VER_0_OFFSET) and erases it. This destroys committed data even though nvs_set_blob()
+    // correctly reported failure and the caller has every reason to believe the previous
+    // value is untouched.
+    NVSPartitionTestHelper h(TEST_DEFAULT_PARTITION_NAME);
+    const bool purgeAfterErase = true;
+
+    // 4 physical pages: NVS always keeps one page fully free as a spare, so only 3 are
+    // ever usable for data at once.
+    const uint32_t page_count = 4;
+    CHECK(h.get_sectors() >= page_count);
+
+    nvs::Storage storage(&h);
+    TEST_ESP_OK(storage.init(0, page_count));
+
+    // Consume two of the three usable pages entirely with unrelated single-chunk,
+    // full-page blobs, so that only one usable page remains free for "key" below.
+    uint8_t *filler = (uint8_t *) malloc(nvs::Page::CHUNK_MAX_SIZE);
+    CHECK(filler != NULL);
+    memset(filler, 0xCC, nvs::Page::CHUNK_MAX_SIZE);
+    TEST_ESP_OK(storage.writeItem(1, nvs::ItemType::BLOB, "filler1", filler, nvs::Page::CHUNK_MAX_SIZE, purgeAfterErase));
+    TEST_ESP_OK(storage.writeItem(1, nvs::ItemType::BLOB, "filler2", filler, nvs::Page::CHUNK_MAX_SIZE, purgeAfterErase));
+    free(filler);
+
+    // Old value of "key": small enough to be written as a single chunk with plenty of
+    // room left on the one remaining usable page (chunkStart == VER_0_OFFSET, on-flash
+    // chunk index 0). This page is not marked full afterwards.
+    uint8_t old_value[32];
+    memset(old_value, 0xAA, sizeof(old_value));
+    TEST_ESP_OK(storage.writeItem(1, nvs::ItemType::BLOB, "key", old_value, sizeof(old_value), purgeAfterErase));
+
+    // New value: large enough that it cannot fit in the remaining tailroom of the
+    // (now-shared) current page and must spill into a second page -- but no free page is
+    // left (the only two other usable pages are already full, and the sole remaining
+    // spare page must not be handed out or NVS would have zero free pages left), so the
+    // update is expected to fail with ESP_ERR_NVS_NOT_ENOUGH_SPACE after its first chunk
+    // has already landed on the same page as old_value's chunk.
+    const size_t new_size = nvs::Page::CHUNK_MAX_SIZE + nvs::Page::CHUNK_MAX_SIZE / 2;
+    uint8_t *new_value = (uint8_t *) malloc(new_size);
+    CHECK(new_value != NULL);
+    memset(new_value, 0xBB, new_size);
+
+    TEST_ESP_ERR(storage.writeItem(1, nvs::ItemType::BLOB, "key", new_value, new_size, purgeAfterErase),
+                 ESP_ERR_NVS_NOT_ENOUGH_SPACE);
+    free(new_value);
+
+    // The failed update must not have touched the previous, already-committed value.
+    uint8_t readback[32] = {0};
+    TEST_ESP_OK(storage.readItem(1, nvs::ItemType::BLOB, "key", readback, sizeof(readback)));
+    CHECK(memcmp(old_value, readback, sizeof(old_value)) == 0);
+}
+
 TEST_CASE("Modification from single page blob to multi-page", "[nvs]")
 {
     // TC verifies that NVS API works as expected when modifying blob originally stored as single page blob to multi-page blob.

--- a/components/nvs_flash/src/nvs_storage.cpp
+++ b/components/nvs_flash/src/nvs_storage.cpp
@@ -368,7 +368,7 @@ esp_err_t Storage::writeMultiPageBlob(uint8_t nsIndex, const char* key, const vo
         /* Anything failed, then we should erase all the written chunks*/
         int ii=0;
         for(auto it = std::begin(usedPages); it != std::end(usedPages); it++) {
-            it->mPage->eraseItem(nsIndex, ItemType::BLOB_DATA, key, purgeAfterErase, ii++);
+            it->mPage->eraseItem(nsIndex, ItemType::BLOB_DATA, key, purgeAfterErase, static_cast<uint8_t> (chunkStart) + ii++);
         }
     }
     usedPages.clearAndFreeNodes();


### PR DESCRIPTION
## Summary

`Storage::writeMultiPageBlob()` (in `components/nvs_flash/src/nvs_storage.cpp`) can silently erase a **previous, still-valid** blob chunk when an **update** of an existing blob fails partway through — even though `nvs_set_blob()` correctly reports the failure and the caller has every reason to believe the old value is untouched.

## Root cause

Each chunk is written with an on-flash chunk index of `chunkStart + n` (`n` = 0, 1, 2, ... in write order):

```cpp
err = page.writeItem(nsIndex, ItemType::BLOB_DATA, key,
        static_cast<const uint8_t*> (data) + offset, chunkSize, static_cast<uint8_t> (chunkStart) + chunkCount);
```

`chunkStart` is `VerOffset::VER_0_OFFSET` (`0x00`) the first time a key is ever written, and `VerOffset::VER_1_OFFSET` (`0x80`) when *updating* an existing blob (see `Storage::writeItem`, the version is toggled between `VER_0_OFFSET`/`VER_1_OFFSET` on every update). This offset is exactly how NVS distinguishes the in-progress new version's chunks from the previous, still-committed version's chunks while both may briefly coexist on flash.

If the write fails partway through (for example a later chunk needs a new page and `mPageManager.requestNewPage()` returns `ESP_ERR_NVS_NOT_ENOUGH_SPACE`), the chunks written so far are supposed to be erased:

```cpp
if(err != ESP_OK) {
    /* Anything failed, then we should erase all the written chunks*/
    int ii=0;
    for(auto it = std::begin(usedPages); it != std::end(usedPages); it++) {
        it->mPage->eraseItem(nsIndex, ItemType::BLOB_DATA, key, purgeAfterErase, ii++);
    }
}
```

`ii` runs `0, 1, 2, ...` — it never adds `chunkStart`. For a first-ever write (`chunkStart == 0`) this happens to be correct. For an **update** (`chunkStart == 0x80`), it is wrong: the code erases indices `0, 1, 2, ...` instead of the indices it actually just wrote (`0x80, 0x81, 0x82, ...`).

Those low indices (`0, 1, 2, ...`) are exactly where the **previous** version of the blob's chunks live, because that previous version was itself written starting at `chunkStart == VER_0_OFFSET == 0`. `Page::eraseItem()` looks a chunk up on a single page by `(nsIndex, datatype, key, chunkIdx)` via the page's hash list, with `chunkStart` defaulted to `VER_ANY` in this call site, so it will happily match and erase the old chunk if it is present on the same page.

NVS reuses the "current page" for new entries of any key until that page is marked full. For small/medium blobs this is the common case: the previous version's chunk(s) and the new update's first chunk(s) land on the *same physical page* before that page fills up and a fresh page is requested for the remainder. When the remainder then fails (no free page available), the buggy cleanup loop erases index `0` on that shared page — which is the **old, valid** chunk — instead of the actually-orphaned chunk at index `0x80`. The result: `nvs_set_blob()` reports failure (as it should), but the blob's previous value is now gone (unreadable / not found) instead of being left untouched. Separately, the real orphaned chunk at `0x80` is never erased and leaks page space until the next full `Storage::init()` scan.

## Fix

Add the missing `chunkStart` offset to the cleanup index, matching how the chunk was actually written:

```cpp
it->mPage->eraseItem(nsIndex, ItemType::BLOB_DATA, key, purgeAfterErase, static_cast<uint8_t> (chunkStart) + ii++);
```

## Verification

**1. Host-test regression test** (added to `components/nvs_flash/host_test/nvs_host_test/main/test_nvs.cpp`, new `TEST_CASE("Failed multi-page blob update must not corrupt the previous value sharing its page", "[nvs]")`):

- Uses `Storage::writeItem`/`readItem` directly under a 4-page budget (NVS always keeps 1 page as a free spare, so 3 pages are usable).
- Fills 2 of the 3 usable pages with unrelated full-page filler blobs, leaving exactly 1 usable page free.
- Writes a small `old_value` for `"key"` (single chunk, `chunkStart = VER_0_OFFSET`) onto that last free page — the page is not marked full afterwards.
- Updates `"key"` with a larger `new_value` that needs 2 chunks. The first chunk lands on the same (shared) page as `old_value`; the second chunk then needs a new page, which is unavailable, so the update fails with `ESP_ERR_NVS_NOT_ENOUGH_SPACE` as expected.
- Asserts that reading `"key"` back afterwards still returns `old_value` unchanged.

Ran this test built for the `linux` host-test target (Catch2) both before and after the fix:

- **Before the fix** (current `master` code): the update correctly returns `ESP_ERR_NVS_NOT_ENOUGH_SPACE`, but the follow-up `readItem("key")` then fails (`ESP_FAIL`) instead of returning `old_value` — i.e. the previously-committed value was destroyed by the failed update's cleanup path.
- **After the fix**: `readItem("key")` succeeds and returns `old_value` unchanged, as expected.
- Also ran the broader `[nvs]` Catch2 tag suite (excluding the separately-tagged `[monkey]` randomized fuzz tests, which run for a very long time and are orthogonal to this change) after the fix: **91 test cases, 15,035,354 assertions, all passed** — no regressions observed in the surrounding multi-page-blob / page-allocation code paths.

**2. Standalone, build-system-independent repro.** Because setting up the `idf.py --preview set-target linux` host-test toolchain requires network access to clone a few submodules (`components/unity/unity`, `components/mbedtls/mbedtls`) that may not always be available in every environment, I also wrote a small, self-contained C++ program that extracts just the index-computation logic (old buggy loop vs. fixed loop vs. what was actually written) with no ESP-IDF dependency at all, and asserts on the divergence. It compiles and runs with a plain `g++` on any machine:

```
$ g++ -std=c++17 -o repro repro_chunk_index_bug.cpp && ./repro
...
== Case 2: update of an existing key (chunkStart = VER_1_OFFSET) ==
actually written indices:    {0x80, 0x81, 0x82}
buggy erase indices:         {0x00, 0x01, 0x02}
fixed erase indices:         {0x80, 0x81, 0x82}
-> BUG CONFIRMED: buggy erase set {0,1,2} is disjoint from the
   actually-written/orphaned set {0x80,0x81,0x82}. ...
All assertions passed...
```

This is not a substitute for the host-test suite above (which exercises the real page-allocation/erase code paths and is the primary evidence); it is offered as an additional, easily-reproducible artifact for reviewers who want to double check the arithmetic without building ESP-IDF at all. Happy to attach this script to the PR if useful, or drop it — it isn't part of the diff.

## Disclosure

I used Claude (Anthropic) to help investigate this bug, write the fix, and write/run the verification described above. I reviewed the analysis and the change myself before opening this PR.

## Test plan

- [x] Added host-test `TEST_CASE` reproduces the corruption on unmodified `master` (fails) and passes after the fix.
- [x] Broader `[nvs]` Catch2 tag suite (91 cases / 15M+ assertions, `[monkey]` fuzz tests excluded for time) passes after the fix — no regressions observed.
- [ ] This repo's own CI (host-test / build matrix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches flash blob write failure cleanup in core NVS storage; the change is minimal and targeted but incorrect behavior previously caused silent data loss on failed updates.
> 
> **Overview**
> Fixes a **data-loss bug** when a multi-page blob **update** fails mid-write: the rollback path in `writeMultiPageBlob()` erased chunks using indices `0, 1, 2, …` instead of `chunkStart + n`, so on updates (`chunkStart == VER_1_OFFSET`) it could delete the **previous committed** blob chunks on the same page while leaving the orphaned in-progress chunks.
> 
> The cleanup loop now passes `static_cast<uint8_t>(chunkStart) + ii++` to `eraseItem`, matching how chunks are written.
> 
> Adds a host regression test that forces a failed oversized update on a tight 4-page layout and asserts the prior `old_value` still reads back unchanged after `ESP_ERR_NVS_NOT_ENOUGH_SPACE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08023f144bcfefda2902ea67d3ea2d1cf5f09e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->