### PR TITLE
fix(esp_netif): pass address of netif handle in NETIF_PPP_CONNECT_FAILED (IDFGH-18088)

### DIFF
--- a/components/esp_event/host_test/esp_event_unit_test/main/esp_event_test.cpp
+++ b/components/esp_event/host_test/esp_event_unit_test/main/esp_event_test.cpp
@@ -8,6 +8,9 @@
 */
 
 #include <stdio.h>
+#include <string.h>
+#include <deque>
+#include <vector>
 #include "esp_event.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -40,6 +43,94 @@ static esp_event_loop_args_t test_event_get_default_loop_args(void)
 }
 
 void dummy_handler(void* event_handler_arg, esp_event_base_t event_base, int32_t event_id, void* event_data) { }
+
+/*
+ * Minimal in-memory queue backing the mocked FreeRTOS queue primitives.
+ *
+ * The event data tests below need a posted event to survive the round trip from
+ * esp_event_post_to() to esp_event_loop_run(); the *_Ignore mocks used by the
+ * other test cases in this file discard the payload instead. The size of a
+ * queue item is learned from the xQueueGenericCreate() call, so this fake needs
+ * no knowledge of the (private) esp_event_post_instance_t type.
+ */
+size_t s_queue_item_size = 0;
+std::deque<std::vector<uint8_t> > s_queue_items;
+
+QueueHandle_t fake_queue_create(const UBaseType_t, const UBaseType_t item_size, const uint8_t, int)
+{
+    s_queue_item_size = item_size;
+    s_queue_items.clear();
+    return reinterpret_cast<QueueHandle_t>(0xdeadbeef);
+}
+
+BaseType_t fake_queue_send(QueueHandle_t, const void* const item, TickType_t, const BaseType_t, int)
+{
+    const uint8_t* bytes = static_cast<const uint8_t*>(item);
+    s_queue_items.push_back(std::vector<uint8_t>(bytes, bytes + s_queue_item_size));
+    return pdTRUE;
+}
+
+BaseType_t fake_queue_receive(QueueHandle_t, void* const buffer, TickType_t, int)
+{
+    if (s_queue_items.empty()) {
+        return pdFALSE;
+    }
+    memcpy(buffer, s_queue_items.front().data(), s_queue_item_size);
+    s_queue_items.pop_front();
+    return pdTRUE;
+}
+
+/*
+ * Stand-in for an opaque handle type such as esp_netif_t. Only the first member
+ * matters: it is what a caller passing the handle by value (instead of by
+ * address) ends up delivering to the handler.
+ */
+struct fake_handle_obj {
+    void* first_member;
+    uint32_t magic;
+};
+
+void* const FIRST_MEMBER_SENTINEL = reinterpret_cast<void*>(0xA5A5A5A5);
+
+esp_event_base_t const TEST_BASE = "TEST_BASE";
+const int32_t TEST_EVENT_ID = 1;
+
+void* s_delivered_handle = nullptr;
+
+void capture_handle_handler(void*, esp_event_base_t, int32_t, void* event_data)
+{
+    // The documented contract for an event whose data is a handle: the handler
+    // receives a pointer to the handle, so it dereferences once to get it.
+    s_delivered_handle = *static_cast<void**>(event_data);
+}
+
+void install_queue_fakes(void)
+{
+    xQueueGenericCreate_Stub(fake_queue_create);
+    xQueueGenericSend_Stub(fake_queue_send);
+    xQueueReceive_Stub(fake_queue_receive);
+    xQueueCreateMutex_IgnoreAndReturn(reinterpret_cast<QueueHandle_t>(0xfeedface));
+    vQueueDelete_Ignore();
+    xQueueTakeMutexRecursive_IgnoreAndReturn(pdTRUE);
+    xQueueGiveMutexRecursive_IgnoreAndReturn(pdTRUE);
+    xTaskGetCurrentTaskHandle_IgnoreAndReturn(reinterpret_cast<TaskHandle_t>(1));
+    xTaskGetTickCount_IgnoreAndReturn(0);
+    vPortEnterCritical_Ignore();
+    vPortExitCritical_Ignore();
+}
+
+void remove_queue_fakes(void)
+{
+    xQueueCreateMutex_StopIgnore();
+    vQueueDelete_StopIgnore();
+    xQueueTakeMutexRecursive_StopIgnore();
+    xQueueGiveMutexRecursive_StopIgnore();
+    xTaskGetCurrentTaskHandle_StopIgnore();
+    xTaskGetTickCount_StopIgnore();
+    vPortEnterCritical_StopIgnore();
+    vPortExitCritical_StopIgnore();
+    s_queue_items.clear();
+}
 
 }
 
