### PR TITLE
fix(spiffs): fix off-by-one in spiffsgen.py obj name length check (IDFGH-17964)

### DIFF
--- a/components/spiffs/spiffsgen.py
+++ b/components/spiffs/spiffsgen.py
@@ -423,7 +423,13 @@ class SpiffsFS:
         return self.remaining_blocks <= 0
 
     def create_file(self, img_path, file_path):  # type: (str, str) -> None
-        if len(img_path) > self.build_config.obj_name_len:
+        # obj_name_len includes the zero-termination character (see Kconfig
+        # help for CONFIG_SPIFFS_OBJ_NAME_LEN), so the maximum number of
+        # actual name characters is obj_name_len - 1. Without the "- 1" here,
+        # a name exactly obj_name_len characters long is wrongly accepted and
+        # SpiffsObjIndexPage.to_binary() ends up writing zero NUL bytes into
+        # the reserved name field.
+        if len(img_path) > self.build_config.obj_name_len - 1:
             log.die(f"object name '{img_path}' too long")
 
         name = img_path


### PR DESCRIPTION
## Summary

`spiffsgen.py`'s `SpiffsFS.create_file()` rejects a name only when it is *strictly longer* than `obj_name_len`:

```python
def create_file(self, img_path, file_path):  # type: (str, str) -> None
    if len(img_path) > self.build_config.obj_name_len:
        log.die(f"object name '{img_path}' too long")
```

But `CONFIG_SPIFFS_OBJ_NAME_LEN`'s own help text (`components/spiffs/Kconfig`) documents that this length **includes the zero-termination character**:

> Object name maximum length. Note that this length include the zero-termination character, meaning maximum string of characters can at most be SPIFFS_OBJ_NAME_LEN - 1.

So a name that is *exactly* `obj_name_len` characters long is currently accepted, even though it shouldn't be.

That matters because `SpiffsObjIndexPage.to_binary()` — the only place that consumes a name after this check — writes the name into a fixed-size, `obj_name_len`-byte reserved field and pads the remainder with NUL bytes computed as:

```python
img += self.name.encode() + (
    b'\x00'
    * (
        (self.build_config.obj_name_len - len(self.name))
        + self.build_config.meta_len
        + self.build_config.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED_PAD
    )
)
```

When `len(self.name) == obj_name_len`, the `(obj_name_len - len(name))` term is exactly `0`, so **zero NUL bytes** are written between the name and whatever follows it (the metadata region). The generated image's fixed-size name field then has no NUL terminator anywhere in its reserved region.

## Fix

One-line boundary fix in `components/spiffs/spiffsgen.py`, `SpiffsFS.create_file()`:

```diff
- if len(img_path) > self.build_config.obj_name_len:
+ if len(img_path) > self.build_config.obj_name_len - 1:
```

This makes the generator's length check match the semantics that `CONFIG_SPIFFS_OBJ_NAME_LEN`'s own Kconfig help text documents, guaranteeing at least one reserved byte after the name is always zero.

## Verification performed

- Re-derived the bug directly from the current `master` source (not from any prior report): read `components/spiffs/spiffsgen.py` (`create_file()` and `SpiffsObjIndexPage.to_binary()`) and `components/spiffs/Kconfig`.
- Wrote a standalone reproduction script that drives the real `_generate_spiffs_image()` end-to-end (the same function the CLI calls) with a file whose image path (`'/' + relpath`) is exactly `obj_name_len` (32, the default) characters long. Before the fix: the file is accepted and the produced image's 32-byte reserved name field (`/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`) contains **zero** NUL bytes. After the fix: the same input is correctly rejected with `object name '...' too long`.
- Confirmed the boundary is otherwise unaffected: a name of `obj_name_len - 1` characters (the legitimate maximum) is still accepted and is still NUL-terminated in the output, both before and after the fix. A name of `obj_name_len + 1` characters was already correctly rejected before the fix and remains rejected after.
- Ran the existing official test, `components/spiffs/test_spiffsgen/test_spiffsgen.py::SpiffsgenTest.test_configs`, against the patched module — it passes (`OK`), confirming no regression.
- Ran `ruff check` / `ruff format --diff` on the changed file against the repo's `ruff.toml` — clean, no issues.
- Searched existing PRs/issues on this repo (`spiffsgen`, `obj_name_len`, `SPIFFS_OBJ_NAME_LEN`, "object name", "spiffs name length", "zero-termination", etc.) — found no duplicate or competing fix for this specific boundary check.

## Disclosure

Generative AI (Claude) was used to help investigate this issue (re-deriving the bug from current source, constructing and running the reproduction/verification scripts) and to implement this fix. All findings and the change were reviewed by a human before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boundary check in the image generator with no runtime firmware changes; only affects edge-case names at the maximum length.
> 
> **Overview**
> **`spiffsgen.py`** now treats **`CONFIG_SPIFFS_OBJ_NAME_LEN`** as including the NUL terminator, matching **`components/spiffs/Kconfig`**.
> 
> In **`SpiffsFS.create_file()`**, the max-name check changes from **`len(img_path) > obj_name_len`** to **`len(img_path) > obj_name_len - 1`**, so paths with exactly **`obj_name_len`** characters are rejected instead of accepted. That avoids **`SpiffsObjIndexPage.to_binary()`** writing a full-length name with no padding NUL in the reserved name field.
> 
> Inline comments document the Kconfig semantics and why the **`- 1`** is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e628a207acc0d24751b74a4ea09dff137aa9c734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->