### PR TITLE
docs(freertos): document zero-length send restriction (IDFGH-18075)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/message_buffer.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/message_buffer.h
@@ -337,6 +337,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * on a 32-bit architecture, so on most 32-bit architecture setting
  * xDataLengthBytes to 20 will reduce the free space in the message buffer by 24
  * bytes (20 bytes of message data and 4 bytes to hold the message length).
+ * xDataLengthBytes must be greater than 0.
  *
  * @param xTicksToWait The maximum amount of time the calling task should remain
  * in the Blocked state to wait for enough space to become available in the
@@ -440,6 +441,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * on a 32-bit architecture, so on most 32-bit architecture setting
  * xDataLengthBytes to 20 will reduce the free space in the message buffer by 24
  * bytes (20 bytes of message data and 4 bytes to hold the message length).
+ * xDataLengthBytes must be greater than 0.
  *
  * @param pxHigherPriorityTaskWoken  It is possible that a message buffer will
  * have a task blocked on it waiting for data.  Calling

--- a/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/stream_buffer.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/stream_buffer.h
@@ -539,7 +539,7 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  * into the stream buffer.
  *
  * @param xDataLengthBytes   The maximum number of bytes to copy from pvTxData
- * into the stream buffer.
+ * into the stream buffer.  This value must be greater than 0.
  *
  * @param xTicksToWait The maximum amount of time the task should remain in the
  * Blocked state to wait for enough space to become available in the stream
@@ -640,7 +640,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
  * buffer.
  *
  * @param xDataLengthBytes The maximum number of bytes to copy from pvTxData
- * into the stream buffer.
+ * into the stream buffer.  This value must be greater than 0.
  *
  * @param pxHigherPriorityTaskWoken  It is possible that a stream buffer will
  * have a task blocked on it waiting for data.  Calling

--- a/components/freertos/FreeRTOS-Kernel/include/freertos/message_buffer.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/message_buffer.h
@@ -298,6 +298,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * on a 32-bit architecture, so on most 32-bit architecture setting
  * xDataLengthBytes to 20 will reduce the free space in the message buffer by 24
  * bytes (20 bytes of message data and 4 bytes to hold the message length).
+ * xDataLengthBytes must be greater than 0.
  *
  * @param xTicksToWait The maximum amount of time the calling task should remain
  * in the Blocked state to wait for enough space to become available in the
@@ -389,6 +390,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * on a 32-bit architecture, so on most 32-bit architecture setting
  * xDataLengthBytes to 20 will reduce the free space in the message buffer by 24
  * bytes (20 bytes of message data and 4 bytes to hold the message length).
+ * xDataLengthBytes must be greater than 0.
  *
  * @param pxHigherPriorityTaskWoken  It is possible that a message buffer will
  * have a task blocked on it waiting for data.  Calling

--- a/components/freertos/FreeRTOS-Kernel/include/freertos/stream_buffer.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/stream_buffer.h
@@ -307,7 +307,7 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  * into the stream buffer.
  *
  * @param xDataLengthBytes   The maximum number of bytes to copy from pvTxData
- * into the stream buffer.
+ * into the stream buffer.  This value must be greater than 0.
  *
  * @param xTicksToWait The maximum amount of time the task should remain in the
  * Blocked state to wait for enough space to become available in the stream
@@ -396,7 +396,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
  * buffer.
  *
  * @param xDataLengthBytes The maximum number of bytes to copy from pvTxData
- * into the stream buffer.
+ * into the stream buffer.  This value must be greater than 0.
  *
  * @param pxHigherPriorityTaskWoken  It is possible that a stream buffer will
  * have a task blocked on it waiting for data.  Calling


### PR DESCRIPTION
## Description

Document that `xDataLengthBytes` must be greater than zero for stream-buffer and message-buffer send APIs. The clarification is applied to task and ISR variants in both ESP-IDF FreeRTOS kernel headers.

## Verification

- `git diff --check`
- confirmed all eight send parameter descriptions include the precondition

Closes #18918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to FreeRTOS public headers; no code or behavior changes.
> 
> **Overview**
> Documents that **`xDataLengthBytes` must be greater than 0** for stream-buffer and message-buffer **send** APIs (task and ISR variants).
> 
> The note is added to the `@param xDataLengthBytes` Doxygen blocks in **four** header pairs: `FreeRTOS-Kernel` and `FreeRTOS-Kernel-SMP` trees, in `stream_buffer.h` and `message_buffer.h`. **No runtime or API behavior changes**—only public header documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b792b7c7974d720c087f29cf3a5e691f0bda25b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->