### PR TITLE
fix/update BLE log SPI LBM (IDFGH-17969)

### DIFF
--- a/components/bt/common/ble_log/Kconfig.in
+++ b/components/bt/common/ble_log/Kconfig.in
@@ -7,14 +7,6 @@ config BLE_LOG_ENABLED
         Enable BT Log Async Output
 
 if BLE_LOG_ENABLED
-    config BLE_LOG_LBM_AUTO_FLUSH
-        bool "Enable automatic BLE Log LBM buffer flush"
-        default n
-        help
-            Periodically flush partially-filled BLE Log LBM transport buffers
-            that remain pending, reducing latency for low-volume or
-            intermittent logging.
-
     config BLE_LOG_TASK_STACK_SIZE
         int "Stack size for BLE Log Task"
         default 1024 if IDF_TARGET_ARCH_RISCV
@@ -23,40 +15,49 @@ if BLE_LOG_ENABLED
         help
             Stack size for BLE Log Task
 
-    config BLE_LOG_LBM_TRANS_BUF_SIZE
-        int "Total buffer memory per common LBM (bytes)"
-        default 2048
+    config BLE_LOG_POOL_TRANS_CNT
+        int "Number of transport buffers in the unified pool"
+        default 16
         help
-            Total buffer memory allocated for each common pool log buffer
-            manager (LBM). This memory is divided equally among internal
-            transport buffers. Must be a multiple of BLE_LOG_TRANS_BUF_CNT
-            (currently 4).
+            Total number of transport buffers in the global BLE Log buffer
+            pool. All task / ISR / Link Layer log writers allocate from this
+            single pool. Must be within [2, 32] because buffer availability is
+            tracked with 32-bit hint bitmaps.
 
-            The common pool contains:
-            - BLE_LOG_LBM_ATOMIC_LOCK_TASK_CNT atomic LBMs (task context)
-            - BLE_LOG_LBM_ATOMIC_LOCK_ISR_CNT atomic LBMs (ISR context)
-            - 2 spinlock-protected LBMs (one for task, one for ISR fallback)
-
-            Total common pool memory:
-            (ATOMIC_TASK_CNT + ATOMIC_ISR_CNT + 2) * BLE_LOG_LBM_TRANS_BUF_SIZE
-
-    config BLE_LOG_LBM_ATOMIC_LOCK_TASK_CNT
-        int "Count of log buffer managers with atomic lock protection for task context"
-        default 2
-        help
-            BLE Log module will search for an LBM with atomic lock protection first; if
-            all LBMs with atomic lock protection are unavailable, BLE Log module will
-            try to use the LBM with spin lock protection. So the more LBMs with atomic
-            lock protection are created, the better the logging performance will be.
-
-    config BLE_LOG_LBM_ATOMIC_LOCK_ISR_CNT
-        int "Count of log buffer managers with atomic lock protection for ISR context"
+    config BLE_LOG_POOL_ISR_RESERVE_CNT
+        int "Transport buffers reserved for ISR context"
         default 1
         help
-            BLE Log module will search for an LBM with atomic lock protection first; if
-            all LBMs with atomic lock protection are unavailable, BLE Log module will
-            try to use the LBM with spin lock protection. So the more LBMs with atomic
-            lock protection are created, the more ISRs can nest.
+            Number of buffers reserved for ISR context. ISR writers use the
+            shared region first and only fall back to this reserve when the
+            shared region is exhausted, so task bursts cannot starve ISR logs
+            completely. Must be less than BLE_LOG_POOL_TRANS_CNT (at least one
+            shared buffer must remain).
+
+    config BLE_LOG_POOL_TRANS_SIZE
+        int "Per-transport buffer size (bytes)"
+        default 512
+        help
+            Size in bytes of each transport buffer. A single log frame
+            (including header and checksum overhead) must fit in one buffer.
+
+    config BLE_LOG_POOL_ISR_OPEN_SCAN_MAX
+        int "Max OPEN buffers an ISR writer scans (0 = scan all)"
+        default 0
+        help
+            Upper bound on the number of OPEN buffers an ISR-context writer
+            scans while looking for one to append to. 0 means scan all buffers.
+            A small value bounds worst-case ISR time at the cost of log packing
+            efficiency.
+
+    config BLE_LOG_POOL_TASK_WAIT_TIMEOUT_MS
+        int "Task backpressure wait timeout (ms, 0 = wait forever)"
+        default 50
+        help
+            When no transport buffer is available, a task-context writer blocks
+            (backpressure) up to this timeout waiting for a buffer to be
+            recycled, instead of dropping the log. 0 means block indefinitely
+            (portMAX_DELAY). ISR context never blocks.
 
     config BLE_LOG_IS_ESP_CONTROLLER
         bool "Current BLE Controller is ESP BLE Controller"
@@ -85,22 +86,6 @@ if BLE_LOG_ENABLED
             Enable BLE Log for Link Layer
 
     if BLE_LOG_LL_ENABLED
-        config BLE_LOG_LBM_LL_TRANS_BUF_SIZE
-            int "Total buffer memory per Link Layer LBM (bytes)"
-            default 2048
-            help
-                Total buffer memory allocated for each Link Layer dedicated
-                log buffer manager (LBM). This memory is divided equally among
-                internal transport buffers. Must be a multiple of
-                BLE_LOG_TRANS_BUF_CNT (currently 4).
-
-                There are 2 Link Layer LBMs without lock protection (each is
-                accessed from a single context only):
-                - LL task LBM (Link Layer task context logs)
-                - LL HCI LBM (Link Layer HCI context logs)
-
-                Total LL pool memory: 2 * BLE_LOG_LBM_LL_TRANS_BUF_SIZE
-
         config BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT_ENABLED
             bool "Enable LL HCI Log Payload Length Limit"
             default n

--- a/components/bt/common/ble_log/src/ble_log_lbm.c
+++ b/components/bt/common/ble_log/src/ble_log_lbm.c
@@ -11,7 +11,6 @@
 #include "ble_log.h"
 #include "ble_log_lbm.h"
 #include "ble_log_rt.h"
-#include "esp_log.h"
 
 #if CONFIG_SOC_ESP_NIMBLE_CONTROLLER
 #if CONFIG_BT_DUAL_MODE_ARCH
@@ -23,175 +22,366 @@
 #endif // CONFIG_BT_DUAL_MODE_ARCH
 #endif /* CONFIG_SOC_ESP_NIMBLE_CONTROLLER */
 
-/* VARIABLE */
-#define TAG "ble_log"
-#define BLE_LOG_LBM_WAIT_TIMEOUT_MS (1000)
+/* MACRO */
+#if CONFIG_BLE_LOG_POOL_TASK_WAIT_TIMEOUT_MS > 0
+#define BLE_LOG_POOL_TASK_WAIT_TICKS            pdMS_TO_TICKS(CONFIG_BLE_LOG_POOL_TASK_WAIT_TIMEOUT_MS)
+#else
+#define BLE_LOG_POOL_TASK_WAIT_TICKS            portMAX_DELAY
+#endif
 
+#if CONFIG_BLE_LOG_POOL_ISR_OPEN_SCAN_MAX > 0
+#define BLE_LOG_POOL_ISR_OPEN_SCAN_MAX          CONFIG_BLE_LOG_POOL_ISR_OPEN_SCAN_MAX
+#else
+#define BLE_LOG_POOL_ISR_OPEN_SCAN_MAX          BLE_LOG_POOL_TRANS_CNT
+#endif
+
+/* ------------------------------- */
+/*     Global Pool Context         */
+/* ------------------------------- */
+typedef struct {
+    ble_log_prph_trans_t *trans[BLE_LOG_POOL_TRANS_CNT];
+
+    /* Hint bitmaps: a set bit means "this buffer is likely FREE/OPEN". The
+     * real ownership is the per-buffer atomic_lock; bitmaps only accelerate
+     * candidate lookup and may be transiently stale. */
+    volatile uint32_t free_bitmap;
+    volatile uint32_t open_bitmap;
+
+    /* Domain masks (static after init). */
+    uint32_t shared_mask;
+    uint32_t isr_reserve_mask;
+
+    /* Round-robin scan cursors. */
+    volatile uint32_t open_cursor;
+    volatile uint32_t free_cursor;
+
+    /* In-flight (SENDING) pool buffers and its peak. */
+    volatile uint32_t inflight;
+    volatile uint32_t inflight_peak;
+
+    /* Number of task writers currently blocked waiting for a buffer. */
+    volatile uint32_t waiting_task_count;
+
+    /* Event-only counting semaphore used to wake blocked task writers.
+     * Not a lock: it carries no ownership and never protects shared data. */
+    SemaphoreHandle_t sem;
+} ble_log_pool_t;
+
+/* VARIABLE */
 BLE_LOG_STATIC volatile uint32_t lbm_ref_count = 0;
 BLE_LOG_STATIC bool lbm_inited = false;
 BLE_LOG_STATIC bool lbm_enabled = false;
-BLE_LOG_STATIC volatile bool flush_in_progress = false;
-BLE_LOG_STATIC ble_log_lbm_ctx_t *lbm_ctx = NULL;
+BLE_LOG_STATIC ble_log_pool_t g_pool;
 BLE_LOG_STATIC ble_log_stat_mgr_t *stat_mgr_ctx[BLE_LOG_SRC_MAX] = {0};
 
 /* PRIVATE FUNCTION DECLARATION */
+BLE_LOG_STATIC ble_log_prph_trans_t *ble_log_pool_acquire(size_t log_len, bool is_isr);
+BLE_LOG_STATIC void ble_log_pool_seal_and_send(ble_log_prph_trans_t *trans);
 BLE_LOG_STATIC
-bool ble_log_lbm_acquire_trans(size_t log_len, ble_log_lbm_t **out_lbm,
-                               ble_log_prph_trans_t ***out_trans);
-BLE_LOG_STATIC void ble_log_lbm_release(ble_log_lbm_t *lbm);
-BLE_LOG_STATIC
-ble_log_prph_trans_t **ble_log_lbm_get_trans(ble_log_lbm_t *lbm, size_t log_len);
-BLE_LOG_STATIC bool ble_log_lbm_flush_all_trans(void);
-BLE_LOG_STATIC void ble_log_lbm_reset_stats(void);
-BLE_LOG_STATIC
-void ble_log_lbm_write_trans(ble_log_prph_trans_t **trans, ble_log_src_t src_code,
-                             const uint8_t *addr, uint16_t len,
-                             const uint8_t *addr_append, uint16_t len_append, bool omdata);
-BLE_LOG_STATIC
-bool ble_log_write_hex_core(ble_log_src_t src_code, const uint8_t *addr, size_t len);
-#if BLE_LOG_UART_REDIR_ENABLED
-BLE_LOG_STATIC
-void ble_log_lbm_stream_seal(ble_log_prph_trans_t **trans, ble_log_src_t src_code);
-#endif /* BLE_LOG_UART_REDIR_ENABLED */
+void ble_log_pool_write_frame(ble_log_prph_trans_t *trans, ble_log_src_t src_code,
+                              const uint8_t *addr, uint16_t len,
+                              const uint8_t *addr_append, uint16_t len_append, bool omdata);
 BLE_LOG_STATIC void ble_log_stat_mgr_update(ble_log_src_t src_code, uint32_t len, bool lost);
+BLE_LOG_STATIC void ble_log_pool_wake_all(void);
+#if BLE_LOG_UART_REDIR_ENABLED
+BLE_LOG_STATIC void ble_log_redir_seal(ble_log_prph_trans_t *trans, ble_log_src_t src_code);
+#endif /* BLE_LOG_UART_REDIR_ENABLED */
 
 /* ------------------------- */
-/*     PRIVATE INTERFACE     */
+/*     BITMAP HELPERS        */
 /* ------------------------- */
-BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-bool ble_log_lbm_acquire_trans(size_t log_len, ble_log_lbm_t **out_lbm,
-                               ble_log_prph_trans_t ***out_trans)
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC BLE_LOG_INLINE
+void ble_log_pool_bitmap_set(volatile uint32_t *bitmap, uint8_t id)
 {
-    *out_lbm = NULL;
-    *out_trans = NULL;
+    __atomic_fetch_or(bitmap, (1u << id), __ATOMIC_RELEASE);
+}
 
-    ble_log_lbm_t *lbm;
-    ble_log_prph_trans_t **trans;
-    ble_log_lbm_t *atomic_pool;
-    ble_log_lbm_t *spin_lbm;
-    int atomic_pool_size;
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC BLE_LOG_INLINE
+void ble_log_pool_bitmap_clear(volatile uint32_t *bitmap, uint8_t id)
+{
+    __atomic_fetch_and(bitmap, ~(1u << id), __ATOMIC_RELEASE);
+}
 
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC BLE_LOG_INLINE
+bool ble_log_pool_id_task_usable(uint8_t id)
+{
+    return (g_pool.shared_mask & (1u << id)) != 0;
+}
+
+/* ------------------------- */
+/*     WAKE HELPERS          */
+/* ------------------------- */
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC void ble_log_pool_wake_one(void)
+{
+    if (!g_pool.sem) {
+        return;
+    }
     if (BLE_LOG_IN_ISR()) {
-        atomic_pool = lbm_ctx->atomic_pool_isr;
-        spin_lbm = &(lbm_ctx->spin_isr);
-        atomic_pool_size = BLE_LOG_LBM_ATOMIC_ISR_CNT;
+        BaseType_t woken = pdFALSE;
+        xSemaphoreGiveFromISR(g_pool.sem, &woken);
+        if (woken) {
+            portYIELD_FROM_ISR(woken);
+        }
     } else {
-        atomic_pool = lbm_ctx->atomic_pool_task;
-        spin_lbm = &(lbm_ctx->spin_task);
-        atomic_pool_size = BLE_LOG_LBM_ATOMIC_TASK_CNT;
+        xSemaphoreGive(g_pool.sem);
+    }
+}
+
+/* Task context only: release all potentially-blocked task writers. */
+BLE_LOG_STATIC void ble_log_pool_wake_all(void)
+{
+    if (!g_pool.sem) {
+        return;
+    }
+    for (int i = 0; i < BLE_LOG_POOL_TRANS_CNT; i++) {
+        /* May fail with pdFALSE when the semaphore is already at max; that is
+         * harmless — a token per possible waiter is enough to release them. */
+        (void)xSemaphoreGive(g_pool.sem);
+    }
+}
+
+/* -------------------------------------- */
+/*     UNIFIED TRANSPORT RECYCLE          */
+/* -------------------------------------- */
+BLE_LOG_IRAM_ATTR void ble_log_lbm_recycle_trans(ble_log_prph_trans_t *trans)
+{
+    trans->pos = 0;
+
+    if (trans->id == BLE_LOG_TRANS_ID_NONE) {
+        /* Redirection transport: not part of the pool, no bitmap/inflight. */
+        __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_FREE, __ATOMIC_RELEASE);
+        return;
     }
 
-    /* Try each atomic LBM: acquire lock, check buffer, fallback on failure */
-    for (int i = 0; i < atomic_pool_size; i++) {
-        lbm = &atomic_pool[i];
-        if (ble_log_cas_acquire(&(lbm->atomic_lock))) {
-            trans = ble_log_lbm_get_trans(lbm, log_len);
-            if (trans) {
-                *out_lbm = lbm;
-                *out_trans = trans;
-                return true;
-            }
-            ble_log_cas_release(&(lbm->atomic_lock));
+    __atomic_sub_fetch(&g_pool.inflight, 1, __ATOMIC_RELAXED);
+
+    /* CRITICAL store order: publish FREE state before advertising the buffer
+     * in free_bitmap. An allocator that sees the hint bit will acquire the
+     * lock and re-check state; the release on free_bitmap pairs with the
+     * allocator's acquire so it never observes a stale non-FREE state. */
+    __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_FREE, __ATOMIC_RELEASE);
+    ble_log_pool_bitmap_set(&g_pool.free_bitmap, trans->id);
+
+    if (ble_log_pool_id_task_usable(trans->id) &&
+        __atomic_load_n(&g_pool.waiting_task_count, __ATOMIC_ACQUIRE) > 0) {
+        ble_log_pool_wake_one();
+    }
+}
+
+/* -------------------------------------- */
+/*     SEAL AND SUBMIT (holds lock)       */
+/* -------------------------------------- */
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC void ble_log_pool_seal_and_send(ble_log_prph_trans_t *trans)
+{
+    __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_SENDING, __ATOMIC_RELAXED);
+    /* Defensive: a SENDING buffer must not linger in any hint bitmap. */
+    ble_log_pool_bitmap_clear(&g_pool.open_bitmap, trans->id);
+
+    uint32_t infl = __atomic_add_fetch(&g_pool.inflight, 1, __ATOMIC_RELAXED);
+    uint32_t peak = __atomic_load_n(&g_pool.inflight_peak, __ATOMIC_RELAXED);
+    while (infl > peak) {
+        if (__atomic_compare_exchange_n(&g_pool.inflight_peak, &peak, infl,
+                                        true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+            break;
         }
     }
 
-    /* Last resort: spinlock LBM */
-    lbm = spin_lbm;
-    BLE_LOG_ACQUIRE_SPIN_LOCK(&(lbm->spin_lock));
-    trans = ble_log_lbm_get_trans(lbm, log_len);
+    /* Release the lock BEFORE submitting. The buffer is now in no bitmap and
+     * is SENDING, so no other writer can find it; submitting outside the lock
+     * avoids racing tx_done against the lock owner. */
+    ble_log_cas_release(&trans->atomic_lock);
+    ble_log_rt_queue_trans(trans);
+}
+
+/* -------------------------------------- */
+/*     OPEN BUFFER LOOKUP                 */
+/* -------------------------------------- */
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
+ble_log_prph_trans_t *ble_log_pool_try_find_open(uint32_t domain_mask, uint32_t frame_len, bool is_isr)
+{
+    uint32_t bm = __atomic_load_n(&g_pool.open_bitmap, __ATOMIC_ACQUIRE) & domain_mask;
+    if (!bm) {
+        return NULL;
+    }
+
+    uint32_t start = __atomic_load_n(&g_pool.open_cursor, __ATOMIC_RELAXED);
+    int scan_limit = is_isr ? BLE_LOG_POOL_ISR_OPEN_SCAN_MAX : BLE_LOG_POOL_TRANS_CNT;
+    int scanned = 0;
+
+    for (int i = 0; i < BLE_LOG_POOL_TRANS_CNT; i++) {
+        uint8_t id = (uint8_t)((start + i) % BLE_LOG_POOL_TRANS_CNT);
+        if (!(bm & (1u << id))) {
+            continue;
+        }
+        if (scanned++ >= scan_limit) {
+            break;
+        }
+
+        ble_log_prph_trans_t *trans = g_pool.trans[id];
+        /* Ownership: hint bit alone is not enough, take the lock. */
+        if (!ble_log_cas_acquire(&trans->atomic_lock)) {
+            continue;
+        }
+        if (__atomic_load_n(&trans->state, __ATOMIC_RELAXED) != BLE_LOG_TRANS_STATE_OPEN) {
+            /* Stale hint: leave the bitmap alone, owner will maintain it. */
+            ble_log_cas_release(&trans->atomic_lock);
+            continue;
+        }
+
+        if (BLE_LOG_TRANS_FREE_SPACE(trans) >= frame_len) {
+            ble_log_pool_bitmap_clear(&g_pool.open_bitmap, id);
+            __atomic_store_n(&g_pool.open_cursor,
+                             (id + 1u) % BLE_LOG_POOL_TRANS_CNT, __ATOMIC_RELAXED);
+            return trans;   /* returned locked */
+        }
+
+        if (trans->pos > 0) {
+            ble_log_pool_bitmap_clear(&g_pool.open_bitmap, id);
+            ble_log_pool_seal_and_send(trans);   /* releases the lock */
+            continue;
+        }
+
+        /* Abnormal: OPEN yet empty. Revert to FREE defensively. */
+        __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_FREE, __ATOMIC_RELEASE);
+        ble_log_pool_bitmap_set(&g_pool.free_bitmap, id);
+        ble_log_pool_bitmap_clear(&g_pool.open_bitmap, id);
+        ble_log_cas_release(&trans->atomic_lock);
+    }
+
+    return NULL;
+}
+
+/* -------------------------------------- */
+/*     FREE BUFFER ALLOCATION             */
+/* -------------------------------------- */
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
+ble_log_prph_trans_t *ble_log_pool_alloc_from_mask(uint32_t mask)
+{
+    uint32_t bm = __atomic_load_n(&g_pool.free_bitmap, __ATOMIC_ACQUIRE) & mask;
+    if (!bm) {
+        return NULL;
+    }
+
+    uint32_t start = __atomic_load_n(&g_pool.free_cursor, __ATOMIC_RELAXED);
+    for (int i = 0; i < BLE_LOG_POOL_TRANS_CNT; i++) {
+        uint8_t id = (uint8_t)((start + i) % BLE_LOG_POOL_TRANS_CNT);
+        if (!(bm & (1u << id))) {
+            continue;
+        }
+
+        ble_log_prph_trans_t *trans = g_pool.trans[id];
+        if (!ble_log_cas_acquire(&trans->atomic_lock)) {
+            /* Contended hint: do not touch the bitmap. */
+            continue;
+        }
+        if (__atomic_load_n(&trans->state, __ATOMIC_RELAXED) != BLE_LOG_TRANS_STATE_FREE) {
+            /* Stale hint: do not touch the bitmap, owner maintains it. */
+            ble_log_cas_release(&trans->atomic_lock);
+            continue;
+        }
+
+        /* Confirmed owner: only now clear the hint bit. */
+        ble_log_pool_bitmap_clear(&g_pool.free_bitmap, id);
+        trans->pos = 0;
+        __atomic_store_n(&g_pool.free_cursor,
+                         (id + 1u) % BLE_LOG_POOL_TRANS_CNT, __ATOMIC_RELAXED);
+        return trans;   /* returned locked */
+    }
+
+    return NULL;
+}
+
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
+ble_log_prph_trans_t *ble_log_pool_try_alloc_free(bool is_isr)
+{
+    ble_log_prph_trans_t *trans = ble_log_pool_alloc_from_mask(g_pool.shared_mask);
     if (trans) {
-        *out_lbm = lbm;
-        *out_trans = trans;
-        return true;
+        return trans;
     }
-    BLE_LOG_RELEASE_SPIN_LOCK(&(lbm->spin_lock));
-
-    return false;
+    if (is_isr) {
+        trans = ble_log_pool_alloc_from_mask(g_pool.isr_reserve_mask);
+        if (trans) {
+            return trans;
+        }
+    }
+    return NULL;
 }
 
+/* -------------------------------------- */
+/*     ACQUIRE (with task backpressure)   */
+/* -------------------------------------- */
 BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-void ble_log_lbm_release(ble_log_lbm_t *lbm)
