### PR TITLE
fix (wpa_supplicant) discarded const pointer qualifiers (IDFGH-17977)

### DIFF
--- a/components/wpa_supplicant/src/tls/tlsv1_client.c
+++ b/components/wpa_supplicant/src/tls/tlsv1_client.c
@@ -614,7 +614,7 @@ int tlsv1_client_prf(struct tlsv1_client *conn, const char *label,
 int tlsv1_client_get_cipher(struct tlsv1_client *conn, char *buf,
 			    size_t buflen)
 {
-	char *cipher;
+	const char *cipher;
 
 	switch (conn->rl.cipher_suite) {
 	case TLS_RSA_WITH_RC4_128_MD5:

--- a/components/wpa_supplicant/src/tls/x509v3.c
+++ b/components/wpa_supplicant/src/tls/x509v3.c
@@ -459,7 +459,7 @@ int x509_parse_name(const u8 *buf, size_t len, struct x509_name *name,
 }
 
 
-static char * x509_name_attr_str(enum x509_name_attr_type type)
+static const char * x509_name_attr_str(enum x509_name_attr_type type)
 {
 	switch (type) {
 	case X509_NAME_ATTR_NOT_USED:


### PR DESCRIPTION
## Description

Fix a couple of discarded pointer qualifiers so that ESP-IDF6.0.2 can build without disable compiler safeties.

See: "HINT: The error(s) 'discarded-qualifiers' may appear after IDF upgrade since previous versions were not considering those warnings as errors."

## Testing

Was able to build MCVE for  #18726 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two local type-only changes in wpa_supplicant TLS helpers; no logic or API behavior changes.
> 
> **Overview**
> Fixes **discarded-qualifiers** build failures on ESP-IDF 6.0.2+ by typing string-literal pointers as `const char *` instead of `char *`.
> 
> In `tlsv1_client_get_cipher`, the local `cipher` variable is now `const char *` before `os_strlcpy` copies into the caller buffer. In `x509v3.c`, `x509_name_attr_str` now returns `const char *` to match its string-literal return values used when formatting X.509 names.
> 
> No runtime behavior change—only type correctness for stricter compilers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a604822a49b723c5864800096e79bd51f8baf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->