### PR TITLE
feat(vfs): list synthetic parent directories of mount points (IDFGH-18065)

### DIFF
--- a/components/vfs/Kconfig
+++ b/components/vfs/Kconfig
@@ -38,6 +38,18 @@ menu "Virtual file system"
             Disabling this option can save memory when the support for these functions
             is not required.
 
+    config VFS_SUPPORT_SYNTHETIC_ROOT
+        bool "List synthetic parent directories of mount points"
+        default n
+        depends on VFS_SUPPORT_DIR
+        help
+            If enabled, opendir()/readdir()/stat() also work on the root ("/") and on the
+            intermediate parent directories of registered mount points, so the mount point
+            hierarchy can be browsed even though no filesystem is mounted there.
+
+            Disabled by default, as it adds code and a small per-call check to the directory
+            functions.
+
     config VFS_SUPPORT_SELECT
         bool "Provide select function"
         default y

--- a/components/vfs/test_apps/main/test_vfs_paths.c
+++ b/components/vfs/test_apps/main/test_vfs_paths.c
@@ -10,11 +10,13 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/fcntl.h>
+#include <sys/stat.h>
 #include <dirent.h>
 #include "esp_vfs.h"
 #include "esp_vfs_ops.h"
 #include "unity.h"
 #include "esp_log.h"
+#include "sdkconfig.h"
 
 /* Dummy VFS implementation to check if VFS is called or not with expected path
  */
@@ -453,3 +455,109 @@ TEST_CASE("vfs survives repeated register/unregister cycles", "[vfs]")
         }
     }
 }