+ble_log_prph_trans_t *ble_log_pool_acquire(size_t log_len, bool is_isr)
 {
-    switch (lbm->lock_type) {
-    case BLE_LOG_LBM_LOCK_ATOMIC:
-        ble_log_cas_release(&(lbm->atomic_lock));
-        break;
-    case BLE_LOG_LBM_LOCK_SPIN:
-        BLE_LOG_RELEASE_SPIN_LOCK(&lbm->spin_lock);
-        break;
-    case BLE_LOG_LBM_LOCK_NONE:
-    default:
-        break;
+    uint32_t frame_len = (uint32_t)log_len + BLE_LOG_FRAME_OVERHEAD;
+    if (frame_len > BLE_LOG_POOL_TRANS_SIZE) {
+        /* Frame can never fit a single transport; drop it. */
+        return NULL;
+    }
+
+    uint32_t open_mask = is_isr ? (g_pool.shared_mask | g_pool.isr_reserve_mask)
+                                : g_pool.shared_mask;
+
+    /* Task writers may block for a buffer; ISR / scheduler-suspended / the
+     * runtime task itself must never block (would stall recycling). */
+    bool can_block = !is_isr &&
+                     (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) &&
+                     !ble_log_rt_in_self_task();
+
+    ble_log_prph_trans_t *trans;
+    for (;;) {
+        trans = ble_log_pool_try_find_open(open_mask, frame_len, is_isr);
+        if (trans) {
+            return trans;
+        }
+        trans = ble_log_pool_try_alloc_free(is_isr);
+        if (trans) {
+            return trans;
+        }
+
+        if (!can_block || !lbm_enabled) {
+            return NULL;
+        }
+
+        __atomic_add_fetch(&g_pool.waiting_task_count, 1, __ATOMIC_ACQ_REL);
+
+        /* Second scan closes the window between the first failed scan and the
+         * waiting_task_count increment (a tx_done may have recycled a buffer
+         * without waking anyone). */
+        trans = ble_log_pool_try_find_open(open_mask, frame_len, is_isr);
+        if (!trans) {
+            trans = ble_log_pool_try_alloc_free(is_isr);
+        }
+        if (trans) {
+            __atomic_sub_fetch(&g_pool.waiting_task_count, 1, __ATOMIC_ACQ_REL);
+            return trans;
+        }
+
+        /* Block without holding a module reference so flush/deinit can drain
+         * ref_count. Re-acquire the reference before touching pool state. */
+        BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
+        xSemaphoreTake(g_pool.sem, BLE_LOG_POOL_TASK_WAIT_TICKS);
+        BLE_LOG_REF_COUNT_ACQUIRE(&lbm_ref_count);
+        __atomic_sub_fetch(&g_pool.waiting_task_count, 1, __ATOMIC_ACQ_REL);
+
+        if (!lbm_enabled) {
+            /* Pool is closing (disable/flush/deinit woke us). Give up.
+             * Only task context reaches here (can_block implies !is_isr). */
+            return NULL;
+        }
+        /* Otherwise loop and retry the scan. */
     }
 }
 
-BLE_LOG_STATIC bool ble_log_lbm_flush_all_trans(void)
-{
-    ble_log_lbm_t *lbm;
-    ble_log_prph_trans_t **trans;
-    bool in_progress;
-    TickType_t start_tick = xTaskGetTickCount();
-
-    /* Queue transports with logs */
-    for (int i = 0; i < BLE_LOG_LBM_CNT; i++) {
-        lbm = &(lbm_ctx->lbm_pool[i]);
-        int trans_idx = lbm->trans_idx;
-        for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-            trans = &(lbm->trans[trans_idx]);
-            if (!__atomic_load_n(&(*trans)->prph_owned, __ATOMIC_ACQUIRE) &&
-                (*trans)->pos) {
-                ble_log_rt_queue_trans(trans);
-            }
-            trans_idx = (trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
-        }
-    }
-
-    /* Wait for transportation to finish */
-    do {
-        in_progress = false;
-        for (int i = 0; i < BLE_LOG_LBM_CNT; i++) {
-            lbm = &(lbm_ctx->lbm_pool[i]);
-            for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-                trans = &(lbm->trans[j]);
-                in_progress |= __atomic_load_n(&(*trans)->prph_owned, __ATOMIC_ACQUIRE);
-            }
-        }
-        if (in_progress) {
-            if ((xTaskGetTickCount() - start_tick) >=
-                pdMS_TO_TICKS(BLE_LOG_LBM_WAIT_TIMEOUT_MS)) {
-                ESP_LOGE(TAG, "Timed out waiting for BLE Log transports");
-                return false;
-            }
-            vTaskDelay(1);
-        }
-    } while (in_progress);
-
-    return true;
-}
-
-BLE_LOG_STATIC void ble_log_lbm_reset_stats(void)
-{
-    ble_log_lbm_t *lbm;
-
-    for (int i = 0; i < BLE_LOG_SRC_MAX; i++) {
-        BLE_LOG_MEMSET(stat_mgr_ctx[i], 0, sizeof(ble_log_stat_mgr_t));
-    }
-
-    for (int i = 0; i < BLE_LOG_LBM_CNT; i++) {
-        lbm = &(lbm_ctx->lbm_pool[i]);
-        __atomic_store_n(&lbm->trans_inflight, 0, __ATOMIC_RELAXED);
-        __atomic_store_n(&lbm->trans_inflight_peak, 0, __ATOMIC_RELAXED);
-    }
-    ble_log_prph_reset_util_counters();
-}
-
+/* -------------------------------------- */
+/*     WRITE ONE FRAME (holds lock)       */
+/* -------------------------------------- */
 BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-void ble_log_lbm_write_trans(ble_log_prph_trans_t **trans, ble_log_src_t src_code,
-                             const uint8_t *addr, uint16_t len,
-                             const uint8_t *addr_append, uint16_t len_append, bool omdata)
+void ble_log_pool_write_frame(ble_log_prph_trans_t *trans, ble_log_src_t src_code,
+                              const uint8_t *addr, uint16_t len,
+                              const uint8_t *addr_append, uint16_t len_append, bool omdata)
 {
-    /* Preparation before writing */
-    uint8_t *buf = (*trans)->buf + (*trans)->pos;
+    uint8_t *buf = trans->buf + trans->pos;
     uint16_t payload_len = len + len_append;
     ble_log_stat_mgr_t *stat_mgr = stat_mgr_ctx[src_code];
     uint32_t frame_sn = BLE_LOG_GET_FRAME_SN(&(stat_mgr->frame_sn));
@@ -221,51 +411,129 @@ void ble_log_lbm_write_trans(ble_log_prph_trans_t **trans, ble_log_src_t src_cod
     uint32_t checksum = ble_log_fast_checksum((const uint8_t *)buf, BLE_LOG_FRAME_HEAD_LEN + payload_len);
     BLE_LOG_MEMCPY(buf + BLE_LOG_FRAME_HEAD_LEN + payload_len, &checksum, BLE_LOG_FRAME_TAIL_LEN);
 
-    /* Update peripheral transport */
-    (*trans)->pos += payload_len + BLE_LOG_FRAME_OVERHEAD;
-
+    /* Update transport */
+    trans->pos += payload_len + BLE_LOG_FRAME_OVERHEAD;
     ble_log_stat_mgr_update(src_code, payload_len, false);
 
-    /* Queue trans if full */
-    if (BLE_LOG_TRANS_FREE_SPACE((*trans)) <= BLE_LOG_FRAME_OVERHEAD) {
-        ble_log_rt_queue_trans(trans);
+    /* Completion: seal if nearly full, otherwise publish as OPEN. */
+    if (BLE_LOG_TRANS_FREE_SPACE(trans) <= BLE_LOG_FRAME_OVERHEAD) {
+        ble_log_pool_seal_and_send(trans);      /* releases the lock */
+    } else {
+        __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_OPEN, __ATOMIC_RELAXED);
+        ble_log_pool_bitmap_set(&g_pool.open_bitmap, trans->id);
+        ble_log_cas_release(&trans->atomic_lock);
     }
 }
 
 #if BLE_LOG_UART_REDIR_ENABLED
+/* ------------------------------------------------- */
+/*     STREAM WRITE INTERFACE (UART redirection)     */
+/*                                                   */
+/* Stream mode appends raw data into a transport     */
+/* buffer with deferred frame encapsulation.         */
+/* Redirection transports are single-writer under    */
+/* redir->mutex; their only concurrent mutation is   */
+/* the UART tx-done recycle (state SENDING -> FREE),  */
+/* so state access uses atomics.                     */
+/* ------------------------------------------------- */
 BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-void ble_log_lbm_stream_seal(ble_log_prph_trans_t **trans, ble_log_src_t src_code)
+ble_log_prph_trans_t *ble_log_redir_get_trans(ble_log_redir_t *redir, ble_log_src_t src_code, size_t log_len)
 {
-    if ((*trans)->pos <= BLE_LOG_FRAME_HEAD_LEN) {
+    for (int i = 0; i < BLE_LOG_TRANS_BUF_CNT; i++) {
+        ble_log_prph_trans_t *trans = redir->trans[redir->trans_idx];
+        if (__atomic_load_n(&trans->state, __ATOMIC_ACQUIRE) != BLE_LOG_TRANS_STATE_SENDING) {
+            if (BLE_LOG_TRANS_FREE_SPACE(trans) >= (log_len + BLE_LOG_FRAME_OVERHEAD)) {
+                return trans;
+            }
+            if (trans->pos > BLE_LOG_FRAME_HEAD_LEN) {
+                ble_log_redir_seal(trans, src_code);
+            }
+        }
+        redir->trans_idx = (redir->trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
+    }
+    return NULL;
+}
+
+BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
+void ble_log_redir_seal(ble_log_prph_trans_t *trans, ble_log_src_t src_code)
+{
+    if (trans->pos <= BLE_LOG_FRAME_HEAD_LEN) {
         return;
     }
 
-    uint16_t payload_len = (*trans)->pos - BLE_LOG_FRAME_HEAD_LEN;
+    uint16_t payload_len = trans->pos - BLE_LOG_FRAME_HEAD_LEN;
     ble_log_stat_mgr_t *stat_mgr = stat_mgr_ctx[src_code];
     uint32_t frame_sn = BLE_LOG_GET_FRAME_SN(&(stat_mgr->frame_sn));
     ble_log_frame_head_t frame_head = {
         .length = payload_len,
         .frame_meta = BLE_LOG_MAKE_FRAME_META(src_code, frame_sn),
     };
-    BLE_LOG_MEMCPY((*trans)->buf, &frame_head, BLE_LOG_FRAME_HEAD_LEN);
+    BLE_LOG_MEMCPY(trans->buf, &frame_head, BLE_LOG_FRAME_HEAD_LEN);
 
-    uint32_t checksum = ble_log_fast_checksum((*trans)->buf, (*trans)->pos);
-    BLE_LOG_MEMCPY((*trans)->buf + (*trans)->pos, &checksum, BLE_LOG_FRAME_TAIL_LEN);
-    (*trans)->pos += BLE_LOG_FRAME_TAIL_LEN;
+    uint32_t checksum = ble_log_fast_checksum(trans->buf, trans->pos);
+    BLE_LOG_MEMCPY(trans->buf + trans->pos, &checksum, BLE_LOG_FRAME_TAIL_LEN);
+    trans->pos += BLE_LOG_FRAME_TAIL_LEN;
 
     ble_log_stat_mgr_update(src_code, payload_len, false);
 
+    __atomic_store_n(&trans->state, BLE_LOG_TRANS_STATE_SENDING, __ATOMIC_RELAXED);
     ble_log_rt_queue_trans(trans);
+}
+
+BLE_LOG_IRAM_ATTR
+void ble_log_lbm_stream_write(ble_log_redir_t *redir, ble_log_src_t src_code,
+                               const uint8_t *data, size_t len)
+{
+    while (len > 0) {
+        ble_log_prph_trans_t *trans = ble_log_redir_get_trans(redir, src_code, 0);
+        if (!trans) {
+            ble_log_stat_mgr_update(src_code, len, true);
+            return;
+        }
+
+        if (trans->pos == 0) {
+            trans->pos = BLE_LOG_FRAME_HEAD_LEN;
+        }
+
+        uint16_t available = BLE_LOG_TRANS_FREE_SPACE(trans);
+        if (available <= BLE_LOG_FRAME_TAIL_LEN) {
+            ble_log_redir_seal(trans, src_code);
+            continue;
+        }
+        available -= BLE_LOG_FRAME_TAIL_LEN;
+
+        size_t to_write = (len < available) ? len : available;
+        BLE_LOG_MEMCPY(trans->buf + trans->pos, data, to_write);
+        trans->pos += to_write;
+        data += to_write;
+        len -= to_write;
+
+        if (BLE_LOG_TRANS_FREE_SPACE(trans) <= BLE_LOG_FRAME_OVERHEAD) {
+            ble_log_redir_seal(trans, src_code);
+        }
+    }
+}
+
+BLE_LOG_IRAM_ATTR
+void ble_log_lbm_stream_flush(ble_log_redir_t *redir, ble_log_src_t src_code)
+{
+    int trans_idx = redir->trans_idx;
+    for (int i = 0; i < BLE_LOG_TRANS_BUF_CNT; i++) {
+        ble_log_prph_trans_t *trans = redir->trans[trans_idx];
+        if (__atomic_load_n(&trans->state, __ATOMIC_ACQUIRE) != BLE_LOG_TRANS_STATE_SENDING &&
+            trans->pos > BLE_LOG_FRAME_HEAD_LEN) {
+            ble_log_redir_seal(trans, src_code);
+        }
+        trans_idx = (trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
+    }
 }
 #endif /* BLE_LOG_UART_REDIR_ENABLED */
 
 BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
 void ble_log_stat_mgr_update(ble_log_src_t src_code, uint32_t len, bool lost)
 {
-    /* Get statistic manager by source code */
     ble_log_stat_mgr_t *stat_mgr = stat_mgr_ctx[src_code];
 
-    /* Update aligned counters */
     uint32_t bytes_cnt = len + BLE_LOG_FRAME_OVERHEAD;
     if (lost) {
         BLE_LOG_GET_FRAME_SN(&(stat_mgr->frame_sn));  /* consume SN for loss detection */
@@ -275,35 +543,6 @@ void ble_log_stat_mgr_update(ble_log_src_t src_code, uint32_t len, bool lost)
         __atomic_fetch_add(&stat_mgr->written_frame_cnt, 1, __ATOMIC_RELAXED);
         __atomic_fetch_add(&stat_mgr->written_bytes_cnt, bytes_cnt, __ATOMIC_RELAXED);
     }
-}
-
-BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-bool ble_log_write_hex_core(ble_log_src_t src_code, const uint8_t *addr, size_t len)
-{
-    /* Get transport from the best available pool */
-    size_t payload_len = len + sizeof(uint32_t);
-    ble_log_lbm_t *lbm;
-    ble_log_prph_trans_t **trans;
-    if (!ble_log_lbm_acquire_trans(payload_len, &lbm, &trans)) {
-        goto failed;
-    }
-
-    /* Write transport */
-    uint32_t os_ts = pdTICKS_TO_MS(BLE_LOG_IN_ISR()?
-                                   xTaskGetTickCountFromISR():
-                                   xTaskGetTickCount());
-    ble_log_lbm_write_trans(trans, src_code, (const uint8_t *)&os_ts,
-                            sizeof(uint32_t), addr, len, false);
-
-    /* Release */
-    ble_log_lbm_release(lbm);
-    return true;
-
-failed:
-    if (lbm_inited) {
-        ble_log_stat_mgr_update(src_code, payload_len, true);
-    }
-    return false;
 }
 
 /* -------------------------- */
@@ -316,54 +555,34 @@ bool ble_log_lbm_init(void)
         return true;
     }
 
-    /* Initialize LBM context */
-    lbm_ctx = (ble_log_lbm_ctx_t *)BLE_LOG_MALLOC(sizeof(ble_log_lbm_ctx_t));
-    if (!lbm_ctx) {
+    BLE_LOG_MEMSET(&g_pool, 0, sizeof(g_pool));
+
+    /* Counting semaphore used only to wake blocked task writers. Max equals
+     * the number of task-usable (shared) buffers; initial count is 0. */
+    g_pool.sem = xSemaphoreCreateCounting(BLE_LOG_POOL_SHARED_CNT, 0);
+    if (!g_pool.sem) {
         goto exit;
     }
-    BLE_LOG_MEMSET(lbm_ctx, 0, sizeof(ble_log_lbm_ctx_t));
 
-    /* Initialize peripheral transport for common LBMs */
-    ble_log_lbm_t *lbm;
-    for (int i = 0; i < BLE_LOG_LBM_COMMON_CNT; i++) {
-        lbm = &(lbm_ctx->lbm_common_pool[i]);
-        for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-            if (!ble_log_prph_trans_init(&(lbm->trans[j]),
-                                         BLE_LOG_TRANS_SIZE)) {
-                goto exit;
-            }
-            lbm->trans[j]->owner = (void *)lbm;
+    /* Allocate the transport buffers of the global pool. */
+    for (int id = 0; id < BLE_LOG_POOL_TRANS_CNT; id++) {
+        if (!ble_log_prph_trans_init(&(g_pool.trans[id]), BLE_LOG_POOL_TRANS_SIZE)) {
+            goto exit;
         }
+        g_pool.trans[id]->id = (uint8_t)id;
+        g_pool.trans[id]->state = BLE_LOG_TRANS_STATE_FREE;
+        g_pool.trans[id]->atomic_lock = false;
     }
 
-    /* Initialize lock types for atomic pool */
-    for (int i = 0; i < BLE_LOG_LBM_ATOMIC_CNT; i++) {
-        lbm_ctx->atomic_pool[i].lock_type = BLE_LOG_LBM_LOCK_ATOMIC;
-    }
-
-    /* Initialize lock types for spin pool */
-    for (int i = 0; i < BLE_LOG_LBM_SPIN_MAX; i++) {
-        lbm_ctx->spin_pool[i].lock_type = BLE_LOG_LBM_LOCK_SPIN;
-        portMUX_INITIALIZE(&(lbm_ctx->spin_pool[i].spin_lock));
-    }
-
-#if CONFIG_BLE_LOG_LL_ENABLED
-    for (int i = 0; i < BLE_LOG_LBM_LL_MAX; i++) {
-        lbm = &(lbm_ctx->lbm_ll_pool[i]);
-        for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-            if (!ble_log_prph_trans_init(&(lbm->trans[j]),
-                                         BLE_LOG_TRANS_LL_SIZE)) {
-                goto exit;
-            }
-            lbm->trans[j]->owner = (void *)lbm;
-        }
-    }
-
-    /* Initialize lock types for LL pool */
-    for (int i = 0; i < BLE_LOG_LBM_LL_MAX; i++) {
-        lbm_ctx->lbm_ll_pool[i].lock_type = BLE_LOG_LBM_LOCK_NONE;
-    }
-#endif /* CONFIG_BLE_LOG_LL_ENABLED */
+    /* Domain masks: low SHARED_CNT bits are shared, the rest is ISR reserve. */
+    uint32_t all_mask = (BLE_LOG_POOL_TRANS_CNT >= 32)
+                        ? 0xFFFFFFFFu : ((1u << BLE_LOG_POOL_TRANS_CNT) - 1u);
+    uint32_t shared_mask = (BLE_LOG_POOL_SHARED_CNT >= 32)
+                           ? 0xFFFFFFFFu : ((1u << BLE_LOG_POOL_SHARED_CNT) - 1u);
+    g_pool.shared_mask = shared_mask;
+    g_pool.isr_reserve_mask = all_mask & ~shared_mask;
+    g_pool.free_bitmap = all_mask;    /* every buffer starts FREE */
+    g_pool.open_bitmap = 0;
 
     /* Initialize statistic manager context */
     for (int i = 0; i < BLE_LOG_SRC_MAX; i++) {
@@ -374,7 +593,6 @@ bool ble_log_lbm_init(void)
         BLE_LOG_MEMSET(stat_mgr_ctx[i], 0, sizeof(ble_log_stat_mgr_t));
     }
 
-    /* Initialization done */
     lbm_ref_count = 0;
     lbm_inited = true;
     lbm_enabled = false;
@@ -391,16 +609,16 @@ void ble_log_lbm_deinit(void)
     lbm_inited = false;
     lbm_enabled = false;
 
-    /* Disable module and wait for all references to be released */
-    TickType_t start_tick = xTaskGetTickCount();
-    while (__atomic_load_n(&lbm_ref_count, __ATOMIC_ACQUIRE) > 0) {
-        if ((xTaskGetTickCount() - start_tick) >=
-            pdMS_TO_TICKS(BLE_LOG_LBM_WAIT_TIMEOUT_MS)) {
-            ESP_LOGE(TAG, "Timed out waiting for BLE Log references during deinit");
-        }
-        BLE_LOG_ASSERT((xTaskGetTickCount() - start_tick) <
-                       pdMS_TO_TICKS(BLE_LOG_LBM_WAIT_TIMEOUT_MS));
-        vTaskDelay(1);
+    /* Wake any blocked task writers and wait until BOTH the reference count
+     * and the waiting-task count drain to zero. Blocked writers hold no
+     * reference while parked, so waiting on ref_count alone could free the
+     * pool while a woken task still touches it (use-after-free). */
+    uint32_t time_waited = 0;
+    while ((__atomic_load_n(&lbm_ref_count, __ATOMIC_ACQUIRE) > 0) ||
+           (__atomic_load_n(&g_pool.waiting_task_count, __ATOMIC_ACQUIRE) > 0)) {
+        ble_log_pool_wake_all();
+        vTaskDelay(pdMS_TO_TICKS(1));
+        BLE_LOG_ASSERT(time_waited++ < 1000);
     }
 
     /* Release statistic manager context */
@@ -411,48 +629,15 @@ void ble_log_lbm_deinit(void)
         }
     }
 
-    /* Release LBM */
-    if (lbm_ctx) {
-        /* Release peripheral transport for common pools */
-        ble_log_lbm_t *lbm;
-        for (int i = 0; i < BLE_LOG_LBM_CNT; i++) {
-            lbm = &(lbm_ctx->lbm_pool[i]);
-            for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-                ble_log_prph_trans_deinit(&(lbm->trans[j]));
-            }
-        }
-
-        /* Release LBM context */
-        BLE_LOG_FREE(lbm_ctx);
-        lbm_ctx = NULL;
-    }
-}
-
-BLE_LOG_IRAM_ATTR BLE_LOG_STATIC
-ble_log_prph_trans_t **ble_log_lbm_get_trans(ble_log_lbm_t *lbm, size_t log_len)
-{
-    /* Check if available buffer can contain incoming log */
-    ble_log_prph_trans_t **trans;
-    for (int i = 0; i < BLE_LOG_TRANS_BUF_CNT; i++) {
-        trans = &(lbm->trans[lbm->trans_idx]);
-        if (!__atomic_load_n(&(*trans)->prph_owned, __ATOMIC_ACQUIRE)) {
-            /* Return if there's enough free space in current transport */
-            if (BLE_LOG_TRANS_FREE_SPACE((*trans)) >= (log_len + BLE_LOG_FRAME_OVERHEAD)) {
-                return trans;
-            }
-
-            /* Queue transport if there's insufficient free space */
-            if ((*trans)->pos) {
-                ble_log_rt_queue_trans(trans);
-            }
-        }
-
-        /* Current transport unavailable, switch to the other */
-        lbm->trans_idx = (lbm->trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
+    /* Release transport buffers */
+    for (int id = 0; id < BLE_LOG_POOL_TRANS_CNT; id++) {
+        ble_log_prph_trans_deinit(&(g_pool.trans[id]));
     }
 
-    /* All buffers are unavailable */
-    return NULL;
+    if (g_pool.sem) {
+        vSemaphoreDelete(g_pool.sem);
+        g_pool.sem = NULL;
+    }
 }
 
 void ble_log_write_enh_stat(void)
@@ -485,90 +670,6 @@ deref:
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
 }
 
-#if BLE_LOG_UART_REDIR_ENABLED
-/* ------------------------------------------------- */
-/*     STREAM WRITE INTERFACE                        */
-/*                                                   */
-/* Stream mode appends raw data into a transport     */
-/* buffer with deferred frame encapsulation:         */
-/*   - Header space is reserved on first write       */
-/*   - Data is memcpy'd after the reserved header    */
-/*   - Header and checksum are filled in at seal     */
-/*                                                   */
-/* get_trans(lbm, 0) reuse safety:                   */
-/*                                                   */
-/* get_trans auto-queues a buffer raw (no seal) when */
-/* free_space < log_len + FRAME_OVERHEAD.  With      */
-/* log_len = 0, this triggers at free_space < 10.    */
-/*                                                   */
-/* To prevent unsealed stream data from being sent   */
-/* raw, stream_write auto-seals at free_space <= 10. */
-/* This guarantees that any unsealed stream buffer   */
-/* seen by get_trans always has free_space > 10,     */
-/* so get_trans returns it directly without queuing.  */
-/* ------------------------------------------------- */
-BLE_LOG_IRAM_ATTR
-void ble_log_lbm_stream_write(ble_log_lbm_t *lbm, ble_log_src_t src_code,
-                               const uint8_t *data, size_t len)
-{
-    while (len > 0) {
-        ble_log_prph_trans_t **trans = ble_log_lbm_get_trans(lbm, 0);
-        if (!trans) {
-            ble_log_stat_mgr_update(src_code, len, true);
-            return;
-        }
-
-        if ((*trans)->pos == 0) {
-            (*trans)->pos = BLE_LOG_FRAME_HEAD_LEN;
-        }
-
-        uint16_t available = BLE_LOG_TRANS_FREE_SPACE((*trans));
-        if (available <= BLE_LOG_FRAME_TAIL_LEN) {
-            ble_log_lbm_stream_seal(trans, src_code);
-            continue;
-        }
-        available -= BLE_LOG_FRAME_TAIL_LEN;
-
-        size_t to_write = (len < available) ? len : available;
-        BLE_LOG_MEMCPY((*trans)->buf + (*trans)->pos, data, to_write);
-        (*trans)->pos += to_write;
-        data += to_write;
-        len -= to_write;
-
-        if (BLE_LOG_TRANS_FREE_SPACE((*trans)) <= BLE_LOG_FRAME_OVERHEAD) {
-            ble_log_lbm_stream_seal(trans, src_code);
-        }
-    }
-}
-
-BLE_LOG_IRAM_ATTR
-void ble_log_lbm_stream_flush(ble_log_lbm_t *lbm, ble_log_src_t src_code)
-{
-    int trans_idx = lbm->trans_idx;
-    for (int i = 0; i < BLE_LOG_TRANS_BUF_CNT; i++) {
-        ble_log_prph_trans_t **trans = &(lbm->trans[trans_idx]);
-        if (!__atomic_load_n(&(*trans)->prph_owned, __ATOMIC_ACQUIRE) &&
-            (*trans)->pos > BLE_LOG_FRAME_HEAD_LEN) {
-            ble_log_lbm_stream_seal(trans, src_code);
-        }
-        trans_idx = (trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
-    }
-}
-#endif /* BLE_LOG_UART_REDIR_ENABLED */
-
-BLE_LOG_STATIC void ble_log_emit_buf_util(ble_log_lbm_t *lbm, uint8_t lbm_id)
-{
-    ble_log_buf_util_t util = {
-        .int_src_code   = BLE_LOG_INT_SRC_BUF_UTIL,
-        .lbm_id         = lbm_id,
-        .trans_cnt      = BLE_LOG_TRANS_BUF_CNT,
-        .inflight_peak  = (uint8_t)__atomic_load_n(
-                              &lbm->trans_inflight_peak, __ATOMIC_RELAXED),
-    };
-    ble_log_write_hex(BLE_LOG_SRC_INTERNAL,
-                      (const uint8_t *)&util, sizeof(ble_log_buf_util_t));
-}
-
 void ble_log_write_buf_util(void)
 {
     BLE_LOG_REF_COUNT_ACQUIRE(&lbm_ref_count);
@@ -576,61 +677,27 @@ void ble_log_write_buf_util(void)
         goto deref;
     }
 
-    ble_log_emit_buf_util(&lbm_ctx->spin_task,
-        BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_COMMON_TASK, 0));
-    for (int i = 0; i < BLE_LOG_LBM_ATOMIC_TASK_CNT; i++) {
-        ble_log_emit_buf_util(&lbm_ctx->atomic_pool_task[i],
-            BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_COMMON_TASK, 1 + i));
-    }
-
-    ble_log_emit_buf_util(&lbm_ctx->spin_isr,
-        BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_COMMON_ISR, 0));
-    for (int i = 0; i < BLE_LOG_LBM_ATOMIC_ISR_CNT; i++) {
-        ble_log_emit_buf_util(&lbm_ctx->atomic_pool_isr[i],
-            BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_COMMON_ISR, 1 + i));
-    }
-
-#if CONFIG_BLE_LOG_LL_ENABLED
-    ble_log_emit_buf_util(&lbm_ctx->lbm_ll_task,
-        BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_LL, 0));
-    ble_log_emit_buf_util(&lbm_ctx->lbm_ll_hci,
-        BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_LL, 1));
-#endif
+    /* Single record representing the whole unified pool. */
+    ble_log_buf_util_t util = {
+        .int_src_code   = BLE_LOG_INT_SRC_BUF_UTIL,
+        .lbm_id         = BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_COMMON_TASK, 0),
+        .trans_cnt      = BLE_LOG_POOL_TRANS_CNT,
+        .inflight_peak  = (uint8_t)__atomic_load_n(&g_pool.inflight_peak, __ATOMIC_RELAXED),
+    };
+    ble_log_write_hex(BLE_LOG_SRC_INTERNAL, (const uint8_t *)&util, sizeof(ble_log_buf_util_t));
 
 #if BLE_LOG_UART_REDIR_ENABLED
