### PR TITLE
feat(wear_levelling): add non-destructive mount and probe (IDFGH-18043)

### DIFF
--- a/components/wear_levelling/README.rst
+++ b/components/wear_levelling/README.rst
@@ -32,7 +32,9 @@ Wear Levelling access API functions
 
 This is the set of API functions for working with data in flash:
 
-- ``wl_mount`` - initializes the wear levelling module and mounts the specified partition
+- ``wl_mount`` - initializes the wear levelling module and mounts the specified partition, formatting it if it does not already contain a valid instance
+- ``wl_mount_no_format`` - like ``wl_mount``, but never writes; mounts only an already-valid instance, or returns ``ESP_ERR_NOT_FOUND`` and leaves flash untouched
+- ``wl_probe`` - checks whether a partition holds a valid instance without writing to flash
 - ``wl_unmount`` - unmounts the partition and deinitializes the wear levelling module
 - ``wl_erase_range`` - erases a range of addresses in flash
 - ``wl_write`` - writes data to a partition

--- a/components/wear_levelling/WL_Ext_Perf.cpp
+++ b/components/wear_levelling/WL_Ext_Perf.cpp
@@ -48,9 +48,9 @@ esp_err_t WL_Ext_Perf::config(WL_Config_s *cfg, Flash_Access *partition)
     return WL_Flash::config(cfg, partition);
 }
 
-esp_err_t WL_Ext_Perf::init()
+esp_err_t WL_Ext_Perf::init(bool allow_formatting)
 {
-    return WL_Flash::init();
+    return WL_Flash::init(allow_formatting);
 }
 
 size_t WL_Ext_Perf::get_flash_size()

--- a/components/wear_levelling/WL_Ext_Safe.cpp
+++ b/components/wear_levelling/WL_Ext_Safe.cpp
@@ -63,16 +63,16 @@ esp_err_t WL_Ext_Safe::config(WL_Config_s *cfg, Flash_Access *partition)
     return ESP_OK;
 }
 
-esp_err_t WL_Ext_Safe::init()
+esp_err_t WL_Ext_Safe::init(bool allow_formatting)
 {
     esp_err_t result = ESP_OK;
     ESP_LOGV(TAG, "%s", __func__);
 
-    result = WL_Ext_Perf::init();
+    result = WL_Ext_Perf::init(allow_formatting);
     WL_EXT_RESULT_CHECK(result);
 
     //check if any buffer write operation was pending and recover data if needed
-    result = this->recover();
+    result = this->recover(allow_formatting);
     return result;
 }
 
@@ -82,7 +82,7 @@ size_t WL_Ext_Safe::get_flash_size()
     return WL_Ext_Perf::get_flash_size() - 2 * this->flash_sector_size;
 }
 