+
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+
+/* Count how many times a directory entry with the given name is returned by readdir().
+ * Other mount points may be registered by the system, so a listing is checked by looking
+ * for the expected entries rather than by asserting an exact entry count.
+ */
+static int count_dir_entries(const char* path, const char* name)
+{
+    DIR* dir = opendir(path);
+    TEST_ASSERT_NOT_NULL(dir);
+    int count = 0;
+    struct dirent* de;
+    while ((de = readdir(dir)) != NULL) {
+        TEST_ASSERT_EQUAL(DT_DIR, de->d_type);
+        if (strcmp(de->d_name, name) == 0) {
+            ++count;
+        }
+    }
+    closedir(dir);
+    return count;
+}
+
+TEST_CASE("vfs lists synthetic parent directories", "[vfs]")
+{
+    dummy_vfs_t inst = { .match_path = "", .called = false };
+    TEST_ESP_OK( esp_vfs_register_fs("/foo", &s_dummy_vfs, ESP_VFS_FLAG_CONTEXT_PTR, &inst) );
+    TEST_ESP_OK( esp_vfs_register_fs("/dev/aaa", &s_dummy_vfs, ESP_VFS_FLAG_CONTEXT_PTR, &inst) );
+    TEST_ESP_OK( esp_vfs_register_fs("/dev/bbb", &s_dummy_vfs, ESP_VFS_FLAG_CONTEXT_PTR, &inst) );
+
+    /* The root lists the first path component of every mount, and mounts sharing a
+     * component (/dev/aaa and /dev/bbb both yield "dev") are listed only once. */
+    TEST_ASSERT_EQUAL(1, count_dir_entries("/", "foo"));
+    TEST_ASSERT_EQUAL(1, count_dir_entries("/", "dev"));
+
+    /* An intermediate directory lists the mounts directly underneath it. */
+    TEST_ASSERT_EQUAL(1, count_dir_entries("/dev", "aaa"));
+    TEST_ASSERT_EQUAL(1, count_dir_entries("/dev", "bbb"));
+
+    /* A trailing separator is accepted, just as it is for real mounts. */
+    TEST_ASSERT_EQUAL(1, count_dir_entries("/dev/", "aaa"));
+
+    /* Synthetic directories can be stat()ed as read-only directories. */
+    struct stat st;
+    TEST_ASSERT_EQUAL(0, stat("/", &st));
+    TEST_ASSERT_EQUAL(S_IFDIR, st.st_mode & S_IFMT);
+    TEST_ASSERT_EQUAL(0, stat("/dev", &st));
+    TEST_ASSERT_EQUAL(S_IFDIR, st.st_mode & S_IFMT);
+
+    /* A path with no mount underneath it is not a directory. */
+    TEST_ASSERT_EQUAL(-1, stat("/nonexistent", &st));
+
+    /* telldir()/seekdir() return to the same entry, and rewinddir() restarts the listing. */
+    DIR* dir = opendir("/dev");
+    TEST_ASSERT_NOT_NULL(dir);
+    TEST_ASSERT_NOT_NULL(readdir(dir));
+    long pos = telldir(dir);
+    char name_at_pos[sizeof(((struct dirent*)0)->d_name)];
+    struct dirent* de = readdir(dir);
+    TEST_ASSERT_NOT_NULL(de);
+    strlcpy(name_at_pos, de->d_name, sizeof(name_at_pos));
+    seekdir(dir, pos);
+    de = readdir(dir);
+    TEST_ASSERT_NOT_NULL(de);
+    TEST_ASSERT_EQUAL_STRING(name_at_pos, de->d_name);
+    rewinddir(dir);
+    TEST_ASSERT_NOT_NULL(readdir(dir));
+    closedir(dir);
+
+    TEST_ESP_OK( esp_vfs_unregister("/foo") );
+    TEST_ESP_OK( esp_vfs_unregister("/dev/aaa") );
+    TEST_ESP_OK( esp_vfs_unregister("/dev/bbb") );
+}
+
+TEST_CASE("vfs synthetic dirs defer to a fallback filesystem", "[vfs]")
+{
+    /* A fallback VFS (empty prefix) owns every otherwise-unmatched path, including "/" and
+     * the parents of other mounts, so the synthetic listing must not shadow it. */
+    dummy_vfs_t fallback = { .match_path = "", .called = false };
+    TEST_ESP_OK( esp_vfs_register_fs("", &s_dummy_vfs, ESP_VFS_FLAG_CONTEXT_PTR, &fallback) );
+    dummy_vfs_t dev = { .match_path = "", .called = false };
+    TEST_ESP_OK( esp_vfs_register_fs("/dev/aaa", &s_dummy_vfs, ESP_VFS_FLAG_CONTEXT_PTR, &dev) );
+
+    /* opendir("/") is routed to the fallback, not synthesized. */
+    fallback.match_path = "/";
+    fallback.called = false;
+    DIR* dir = opendir("/");
+    TEST_ASSERT_TRUE(fallback.called);
+    if (dir) {
+        closedir(dir);
+    }
+
+    /* An intermediate parent ("/dev") is likewise routed to the fallback. */
+    fallback.match_path = "/dev";
+    fallback.called = false;
+    dir = opendir("/dev");
+    TEST_ASSERT_TRUE(fallback.called);
+    if (dir) {
+        closedir(dir);
+    }
+
+    TEST_ESP_OK( esp_vfs_unregister("") );
+    TEST_ESP_OK( esp_vfs_unregister("/dev/aaa") );
+}
+
+#endif // CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT

--- a/components/vfs/test_apps/sdkconfig.defaults
+++ b/components/vfs/test_apps/sdkconfig.defaults
@@ -10,5 +10,8 @@ CONFIG_ESP_TASK_WDT_INIT=n
 
 CONFIG_VFS_MAX_COUNT=10
 
+# Exercise the synthetic parent directory listing (opt-in feature)
+CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT=y
+
 # We should still run tests for all variants...
 CONFIG_VFS_SUPPRESS_CTX_DEPRECATION=y

--- a/components/vfs/vfs_calls.c
+++ b/components/vfs/vfs_calls.c
@@ -16,6 +16,7 @@
 #include <sys/unistd.h>
 #include <sys/lock.h>
 #include <sys/param.h>
+#include <sys/stat.h>
 #include <dirent.h>
 #include "inttypes_ext.h"
 #include "freertos/FreeRTOS.h"
