### PR TITLE
fix(esp_wifi): Ignore STA got-ip from other WIFI_STA-type netifs (IDFGH-18005)

### DIFF
--- a/components/esp_wifi/src/wifi_default.c
+++ b/components/esp_wifi/src/wifi_default.c
@@ -169,6 +169,16 @@ static void wifi_default_action_ap_stop(void *arg, esp_event_base_t base, int32_
 static void wifi_default_action_sta_got_ip(void *arg, esp_event_base_t base, int32_t event_id, void *data)
 {
     if (s_wifi_netifs[WIFI_IF_STA] != NULL) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)data;
+        /* IP_EVENT_STA_GOT_IP is shared by every WIFI_STA-type esp_netif. A second such netif that
+         * is not the Wi-Fi STA (e.g. one whose netif reuses the default WIFI_STA inherent config)
+         * posts the same event id. Acting on it here would spuriously call
+         * esp_wifi_internal_set_sta_ip() for a Wi-Fi STA that has not obtained an
+         * IP, and log the Wi-Fi netif's description for the other interface's address. Only handle
+         * the event that belongs to the Wi-Fi STA netif. */
+        if (event->esp_netif != s_wifi_netifs[WIFI_IF_STA]) {
+            return;
+        }
         ESP_LOGD(TAG, "Got IP wifi default handler entered");
         int ret = esp_wifi_internal_set_sta_ip();
         if (ret != ESP_OK) {


### PR DESCRIPTION
## Description

`wifi_default_action_sta_got_ip()` is registered globally on `IP_EVENT_STA_GOT_IP`
and acts unconditionally on `s_wifi_netifs[WIFI_IF_STA]`. That event id is shared by
every `WIFI_STA`-type `esp_netif`, so when a second such interface exists (its netif
reusing the default WIFI_STA inherent config), the handler also fires for that
interface's got-ip and:

- spuriously calls `esp_wifi_internal_set_sta_ip()` for the Wi-Fi STA, which has not
  obtained an IP; and
- passes the Wi-Fi netif to `esp_netif_action_got_ip()`, logging the Wi-Fi netif's
  description for the other interface's address.

This returns early unless the event's netif is the Wi-Fi STA netif. Single-netif setups
are unaffected, the event netif always matches. IPv6 needs no equivalent change: the
default STA handlers register no `IP_EVENT_GOT_IP6` handler.

## Related

No existing tracking issue found, but happy to open one if preferred. The same netif-guard
pattern is already used by the NAN app's `IP_EVENT_GOT_IP6` handler
(`wifi_apps/nan_app/src/nan_app.c`).

## Testing

Verified on ESP32-C5 (ESP-IDF v5.5.4) with two `WIFI_STA`-type `esp_netif` instances (the internal Wi-Fi STA plus a second radio's netif that reuses the default WIFI_STA
inherent config) both obtaining DHCP leases concurrently:

- **Before:** two `esp_netif_handlers: <desc> ip: …` lines, one mislabeling the second
  interface's address under the Wi-Fi netif's description, plus a spurious
  `esp_wifi_internal_set_sta_ip()` on the non-Wi-Fi lease.
- **After:** exactly one line, for the Wi-Fi STA's own address; the second interface's
  got-ip is handled by its own handler. Both interfaces remain functional; single-STA
  behavior is unchanged.

---

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted guard in an internal event handler; no public API change and standard single-STA behavior is preserved.
> 
> **Overview**
> The default Wi-Fi STA handler for `IP_EVENT_STA_GOT_IP` now **ignores got-ip events that are not for the primary Wi-Fi STA netif** (`s_wifi_netifs[WIFI_IF_STA]`).
> 
> Because every `WIFI_STA`-type `esp_netif` can post the same event id, a second STA-shaped interface (for example another radio reusing the default STA inherent config) used to trigger `esp_wifi_internal_set_sta_ip()` and `esp_netif_action_got_ip()` on the wrong netif—mislabeled logs and spurious internal STA IP updates. **Single-netif setups are unchanged** when `event->esp_netif` always matches the Wi-Fi STA netif.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060f57354bdbe0bbc6cbfe188209993a1fdbf3bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->