@@ -157,4 +248,76 @@ TEST_CASE("registering with ANY_BASE but specific ID fails")
                                           47,
                                           dummy_handler,
                                           nullptr) == ESP_ERR_INVALID_ARG);
+}
+
+/*
+ * esp_event_post*() treats event_data as the *source address* of the payload and
+ * copies event_data_size bytes out of it. Posting a handle therefore requires
+ * passing the address of the handle variable, not the handle itself.
+ *
+ * Getting this wrong silently delivers the first sizeof(handle) bytes of the
+ * pointed-to object to the handler, which then interprets them as a pointer.
+ * See the NETIF_PPP_CONNECT_FAILED regression fixed alongside these tests.
+ */
+TEST_CASE("posting a handle by address delivers the handle to the handler")
+{
+    CMOCK_SETUP();
+    install_queue_fakes();
+
+    fake_handle_obj obj = { FIRST_MEMBER_SENTINEL, 0x600DF00D };
+    fake_handle_obj* handle = &obj;
+    s_delivered_handle = nullptr;
+
+    esp_event_loop_handle_t loop = nullptr;
+    esp_event_loop_args_t loop_args = test_event_get_default_loop_args();
+    loop_args.task_name = nullptr; // no dedicated task, run the loop inline
+
+    REQUIRE(ESP_OK == esp_event_loop_create(&loop_args, &loop));
+    REQUIRE(ESP_OK == esp_event_handler_register_with(loop, TEST_BASE, TEST_EVENT_ID,
+                                                      capture_handle_handler, nullptr));
+
+    // Correct usage: pass the address of the handle variable.
+    REQUIRE(ESP_OK == esp_event_post_to(loop, TEST_BASE, TEST_EVENT_ID,
+                                        &handle, sizeof(handle), 0));
+    CHECK(ESP_OK == esp_event_loop_run(loop, 0));
+
+    // The handler must receive the handle itself...
+    CHECK(s_delivered_handle == handle);
+    // ...and it must be safe to dereference, unlike the byte pattern the
+    // incorrect form would have produced.
+    CHECK(static_cast<fake_handle_obj*>(s_delivered_handle)->magic == 0x600DF00D);
+
+    CHECK(ESP_OK == esp_event_loop_delete(loop));
+    remove_queue_fakes();
+}
+
+TEST_CASE("posting a handle by value delivers the object's first member instead")
+{
+    CMOCK_SETUP();
+    install_queue_fakes();
+
+    fake_handle_obj obj = { FIRST_MEMBER_SENTINEL, 0x600DF00D };
+    fake_handle_obj* handle = &obj;
+    s_delivered_handle = nullptr;
+
+    esp_event_loop_handle_t loop = nullptr;
+    esp_event_loop_args_t loop_args = test_event_get_default_loop_args();
+    loop_args.task_name = nullptr;
+
+    REQUIRE(ESP_OK == esp_event_loop_create(&loop_args, &loop));
+    REQUIRE(ESP_OK == esp_event_handler_register_with(loop, TEST_BASE, TEST_EVENT_ID,
+                                                      capture_handle_handler, nullptr));
+
+    // Incorrect usage, kept here to pin down the failure mode: the handle is
+    // passed by value, so sizeof(handle) bytes are copied *from the object*.
+    REQUIRE(ESP_OK == esp_event_post_to(loop, TEST_BASE, TEST_EVENT_ID,
+                                        handle, sizeof(handle), 0));
+    CHECK(ESP_OK == esp_event_loop_run(loop, 0));
+
+    // The handler gets obj.first_member reinterpreted as a handle - garbage.
+    CHECK(s_delivered_handle == FIRST_MEMBER_SENTINEL);
+    CHECK(s_delivered_handle != handle);
+
+    CHECK(ESP_OK == esp_event_loop_delete(loop));
+    remove_queue_fakes();
 }

--- a/components/esp_netif/lwip/esp_netif_lwip_ppp.c
+++ b/components/esp_netif/lwip/esp_netif_lwip_ppp.c
@@ -308,7 +308,7 @@ esp_err_t esp_netif_start_ppp(esp_netif_t *esp_netif)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "%s: PPP connection cannot be started", __func__);
         if (ppp_ctx->ppp_error_event_enabled) {
-            esp_event_post(NETIF_PPP_STATUS, NETIF_PPP_CONNECT_FAILED, esp_netif, sizeof(esp_netif), 0);
+            esp_event_post(NETIF_PPP_STATUS, NETIF_PPP_CONNECT_FAILED, &esp_netif, sizeof(esp_netif), 0);
         }
         return ESP_FAIL;
     }


### PR DESCRIPTION
## What

`NETIF_PPP_CONNECT_FAILED` delivers a corrupted `event_data` to subscribers. This passes the address of the netif handle instead of the handle itself, and adds host-side tests covering the underlying event-data contract.

Fixes #15386.

