### PR TITLE
feat(esp-tls): add opt-in TCP_NODELAY Kconfig (IDFGH-18014)

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -22,6 +22,15 @@ menu "ESP-TLS"
                 esp_tls_stack_ops_t interface.
     endchoice
 
+    config ESP_TLS_ENABLE_TCP_NODELAY
+        bool "Enable TCP_NODELAY (disable Nagle's algorithm) on ESP-TLS sockets"
+        default n
+        help
+            Set TCP_NODELAY on every ESP-TLS client connection socket, disabling Nagle's algorithm.
+            Recommended for latency-sensitive small-message traffic (e.g. MQTT), where Nagle
+            interacting with the peer's delayed-ACK can stall a small write by ~40-200 ms until
+            the delayed-ACK timer fires. Off by default (no behavior change).
+
     config ESP_TLS_USE_DS_PERIPHERAL
         bool "Use Digital Signature (DS) Peripheral with ESP-TLS"
         depends on ESP_TLS_USING_MBEDTLS && SOC_DIG_SIGN_SUPPORTED

--- a/components/esp-tls/esp_tls.c
+++ b/components/esp-tls/esp_tls.c
@@ -317,6 +317,16 @@ static esp_err_t esp_tls_set_socket_options(int fd, const esp_tls_cfg_t *cfg)
             return ESP_ERR_ESP_TLS_SOCKET_SETOPT_FAILED;
         }
 
+#if CONFIG_ESP_TLS_ENABLE_TCP_NODELAY
+        /* Disable Nagle's algorithm. Small control-plane writes (e.g. MQTT PUBLISH/PUBACK/PINGREQ)
+         * otherwise interact with the peer's delayed-ACK and stall ~40-200 ms until its timer fires.
+         * Non-fatal: a latency hint, not required for a correct connection (unlike the timeouts). */
+        int nodelay = 1;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) != 0) {
+            ESP_LOGW(TAG, "Fail to setsockopt TCP_NODELAY (non-fatal)");
+        }
+#endif
+
         if (cfg->keep_alive_cfg && cfg->keep_alive_cfg->keep_alive_enable) {
             int keep_alive_enable = 1;
             int keep_alive_idle = cfg->keep_alive_cfg->keep_alive_idle;


### PR DESCRIPTION
## Description

Add `CONFIG_ESP_TLS_ENABLE_TCP_NODELAY` (default `n`). When enabled, `esp_tls_set_socket_options()` sets `TCP_NODELAY` on the connection socket alongside the existing `SO_*TIMEO` / keepalive options, disabling Nagle's algorithm.

Motivation: latency-sensitive small-message protocols (notably MQTT: PUBLISH/PUBACK/PINGREQ) stall when Nagle interacts with the peer's delayed-ACK. A small write is withheld until the prior segment is ACKed, while the peer holds that ACK for ~40-200 ms, so each small write waits for the delayed-ACK timer. Setting `TCP_NODELAY` lets small records go out immediately.

The setsockopt is non-fatal (a latency hint, not required for a correct connection), so a failure only warns. Off by default means no behavior change for existing users.

## Related

_None._

## Testing

`make build` (ESP-IDF). Verified the option compiles out when `n` (default) and that the `TCP_NODELAY` path is gated behind `#if CONFIG_ESP_TLS_ENABLE_TCP_NODELAY`.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-off socket tuning with non-fatal setsockopt; no auth, TLS, or API contract changes.
> 
> **Overview**
> Adds **`CONFIG_ESP_TLS_ENABLE_TCP_NODELAY`** (default **off**) so existing builds keep current TCP behavior.
> 
> When enabled, **`esp_tls_set_socket_options()`** sets **`TCP_NODELAY`** on client connection sockets (same path as timeouts and keepalive), aimed at reducing latency for small writes (e.g. MQTT) when Nagle and delayed ACK interact. A failed **`setsockopt`** only logs a warning and does not fail the connection setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850d652f004ce3098904c28aa89a4226ed1f2332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->