-    ble_log_lbm_t *redir_lbm = ble_log_prph_get_redir_lbm();
-    if (redir_lbm) {
-        ble_log_emit_buf_util(redir_lbm,
-            BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_REDIR, 0));
+    ble_log_redir_t *redir = ble_log_prph_get_redir_lbm();
+    if (redir) {
+        ble_log_buf_util_t redir_util = {
+            .int_src_code   = BLE_LOG_INT_SRC_BUF_UTIL,
+            .lbm_id         = BLE_LOG_BUF_UTIL_MAKE_ID(BLE_LOG_BUF_UTIL_POOL_REDIR, 0),
+            .trans_cnt      = BLE_LOG_TRANS_BUF_CNT,
+            .inflight_peak  = 0,
+        };
+        ble_log_write_hex(BLE_LOG_SRC_INTERNAL, (const uint8_t *)&redir_util, sizeof(ble_log_buf_util_t));
     }
 #endif
-
-deref:
-    BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
-}
-
-void ble_log_write_final_stat(void)
-{
-    BLE_LOG_REF_COUNT_ACQUIRE(&lbm_ref_count);
-    if (!lbm_inited) {
-        goto deref;
-    }
-
-    ble_log_final_stat_t final_stat;
-    final_stat.int_src_code = BLE_LOG_INT_SRC_FINAL_STAT;
-    final_stat.src_cnt = BLE_LOG_SRC_MAX;
-
-    BLE_LOG_ENTER_CRITICAL();
-    for (int i = 0; i < BLE_LOG_SRC_MAX; i++) {
-        ble_log_final_stat_entry_t *entry = &final_stat.entries[i];
-        entry->src_code = i;
-        BLE_LOG_MEMCPY(&entry->written_frame_cnt,
-                       &stat_mgr_ctx[i]->written_frame_cnt,
-                       4 * sizeof(uint32_t));
-    }
-    BLE_LOG_EXIT_CRITICAL();
-
-    ble_log_write_internal((const uint8_t *)&final_stat, sizeof(final_stat));
 
 deref:
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
@@ -645,6 +712,10 @@ bool ble_log_enable(bool enable)
         return false;
     }
     lbm_enabled = enable;
