### PR TITLE
fix(mocks): add missing `esp_hal_*` includes (IDFGH-17968)

### DIFF
--- a/tools/mocks/driver/CMakeLists.txt
+++ b/tools/mocks/driver/CMakeLists.txt
@@ -16,6 +16,13 @@ set(include_dirs
     "${original_driver_dir}/i2c/include"
     "${IDF_PATH}/components/esp_driver_usb_serial_jtag/include")
 
+list(APPEND include_dirs
+     "${IDF_PATH}/components/esp_hal_gpio/include"
+     "${IDF_PATH}/components/esp_hal_gpio/linux/include"
+     "${IDF_PATH}/components/esp_hal_gpspi/include"
+     "${IDF_PATH}/components/esp_hal_rmt/include"
+     "${IDF_PATH}/components/esp_hal_i2c/include")
+
 # Note: "hal" and "soc" are only required for corresponding header files and their definitions
 # here, they don't provide functionality when built for running on the host.
 idf_component_mock(INCLUDE_DIRS ${include_dirs}


### PR DESCRIPTION
Mocks currently fail to compile due to missing includes of `esp_hal_*` directories. This small PR adds those directories for the GPIO, SPI, RMT and I2C mocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CMake-only include path fix for Linux host mocks; no runtime or on-device driver behavior changes.
> 
> **Overview**
> Host **driver mocks** were failing to compile because mocked `esp_driver_*` headers now pull in **`esp_hal_*`** types and headers that were not on the mock component’s include path.
> 
> This change **`list(APPEND)`** five include directories to `tools/mocks/driver/CMakeLists.txt`: `esp_hal_gpio` (plus `linux`), `esp_hal_gpspi`, `esp_hal_rmt`, and `esp_hal_i2c`, aligned with the GPIO, SPI, RMT, and I2C mocks already listed there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8fbfe6c3894d67c888f37f1ff1bb3fa15d6177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->