### PR TITLE
docs(i2c): Clarify device address values (IDFGH-17966)

### DIFF
--- a/docs/en/api-reference/peripherals/i2c.rst
+++ b/docs/en/api-reference/peripherals/i2c.rst
@@ -101,7 +101,7 @@ If the configurations in :cpp:type:`i2c_master_bus_config_t` is specified, then 
 I2C master device requires the configuration that specified by :cpp:type:`i2c_device_config_t`:
 
 - :cpp:member:`i2c_device_config_t::dev_addr_length` configure the address bit length of the slave device. It can be chosen from enumerator :cpp:enumerator:`I2C_ADDR_BIT_LEN_7` or :cpp:enumerator:`I2C_ADDR_BIT_LEN_10` (if supported).
-- :cpp:member:`i2c_device_config_t::device_address` sets the I2C device raw address. Please parse the device address to this member directly. For example, the device address is 0x28, then parse 0x28 to :cpp:member:`i2c_device_config_t::device_address`, don't carry a write or read bit.
+- :cpp:member:`i2c_device_config_t::device_address` sets the I2C 7-bit device address *without* the read/write bit. For example, if the manufacturer specifies "0x28 (write) 0x29 (read)", the value should be ``(0x28 >> 1)``.
 - :cpp:member:`i2c_device_config_t::scl_speed_hz` sets the SCL line frequency of this device.
 - :cpp:member:`i2c_device_config_t::scl_wait_us` sets the SCL await time (in μs). Usually this value should not be very small because slave stretch will happen in pretty long time (It's possible even stretch for 12 ms). Set ``0`` means use default register value.
 


### PR DESCRIPTION
## Description

I found the original wording for how to supply an I2C device address a little confusing - it makes sense now that I understand the principle, but I originally didn't realise the address excluded the read/write bit, and didn't notice my mistake until I connected an oscilloscope to the I2C bus to figure out why it wasn't working.

It seems like at least TI and Analog Devices (not sure about other manufacturers) sometimes specify separate read and write addresses, so I feel like it would make sense to explicitly state how to convert from read/write addresses to the correct 7-bit address (namely with a bit shift).

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the **`i2c_device_config_t::device_address`** bullet in the I2C peripheral docs so it states the field is the **7-bit address without the R/W bit**, replacing the older guidance to pass the “raw” address (e.g. `0x28`) directly.
> 
> Adds a **datasheet-style example** for separate write/read byte values (e.g. `0x28` / `0x29`) and shows converting with ``(0x28 >> 1)`` so users do not configure the shifted 8-bit values the driver already applies internally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e320b4dcb28e66c6f6439b6725cbc5d4e0a0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->