### PR TITLE
docs: fix duplicate word typos across docs and hal (IDFGH-18006)

### DIFF
--- a/components/hal/README.md
+++ b/components/hal/README.md
@@ -8,7 +8,7 @@ In a broad sense, the HAL layer consists of two sub-layers: HAL (upper) and Low-
 
 ## Low-Level (`hal/<periph>_ll.h`)
 
-Functions defined in the file must be static inlined. The first argument of an LL function is usually a pointer to the peripheral's base address [^1]. At the moment, each ESP target has its own set of Low-Level drivers. They're located under path e.g. `components/hal/<target>/include/hal/<periph>_ll.h`. We wish the the low-level functions could be as independent as possible, so that the caller doesn't need to worry about conflict between different sub-modules. For example, when resetting the driver of module A, the module B is also reset by accident. However, the digital design is not perfect, coupling happens from time to time.
+Functions defined in the file must be static inlined. The first argument of an LL function is usually a pointer to the peripheral's base address [^1]. At the moment, each ESP target has its own set of Low-Level drivers. They're located under path e.g. `components/hal/<target>/include/hal/<periph>_ll.h`. We wish the low-level functions could be as independent as possible, so that the caller doesn't need to worry about conflict between different sub-modules. For example, when resetting the driver of module A, the module B is also reset by accident. However, the digital design is not perfect, coupling happens from time to time.
 
 ### Handling Shared Registers
 

--- a/docs/en/api-guides/kconfig/component-configuration-guide.rst
+++ b/docs/en/api-guides/kconfig/component-configuration-guide.rst
@@ -93,7 +93,7 @@ Detailed explanation of the backward compatibility mechanism:
 
 If the user has set any value for the old config option (e.g. old config name is used in ``sdkconfig`` or ``sdkconfig.defaults``) without ``sdkconfig.rename`` file provided, this value would be **silently ignored**. This behavior is the default of the Kconfig system and is not a bug. In the original project (configuration of the linux kernel) this behavior was desired and is still desired in many projects.
 
-This behavior is suppressed in ESP-IDF by the the configuration tool (invoked by ``idf.py menuconfig``). This tool generates compatibility statements for all the renamed options in the ``sdkconfig`` file. In more detail, the following approach is used to prevent the above mentioned situation:
+This behavior is suppressed in ESP-IDF by the configuration tool (invoked by ``idf.py menuconfig``). This tool generates compatibility statements for all the renamed options in the ``sdkconfig`` file. In more detail, the following approach is used to prevent the above mentioned situation:
 
 1. Configuration tool searches the whole ESP-IDF folder for ``sdkconfig.rename`` files. If the project target (``<chip>``) matches the last suffix of any ``sdkconfig.rename.<chip>`` file, the file will be used in the next step as well.
 

--- a/docs/en/api-reference/system/efuse.rst
+++ b/docs/en/api-reference/system/efuse.rst
@@ -400,7 +400,7 @@ How to Add a New Field
 
 The number of bits not included in square brackets are free (some bits are reserved by Espressif). All fields are checked for overlapping bits.
 
-To add child fields to an existing field, :ref:`structured-efuse-fields` can be used. The following example demonstrates adding of the the fields ``SERIAL_NUMBER``, ``MODEL_NUMBER`` and ``HARDWARE_REV`` to an existing ``USER_DATA`` field by using the ``.`` operator:
+To add child fields to an existing field, :ref:`structured-efuse-fields` can be used. The following example demonstrates adding of the fields ``SERIAL_NUMBER``, ``MODEL_NUMBER`` and ``HARDWARE_REV`` to an existing ``USER_DATA`` field by using the ``.`` operator:
 
 .. code-block:: none
 

--- a/docs/en/api-reference/system/freertos.rst
+++ b/docs/en/api-reference/system/freertos.rst
@@ -83,7 +83,7 @@ Unlike Vanilla FreeRTOS, users of FreeRTOS in ESP-IDF **must never call** :cpp:f
 Background Tasks
 ^^^^^^^^^^^^^^^^
 
-During startup, ESP-IDF and the FreeRTOS kernel automatically create multiple tasks that run in the background (listed in the the table below).
+During startup, ESP-IDF and the FreeRTOS kernel automatically create multiple tasks that run in the background (listed in the table below).
 
 .. list-table:: List of Tasks Created During Startup
     :widths: 10 75 5 5 5


### PR DESCRIPTION
This PR removes duplicated "the" typos found in the HAL README and various documentation files (FreeRTOS, eFuse, and Kconfig).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fixes with no code or configuration impact.
> 
> **Overview**
> Fixes **duplicate-word typos** in prose only—no API, config, or runtime behavior changes.
> 
> In **`components/hal/README.md`**, removes an extra **"the"** in the Low-Level section ("the the low-level" → "the low-level"). In **`docs/en`**, the same cleanup appears in the Kconfig backward-compatibility guide ("by the the configuration" → "by the configuration"), the eFuse "How to Add a New Field" example ("adding of the the fields" → "adding of the fields"), and the FreeRTOS startup docs ("in the the table" → "in the table").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8544b40df3ee1790e97b273f310c9237a97c5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->