### PR TITLE
fix(esp_https_server): restore use_secure_element initializer in HTTPD_SSL_CONFIG_DEFAULT() (IDFGH-18077)

### DIFF
--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -234,6 +234,7 @@ typedef struct httpd_ssl_config httpd_ssl_config_t;
     .port_secure = 443,                           \
     .port_insecure = 80,                          \
     .session_tickets = false,                     \
+    .use_secure_element = false,                  \
     .user_cb = NULL,                              \
     .ssl_userdata = NULL,                         \
     .cert_select_cb = NULL,                       \


### PR DESCRIPTION

Commit 36090b71611 removed `use_secure_element` from `httpd_ssl_config` and
the `HTTPD_SSL_CONFIG_DEFAULT()` macro, but commit 8fe74703bc9 restored
the `use_secure_element` member _without restoring it to the macro_.

That leaves `HTTPD_SSL_CONFIG_DEFAULT()` failing to initialize that member
of the `httpd_ssl_config` struct.  C tolerates the gap in designated
initializers, but C++ diagnoses it, so C++ builds using the documented default
macro with `-Werror` now fail:

```
esp_https_server.h:243:1: error: missing initializer for member
  'httpd_ssl_config::use_secure_element' [-Werror=missing-field-initializers]
```

This PR restores the initializer, setting it to `false`, in declaration order. The
member is deprecated and non-functional, and `httpd_ssl_start()` returns
`ESP_ERR_NOT_SUPPORTED` if it is set — so nothing changes behaviorally.

`release/v6.0` carries the same gap, through the cherry-picks d93ab71681a1 and
d79940bd3b48, so this fix will need backporting there as well.