### PR TITLE
fix(spi_master): avoid NULL memcpy when DMA buffer setup fails (IDFGH-18048)

### DIFF
--- a/components/esp_driver_spi/src/gpspi/spi_master.c
+++ b/components/esp_driver_spi/src/gpspi/spi_master.c
@@ -1180,22 +1180,28 @@ static SPI_MASTER_ISR_ATTR esp_err_t setup_priv_desc(spi_host_t *host, spi_trans
     uint32_t* rcv_ptr = (trans_desc->flags & SPI_TRANS_USE_RXDATA) ? (uint32_t *)trans_desc->rx_data : (uint32_t *)trans_desc->rx_buffer;
     // tx memory assign
     uint32_t *send_ptr = (trans_desc->flags & SPI_TRANS_USE_TXDATA) ? (uint32_t *)trans_desc->tx_data : (uint32_t *)trans_desc->tx_buffer;
+    // clean_up below calls uninstall_priv_desc(), which reads both fields, so keep them
+    // valid from the start and re-point them only once a temporary buffer is allocated.
+    priv_desc->buffer_to_send = send_ptr;
+    priv_desc->buffer_to_rcv = rcv_ptr;
+
     if (!bus_attr->dma_enabled) {
-        priv_desc->buffer_to_send = send_ptr;
-        priv_desc->buffer_to_rcv = rcv_ptr;
         return ESP_OK;
     }
 
     bool use_psram = trans_desc->flags & SPI_TRANS_DMA_USE_PSRAM;
     bool auto_malloc = !(trans_desc->flags & SPI_TRANS_DMA_BUFFER_ALIGN_MANUAL);
-    esp_err_t ret = spicommon_dma_setup_priv_buffer(host->id, send_ptr, (trans_desc->length + 7) / 8, true, use_psram, auto_malloc, (void *)&priv_desc->buffer_to_send);
+    esp_err_t ret = spicommon_dma_setup_priv_buffer(host->id, send_ptr, (trans_desc->length + 7) / 8, true, use_psram, auto_malloc, &send_ptr);
     if (ret != ESP_OK) {
         goto clean_up;
     }
-    ret = spicommon_dma_setup_priv_buffer(host->id, rcv_ptr, (trans_desc->rxlength + 7) / 8, false, use_psram, auto_malloc, &priv_desc->buffer_to_rcv);
+    priv_desc->buffer_to_send = send_ptr;
+
+    ret = spicommon_dma_setup_priv_buffer(host->id, rcv_ptr, (trans_desc->rxlength + 7) / 8, false, use_psram, auto_malloc, &rcv_ptr);
     if (ret != ESP_OK) {
         goto clean_up;
     }
+    priv_desc->buffer_to_rcv = rcv_ptr;
     return ret;
 
 clean_up:


### PR DESCRIPTION
## Description

`setup_priv_desc()` in `components/esp_driver_spi/src/gpspi/spi_master.c` passed the
descriptor's `buffer_to_send` / `buffer_to_rcv` fields directly as the output
parameters of `spicommon_dma_setup_priv_buffer()`, and its `clean_up` path calls
`uninstall_priv_desc()`, which reads both.

`spicommon_dma_setup_priv_buffer()` only writes `*ret_buffer` on success. Every
failure path returns before that assignment (`ESP_ERR_NOT_SUPPORTED` for PSRAM on
ESP32-S2/SPI3, `ESP_ERR_INVALID_STATE` when a buffer needs realignment but
`SPI_TRANS_DMA_BUFFER_ALIGN_MANUAL` forbids allocating, `ESP_ERR_NO_MEM` on
allocation failure). Callers initialise the descriptor as `{ .trans = trans_desc }`,
so on failure the fields were still `NULL` and `uninstall_priv_desc()` ran
`memcpy(orig_rx_buffer, NULL, (rxlength + 7) / 8)`, crashing with a load access
fault. Since `check_trans_valid()` defaults `rxlength` to `length` in full-duplex
mode, the copy length is non-zero, so this is a hard crash rather than a no-op.

A temporary TX buffer allocated before the RX setup failed was also leaked, because
its pointer was never stored where `uninstall_priv_desc()` could free it.

The fix assigns both fields from the caller's buffers up front, then passes locals
to `spicommon_dma_setup_priv_buffer()` and re-points each field only after its call
succeeds. On failure the fields still reference the caller's buffers, so
`uninstall_priv_desc()` neither copies from `NULL` nor frees them; on partial
success the already-allocated TX temporary is tracked and freed. This also removes
the `(void *)` cast that was working around the `const uint32_t *` field type.

No API or behavioural change on the success path.

## Related

<!-- No public issue is on file for this; add `Fixes #NNN` if one exists. -->

## Testing

Originally reproduced on ESP32-C5 with a DMA-enabled bus, an RX buffer in
non-DMA-capable memory, and the internal heap exhausted so that the RX
`spicommon_dma_setup_priv_buffer()` call returns `ESP_ERR_NO_MEM`. Before the fix
this faults in `uninstall_priv_desc()`; after it, `spi_device_transmit()` returns
the error cleanly.

The same crash is reachable deterministically without exhausting the heap, which is
the better regression test:

- DMA-enabled bus, full duplex, `flags = SPI_TRANS_DMA_BUFFER_ALIGN_MANUAL`
- TX buffer aligned with an aligned length, so its setup succeeds
- RX buffer pointer deliberately offset by one byte, so address misalignment
  requires a temporary buffer that `auto_malloc == false` refuses to allocate

Pre-fix this faults; post-fix `spi_device_transmit()` returns
`ESP_ERR_INVALID_STATE`.

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DMA transaction setup and teardown in the SPI master driver—failure paths only, but incorrect cleanup logic could still affect stability or memory on edge cases.
> 
> **Overview**
> **`setup_priv_desc()`** in `spi_master.c` now seeds **`buffer_to_send`** and **`buffer_to_rcv`** from the transaction’s TX/RX pointers before any DMA setup, and only updates each field after the corresponding **`spicommon_dma_setup_priv_buffer()`** succeeds (via local pointers instead of writing through the descriptor during setup).
> 
> On DMA buffer setup failure, the **`clean_up`** path still calls **`uninstall_priv_desc()`**, which previously saw unset fields and could **`memcpy`** from **NULL** or miss freeing a TX temp buffer allocated before RX setup failed. Failed setups now return errors cleanly (e.g. **`ESP_ERR_NO_MEM`**, **`ESP_ERR_INVALID_STATE`**) without a load-access fault; the success path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e276332b37660c7344d752eeb704b5ae85d7adef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->