### PR TITLE
fix(openthread): restore ot_network_auto_start() call in ot_br example (IDFGH-17984)

### DIFF
--- a/examples/openthread/ot_br/main/esp_ot_br.c
+++ b/examples/openthread/ot_br/main/esp_ot_br.c
@@ -134,4 +134,7 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_coex_wifi_i154_enable());
 #endif
 #endif
+#if CONFIG_OPENTHREAD_NETWORK_AUTO_START
+    ot_network_auto_start();
+#endif
 }


### PR DESCRIPTION
## Description

On cold boot, `ot state` stays disabled in the ot_br example even when `CONFIG_OPENTHREAD_NETWORK_AUTO_START=y` and a valid Active Dataset is already persisted in NVS. Wi-Fi connects and the border-routing services start correctly, but the Thread interface itself is never enabled: the device only attaches after manually re-entering `ot dataset ... commit active` + `ot ifconfig up` + `ot thread start` over serial on every reboot.

`esp_openthread_border_router_start()` only brings up Wi-Fi and the border-routing services, but it never calls otIp6SetEnabled/otThreadSetEnabled.
The call that does this, `ot_network_auto_start()`, was dropped from ot_br's `app_main()` in 06972956fe8089d9ed17644fc9b1446d58139738 ("optimized the autostart macro"), while `CONFIG_OPENTHREAD_BORDER_ROUTER_AUTO_START` and `CONFIG_OPENTHREAD_NETWORK_AUTO_START` were being consolidated into a single Kconfig option. ot_cli's `app_main()` was not touched by that commit and still calls `ot_network_auto_start()`.

This PR restores the `ot_network_auto_start()` call in `ot_br`'s `app_main()`,
matching `ot_cli`. No Kconfig/sdkconfig changes are needed.

## Related

No existing issue or PR found for this.
Regression introduced in 06972956fe8089d9ed17644fc9b1446d58139738.

## Testing

Tested on an ESP32-C6, standalone single-chip Thread Border Router, `ot_br` example, ESP-IDF v6.0.2.
Before, `ot dataset active -x` confirms the Active Dataset persists correctly, but `ot state` output was `disabled` after a cold boot.
After the fix, the device auto-attaches on boot with no serial commands.

No automated test added: verifying `ot state` after a cold boot requires hardware-in-the-loop testing, which the existing `sdkconfig.ci.br_autostart` CI config doesn't cover.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded call in an example app that restores prior autostart behavior; no Kconfig or core stack API changes.
> 
> **Overview**
> Restores **`ot_network_auto_start()`** in the **`ot_br`** example’s `app_main()` when `CONFIG_OPENTHREAD_NETWORK_AUTO_START` is enabled, aligning startup with **`ot_cli`**.
> 
> Border-router startup (`esp_openthread_border_router_start()`) only brings up Wi‑Fi and border-routing services; it does not enable the Thread stack from a persisted Active Dataset. Without this call, cold boot leaves `ot state` **disabled** until manual CLI steps, even when auto-start is configured in Kconfig.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381b477867d3f662aff06f706a1ac77523efdcf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->