-esp_err_t WL_Ext_Safe::recover()
+esp_err_t WL_Ext_Safe::recover(bool allow_formatting)
 {
     esp_err_t result = ESP_OK;
 
@@ -94,6 +94,10 @@ esp_err_t WL_Ext_Safe::recover()
 
     // check if we have any incomplete transaction pending.
     if (state.sector_restore_sign == WL_EXT_SAFE_OK) {
+        // A pending transaction requires writes to complete. In no-format mode leave flash untouched.
+        if (!allow_formatting) {
+            return ESP_ERR_NOT_FOUND;
+        }
 
         // recover data from dump_addr and store it to temporary storage sector_buffer.
         result = this->read(this->dump_addr, this->sector_buffer, this->flash_sector_size);

--- a/components/wear_levelling/WL_Flash.cpp
+++ b/components/wear_levelling/WL_Flash.cpp
@@ -107,7 +107,7 @@ esp_err_t WL_Flash::config(wl_config_t *cfg, Flash_Access *partition)
     return ESP_OK;
 }
 
-esp_err_t WL_Flash::init()
+esp_err_t WL_Flash::init(bool allow_formatting)
 {
     esp_err_t result = ESP_OK;
     if (this->configured == false) {
@@ -139,6 +139,12 @@ esp_err_t WL_Flash::init()
              this->state.wl_dummy_sec_move_count);
 
     ESP_LOGD(TAG, "%s starts: crc1= 0x%08" PRIx32 ", crc2 = 0x%08" PRIx32 ", this->state.crc= 0x%08" PRIx32 ", state_copy->crc= 0x%08" PRIx32 ", version=%" PRIu32 ", read_version=%" PRIu32, __func__, crc1, crc2, this->state.crc32, state_copy->crc32, this->cfg.version, this->state.version);
+    // Non-destructive mount: only a pristine, in-sync, current-version instance can be
+    // mounted without any write. Any other state needs a format or a recovery/upgrade
+    // write, so refuse and leave the flash untouched.
+    if (!allow_formatting && !((crc1 == this->state.crc32) && (crc2 == state_copy->crc32) && (crc1 == crc2) && (this->state.version == this->cfg.version))) {
+        return ESP_ERR_NOT_FOUND;
+    }
     if ((crc1 == this->state.crc32) && (crc2 == state_copy->crc32)) {
         // The state is OK. Check the ID
         if (this->state.version != this->cfg.version) {

--- a/components/wear_levelling/host_test/main/test_wl.cpp
+++ b/components/wear_levelling/host_test/main/test_wl.cpp
@@ -451,6 +451,206 @@ TEST_CASE("power down between WL status 1 and WL status 2 update", "[wear_levell
 }
 
 /* ======================================================================== */
+/* Non-destructive mount (wl_mount_no_format / wl_probe) tests              */
+/* ======================================================================== */
+
+// Offset and size of the WL config/state tail region - the only region wl_mount() formats
+static void get_wl_tail_region(const esp_partition_t *partition, size_t *tail_offset, size_t *tail_size)
+{
+    size_t offset_state_1, offset_state_2, size_state = 0;
+    calculate_wl_state_address_info(partition, &offset_state_1, &offset_state_2, &size_state);
+    *tail_offset = offset_state_1;
+    *tail_size = partition->size - offset_state_1;
+}
+
+TEST_CASE("wl_mount_no_format on fresh flash returns NOT_FOUND and does not touch flash", "[wear_levelling]")
+{
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+    REQUIRE(partition != NULL);
+
+    size_t tail_offset, tail_size;
+    get_wl_tail_region(partition, &tail_offset, &tail_size);
+
+    // Erase the whole partition, then snapshot the tail
+    REQUIRE(esp_partition_erase_range(partition, 0, partition->size) == ESP_OK);
+
+    uint8_t *before = (uint8_t *) malloc(tail_size);
+    uint8_t *after = (uint8_t *) malloc(tail_size);
+    REQUIRE(before != NULL);
+    REQUIRE(after != NULL);
+    REQUIRE(esp_partition_read(partition, tail_offset, before, tail_size) == ESP_OK);
+
+    wl_handle_t wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount_no_format(partition, &wl_handle) == ESP_ERR_NOT_FOUND);
+    REQUIRE(wl_handle == WL_INVALID_HANDLE);
+
+    // Tail must still be all-0xFF
+    REQUIRE(esp_partition_read(partition, tail_offset, after, tail_size) == ESP_OK);
+    REQUIRE(memcmp(before, after, tail_size) == 0);
+    for (size_t i = 0; i < tail_size; i++) {
+        REQUIRE(after[i] == 0xFF);
+    }
+
+    free(before);
+    free(after);
+}
+
+TEST_CASE("wl_mount_no_format on a valid instance succeeds and reads the same data", "[wear_levelling]")
+{
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+    REQUIRE(partition != NULL);
+
+    // Create a valid instance with wl_mount()
+    REQUIRE(esp_partition_erase_range(partition, 0, partition->size) == ESP_OK);
+
+    wl_handle_t wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount(partition, &wl_handle) == ESP_OK);
+
+    size_t sector_size = wl_sector_size(wl_handle);
+    uint8_t *pattern = (uint8_t *) malloc(sector_size);
+    uint8_t *readback = (uint8_t *) malloc(sector_size);
+    REQUIRE(pattern != NULL);
+    REQUIRE(readback != NULL);
+    for (size_t i = 0; i < sector_size; i++) {
+        pattern[i] = (uint8_t)(i * 7 + 1);
+    }
+
+    REQUIRE(wl_erase_range(wl_handle, 0, sector_size) == ESP_OK);
+    REQUIRE(wl_write(wl_handle, 0, pattern, sector_size) == ESP_OK);
+    REQUIRE(wl_unmount(wl_handle) == ESP_OK);
+
+    // No-format mount must succeed and expose the same data
+    wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount_no_format(partition, &wl_handle) == ESP_OK);
+    REQUIRE(wl_handle != WL_INVALID_HANDLE);
+
+    REQUIRE(wl_read(wl_handle, 0, readback, sector_size) == ESP_OK);
+    REQUIRE(memcmp(pattern, readback, sector_size) == 0);
+
+    REQUIRE(wl_unmount(wl_handle) == ESP_OK);
+
+    free(pattern);
+    free(readback);
+}
+
+TEST_CASE("wl_mount_no_format on foreign data returns NOT_FOUND and does not touch flash", "[wear_levelling]")
+{
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+    REQUIRE(partition != NULL);
+
+    size_t tail_offset, tail_size;
+    get_wl_tail_region(partition, &tail_offset, &tail_size);
+
+    // Fill the tail with non-0xFF, non-WL bytes (the case wl_mount() would reformat)
+    uint8_t *foreign = (uint8_t *) malloc(tail_size);
+    uint8_t *after = (uint8_t *) malloc(tail_size);
+    REQUIRE(foreign != NULL);
+    REQUIRE(after != NULL);
+    for (size_t i = 0; i < tail_size; i++) {
+        foreign[i] = (uint8_t)(0xA5 ^ (i & 0x7F));
+    }
+    REQUIRE(esp_partition_erase_range(partition, tail_offset, tail_size) == ESP_OK);
+    REQUIRE(esp_partition_write(partition, tail_offset, foreign, tail_size) == ESP_OK);
+
+    wl_handle_t wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount_no_format(partition, &wl_handle) == ESP_ERR_NOT_FOUND);
+    REQUIRE(wl_handle == WL_INVALID_HANDLE);
+
+    // Foreign data must be byte-identical
+    REQUIRE(esp_partition_read(partition, tail_offset, after, tail_size) == ESP_OK);
+    REQUIRE(memcmp(foreign, after, tail_size) == 0);
+
+    free(foreign);
+    free(after);
+}
+
+TEST_CASE("wl_mount_no_format on a degraded instance returns NOT_FOUND without writing", "[wear_levelling]")
+{
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+    REQUIRE(partition != NULL);
+
+    // Create a valid instance
+    REQUIRE(esp_partition_erase_range(partition, 0, partition->size) == ESP_OK);
+    wl_handle_t wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount(partition, &wl_handle) == ESP_OK);
+    REQUIRE(wl_unmount(wl_handle) == ESP_OK);
+
+    // Resolve the state/tail offsets while the instance is still valid (this mounts internally)
+    size_t offset_state_1, offset_state_2, size_state = 0;
+    calculate_wl_state_address_info(partition, &offset_state_1, &offset_state_2, &size_state);
+    size_t tail_offset, tail_size;
+    get_wl_tail_region(partition, &tail_offset, &tail_size);
+
+    // Corrupt one state copy, as a power-down mid-update would. wl_mount() would recover
+    // this, but wl_mount_no_format() must refuse without writing anything.
+    uint8_t *blank = (uint8_t *) malloc(size_state);
+    REQUIRE(blank != NULL);
+    memset(blank, 0xFF, size_state);
+    REQUIRE(esp_partition_erase_range(partition, offset_state_1, size_state) == ESP_OK);
+    REQUIRE(esp_partition_write(partition, offset_state_1, blank, size_state) == ESP_OK);
+
+    uint8_t *before = (uint8_t *) malloc(tail_size);
+    uint8_t *after = (uint8_t *) malloc(tail_size);
+    REQUIRE(before != NULL);
+    REQUIRE(after != NULL);
+    REQUIRE(esp_partition_read(partition, tail_offset, before, tail_size) == ESP_OK);
+
+    wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount_no_format(partition, &wl_handle) == ESP_ERR_NOT_FOUND);
+    REQUIRE(wl_handle == WL_INVALID_HANDLE);
+
+    REQUIRE(esp_partition_read(partition, tail_offset, after, tail_size) == ESP_OK);
+    REQUIRE(memcmp(before, after, tail_size) == 0);
+
+    // Sanity: wl_mount() still recovers the same degraded instance
+    REQUIRE(wl_mount(partition, &wl_handle) == ESP_OK);
+    REQUIRE(wl_unmount(wl_handle) == ESP_OK);
+
+    free(blank);
+    free(before);
+    free(after);
+}
+
+TEST_CASE("wl_probe reports presence without modifying flash", "[wear_levelling]")
+{
+    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "storage");
+    REQUIRE(partition != NULL);
+
+    size_t tail_offset, tail_size;
+    get_wl_tail_region(partition, &tail_offset, &tail_size);
+
+    // FRESH: probe on erased flash returns NOT_FOUND and leaves it all-0xFF.
+    REQUIRE(esp_partition_erase_range(partition, 0, partition->size) == ESP_OK);
+
+    uint8_t *before = (uint8_t *) malloc(tail_size);
+    uint8_t *after = (uint8_t *) malloc(tail_size);
+    REQUIRE(before != NULL);
+    REQUIRE(after != NULL);
+    REQUIRE(esp_partition_read(partition, tail_offset, before, tail_size) == ESP_OK);
+
+    REQUIRE(wl_probe(partition) == ESP_ERR_NOT_FOUND);
+
+    REQUIRE(esp_partition_read(partition, tail_offset, after, tail_size) == ESP_OK);
+    REQUIRE(memcmp(before, after, tail_size) == 0);
+    for (size_t i = 0; i < tail_size; i++) {
+        REQUIRE(after[i] == 0xFF);
+    }
+
+    // VALID: probe reports presence, and (no flush on teardown) leaves the tail unchanged
+    wl_handle_t wl_handle = WL_INVALID_HANDLE;
+    REQUIRE(wl_mount(partition, &wl_handle) == ESP_OK);
+    REQUIRE(wl_unmount(wl_handle) == ESP_OK);
+
+    REQUIRE(esp_partition_read(partition, tail_offset, before, tail_size) == ESP_OK);
+    REQUIRE(wl_probe(partition) == ESP_OK);
+    REQUIRE(esp_partition_read(partition, tail_offset, after, tail_size) == ESP_OK);
+    REQUIRE(memcmp(before, after, tail_size) == 0);
+
+    free(before);
+    free(after);
+}
+
+/* ======================================================================== */
 /* BDL (Block Device Layer) interface tests                                 */
 /* ======================================================================== */
 

