### PR TITLE
fix(freertos): prevent critical section overlap (IDFGH-18064)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel-SMP/portable/xtensa/port.c
+++ b/components/freertos/FreeRTOS-Kernel-SMP/portable/xtensa/port.c
@@ -171,7 +171,6 @@ void vPortExitCriticalIDF(portMUX_TYPE *lock)
      * to re-enable interrupts if this is the last call to exit the critical. We
      * can use the nesting count to determine whether this is the last exit call.
      */
-    spinlock_release(lock);
     BaseType_t coreID = xPortGetCoreID();
     BaseType_t nesting = port_uxCriticalNestingIDF[coreID];
 
@@ -181,11 +180,15 @@ void vPortExitCriticalIDF(portMUX_TYPE *lock)
     if (nesting > 0) {
         nesting--;
         port_uxCriticalNestingIDF[coreID] = nesting;
+        spinlock_release(lock);
 
         //This is the last exit call, restore the saved interrupt level
         if ( nesting == 0 ) {
             XTOS_RESTORE_JUST_INTLEVEL((int) port_uxCriticalOldInterruptStateIDF[coreID]);
         }
+    }
+    else {
+        spinlock_release(lock);
     }
 }
 

--- a/components/freertos/FreeRTOS-Kernel/portable/riscv/port.c
+++ b/components/freertos/FreeRTOS-Kernel/portable/riscv/port.c
@@ -569,7 +569,6 @@ void __attribute__((optimize("-O3"))) vPortExitCriticalMultiCore(portMUX_TYPE *m
      * to re-enable interrupts if this is the last call to exit the critical. We
      * can use the nesting count to determine whether this is the last exit call.
      */
-    spinlock_release(mux);
     BaseType_t coreID = xPortGetCoreID();
     BaseType_t nesting = port_uxCriticalNesting[coreID];
 
@@ -579,11 +578,15 @@ void __attribute__((optimize("-O3"))) vPortExitCriticalMultiCore(portMUX_TYPE *m
     if (nesting > 0) {
         nesting--;
         port_uxCriticalNesting[coreID] = nesting;
+        spinlock_release(mux);
 
         //This is the last exit call, restore the saved interrupt level
         if ( nesting == 0 ) {
             portCLEAR_INTERRUPT_MASK_FROM_ISR(port_uxOldInterruptState[coreID]);
         }
+    }
+    else {
+        spinlock_release(mux);
     }
 }
 

--- a/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c
+++ b/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c
@@ -538,7 +538,6 @@ void __attribute__((optimize("-O3"))) vPortExitCritical(portMUX_TYPE *mux)
      * to re-enable interrupts if this is the last call to exit the critical. We
      * can use the nesting count to determine whether this is the last exit call.
      */
-    spinlock_release(mux);
     BaseType_t coreID = xPortGetCoreID();
     BaseType_t nesting = port_uxCriticalNesting[coreID];
 
@@ -548,11 +547,15 @@ void __attribute__((optimize("-O3"))) vPortExitCritical(portMUX_TYPE *mux)
     if (nesting > 0) {
         nesting--;
         port_uxCriticalNesting[coreID] = nesting;
+        spinlock_release(mux);
 
         //This is the last exit call, restore the saved interrupt level
         if ( nesting == 0 ) {
             portCLEAR_INTERRUPT_MASK_FROM_ISR(port_uxOldInterruptState[coreID]);
         }
+    }
+    else {
+        spinlock_release(mux);
     }
 }
 


### PR DESCRIPTION
## Description

Summary: Fix a narrow race condition where critical sections can overlap for about 10 instructions, and if interrupted there, can lead to a crash.

Motivation: support running multiple threads.

## Related

Fixes  #18903 

## Testing

I ran it for a while, but that only exercises FreeRTOS-Kernel/portable/xtensa/port.c. I patched the others that used a spinlock in the same way, but FreeRTOS-Kernel-SML/portable/riscv/port.c does not, so it is unchanged.

These crashes are quite rare - the only evidence I have of them is from customer coredumps indicating that the critical section was corrupted. See #18903 for more details.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary. I wish I could write a test for this but I can't figure out how to reliably cause one.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core kernel synchronization on all ESP-IDF targets; incorrect ordering could deadlock or worsen concurrency bugs, though the change aligns release with the documented nested-exit model.
> 
> **Overview**
> Fixes a narrow race where **critical sections could overlap** for a handful of instructions on Xtensa and RISC-V FreeRTOS ports (including SMP Xtensa IDF critical paths).
> 
> **`vPortExitCritical` / `vPortExitCriticalIDF` / `vPortExitCriticalMultiCore`** no longer call **`spinlock_release`** at the start of exit. The mux is released **after** the per-core nesting count is decremented, and only then is the saved interrupt level restored on the outermost exit. An **`else`** branch still releases the spinlock if nesting is already zero (e.g. assert/debug paths).
> 
> This keeps the spinlock held until nesting is updated while interrupts stay masked, so another context cannot slip into the same critical region during that window—addressing rare crashes from corrupted critical nesting under multithreaded load (#18903).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2977e7452453d85d817ef2b47d00c1ca7d38a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->