### PR TITLE
feat(ppa): Expose blend bypass mode (IDFGH-18079)

### DIFF
--- a/components/esp_driver_ppa/include/driver/ppa.h
+++ b/components/esp_driver_ppa/include/driver/ppa.h
@@ -249,6 +249,7 @@ typedef struct {
     color_pixel_rgb888_data_t fg_ck_rgb_high_thres;/*!< The higher threshold of the color-keying range for the foreground, in RGB888 format */
     color_pixel_rgb888_data_t ck_rgb_default_val;  /*!< The color to overwrite when a pixel, where its background element and foreground element are both within their color-keying ranges, in RGB888 format */
     bool ck_reverse_bg2fg;                         /*!< If this bit is set, in color-keying, for the pixel, where its background element is in the color range, but its foreground element is not in the color range, it will output the foreground element instead of the background element */
+    bool bypass_blend;                             /*!< Bypass blend arithmetic. The background color is forwarded through the output format converter, while an A4/A8 foreground supplies the output alpha */
 
     ppa_trans_mode_t mode;                         /*!< Determines whether to block inside the operation functions, see `ppa_trans_mode_t` */
     void *user_data;                               /*!< User registered data to be passed into `done_cb` callback function */

--- a/components/esp_driver_ppa/src/ppa_blend.c
+++ b/components/esp_driver_ppa/src/ppa_blend.c
@@ -167,7 +167,11 @@ bool ppa_blend_transaction_on_picked(uint32_t num_chans, const dma2d_trans_chann
     ppa_ll_blend_set_ck_default_rgb(platform->hal.dev, (blend_trans_desc->bg_ck_en && blend_trans_desc->fg_ck_en) ? &blend_trans_desc->ck_rgb_default_val : &rgb888_min);
     ppa_ll_blend_enable_ck_fg_bg_reverse(platform->hal.dev, blend_trans_desc->ck_reverse_bg2fg);
 
-    ppa_ll_blend_start(platform->hal.dev, PPA_LL_BLEND_TRANS_MODE_BLEND);
+    ppa_ll_blend_start(
+        platform->hal.dev,
+        blend_trans_desc->bypass_blend
+            ? PPA_LL_BLEND_TRANS_MODE_BYPASS_BLEND
+            : PPA_LL_BLEND_TRANS_MODE_BLEND);
 
     // No need to yield
     return false;

--- a/components/esp_driver_ppa/src/ppa_priv.h
+++ b/components/esp_driver_ppa/src/ppa_priv.h
@@ -173,6 +173,7 @@ typedef struct {
     color_pixel_rgb888_data_t fg_ck_rgb_high_thres;
     color_pixel_rgb888_data_t ck_rgb_default_val;
     bool ck_reverse_bg2fg;
+    bool bypass_blend;
 
     ppa_trans_mode_t mode;
     void *user_data;

--- a/components/esp_driver_ppa/test_apps/main/test_ppa.cpp
+++ b/components/esp_driver_ppa/test_apps/main/test_ppa.cpp
@@ -478,6 +478,22 @@ static void ppa_blend_basic_data_correctness_check(bool auto_light_sleep)
         0xFF, 0xFF, 0xFF, 0xFF, /**/ 0x5B, 0x53, 0x96, 0xD8, /**/
         //                      /*******************************/
     };
+    const uint8_t bypass_in_rgb888_buf[64] __attribute__((aligned(64))) = {
+        0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF,
+        0x80, 0x40, 0xA0,
+    };
+    const uint8_t bypass_in_a8_buf[64] __attribute__((aligned(64))) = {
+        0x00, 0x7F, 0x80, 0xFF,
+    };
+    const uint8_t bypass_out_argb8888_buf_expected[16] = {
+        0xFF, 0xFF, 0xFF, 0x00,
+        0xFF, 0xFF, 0xFF, 0x7F,
+        0xFF, 0xFF, 0xFF, 0x80,
+        0x80, 0x40, 0xA0, 0xFF,
+    };
+    uint8_t bypass_out_argb8888_buf[64] __attribute__((aligned(64))) = {};
 
 #if CONFIG_PM_ENABLE
     enable_pm_strategy(auto_light_sleep);
@@ -557,6 +573,31 @@ static void ppa_blend_basic_data_correctness_check(bool auto_light_sleep)
         }
         printf("\n");
         TEST_ASSERT_EQUAL_UINT8_ARRAY((void *)out_buf_expected, (void *)out_buf, out_buf_len);
+
+        ppa_blend_oper_config_t bypass_oper_config = {};
+        bypass_oper_config.in_bg.buffer = bypass_in_rgb888_buf;
+        bypass_oper_config.in_bg.pic_w = w;
+        bypass_oper_config.in_bg.pic_h = h;
+        bypass_oper_config.in_bg.block_w = w;
+        bypass_oper_config.in_bg.block_h = h;
+        bypass_oper_config.in_bg.blend_cm = PPA_BLEND_COLOR_MODE_RGB888;
+        bypass_oper_config.in_fg.buffer = bypass_in_a8_buf;
+        bypass_oper_config.in_fg.pic_w = w;
+        bypass_oper_config.in_fg.pic_h = h;
+        bypass_oper_config.in_fg.block_w = w;
+        bypass_oper_config.in_fg.block_h = h;
+        bypass_oper_config.in_fg.blend_cm = PPA_BLEND_COLOR_MODE_A8;
+        bypass_oper_config.out.buffer = bypass_out_argb8888_buf;
+        bypass_oper_config.out.buffer_size = sizeof(bypass_out_argb8888_buf);
+        bypass_oper_config.out.pic_w = w;
+        bypass_oper_config.out.pic_h = h;
+        bypass_oper_config.out.blend_cm = PPA_BLEND_COLOR_MODE_ARGB8888;
+        bypass_oper_config.bypass_blend = true;
+        bypass_oper_config.mode = PPA_TRANS_MODE_BLOCKING;
+
+        TEST_ESP_OK(ppa_do_blend(ppa_client_handle, &bypass_oper_config));
+        TEST_ASSERT_EQUAL_UINT8_ARRAY(bypass_out_argb8888_buf_expected, bypass_out_argb8888_buf,
+                                      sizeof(bypass_out_argb8888_buf_expected));
 
         memcpy(in_fg_buf, in_fg_buf_template, 64);
         esp_cache_msync((void *)in_fg_buf, 64, ESP_CACHE_MSYNC_FLAG_DIR_C2M);


### PR DESCRIPTION
### Summary

Expose the existing PPA blend-bypass hardware mode through
`ppa_blend_oper_config_t`.

The HAL already defines `PPA_LL_BLEND_TRANS_MODE_BYPASS_BLEND`, but the public
driver always starts blend transactions with `PPA_LL_BLEND_TRANS_MODE_BLEND`.
This prevents applications from using the blend engine as a hardware format
converter. One useful case is packing an RGB888 background and an A8/A4
foreground into ARGB8888 without modifying the color channels.

### Changes

- Add `bypass_blend` to `ppa_blend_oper_config_t` and its private transaction
  descriptor.
- Select `PPA_LL_BLEND_TRANS_MODE_BYPASS_BLEND` when requested.
- Extend the existing blend correctness test with RGB888 + A8 to ARGB8888
  byte-exact coverage.
- Run the new assertion through the existing automatic light-sleep loop.

### Compatibility

The new field defaults to `false` for zero-initialized configurations, so
existing blend behavior is unchanged. It occupies padding immediately before
`ppa_trans_mode_t` on current targets, preserving the offsets of `mode` and
`user_data`.

### Testing

`ppa_blend_basic_data_correctness_check` passes on an ESP32-P4 revision 1.3.
The test verifies the complete 2 x 2 ARGB8888 output of an RGB888 + A8 bypass
operation, including the existing automatic light-sleep/retention test
configuration.

### AI assistance

This contribution was prepared with assistance from OpenAI Codex. I reviewed
and validated the implementation, tests, and documentation.

### Related

No related issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in API flag with default false; driver only switches an existing HAL blend mode. Risk is limited to callers who explicitly enable bypass for format packing.
> 
> **Overview**
> Adds **`bypass_blend`** to `ppa_blend_oper_config_t` so applications can use the PPA blend engine’s existing hardware bypass path instead of always running full alpha blending.
> 
> When **`bypass_blend`** is true, the driver starts the transaction with **`PPA_LL_BLEND_TRANS_MODE_BYPASS_BLEND`** (background RGB passes through the output converter; A8/A4 foreground supplies alpha), enabling cases such as **RGB888 + A8 → ARGB8888** without changing color channels. The flag is mirrored in the private blend transaction descriptor and defaults to false for zero-initialized configs, so normal blend behavior is unchanged.
> 
> The blend data-correctness test now includes a byte-exact **2×2** bypass case inside the existing loop (including automatic light-sleep/retention coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34ae8feac9a11535b93925dd665031d4f3e8c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->