+    if (!enable) {
+        /* Release any blocked task writers so they can observe the disable. */
+        ble_log_pool_wake_all();
+    }
     return true;
 }
 
@@ -653,6 +724,7 @@ void ble_log_flush(void)
     /* Prevent concurrent flush — two concurrent callers would deadlock on
      * the ref_count spin-wait (both hold a ref, both wait for ref_count <= 1).
      * Second caller returns immediately instead of deadlocking. */
+    static volatile bool flush_in_progress = false;
     if (__atomic_test_and_set(&flush_in_progress, __ATOMIC_ACQUIRE)) {
         return;
     }
@@ -661,6 +733,8 @@ void ble_log_flush(void)
     if (!lbm_inited) {
         goto deref;
     }
+
+    /* Write enhanced statistics before module disable */
     ble_log_write_enh_stat();
     ble_log_write_buf_util();
 
@@ -671,34 +745,51 @@ void ble_log_flush(void)
     };
     ble_log_write_hex(BLE_LOG_SRC_INTERNAL, (const uint8_t *)&ble_log_info, sizeof(ble_log_info_t));
 
-    /* Disable module and wait for all other references to release */
+    /* Disable module and wait for all other references AND blocked writers to
+     * release. Blocked task writers are woken so they exit the wait loop. */
     bool lbm_enabled_copy = lbm_enabled;
-
     lbm_enabled = false;