## Why

`esp_event_post()` treats `event_data` as the **source address** of the payload and copies `event_data_size` bytes out of it:

```c
/* components/esp_event/esp_event.c */
memcpy(post.data.ptr, event_data, event_data_size);      /* CONFIG_ESP_EVENT_POST_FROM_ISR */
memcpy(event_data_copy, event_data, event_data_size);    /* default path */
```

So delivering a handle requires passing the address of the handle variable. `esp_netif_start_ppp()` passed the handle by value:

```c
esp_event_post(NETIF_PPP_STATUS, NETIF_PPP_CONNECT_FAILED, esp_netif, sizeof(esp_netif), 0);
```

This copies the first `sizeof(esp_netif_t *)` bytes **of the `esp_netif_t` struct**. A handler doing the documented `*(esp_netif_t **)event_data` gets struct contents reinterpreted as a pointer — a wild pointer, not the netif handle.

### Internal-consistency evidence

The same file already posts a netif handle correctly in both of its other `NETIF_PPP_STATUS` call sites:

| Location | Call | |
|---|---|---|
| `esp_netif_lwip_ppp.c:113` | `esp_event_post(NETIF_PPP_STATUS, err_code, &netif, sizeof(netif), 0)` | correct |
| `esp_netif_lwip_ppp.c:166` | `esp_event_post(NETIF_PPP_STATUS, NETIF_PP_PHASE_OFFSET + phase, &netif, sizeof(netif), 0)` | correct |
| `esp_netif_lwip_ppp.c:311` | `esp_event_post(NETIF_PPP_STATUS, NETIF_PPP_CONNECT_FAILED, esp_netif, sizeof(esp_netif), 0)` | **outlier** |

Every other `esp_event_post()` call across `esp_netif` likewise passes an address (`&evt`, `&netif`). That makes line 311 an oversight rather than intentional behaviour, and `git log -S` confirms it has never been corrected on `master`.

Credit for the original report and the one-character diff goes to @gonzzor.

## Tests

Added two cases to the existing `components/esp_event/host_test` app (Catch2, `linux` target). Nothing there previously exercised `event_data` payload delivery, so the contract was untested. The cases back the mocked FreeRTOS queue with a small in-memory fake so a posted event survives the round trip from `esp_event_post_to()` to `esp_event_loop_run()`; the queue item size is taken from the mocked `xQueueGenericCreate()` call, so no private `esp_event` types are needed.

```
$ ./build/test_esp_event_host.elf
All tests passed (26 assertions in 9 test cases)
```

The two new cases demonstrate the corruption mechanism directly:

```
posting a handle by address delivers the handle to the handler
  CHECK( s_delivered_handle == handle )
with expansion:
  0x00007ffc096c19f0 == 0x00007ffc096c19f0

posting a handle by value delivers the object's first member instead
  CHECK( s_delivered_handle == FIRST_MEMBER_SENTINEL )
with expansion:
  0x00000000a5a5a5a5 == 0x00000000a5a5a5a5
```

### Testing caveats

Stated plainly:

- The new tests cover the **`esp_event` data-pointer contract that the fix depends on**. They do not execute `esp_netif_lwip_ppp.c` itself, so they would not fail if line 311 regressed. I did not find a host-testable harness for `esp_netif`; adding one was out of scope here.
- The end-to-end `NETIF_PPP_CONNECT_FAILED` path was **not exercised on hardware** — I have no PPP modem available. The fix itself is verified by inspection against the `esp_event_post()` contract and the file's own internal convention.
- Verified on the `linux` target only. The change is a single argument in target-independent code.

## Checklist

- [x] Change is my own work / Apache-2.0 compatible
- [x] Follows the ESP-IDF style guide; `pre-commit` passes clean (`astyle formatter`, `Check copyright notices`, `codespell` all pass, no files rewritten)
- [x] Single logical change in one commit
- [x] No API, ABI, or Kconfig changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument fix in error-path event posting; aligns with existing conventions and is covered by new contract tests, with no API or ABI changes.
> 
> **Overview**
> Fixes **`NETIF_PPP_CONNECT_FAILED`** so subscribers receive a valid netif handle: `esp_event_post()` now gets **`&esp_netif`** instead of the handle value, matching the other `NETIF_PPP_STATUS` posts in the same file and `esp_event_post()`’s copy-from-source contract.
> 
> Adds **host-side Catch2 coverage** in `esp_event` tests with an in-memory fake FreeRTOS queue so posted payloads survive `esp_event_post_to()` → `esp_event_loop_run()`. Two cases assert correct handle delivery when posting **`&handle`**, and the wrong-by-value path that copies the object’s first member as a bogus pointer (the failure mode this PPP bug exhibited).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63aa463a2b6e37cf37676065dfaa65ac1bd0e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->