### PR TITLE
fix(esp_libc): provide picolibc timespec_get (IDFGH-18035)

### DIFF
--- a/components/esp_libc/CMakeLists.txt
+++ b/components/esp_libc/CMakeLists.txt
@@ -76,6 +76,7 @@ else()
     list(APPEND srcs
          "src/picolibc/picolibc_init.c"
          "src/picolibc/rand.c"
+         "src/picolibc/timespec_get.c"
          "src/picolibc/open_memstream.c"
          "src/picolibc/errno.c"
          "src/picolibc/bufio_setvbuf.c") # TODO IDF-15494: remove this and the following lines

--- a/components/esp_libc/src/picolibc/timespec_get.c
+++ b/components/esp_libc/src/picolibc/timespec_get.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <time.h>
+
+int timespec_get(struct timespec *ts, int base)
+{
+    if (base != TIME_UTC || clock_gettime(CLOCK_REALTIME, ts) < 0) {
+        return 0;
+    }
+    return base;
+}

--- a/components/esp_libc/test_apps/newlib/main/test_time.c
+++ b/components/esp_libc/test_apps/newlib/main/test_time.c
@@ -465,6 +465,17 @@ TEST_CASE("test posix_timers clock_... functions", "[newlib]")
     test_posix_timers_clock();
 }
 
+TEST_CASE("timespec_get returns UTC time", "[newlib]")
+{
+    struct timespec ts = {0};
+
+    TEST_ASSERT_EQUAL_INT(TIME_UTC, timespec_get(&ts, TIME_UTC));
+    TEST_ASSERT_GREATER_OR_EQUAL_INT64(0, ts.tv_sec);
+    TEST_ASSERT_GREATER_OR_EQUAL_INT32(0, ts.tv_nsec);
+    TEST_ASSERT_LESS_THAN_INT32(1000000000L, ts.tv_nsec);
+    TEST_ASSERT_EQUAL_INT(0, timespec_get(&ts, -1));
+}
+
 #ifndef _USE_LONG_TIME_T
 
 static struct timeval get_time(const char *desc, char *buffer)

--- a/components/esp_libc/test_apps/newlib/main/test_time.c
+++ b/components/esp_libc/test_apps/newlib/main/test_time.c
@@ -465,7 +465,8 @@ TEST_CASE("test posix_timers clock_... functions", "[newlib]")
     test_posix_timers_clock();
 }
 
-TEST_CASE("timespec_get returns UTC time", "[newlib]")
+#if CONFIG_LIBC_PICOLIBC
+TEST_CASE("timespec_get returns UTC time", "[picolibc]")
 {
     struct timespec ts = {0};
 
@@ -475,6 +476,7 @@ TEST_CASE("timespec_get returns UTC time", "[newlib]")
     TEST_ASSERT_LESS_THAN_INT32(1000000000L, ts.tv_nsec);
     TEST_ASSERT_EQUAL_INT(0, timespec_get(&ts, -1));
 }
+#endif
 
 #ifndef _USE_LONG_TIME_T
 


### PR DESCRIPTION
## Description

The Picolibc `<time.h>` shipped with the ESP-IDF v6.0 toolchain declares the
C11 `timespec_get()` API, but the Picolibc archives do not provide the symbol.
Any ESP-IDF application that calls the declared API therefore fails to link.

Add the missing implementation to the Picolibc-specific `esp_libc` sources.
`TIME_UTC` is mapped to the existing ESP-IDF `CLOCK_REALTIME` implementation,
while unsupported time bases and clock failures return zero as required by
C11.

The implementation lives in a separate archive object so a future toolchain
that provides `timespec_get()` can satisfy the reference from libc without
pulling in this compatibility object.

Fixes #18889

## Testing

- Confirmed the issue's minimal ESP32-S3 reproducer fails to link with
  `esp-15.2.0_20251204` before the fix:
  `undefined reference to 'timespec_get'`.
- Built the same ESP32-S3 project successfully with the compatibility source
  included; the resulting ELF defines both `clock_gettime` and `timespec_get`.
- Added an `esp_libc` Unity regression test for `TIME_UTC`, the returned
  nanosecond range, and an unsupported time base.
- Ran the applicable pre-commit hooks for all three changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated libc compatibility shim with no auth or data-path changes; behavior is delegated to existing clock_gettime.
> 
> **Overview**
> Picolibc builds now ship a **C11 `timespec_get()`** in `esp_libc` so apps that call the API declared in `<time.h>` link successfully instead of failing with an undefined reference.
> 
> For **`TIME_UTC`**, the new `timespec_get` fills the `timespec` via existing **`clock_gettime(CLOCK_REALTIME)`** and returns `TIME_UTC`; unsupported bases or clock failure return **0** per C11. The source is wired into the Picolibc-only `esp_libc` object list (not Newlib).
> 
> A Unity test in **`test_time.c`** checks successful `TIME_UTC` behavior, sane nanosecond range, and rejection of an invalid base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de8574ce534ced7fbbedf0e5b32eb0087d5ecba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->