### PR TITLE
fix(esp_https_ota): Add missing requirement to `bootloader_support` component (IDFGH-18024)

### DIFF
--- a/components/esp_https_ota/CMakeLists.txt
+++ b/components/esp_https_ota/CMakeLists.txt
@@ -8,6 +8,6 @@ idf_component_register(SRCS "src/esp_https_ota.c"
                     INCLUDE_DIRS "include"
                     REQUIRES esp_http_client esp_bootloader_format esp_app_format
                              esp_event esp_partition
-                    PRIV_REQUIRES log app_update efuse)
+                    PRIV_REQUIRES log app_update bootloader_support efuse)
 
 idf_define_esp_err_codes(HEADERS include/esp_https_ota.h)

--- a/components/esp_https_ota/include/esp_https_ota.h
+++ b/components/esp_https_ota/include/esp_https_ota.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <esp_http_client.h>
-#include <bootloader_common.h>
 #include "esp_app_desc.h"
 #include "esp_bootloader_desc.h"
 #include <sdkconfig.h>

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <bootloader_common.h>
 #include <esp_https_ota.h>
 #include <esp_log.h>
 #include <esp_ota_ops.h>


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Compilation of a component that uses the `esp_https_ota` component and its `esp_https_ota.h` header fails since v6.0.1 with the following error:

```
In file included from /home/tomwagner/Projects/novolto/firmware-esp-idf/components/ota/src/ota.cpp:6:
/home/tomwagner/Projects/novolto/esp-idf/components/esp_https_ota/include/esp_https_ota.h:10:10: fatal error: bootloader_common.h: No such file or directory
   10 | #include <bootloader_common.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
```

Small example:
```
// ota/CMakeLists.txt
idf_component_register(SRCS "src/ota.c"
                       INCLUDE_DIRS "include"
                       PRIV_INCLUDE_DIRS "src"
                       PRIV_REQUIRES "esp_https_ota")

// ota/include/ota/ota.h
#ifndef OTA_OTA_H_
#define OTA_OTA_H_

void perform_ota(const char* url);

#endif // OTA_OTA_H_

// ota/src/ota.c
#include "ota/ota.h"

#include "esp_https_ota.h"

void perform_ota(const char* url) {
    esp_http_client_config_t http_config;
    http_config.url = url;

    esp_https_ota_config_t ota_config;
    ota_config.http_config = &http_config;

    esp_https_ota(&ota_config);
}
```

Cause:
The `esp_https_ota.h` header includes `bootloader_common.h` from the `bootloader_support` component, but the components CMakeLists.txt does not depend on the `bootloader_support` component.
This causes compilation to fail when the header is included, unless the component that the header belongs already depends on `bootloader_support`.
The examples under `examples/system/ota` also seem to depend on `app_update` which in turn publicly depends on `bootloader_support`, so the examples are not affected by this error.

As the header is only needed in the `esp_https_ota.c` source file, add a `PRIV_REQUIRES` for `bootloader_support` and move the include into the .c file.

🚨 **The removal of the `#include` from the header might potentially be a breaking change.**
Users that rely on the transitive include might encounter compilation errors.
I'm not sure if transitive includes are covered by stability guarentees in ESP-IDF.
If that's the case, the PR could be changed to leave the `#include` as-is and instead add
`bootloader_support` as a public dependency of the component.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

It appears that b8c527a87c1930a2446a5148ec16892b14f99c8e is the commit that mistakenly removed the `bootloader_support` requirement.

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

I compiled the provided reproducing code in a new ESP-IDF (master branch) project with only an empty `void app_main()` otherwise.
Compilation fails without the fix as described.
With the fix, compilation succeeds.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low runtime risk, but removing the header include may break builds that relied on the transitive include; the fix is otherwise a small dependency correction.
> 
> **Overview**
> Fixes **build failures since v6.0.1** when a component includes `esp_https_ota.h` but only declares a dependency on `esp_https_ota` (without pulling in `bootloader_support` transitively via `app_update`).
> 
> **`bootloader_support`** is added to **`PRIV_REQUIRES`** in the component CMake file so the implementation can use `bootloader_common.h`. The **`#include <bootloader_common.h>`** is **removed from the public header** and **moved into `esp_https_ota.c`**, where it is actually needed.
> 
> **Note:** Any out-of-tree code that depended on getting `bootloader_common.h` indirectly through `esp_https_ota.h` must include it explicitly or depend on `bootloader_support`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5cef637ae9baaca3dfc1cad110dba58b44696d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->