-    TickType_t start_tick = xTaskGetTickCount();
-    while (__atomic_load_n(&lbm_ref_count, __ATOMIC_ACQUIRE) > 1) {
-        if ((xTaskGetTickCount() - start_tick) >=
-            pdMS_TO_TICKS(BLE_LOG_LBM_WAIT_TIMEOUT_MS)) {
-            ESP_LOGE(TAG, "Timed out waiting for BLE Log writers");
-            goto fail;
+    uint32_t time_waited = 0;
+    while ((__atomic_load_n(&lbm_ref_count, __ATOMIC_ACQUIRE) > 1) ||
+           (__atomic_load_n(&g_pool.waiting_task_count, __ATOMIC_ACQUIRE) > 0)) {
+        ble_log_pool_wake_all();
+        vTaskDelay(pdMS_TO_TICKS(1));
+        BLE_LOG_ASSERT(time_waited++ < 1000);
+    }
+
+    /* Seal every OPEN buffer. Do NOT skip a locked buffer (that would drop its
+     * data); new writes are already stopped, so retry-acquire converges. */
+    for (int id = 0; id < BLE_LOG_POOL_TRANS_CNT; id++) {
+        ble_log_prph_trans_t *trans = g_pool.trans[id];
+        while (!ble_log_cas_acquire(&trans->atomic_lock)) {
+            /* A writer holds the lock only for a single-frame memcpy. */
         }
-        vTaskDelay(1);
+        if (__atomic_load_n(&trans->state, __ATOMIC_RELAXED) == BLE_LOG_TRANS_STATE_OPEN &&
+            trans->pos > 0) {
+            ble_log_pool_bitmap_clear(&g_pool.open_bitmap, id);
+            ble_log_pool_seal_and_send(trans);   /* releases the lock */
+        } else {
+            ble_log_cas_release(&trans->atomic_lock);
+        }
     }
 
-    if (!ble_log_lbm_flush_all_trans()) {
-        goto fail;
+    /* Wait for all in-flight transports to complete. */
+    time_waited = 0;
+    while (__atomic_load_n(&g_pool.inflight, __ATOMIC_ACQUIRE) != 0) {
+        vTaskDelay(pdMS_TO_TICKS(1));
+        BLE_LOG_ASSERT(time_waited++ < 1000);
     }
 
-    ble_log_write_final_stat();
-
-    if (!ble_log_lbm_flush_all_trans()) {
-        goto fail;
+    /* Reset statistics manager after all operations complete */
+    for (int i = 0; i < BLE_LOG_SRC_MAX; i++) {
+        BLE_LOG_MEMSET(stat_mgr_ctx[i], 0, sizeof(ble_log_stat_mgr_t));
     }
-    ble_log_lbm_reset_stats();
+    __atomic_store_n(&g_pool.inflight_peak, 0, __ATOMIC_RELAXED);
+    ble_log_prph_reset_util_counters();
 
-fail:
-    /* Resume enable status after a completed or failed flush. */
+    /* Resume enable status */
     lbm_enabled = lbm_enabled_copy;
+
 deref:
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
     __atomic_clear(&flush_in_progress, __ATOMIC_RELEASE);
@@ -707,33 +798,35 @@ deref:
 BLE_LOG_IRAM_ATTR
 bool ble_log_write_hex(ble_log_src_t src_code, const uint8_t *addr, size_t len)
 {
-    bool ret = false;
-
     BLE_LOG_REF_COUNT_ACQUIRE(&lbm_ref_count);
     if (!lbm_enabled) {
         goto exit;
     }
 
-    ret = ble_log_write_hex_core(src_code, addr, len);
-exit:
-    BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
-    return ret;
-}
+    bool is_isr = BLE_LOG_IN_ISR();
 
-BLE_LOG_IRAM_ATTR
-bool ble_log_write_internal(const uint8_t *addr, size_t len)
-{
-    bool ret = false;
+    /* Payload is [os_ts][user data] */
+    size_t payload_len = len + sizeof(uint32_t);
 
-    BLE_LOG_REF_COUNT_ACQUIRE(&lbm_ref_count);
-    if (!lbm_inited) {
-        goto exit;
+    ble_log_prph_trans_t *trans = ble_log_pool_acquire(payload_len, is_isr);
+    if (!trans) {
+        goto failed;
     }
 
-    ret = ble_log_write_hex_core(BLE_LOG_SRC_INTERNAL, addr, len);
+    uint32_t os_ts = pdTICKS_TO_MS(is_isr ? xTaskGetTickCountFromISR() : xTaskGetTickCount());
+    ble_log_pool_write_frame(trans, src_code, (const uint8_t *)&os_ts,
+                             sizeof(uint32_t), addr, len, false);
+
+    BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
+    return true;
+
+failed:
+    if (lbm_inited) {
+        ble_log_stat_mgr_update(src_code, len + sizeof(uint32_t), true);
+    }
 exit:
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
-    return ret;
+    return false;
 }
 
 #if CONFIG_BLE_LOG_LL_ENABLED
@@ -746,9 +839,8 @@ void ble_log_write_hex_ll(uint32_t len, const uint8_t *addr,
         goto exit;
     }
 
-    /* Source code shall be determined before LBM determination */
-    ble_log_src_t src_code = BLE_LOG_SRC_MAX;
-    bool use_ll_task = false;
+    /* Determine source code from flags */
+    ble_log_src_t src_code;
     if (flag & BIT(BLE_LOG_LL_FLAG_ISR)) {
         src_code = BLE_LOG_SRC_LL_ISR;
     } else if (flag & BIT(BLE_LOG_LL_FLAG_HCI)) {
@@ -757,52 +849,37 @@ void ble_log_write_hex_ll(uint32_t len, const uint8_t *addr,
         src_code = BLE_LOG_SRC_HCI;
     } else {
         src_code = BLE_LOG_SRC_LL_TASK;
-        use_ll_task = true;
     }
     bool omdata = flag & BIT(BLE_LOG_LL_FLAG_OMDATA);
+    bool is_isr = BLE_LOG_IN_ISR();
 
-    /* Determine LBM and get transport */
-    ble_log_lbm_t *lbm;
-    ble_log_prph_trans_t **trans;
-    size_t payload_len;
-
-    if (BLE_LOG_IN_ISR()) {
+    if (is_isr) {
         /* os_mbuf_copydata is in flash and not safe to call from ISR */
         omdata = false;
-
-        payload_len = len + len_append;
-        if (!ble_log_lbm_acquire_trans(payload_len, &lbm, &trans)) {
-            goto failed;
-        }
-    } else {
-        if (use_ll_task) {
-            lbm = &(lbm_ctx->lbm_ll_task);
-        } else {
-            lbm = &(lbm_ctx->lbm_ll_hci);
+    }
 #if CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT_ENABLED
-            if (len_append > CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT) {
-                len_append = CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT;
-            }
-#endif /* CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT_ENABLED */
-        }
-        payload_len = len + len_append;
-        trans = ble_log_lbm_get_trans(lbm, payload_len);
-        if (!trans) {
-            /* LL pools use LOCK_NONE, release is no-op */
-            goto failed;
+    else if (src_code == BLE_LOG_SRC_LL_HCI) {
+        if (len_append > CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT) {
+            len_append = CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT;
         }
     }
+#endif /* CONFIG_BLE_LOG_LL_HCI_LOG_PAYLOAD_LEN_LIMIT_ENABLED */
 
-    /* Write transport */
-    ble_log_lbm_write_trans(trans, src_code, addr, len, addr_append, len_append, omdata);
+    size_t payload_len = len + len_append;
 
-    ble_log_lbm_release(lbm);
+    ble_log_prph_trans_t *trans = ble_log_pool_acquire(payload_len, is_isr);
+    if (!trans) {
+        goto failed;
+    }
+
+    ble_log_pool_write_frame(trans, src_code, addr, len, addr_append, len_append, omdata);
+
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
     return;
 
 failed:
     if (lbm_inited) {
-        ble_log_stat_mgr_update(src_code, payload_len, true);
+        ble_log_stat_mgr_update(src_code, len + len_append, true);
     }
 exit:
     BLE_LOG_REF_COUNT_RELEASE(&lbm_ref_count);
@@ -817,25 +894,16 @@ void ble_log_dump_to_console(void)
         goto deref;
     }
 
-    int trans_idx;
-    ble_log_lbm_t *lbm;
-    ble_log_prph_trans_t *trans;
     BLE_LOG_ENTER_CRITICAL();
     BLE_LOG_CONSOLE("[BLE_LOG_DUMP_START:\n");
-    for (int i = 0; i < BLE_LOG_LBM_CNT; i++) {
-        lbm = &(lbm_ctx->lbm_pool[i]);
-        trans_idx = lbm->trans_idx;
-        for (int j = 0; j < BLE_LOG_TRANS_BUF_CNT; j++) {
-            trans = lbm->trans[trans_idx];
-            BLE_LOG_FEED_WDT();
-
-            for (int k = 0; k < trans->size; k++) {
-                BLE_LOG_CONSOLE("%02x ", trans->buf[k]);
-                if (!(k & 0xFF)) {
-                    BLE_LOG_FEED_WDT();
-                }
+    for (int id = 0; id < BLE_LOG_POOL_TRANS_CNT; id++) {
+        ble_log_prph_trans_t *trans = g_pool.trans[id];
+        BLE_LOG_FEED_WDT();
+        for (int k = 0; k < trans->size; k++) {
+            BLE_LOG_CONSOLE("%02x ", trans->buf[k]);
+            if (!(k & 0xFF)) {
+                BLE_LOG_FEED_WDT();
             }
-            trans_idx = (trans_idx + 1) & (BLE_LOG_TRANS_BUF_CNT - 1);
         }
     }
     BLE_LOG_CONSOLE("\n:BLE_LOG_DUMP_END]\n\n");

--- a/components/bt/common/ble_log/src/ble_log_rt.c
+++ b/components/bt/common/ble_log/src/ble_log_rt.c
@@ -13,6 +13,8 @@
 #include "ble_log_rt.h"
 #include "ble_log_lbm.h"
 
+#include "esp_timer.h"
+
 /* VARIABLE */
 BLE_LOG_STATIC bool rt_inited = false;
 BLE_LOG_STATIC TaskHandle_t rt_task_handle = NULL;
@@ -166,43 +168,42 @@ void ble_log_rt_deinit(void)
     if (rt_queue_handle) {
         ble_log_prph_trans_t *trans = NULL;
         while (xQueueReceive(rt_queue_handle, &trans, 0) == pdTRUE) {
-            ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-            trans->pos = 0;
-            __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-            __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+            ble_log_lbm_recycle_trans(trans);
         }
         vQueueDelete(rt_queue_handle);
         rt_queue_handle = NULL;
     }
 }
 
-BLE_LOG_IRAM_ATTR void ble_log_rt_queue_trans(ble_log_prph_trans_t **trans)
+bool ble_log_rt_in_self_task(void)
 {
-    __atomic_store_n(&(*trans)->prph_owned, true, __ATOMIC_RELAXED);
+    return (rt_task_handle != NULL) &&
+           (xTaskGetCurrentTaskHandle() == rt_task_handle);
+}
 
-    ble_log_lbm_t *lbm = (ble_log_lbm_t *)(*trans)->owner;
-    uint32_t inflight = __atomic_add_fetch(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-    uint32_t peak = __atomic_load_n(&lbm->trans_inflight_peak, __ATOMIC_RELAXED);
-    while (inflight > peak) {
-        if (__atomic_compare_exchange_n(&lbm->trans_inflight_peak, &peak, inflight,
-                                        true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
-            break;
-        }
+/* CRITICAL:
+ * The transport is already sealed (state == SENDING) and removed from every
+ * hint bitmap by the caller. In task context we submit to the peripheral
+ * driver directly; in ISR / scheduler-suspended context we hand the pointer
+ * to the runtime task. Inflight accounting is owned by the pool (seal /
+ * recycle), not by this function. */
+BLE_LOG_IRAM_ATTR void ble_log_rt_queue_trans(ble_log_prph_trans_t *trans)
+{
+    if (!BLE_LOG_IN_ISR() && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
+        ble_log_prph_send_trans(trans);
+        return;
     }
 
     if (BLE_LOG_IN_ISR()) {
         BaseType_t woken = pdFALSE;
         /* Queue depth == total transport buffer count; queue-full is impossible
          * for a valid transport, so the return value is not checked. */
-        xQueueSendFromISR(rt_queue_handle, trans, &woken);
+        xQueueSendFromISR(rt_queue_handle, &trans, &woken);
         portYIELD_FROM_ISR(woken);
-    } else if (xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED) {
-        /* Non-blocking send to avoid configASSERT when scheduler is suspended
-         * (e.g., during light sleep transitions). Queue-full is impossible;
-         * see comment above. */
-        xQueueSend(rt_queue_handle, trans, 0);
     } else {
-        xQueueSend(rt_queue_handle, trans, portMAX_DELAY);
+        /* Scheduler suspended (e.g., light sleep transition): non-blocking send
+         * to avoid configASSERT. Queue-full is impossible; see comment above. */
+        xQueueSend(rt_queue_handle, &trans, 0);
     }
 }
 

--- a/components/bt/common/ble_log/src/internal_include/ble_log_lbm.h
+++ b/components/bt/common/ble_log/src/internal_include/ble_log_lbm.h
@@ -38,109 +38,40 @@ typedef struct {
 #define BLE_LOG_FRAME_OVERHEAD                  (BLE_LOG_FRAME_HEAD_LEN + BLE_LOG_FRAME_TAIL_LEN)
 #define BLE_LOG_MAKE_FRAME_META(src_code, sn)   (((src_code) & 0xFF) | ((sn) << 8))
 
-/* ---------------------------------- */
-/*     Log Buffer Manager Defines     */
-/* ---------------------------------- */
-typedef enum {
-    BLE_LOG_LBM_LOCK_NONE,
-    BLE_LOG_LBM_LOCK_SPIN,
-    BLE_LOG_LBM_LOCK_ATOMIC,
-    BLE_LOG_LBM_LOCK_MUTEX,
-} ble_log_lbm_lock_t;
+/* ------------------------------------- */
+/*     Unified Buffer Pool Defines       */
+/* ------------------------------------- */
+/* Total transport buffers in the global pool. Bitmaps are 32-bit, so the
+ * pool is capped at 32 buffers. */
+#define BLE_LOG_POOL_TRANS_CNT                  CONFIG_BLE_LOG_POOL_TRANS_CNT
+/* Buffers reserved for ISR context when the shared region is exhausted. */
+#define BLE_LOG_POOL_ISR_RESERVE_CNT            CONFIG_BLE_LOG_POOL_ISR_RESERVE_CNT
+/* Shared region: usable by both task and ISR context. */
+#define BLE_LOG_POOL_SHARED_CNT                 (BLE_LOG_POOL_TRANS_CNT - BLE_LOG_POOL_ISR_RESERVE_CNT)
+/* Per-buffer byte size. */
+#define BLE_LOG_POOL_TRANS_SIZE                 CONFIG_BLE_LOG_POOL_TRANS_SIZE
 
-typedef struct {
-    int trans_idx;
-    ble_log_prph_trans_t *trans[BLE_LOG_TRANS_BUF_CNT];
-    ble_log_lbm_lock_t lock_type;
-    union {
-        /* BLE_LOG_LBM_LOCK_NONE */
-        void *none;
-        /* BLE_LOG_LBM_LOCK_SPIN */
-        portMUX_TYPE spin_lock;
-        /* BLE_LOG_LBM_LOCK_ATOMIC */
-        volatile bool atomic_lock;
-        /* BLE_LOG_LBM_LOCK_MUTEX */
-        SemaphoreHandle_t mutex;
-    };
-    uint32_t trans_inflight;
-    uint32_t trans_inflight_peak;
-} ble_log_lbm_t;
-
-/* --------------------------------------- */
-/*     Log Buffer Manager Pool Defines     */
-/* --------------------------------------- */
-enum {
-#if CONFIG_BLE_LOG_LL_ENABLED
-    BLE_LOG_LBM_LL_TASK,
-    BLE_LOG_LBM_LL_HCI,
-#endif /* CONFIG_BLE_LOG_LL_ENABLED */
-    BLE_LOG_LBM_LL_MAX,
-};
-
-enum {
-    BLE_LOG_LBM_SPIN_TASK = 0,
-    BLE_LOG_LBM_SPIN_ISR,
-    BLE_LOG_LBM_SPIN_MAX,
-};
-
-#define BLE_LOG_LBM_ATOMIC_TASK_CNT             CONFIG_BLE_LOG_LBM_ATOMIC_LOCK_TASK_CNT
-#define BLE_LOG_LBM_ATOMIC_ISR_CNT              CONFIG_BLE_LOG_LBM_ATOMIC_LOCK_ISR_CNT
-#define BLE_LOG_LBM_ATOMIC_CNT                  (BLE_LOG_LBM_ATOMIC_TASK_CNT +\
-                                                 BLE_LOG_LBM_ATOMIC_ISR_CNT)
-#define BLE_LOG_LBM_COMMON_CNT                  (BLE_LOG_LBM_ATOMIC_CNT + BLE_LOG_LBM_SPIN_MAX)
-#define BLE_LOG_LBM_CNT                         (BLE_LOG_LBM_COMMON_CNT + BLE_LOG_LBM_LL_MAX)
-
-/* Derived per-buffer size from user-configured total-per-LBM budget */
-#define BLE_LOG_TRANS_SIZE                      (CONFIG_BLE_LOG_LBM_TRANS_BUF_SIZE / BLE_LOG_TRANS_BUF_CNT)
-#define BLE_LOG_TRANS_LL_SIZE                   (CONFIG_BLE_LOG_LBM_LL_TRANS_BUF_SIZE / BLE_LOG_TRANS_BUF_CNT)
-
-/* Unified queue depth derivation */
-#define BLE_LOG_TRANS_POOL_CNT                  (BLE_LOG_LBM_CNT * BLE_LOG_TRANS_BUF_CNT)
+/* UART redirection uses its own small buffer set, not part of the pool. */
 #if BLE_LOG_UART_REDIR_ENABLED
 #define BLE_LOG_TRANS_REDIR_CNT                 BLE_LOG_TRANS_BUF_CNT
 #else
 #define BLE_LOG_TRANS_REDIR_CNT                 (0)
 #endif
-#define BLE_LOG_TRANS_TOTAL_CNT                 (BLE_LOG_TRANS_POOL_CNT + BLE_LOG_TRANS_REDIR_CNT)
 
-/* ------------------------------------------ */
-/*     Log Buffer Manager Context Defines     */
-/* ------------------------------------------ */
+/* Depth used to size the runtime queue and the peripheral driver queue: the
+ * maximum number of transports that can be in flight simultaneously. */
+#define BLE_LOG_TRANS_TOTAL_CNT                 (BLE_LOG_POOL_TRANS_CNT + BLE_LOG_TRANS_REDIR_CNT)
+
+/* ------------------------------------- */
+/*     UART Redirection Manager          */
+/* ------------------------------------- */
+#if BLE_LOG_UART_REDIR_ENABLED
 typedef struct {
-    union {
-        ble_log_lbm_t lbm_pool[BLE_LOG_LBM_CNT];
-        struct {
-            union {
-                ble_log_lbm_t lbm_common_pool[BLE_LOG_LBM_COMMON_CNT];
-                struct {
-                    union {
-                        ble_log_lbm_t spin_pool[BLE_LOG_LBM_SPIN_MAX];
-                        struct {
-                            ble_log_lbm_t spin_task;
-                            ble_log_lbm_t spin_isr;
-                        };
-                    };
-                    union {
-                        ble_log_lbm_t atomic_pool[BLE_LOG_LBM_ATOMIC_CNT];
-                        struct {
-                            ble_log_lbm_t atomic_pool_task[BLE_LOG_LBM_ATOMIC_TASK_CNT];
-                            ble_log_lbm_t atomic_pool_isr[BLE_LOG_LBM_ATOMIC_ISR_CNT];
-                        };
-                    };
-                };
-            };
-            union {
-                ble_log_lbm_t lbm_ll_pool[BLE_LOG_LBM_LL_MAX];
-#if CONFIG_BLE_LOG_LL_ENABLED
-                struct {
-                    ble_log_lbm_t lbm_ll_task;
-                    ble_log_lbm_t lbm_ll_hci;
-                };
-#endif /* CONFIG_BLE_LOG_LL_ENABLED */
-            };
-        };
-    };
-} ble_log_lbm_ctx_t;
+    ble_log_prph_trans_t *trans[BLE_LOG_TRANS_BUF_CNT];
+    SemaphoreHandle_t mutex;
+    int trans_idx;
+} ble_log_redir_t;
+#endif /* BLE_LOG_UART_REDIR_ENABLED */
 
 /* -------------------------------------------- */
 /*     Buffer Utilization Reporting Defines     */
@@ -232,22 +163,15 @@ enum {
 /* ------------------------------- */
 /*     Compile-Time Guards         */
 /* ------------------------------- */
-_Static_assert(CONFIG_BLE_LOG_LBM_TRANS_BUF_SIZE % BLE_LOG_TRANS_BUF_CNT == 0,
-               "Common LBM total buffer size must be a multiple of BLE_LOG_TRANS_BUF_CNT (4)");
-#if CONFIG_BLE_LOG_LL_ENABLED
-_Static_assert(CONFIG_BLE_LOG_LBM_LL_TRANS_BUF_SIZE % BLE_LOG_TRANS_BUF_CNT == 0,
-               "LL LBM total buffer size must be a multiple of BLE_LOG_TRANS_BUF_CNT (4)");
-#endif
-_Static_assert(CONFIG_BLE_LOG_LBM_TRANS_BUF_SIZE / BLE_LOG_TRANS_BUF_CNT >= BLE_LOG_FRAME_OVERHEAD,
-               "Common LBM per-buffer size too small for a single frame");
-_Static_assert(BLE_LOG_TRANS_SIZE >= BLE_LOG_FINAL_STAT_LEN + sizeof(uint32_t) + BLE_LOG_FRAME_OVERHEAD,
-               "Common LBM per-buffer size too small for final statistics frame");
+_Static_assert(BLE_LOG_POOL_TRANS_CNT >= 2 && BLE_LOG_POOL_TRANS_CNT <= 32,
+               "BLE_LOG_POOL_TRANS_CNT must be within [2, 32] (32-bit bitmap)");
+_Static_assert(BLE_LOG_POOL_ISR_RESERVE_CNT >= 0 &&
+               BLE_LOG_POOL_ISR_RESERVE_CNT < BLE_LOG_POOL_TRANS_CNT,
+               "BLE_LOG_POOL_ISR_RESERVE_CNT must leave at least one shared buffer");
+_Static_assert(BLE_LOG_POOL_TRANS_SIZE >= BLE_LOG_FRAME_OVERHEAD,
+               "BLE_LOG_POOL_TRANS_SIZE too small for a single frame");
 _Static_assert((BLE_LOG_TRANS_BUF_CNT & (BLE_LOG_TRANS_BUF_CNT - 1)) == 0,
                "BLE_LOG_TRANS_BUF_CNT must be a power of 2");
-_Static_assert(1 + BLE_LOG_LBM_ATOMIC_TASK_CNT <= 16,
-               "Common task pool exceeds lbm_id 4-bit index limit (max 15)");
-_Static_assert(1 + BLE_LOG_LBM_ATOMIC_ISR_CNT <= 16,
-               "Common ISR pool exceeds lbm_id 4-bit index limit (max 15)");
 _Static_assert(BLE_LOG_TRANS_BUF_CNT <= 255,
                "BLE_LOG_TRANS_BUF_CNT must fit in uint8_t for ble_log_buf_util_t");
 
@@ -256,16 +180,20 @@ _Static_assert(BLE_LOG_TRANS_BUF_CNT <= 255,
 /* --------------------------- */
 bool ble_log_lbm_init(void);
 void ble_log_lbm_deinit(void);
-void ble_log_lbm_enable(bool enable);
-bool ble_log_write_internal(const uint8_t *addr, size_t len);
-void ble_log_write_final_stat(void);
 void ble_log_write_enh_stat(void);
 void ble_log_write_buf_util(void);
+
+/* Unified transport recycle: return a transport to the global pool (or reset
+ * a redirection transport). Safe to call from ISR / driver callback context.
+ * Used by every peripheral tx-done / send-failure path and by the runtime
+ * queue drain, so that buffer recycling behaviour is identical everywhere. */
+void ble_log_lbm_recycle_trans(ble_log_prph_trans_t *trans);
+
 #if BLE_LOG_UART_REDIR_ENABLED
-void ble_log_lbm_stream_write(ble_log_lbm_t *lbm, ble_log_src_t src_code,
+void ble_log_lbm_stream_write(ble_log_redir_t *redir, ble_log_src_t src_code,
                                const uint8_t *data, size_t len);
-void ble_log_lbm_stream_flush(ble_log_lbm_t *lbm, ble_log_src_t src_code);
-ble_log_lbm_t *ble_log_prph_get_redir_lbm(void);
+void ble_log_lbm_stream_flush(ble_log_redir_t *redir, ble_log_src_t src_code);
+ble_log_redir_t *ble_log_prph_get_redir_lbm(void);
 #endif
 
 #endif /* __BLE_LOG_LBM_H__ */

--- a/components/bt/common/ble_log/src/internal_include/ble_log_prph.h
+++ b/components/bt/common/ble_log/src/internal_include/ble_log_prph.h
@@ -14,17 +14,29 @@
 #include "ble_log_util.h"
 
 /* TYPEDEF */
+/* Transport buffer lifecycle state. Ownership of a transport is decided
+ * solely by its per-buffer atomic_lock; state only expresses the lifecycle.
+ * See the unified buffer pool design for the ownership/hint model. */
+typedef enum {
+    BLE_LOG_TRANS_STATE_FREE = 0,   /* empty, allocatable */
+    BLE_LOG_TRANS_STATE_OPEN,       /* holds frame(s), may still be appended */
+    BLE_LOG_TRANS_STATE_SENDING,    /* sealed and handed to the peripheral link */
+} ble_log_trans_state_t;
+
+/* Sentinel id for transports that do not belong to the global pool
+ * (e.g. the UART redirection buffers). */
+#define BLE_LOG_TRANS_ID_NONE                   (0xFF)
+
 typedef struct {
-    bool prph_owned;
+    volatile bool atomic_lock;              /* per-buffer lock, the only ownership source */
+    volatile uint8_t state;                 /* ble_log_trans_state_t */
+    uint8_t id;                             /* pool index, or BLE_LOG_TRANS_ID_NONE */
     uint8_t *buf;
     uint16_t size;
     uint16_t pos;
 
     /* Peripheral implementation specific context */
     void *ctx;
-
-    /* Opaque back-reference to owning LBM, set once at init */
-    void *owner;
 } ble_log_prph_trans_t;
 
 #define BLE_LOG_TRANS_FREE_SPACE(trans)         ((trans)->size - (trans)->pos)

--- a/components/bt/common/ble_log/src/internal_include/ble_log_rt.h
+++ b/components/bt/common/ble_log/src/internal_include/ble_log_rt.h
@@ -32,6 +32,9 @@
 /* INTERFACE */
 bool ble_log_rt_init();
 void ble_log_rt_deinit(void);
-void ble_log_rt_queue_trans(ble_log_prph_trans_t **trans);
+void ble_log_rt_queue_trans(ble_log_prph_trans_t *trans);
+/* True when called from the BLE Log runtime task itself. Used to forbid
+ * blocking backpressure there (it must keep draining the runtime queue). */
+bool ble_log_rt_in_self_task(void);
 
 #endif /* __BLE_LOG_RT_H__ */

--- a/components/bt/common/ble_log/src/prph/ble_log_prph_dummy.c
+++ b/components/bt/common/ble_log/src/prph/ble_log_prph_dummy.c
@@ -82,15 +82,12 @@ void ble_log_prph_trans_deinit(ble_log_prph_trans_t **trans)
 }
 
 /* Dummy transport has no DMA/hardware -- recycle the buffer immediately
- * so that ble_log_lbm_get_trans() can reuse it and ble_log_flush() does
- * not hang waiting for prph_owned to clear.  Real peripherals (UART DMA,
- * SPI DMA) do the same work inside their asynchronous tx_done callbacks. */
+ * so that the pool can reuse it and ble_log_flush() does not hang waiting
+ * for it to drain.  Real peripherals (UART DMA, SPI DMA) do the same work
+ * inside their asynchronous tx_done callbacks. */
 void ble_log_prph_send_trans(ble_log_prph_trans_t *trans)
 {
-    trans->pos = 0;
-    ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-    __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-    __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+    ble_log_lbm_recycle_trans(trans);
 }
 
 void ble_log_prph_reset_util_counters(void) {}

--- a/components/bt/common/ble_log/src/prph/ble_log_prph_spi_master_dma.c
+++ b/components/bt/common/ble_log/src/prph/ble_log_prph_spi_master_dma.c
@@ -39,18 +39,16 @@ BLE_LOG_STATIC void spi_master_dma_pre_tx_cb(spi_transaction_t *spi_trans);
 BLE_LOG_SPI_MASTER_DMA_CB_ATTR BLE_LOG_STATIC void spi_master_dma_tx_done_cb(spi_transaction_t *spi_trans)
 {
     /* SPI slave performance issue workaround */
-    last_tx_done_ts = esp_timer_get_time();
+    last_tx_done_ts = (uint32_t)esp_timer_get_time();
 
     /* Recycle transport */
     ble_log_prph_trans_t *trans = (ble_log_prph_trans_t *)(spi_trans->user);
-    trans->pos = 0;
-    ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-    __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-    __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+    ble_log_lbm_recycle_trans(trans);
 }
 
 BLE_LOG_SPI_MASTER_DMA_CB_ATTR BLE_LOG_STATIC void spi_master_dma_pre_tx_cb(spi_transaction_t *spi_trans)
 {
+    (void)spi_trans;
     /* SPI slave performance issue workaround */
     while ((esp_timer_get_time() - last_tx_done_ts) < BLE_LOG_SPI_TRANS_ITVL_MIN_US) {}
 }
@@ -204,9 +202,9 @@ BLE_LOG_IRAM_ATTR void ble_log_prph_send_trans(ble_log_prph_trans_t *trans)
     spi_trans->length = (tx_len << 3);
     spi_trans->rxlength = 0;
     if (spi_device_queue_trans(dev_handle, spi_trans, 0) != ESP_OK) {
-        ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-        __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-        __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+        /* Driver queue full: no tx_done will fire, recycle here so the buffer
+         * returns to the pool instead of leaking. */
+        ble_log_lbm_recycle_trans(trans);
     }
 }
 

--- a/components/bt/common/ble_log/src/prph/ble_log_prph_uart_dma.c
+++ b/components/bt/common/ble_log/src/prph/ble_log_prph_uart_dma.c
@@ -35,7 +35,7 @@ BLE_LOG_STATIC bool prph_inited = false;
 BLE_LOG_STATIC uhci_controller_handle_t dev_handle = NULL;
 #if BLE_LOG_PRPH_UART_DMA_REDIR
 BLE_LOG_STATIC bool uart_driver_inited = false;
-BLE_LOG_STATIC ble_log_lbm_t *redir_lbm = NULL;
+BLE_LOG_STATIC ble_log_redir_t *redir_lbm = NULL;
 BLE_LOG_STATIC esp_timer_handle_t redir_flush_timer = NULL;
 #endif /* BLE_LOG_PRPH_UART_DMA_REDIR */
 
@@ -56,10 +56,7 @@ BLE_LOG_IRAM_ATTR BLE_LOG_STATIC bool uart_dma_tx_done_cb(
         (uint8_t *)edata->buffer - sizeof(ble_log_prph_trans_ctx_t)
     );
     ble_log_prph_trans_t *trans = uart_trans_ctx->trans;
-    trans->pos = 0;
-    ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-    __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-    __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+    ble_log_lbm_recycle_trans(trans);
     return true;
 }
 
@@ -122,13 +119,12 @@ bool ble_log_prph_init(size_t trans_cnt)
 
 /* Redirection is required when utilizing UART port 0 */
 #if BLE_LOG_PRPH_UART_DMA_REDIR
-    /* Initialize a dedicated LBM for redirection */
-    redir_lbm = (ble_log_lbm_t *)BLE_LOG_MALLOC(sizeof(ble_log_lbm_t));
+    /* Initialize a dedicated redirection manager (separate from the pool) */
+    redir_lbm = (ble_log_redir_t *)BLE_LOG_MALLOC(sizeof(ble_log_redir_t));
     if (!redir_lbm) {
         goto exit;
     }
-    BLE_LOG_MEMSET(redir_lbm, 0, sizeof(ble_log_lbm_t));
-    redir_lbm->lock_type = BLE_LOG_LBM_LOCK_MUTEX;
+    BLE_LOG_MEMSET(redir_lbm, 0, sizeof(ble_log_redir_t));
 
     /* Transport initialization */
     for (int i = 0; i < BLE_LOG_TRANS_BUF_CNT; i++) {
@@ -136,7 +132,9 @@ bool ble_log_prph_init(size_t trans_cnt)
                                      BLE_LOG_UART_REDIR_BUF_SIZE)) {
             goto exit;
         }
-        redir_lbm->trans[i]->owner = (void *)redir_lbm;
+        /* Redirection transports are not part of the global pool. */
+        redir_lbm->trans[i]->id = BLE_LOG_TRANS_ID_NONE;
+        redir_lbm->trans[i]->state = BLE_LOG_TRANS_STATE_FREE;
     }
 
     /* Mutex initialization */
@@ -276,9 +274,8 @@ void ble_log_prph_trans_deinit(ble_log_prph_trans_t **trans)
 BLE_LOG_IRAM_ATTR void ble_log_prph_send_trans(ble_log_prph_trans_t *trans)
 {
     if (uhci_transmit(dev_handle, trans->buf, trans->pos) != ESP_OK) {
-        ble_log_lbm_t *lbm = (ble_log_lbm_t *)trans->owner;
-        __atomic_fetch_sub(&lbm->trans_inflight, 1, __ATOMIC_RELAXED);
-        __atomic_store_n(&trans->prph_owned, false, __ATOMIC_RELEASE);
+        /* No tx_done will fire on failure: recycle here to avoid leaking. */
+        ble_log_lbm_recycle_trans(trans);
     }
 }
 
@@ -327,7 +324,7 @@ int __wrap_uart_write_bytes_with_break(uart_port_t uart_num, const void *src, si
     }
 }
 
-ble_log_lbm_t *ble_log_prph_get_redir_lbm(void)
+ble_log_redir_t *ble_log_prph_get_redir_lbm(void)
 {
     return redir_lbm;
 }
@@ -335,10 +332,5 @@ ble_log_lbm_t *ble_log_prph_get_redir_lbm(void)
 
 void ble_log_prph_reset_util_counters(void)
 {
-#if BLE_LOG_PRPH_UART_DMA_REDIR
-    if (redir_lbm) {
-        __atomic_store_n(&redir_lbm->trans_inflight, 0, __ATOMIC_RELAXED);
-        __atomic_store_n(&redir_lbm->trans_inflight_peak, 0, __ATOMIC_RELAXED);
-    }
-#endif
+    /* Redirection manager keeps no in-flight counters to reset. */
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large concurrency and lifecycle changes in ISR/task logging, flush/deinit, and sdkconfig tuning; mis-tuning or races could cause dropped logs, stalls, or use-after-free if shutdown ordering regresses.
> 
> **Overview**
> Replaces the old **multi-LBM** design (separate atomic/spin/Link Layer managers and per-LBM transport sizing) with a **single global pool** of transport buffers shared by task, ISR, and Link Layer writers.
> 
> **Kconfig** drops per-LBM options (auto-flush, atomic LBM counts, common/LL total memory) and adds pool tuning: `BLE_LOG_POOL_TRANS_CNT`, ISR reserve count, per-buffer size, optional ISR OPEN-scan cap, and task backpressure timeout.
> 
> **Allocation path** uses per-buffer `atomic_lock`, **FREE/OPEN/SENDING** lifecycle, and **free/open hint bitmaps** with round-robin scan. Task writers can **block** on a counting semaphore (with timeout) when the pool is full; ISR writers use shared buffers first, then a reserved ISR region, and never block. **Recycle** is centralized in `ble_log_lbm_recycle_trans()` from runtime drain and UART/SPI/dummy tx-done or send-failure paths.
> 
> **Flush/deinit** wake blocked tasks, wait on both ref count and `waiting_task_count`, seal all OPEN buffers, then wait for pool **inflight** to drain; per-LBM utilization reporting collapses to one pool record. **UART port-0 redirection** stays on a separate `ble_log_redir_t` (not pool IDs). **`ble_log_write_final_stat` / `ble_log_write_internal`** and the old LBM acquire/release write path are removed in favor of direct pool acquire + `ble_log_pool_write_frame`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77586fbe012b74e934e3bffb3292745ac9c5db92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->