### PR TITLE
feat(tools): add -j/--jobs option to idf.py (IDFGH-18013)

### DIFF
--- a/docs/en/api-guides/build-system.rst
+++ b/docs/en/api-guides/build-system.rst
@@ -77,7 +77,13 @@ In the above list, the ``cmake`` command configures the project and generates bu
 
 It's not necessary to run ``cmake`` more than once. After the first build, you only need to run ``ninja`` each time. ``ninja`` will automatically re-invoke ``cmake`` if the project needs reconfiguration.
 
-When using ``idf.py`` with the Ninja generator, you can cap the number of parallel build jobs by setting the ``IDF_PY_BUILD_JOBS`` environment variable. For example:
+You can control the number of parallel build jobs passed to the underlying build tool (Ninja or Make) with the ``-j``/``--jobs`` option of ``idf.py``. For example:
+
+.. code-block:: bash
+
+    idf.py -j 6 build
+
+The same value can be set with the ``IDF_PY_BUILD_JOBS`` environment variable, which is used as the default when ``-j``/``--jobs`` is not given:
 
 .. code-block:: bash
 

--- a/docs/zh_CN/api-guides/build-system.rst
+++ b/docs/zh_CN/api-guides/build-system.rst
@@ -77,7 +77,13 @@ idf.py
 
 没有必要多次运行 ``cmake``。第一次构建后，往后每次只需运行 ``ninja`` 即可。如果项目需要重新配置，``ninja`` 会自动重新调用 ``cmake``。
 
-使用 Ninja 生成器配合 ``idf.py`` 时，可以通过设置环境变量 ``IDF_PY_BUILD_JOBS`` 来限制并行构建任务数。例如：
+使用 ``idf.py`` 时，可以通过 ``-j``/``--jobs`` 选项来控制传递给底层构建工具（Ninja 或 Make）的并行构建任务数。例如：
+
+.. code-block:: bash
+
+    idf.py -j 6 build
+
+也可以通过设置环境变量 ``IDF_PY_BUILD_JOBS`` 来指定该值，当未提供 ``-j``/``--jobs`` 时，该环境变量将作为默认值使用：
 
 .. code-block:: bash
 

--- a/tools/idf_py_actions/constants.py
+++ b/tools/idf_py_actions/constants.py
@@ -29,7 +29,9 @@ GENERATORS: dict[str, str | dict | list] = collections.OrderedDict(
 if os.name != 'nt':
     MAKE_CMD = 'gmake' if platform.system() == 'FreeBSD' else 'make'
     GENERATORS['Unix Makefiles'] = {
-        'command': [MAKE_CMD, '-j', str(multiprocessing.cpu_count() + 2)],
+        # Make, unlike Ninja, does not parallelize by default; run_target() applies this as -j.
+        'default_jobs': multiprocessing.cpu_count() + 2,
+        'command': [MAKE_CMD],
         'version': [MAKE_CMD, '--version'],
         'dry_run': [MAKE_CMD, '-n'],
         'verbose_flag': 'VERBOSE=1',

--- a/tools/idf_py_actions/core_ext.py
+++ b/tools/idf_py_actions/core_ext.py
@@ -538,6 +538,13 @@ def action_extensions(base_actions: dict, project_path: str) -> Any:
                 'type': click.Choice(GENERATORS.keys()),
             },
             {
+                'names': ['-j', '--jobs'],
+                'help': 'Number of parallel build jobs passed to the build tool (Ninja or Make).',
+                'envvar': 'IDF_PY_BUILD_JOBS',
+                'type': click.IntRange(min=1),
+                'default': None,
+            },
+            {
                 'names': ['--dry-run'],
                 'help': "Only process arguments, but don't execute actions.",
                 'is_flag': True,

--- a/tools/idf_py_actions/global_options.py
+++ b/tools/idf_py_actions/global_options.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 global_options = [{
     'names': ['-D', '--define-cache-entry'],

--- a/tools/idf_py_actions/tools.py
+++ b/tools/idf_py_actions/tools.py
@@ -667,18 +667,13 @@ def run_target(
 
     generator_cmd = list(GENERATORS[args.generator]['command'])
 
-    if args.generator == 'Ninja':
-        parallel_level = os.environ.get('IDF_PY_BUILD_JOBS')
-        if parallel_level:
-            try:
-                jobs = int(parallel_level)
-            except ValueError as e:
-                raise FatalError('Environment variable IDF_PY_BUILD_JOBS must be a positive integer') from e
+    # Parallel jobs from -j/--jobs (or IDF_PY_BUILD_JOBS), falling back to the generator's default.
+    jobs = getattr(args, 'jobs', None)
+    if jobs is None:
+        jobs = GENERATORS[args.generator].get('default_jobs')
 
-            if jobs <= 0:
-                raise FatalError('Environment variable IDF_PY_BUILD_JOBS must be a positive integer')
-
-            generator_cmd += ['-j', str(jobs)]
+    if jobs is not None:
+        generator_cmd += ['-j', str(jobs)]
 
     if args.verbose:
         generator_cmd += [GENERATORS[args.generator]['verbose_flag']]


### PR DESCRIPTION
## Description

Add a global `-j`/`--jobs` option to `idf.py` that sets the number of parallel build jobs passed to the underlying build tool (Ninja or Make).

Previously, build parallelism could only be configured via the `IDF_PY_BUILD_JOBS` environment variable, and that value was only honored for the Ninja generator — the Make generator always used a hardcoded `-j <cpu_count + 2>`.

Usage:

```bash
idf.py -j 6 build              # or --jobs 6
IDF_PY_BUILD_JOBS=6 idf.py build   # still works; used as the default for -j
```

Being a root-level option (like `-G` and `--ccache`), it must appear before the subcommand (`idf.py -j 6 build`), at most once.

## Testing

Behavior was verified by exercising the real modules directly:

- CLI parsing — -j 4, --jobs 8, and IDF_PY_BUILD_JOBS=6 all resolve to the correct integer; -j 0, negative, and non-integer values (including a bad IDF_PY_BUILD_JOBS) are rejected at parse time by `click.IntRange(min=1)`.
- With `IDF_PY_BUILD_JOBS` set, `-j` no longer conflicts with the env var (the option is now root-level only, not duplicated onto every subcommand).
- Command construction (run_target):
  - Ninja: ninja when unset, ninja -j 4 when -j 4 is given.
  - Make: make -j 16 by default (cpu + 2), make -j 4 when overridden — a single -j, not a duplicated flag.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and idf.py build-wrapper changes only; behavior is additive and preserves existing env-based configuration for Ninja.
> 
> **Overview**
> Adds a global **`idf.py -j` / `--jobs`** option (with **`IDF_PY_BUILD_JOBS`** as the default when the flag is omitted) to set how many parallel jobs are passed to Ninja or Make.
> 
> **`run_target()`** now resolves job count in one place: CLI/env value first, otherwise the generator’s **`default_jobs`** (Make keeps **`cpu_count + 2`**; Ninja stays unpinned when unset). Make no longer bakes **`-j`** into its static generator command, avoiding duplicate **`-j`** flags when overridden.
> 
> English and Chinese **build-system** docs describe **`idf.py -j 6 build`** and the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6b31044780124e41a8ad2f1179708a90b6ce3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