--- a/components/wear_levelling/include/wear_levelling.h
+++ b/components/wear_levelling/include/wear_levelling.h
@@ -36,6 +36,39 @@ typedef int32_t wl_handle_t;
 esp_err_t wl_mount(const esp_partition_t *partition, wl_handle_t *out_handle);
 
 /**
+* @brief Mount WL for defined partition, but never write to flash
+*
+* Like wl_mount(), but it only mounts a partition that already holds a valid,
+* up-to-date WL instance and performs no writes. If the partition needs any
+* formatting, recovery, or version upgrade, it returns ESP_ERR_NOT_FOUND and
+* leaves the flash untouched. In that case wl_mount() can be used to recover
+* or (re)create the instance.
+*
+* @param partition that will be used for access
+* @param out_handle handle of the WL instance
+*
+* @return
+*       - ESP_OK, if a valid WL instance was found and mounted;
+*       - ESP_ERR_NOT_FOUND, if no valid up-to-date WL instance is present;
+*       - ESP_ERR_INVALID_ARG, if the arguments for WL configuration are not valid;
+*       - ESP_ERR_NO_MEM, if the WL allocation fails because of insufficient memory;
+*/
+esp_err_t wl_mount_no_format(const esp_partition_t *partition, wl_handle_t *out_handle);
+
+/**
+* @brief Check whether a partition holds a valid WL instance, without writing to flash
+*
+* @param partition that will be probed
+*
+* @return
+*       - ESP_OK, if a valid up-to-date WL instance is present on the partition;
+*       - ESP_ERR_NOT_FOUND, if no valid up-to-date WL instance is present;
+*       - ESP_ERR_INVALID_ARG, if the arguments for WL configuration are not valid;
+*       - ESP_ERR_NO_MEM, if the WL allocation fails because of insufficient memory;
+*/
+esp_err_t wl_probe(const esp_partition_t *partition);
+
+/**
 * @brief Unmount WL for defined partition
 *
 * @param handle WL partition handle

--- a/components/wear_levelling/private_include/WL_Ext_Perf.h
+++ b/components/wear_levelling/private_include/WL_Ext_Perf.h
@@ -16,7 +16,7 @@ public:
     ~WL_Ext_Perf() override;
 
     esp_err_t config(WL_Config_s *cfg, Flash_Access *partition) override;
-    esp_err_t init() override;
+    esp_err_t init(bool allow_formatting) override;
 
     size_t get_flash_size() override;
     size_t get_sector_size() override;

--- a/components/wear_levelling/private_include/WL_Ext_Safe.h
+++ b/components/wear_levelling/private_include/WL_Ext_Safe.h
@@ -17,7 +17,7 @@ public:
     ~WL_Ext_Safe() override;
 
     esp_err_t config(WL_Config_s *cfg, Flash_Access *partition) override;
-    esp_err_t init() override;
+    esp_err_t init(bool allow_formatting) override;
 
     size_t get_flash_size() override;
 
@@ -28,7 +28,7 @@ protected:
     uint32_t dump_addr;            // dump buffer address
     uint32_t buff_trans_state_addr;// sector address where state of buffer transaction will be stored
 
-    esp_err_t recover();
+    esp_err_t recover(bool allow_formatting);
 };
 
 #endif // _WL_Ext_Safe_H_

--- a/components/wear_levelling/private_include/WL_Flash.h
+++ b/components/wear_levelling/private_include/WL_Flash.h
@@ -22,7 +22,9 @@ public :
     ~WL_Flash() override;
 
     virtual esp_err_t config(wl_config_t *cfg, Flash_Access *partition);
-    virtual esp_err_t init();
+    // When allow_formatting is false, init() only mounts an already-valid, up-to-date instance without any
+    // write, and returns ESP_ERR_NOT_FOUND (leaving flash untouched) if the partition is not in that state
+    virtual esp_err_t init(bool allow_formatting = true);
 
     size_t get_flash_size() override;
     size_t get_sector_size() override;

--- a/components/wear_levelling/wear_levelling.cpp
+++ b/components/wear_levelling/wear_levelling.cpp
@@ -49,6 +49,8 @@ static wl_instance_t s_instances[MAX_WL_HANDLES];
 static _lock_t s_instances_lock;
 static const char *TAG = "wear_levelling";
 
+static esp_err_t wl_unmount_internal(wl_handle_t handle, bool flush);
+
 static esp_err_t check_handle(wl_handle_t handle, const char *func)
 {
     if (handle == WL_INVALID_HANDLE) {
@@ -66,7 +68,7 @@ static esp_err_t check_handle(wl_handle_t handle, const char *func)
     return ESP_OK;
 }
 
-esp_err_t wl_mount(const esp_partition_t *partition, wl_handle_t *out_handle)
+static esp_err_t wl_mount_internal(const esp_partition_t *partition, wl_handle_t *out_handle, bool formatting_allowed)
 {
     // Initialize variables before the first jump to cleanup label
     void *wl_flash_ptr = NULL;
@@ -156,9 +158,13 @@ esp_err_t wl_mount(const esp_partition_t *partition, wl_handle_t *out_handle)
     }
 
     // Initialise sectors used by WL layer for respective flash driver
-    result = wl_flash->init();
+    result = wl_flash->init(formatting_allowed);
     if (ESP_OK != result) {
-        ESP_LOGE(TAG, "%s: init instance=0x%08" PRIx32 ", result=0x%x", __func__, *out_handle, result);
+        if (result == ESP_ERR_NOT_FOUND && !formatting_allowed) {
+            ESP_LOGD(TAG, "%s: no valid WL instance, instance=0x%08" PRIx32, __func__, *out_handle);
+        } else {
+            ESP_LOGE(TAG, "%s: init instance=0x%08" PRIx32 ", result=0x%x", __func__, *out_handle, result);
+        }
         goto out;
     }
 
@@ -183,7 +189,28 @@ out:
     return result;
 }
 
-esp_err_t wl_unmount(wl_handle_t handle)
+esp_err_t wl_mount(const esp_partition_t *partition, wl_handle_t *out_handle)
+{
+    return wl_mount_internal(partition, out_handle, true);
+}
+
+esp_err_t wl_mount_no_format(const esp_partition_t *partition, wl_handle_t *out_handle)
+{
+    return wl_mount_internal(partition, out_handle, false);
+}
+
+esp_err_t wl_probe(const esp_partition_t *partition)
+{
+    wl_handle_t handle = WL_INVALID_HANDLE;
+    esp_err_t result = wl_mount_no_format(partition, &handle);
+    if (result == ESP_OK) {
+        // Unmount without flushing, so probing does not advance the WL state
+        result = wl_unmount_internal(handle, false);
+    }
+    return result;
+}
+
+static esp_err_t wl_unmount_internal(wl_handle_t handle, bool flush)
 {
     _lock_acquire(&s_instances_lock);
 
@@ -193,7 +220,7 @@ esp_err_t wl_unmount(wl_handle_t handle)
         // running outside the global lock.
         _lock_acquire(&s_instances[handle].lock);
         Flash_Access *part = s_instances[handle].instance->get_part();
-        if (!part->is_readonly()) {
+        if (flush && !part->is_readonly()) {
             result = s_instances[handle].instance->flush();
         }
         part->~Flash_Access();
@@ -207,6 +234,11 @@ esp_err_t wl_unmount(wl_handle_t handle)
 
     _lock_release(&s_instances_lock);
     return result;
+}
+
+esp_err_t wl_unmount(wl_handle_t handle)
+{
+    return wl_unmount_internal(handle, true);
 }
 
 esp_err_t wl_erase_range(wl_handle_t handle, size_t start_addr, size_t size)


### PR DESCRIPTION
<!-- Add the CI labels to trigger the appropriate tests (e.g. "unit_test_esp32") -->
<!-- Make sure the commit message follows the Wiki about "Commit Messages" -->

`wl_mount()` reformats a partition that does not already hold a valid wear levelling instance. If it is pointed at a partition that contains other data (for example a raw FAT partition), it erases that data and returns success, and there is no way to prevent this.

This adds two functions that never write to flash:

- `wl_mount_no_format()` mounts only an already-valid instance, or returns `ESP_ERR_NOT_FOUND` and leaves the flash untouched.
- `wl_probe()` checks whether a valid instance is present, without writing to flash.

`wl_mount()` and `wl_unmount()` are unchanged. Host tests and docs are included.

## Related

No related issues.

/assign me

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core partition mount/init paths and flash write guards; mistakes could block mounts or still write when probing, but behavior is scoped with tests and existing `wl_mount()` unchanged.
> 
> **Overview**
> Adds **`wl_mount_no_format()`** and **`wl_probe()`** so callers can mount or detect wear levelling on a partition **without any flash writes**—avoiding the case where **`wl_mount()`** would format or recover foreign or invalid data.
> 
> Mount logic is refactored through **`wl_mount_internal(..., formatting_allowed)`**; **`WL_Flash::init(bool allow_formatting)`** (and **`WL_Ext_Safe::recover`**) return **`ESP_ERR_NOT_FOUND`** and leave flash unchanged when the instance is missing, foreign, degraded, or needs recovery/version work that would require writes. **`wl_probe()`** uses a no-format mount and **`wl_unmount_internal(..., flush=false)`** so teardown does not flush WL state. **`wl_mount()`** / **`wl_unmount()`** behavior is preserved via the default formatting path and flush-on-unmount.
> 
> Docs and host tests cover fresh flash, valid instances, foreign tail data, corrupted state, and probe idempotency on flash contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4bfd2d23143019ddfb777b64393e3db3591a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->