@@ -210,12 +211,151 @@ int esp_vfs_fsync(int fd)
 
 #ifdef CONFIG_VFS_SUPPORT_DIR
 
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+
+// Synthetic directories: a virtual read-only directory is synthesized above the registered
+// mount points, so the mount point hierarchy can be browsed from the root downward even
+// though no filesystem is mounted there. Each lists the next path component of the mount
+// points below it, and can be traversed to any depth until a real VFS is reached.
+// dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX marks such a DIR.
+#define VFS_SYNTHETIC_DIR_IDX 0xFFFF
+
+typedef struct {
+    DIR dir;
+    struct dirent de;
+    size_t next_index;
+    char child_prefix[ESP_VFS_PATH_MAX + 2]; // directory + '/', the prefix a child mount shares
+} vfs_synthetic_dir_t;
+
+// The prefix every mount directly under directory "dir" must share: "/" for the root,
+// otherwise "dir" with a trailing '/'. A single trailing separator on "dir" is ignored so
+// that "/dev" and "/dev/" behave alike (as they do for real mounts). Returns false for a
+// non-absolute path or if the result doesn't fit.
+static bool vfs_synthetic_child_prefix(const char *dir, char *out, size_t out_size)
+{
+    if (dir == NULL || dir[0] != '/') {
+        return false;
+    }
+    size_t len = strlen(dir);
+    if (len > 1 && dir[len - 1] == '/') {
+        len--;
+    }
+    if (len == 1) { // root ("/")
+        if (out_size < 2) {
+            return false;
+        }
+        out[0] = '/';
+        out[1] = '\0';
+        return true;
+    }
+    if (len + 2 > out_size) {
+        return false;
+    }
+    memcpy(out, dir, len);
+    out[len] = '/';
+    out[len + 1] = '\0';
+    return true;
+}
+
+// If "prefix" is a mount below child_prefix, copy its next path component into out.
+static bool vfs_synthetic_component(const char *prefix, const char *child_prefix, size_t child_prefix_len, char *out, size_t out_size)
+{
+    if (prefix == NULL || strncmp(prefix, child_prefix, child_prefix_len) != 0) {
+        return false;
+    }
+    const char *start = prefix + child_prefix_len;
+    const char *sep = strchr(start, '/');
+    size_t len = sep ? (size_t)(sep - start) : strlen(start);
+    if (len == 0 || len >= out_size) {
+        return false;
+    }
+    memcpy(out, start, len);
+    out[len] = '\0';
+    return true;
+}
+
+// A directory is synthetic when at least one registered mount lives underneath it.
+static bool vfs_is_synthetic_dir(const char *dir)
+{
+    char child_prefix[ESP_VFS_PATH_MAX + 2];
+    if (!vfs_synthetic_child_prefix(dir, child_prefix, sizeof(child_prefix))) {
+        return false;
+    }
+    size_t child_prefix_len = strlen(child_prefix);
+    char component[NAME_MAX + 1];
+    size_t count = get_vfs_count();
+    for (size_t i = 0; i < count; ++i) {
+        const vfs_entry_t *vfs = get_vfs_for_index((int)i);
+        if (vfs != NULL && vfs_synthetic_component(vfs->path_prefix, child_prefix, child_prefix_len, component, sizeof(component))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static DIR *vfs_synthetic_opendir(const char *dir)
+{
+    vfs_synthetic_dir_t *sdir = calloc(1, sizeof(vfs_synthetic_dir_t));
+    if (sdir == NULL) {
+        __errno_r(__getreent()) = ENOMEM;
+        return NULL;
+    }
+    if (!vfs_synthetic_child_prefix(dir, sdir->child_prefix, sizeof(sdir->child_prefix))) {
+        free(sdir);
+        __errno_r(__getreent()) = ENAMETOOLONG;
+        return NULL;
+    }
+    sdir->dir.dd_vfs_idx = VFS_SYNTHETIC_DIR_IDX;
+    return &sdir->dir;
+}
+
+static struct dirent *vfs_synthetic_readdir(vfs_synthetic_dir_t *sdir)
+{
+    char component[sizeof(sdir->de.d_name)];
+    size_t child_prefix_len = strlen(sdir->child_prefix);
+    size_t count = get_vfs_count();
+    while (sdir->next_index < count) {
+        size_t i = sdir->next_index++;
+        const vfs_entry_t *vfs = get_vfs_for_index((int)i);
+        if (vfs == NULL || !vfs_synthetic_component(vfs->path_prefix, sdir->child_prefix, child_prefix_len, component, sizeof(component))) {
+            continue;
+        }
+        // Skip components already emitted: sibling mounts can share the same next component.
+        bool duplicate = false;
+        for (size_t j = 0; j < i && !duplicate; ++j) {
+            const vfs_entry_t *prev = get_vfs_for_index((int)j);
+            char prev_component[sizeof(component)];
+            if (prev != NULL && vfs_synthetic_component(prev->path_prefix, sdir->child_prefix, child_prefix_len, prev_component, sizeof(prev_component))) {
+                duplicate = strcmp(prev_component, component) == 0;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+        sdir->de.d_ino = 0;
+        sdir->de.d_type = DT_DIR;
+        memcpy(sdir->de.d_name, component, strlen(component) + 1);
+        return &sdir->de;
+    }
+    return NULL;
+}
+
+#endif // CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+
 int esp_vfs_stat(struct _reent *r, const char *path, struct stat *st)
 {
     VFS_RETURN_ON_NULL_PTR(r, path, EINVAL, -1);
     VFS_RETURN_ON_NULL_PTR(r, st, EINVAL, -1);
     const vfs_entry_t *vfs = get_vfs_for_path(path);
     if (vfs == NULL) {
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+        if (vfs_is_synthetic_dir(path)) {
+            memset(st, 0, sizeof(*st));
+            st->st_mode = S_IFDIR | 0555;
+            st->st_nlink = 1;
+            return 0;
+        }
+#endif
         VFS_RETURN_ERR(r, ENOENT, -1);
     }
     const char *path_within_vfs = translate_path(vfs, path);
@@ -307,6 +447,11 @@ DIR *esp_vfs_opendir(const char *name)
     VFS_RETURN_ON_NULL_PTR(r, name, EINVAL, NULL);
     const vfs_entry_t *vfs = get_vfs_for_path(name);
     if (vfs == NULL) {
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+        if (vfs_is_synthetic_dir(name)) {
+            return vfs_synthetic_opendir(name);
+        }
+#endif
         VFS_RETURN_ERR(r, ENOENT, NULL);
     }
     const char *path_within_vfs = translate_path(vfs, name);
@@ -322,6 +467,11 @@ struct dirent *esp_vfs_readdir(DIR *pdir)
 {
     struct _reent __attribute__((unused)) *r = __getreent();
     VFS_RETURN_ON_NULL_PTR(r, pdir, EBADF, NULL);
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+    if (pdir->dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX) {
+        return vfs_synthetic_readdir((vfs_synthetic_dir_t *)pdir);
+    }
+#endif
     const vfs_entry_t *vfs = get_vfs_for_index(pdir->dd_vfs_idx);
     if (vfs == NULL) {
         VFS_RETURN_ERR(r, EBADF, NULL);
@@ -337,6 +487,16 @@ int esp_vfs_readdir_r(DIR *pdir, struct dirent *entry, struct dirent* *out_diren
     VFS_RETURN_ON_NULL_PTR(r, pdir, EINVAL, -1);
     VFS_RETURN_ON_NULL_PTR(r, entry, EINVAL, -1);
     VFS_RETURN_ON_NULL_PTR(r, out_dirent, EINVAL, -1);
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+    if (pdir->dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX) {
+        struct dirent *next = vfs_synthetic_readdir((vfs_synthetic_dir_t *)pdir);
+        if (next != NULL) {
+            memcpy(entry, next, sizeof(*entry));
+        }
+        *out_dirent = next != NULL ? entry : NULL;
+        return 0;
+    }
+#endif
     const vfs_entry_t *vfs = get_vfs_for_index(pdir->dd_vfs_idx);
     if (vfs == NULL) {
         VFS_RETURN_ERR(r, EBADF, -1);
@@ -350,6 +510,11 @@ long esp_vfs_telldir(DIR *pdir)
 {
     struct _reent __attribute__((unused)) *r = __getreent();
     VFS_RETURN_ON_NULL_PTR(r, pdir, EBADF, -1);
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+    if (pdir->dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX) {
+        return (long)((vfs_synthetic_dir_t *)pdir)->next_index;
+    }
+#endif
     const vfs_entry_t *vfs = get_vfs_for_index(pdir->dd_vfs_idx);
     if (vfs == NULL) {
         VFS_RETURN_ERR(r, EBADF, -1);
@@ -363,6 +528,12 @@ void esp_vfs_seekdir(DIR *pdir, long loc)
 {
     struct _reent __attribute__((unused)) *r = __getreent();
     VFS_RETURNV_ON_NULL_PTR(r, pdir, EBADF);
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+    if (pdir->dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX) {
+        ((vfs_synthetic_dir_t *)pdir)->next_index = loc < 0 ? 0 : (size_t)loc;
+        return;
+    }
+#endif
     const vfs_entry_t *vfs = get_vfs_for_index(pdir->dd_vfs_idx);
     if (vfs == NULL) {
         VFS_RETURNV_ERR(r, EBADF);
@@ -379,6 +550,12 @@ int esp_vfs_closedir(DIR *pdir)
 {
     struct _reent __attribute__((unused)) *r = __getreent();
     VFS_RETURN_ON_NULL_PTR(r, pdir, EBADF, -1);
+#if CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT
+    if (pdir->dd_vfs_idx == VFS_SYNTHETIC_DIR_IDX) {
+        free(pdir);
+        return 0;
+    }
+#endif
     const vfs_entry_t *vfs = get_vfs_for_index(pdir->dd_vfs_idx);
     if (vfs == NULL) {
         VFS_RETURN_ERR(r, EBADF, -1);

--- a/docs/en/api-reference/storage/vfs.rst
+++ b/docs/en/api-reference/storage/vfs.rst
@@ -206,6 +206,8 @@ When opening files, the FS driver receives only relative paths to files. For exa
 
 VFS does not impose any limit on total file path length, but it does limit the FS path prefix to ``ESP_VFS_PATH_MAX`` characters. Individual FS drivers may have their own filename length limitations.
 
+When the :ref:`CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT` option is enabled (it is disabled by default), a virtual read-only directory is synthesized above the registered mount points, so the mount point hierarchy can be browsed from the root (``/``) downward with ``opendir()`` / ``readdir()`` and queried with ``stat()``. Each such directory lists one entry (of type ``DT_DIR``) per next path component of the mount points below it, and can be traversed to any depth until a registered filesystem is reached.
+
 
 File Descriptors
 ----------------


### PR DESCRIPTION
## Description

No filesystem is mounted at the root or at the intermediate parent directories of registered VFS mount points, so those paths previously could not be opened, listed, or `stat`-ed. This adds an **opt-in** synthetic directory listing so the mount point hierarchy can be browsed from `/` downward:

- `opendir()` / `readdir()` on `/` or an intermediate parent (e.g. `/dev` when `/dev/uart` and `/dev/null` are registered) return one `DT_DIR` entry per next path component of the mounts below it — each shared component listed once.
- `stat()` reports these paths as read-only directories.
- Traversable to any depth until a real registered VFS is reached.

Gated behind a new Kconfig option **`CONFIG_VFS_SUPPORT_SYNTHETIC_DIRS`** (disabled by default), so the directory syscalls are unaffected unless explicitly enabled.

## Testing

- New unit test *"vfs lists synthetic parent directories"* in `components/vfs/test_apps`, covering root & intermediate listings, shared-component de-duplication, `stat()`, and `telldir`/`seekdir`/`rewinddir`.
- Built `components/vfs/test_apps` for esp32c3 with the option **enabled and disabled** — both compile warning-free; the disabled build emits none of the synthetic code.

## Related

- Documentation updated: `docs/en/api-reference/storage/vfs.rst`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core directory syscalls and path resolution, but behavior is gated off by default and defers to any matching registered VFS (including empty-prefix fallback).
> 
> **Overview**
> Adds an **opt-in** `CONFIG_VFS_SUPPORT_SYNTHETIC_ROOT` (default off, requires `VFS_SUPPORT_DIR`) so `/` and intermediate parents of registered mounts can be browsed when no real FS is mounted there.
> 
> When path lookup finds no VFS, the layer can **`stat()`** those paths as read-only directories and **`opendir()` / `readdir()`** (plus **`readdir_r`**, **`telldir`**, **`seekdir`**, **`closedir`**) using a synthetic `DIR` tagged via `dd_vfs_idx`. Listings expose the next path component per mount below that directory, with **duplicate components deduplicated** (e.g. one `dev` for `/dev/aaa` and `/dev/bbb`). **Registered VFS still wins**—including an empty-prefix fallback—so synthetic listings do not override a catch-all driver.
> 
> VFS test app enables the option in `sdkconfig.defaults` and adds Unity cases for listing, `stat`, seek/tell/rewind, and fallback precedence. **Docs** in `vfs.rst` describe the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a5c2bcc6d8aa106472fb789dbca159fe9adef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->