### PR TITLE
docs(freertos): document MutexHolderFromISR SMP operation (IDFGH-18091)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/semphr.h
+++ b/components/freertos/FreeRTOS-Kernel-SMP/include/freertos/semphr.h
@@ -1161,6 +1161,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
  * by a task), return NULL.
  *
+ * Note: On SMP systems, the return value may be invalidated by other core(s).
  */
 #if ( ( configUSE_MUTEXES == 1 ) && ( INCLUDE_xSemaphoreGetMutexHolder == 1 ) )
     #define xSemaphoreGetMutexHolderFromISR( xSemaphore )    xQueueGetMutexHolderFromISR( ( xSemaphore ) )

--- a/components/freertos/FreeRTOS-Kernel/include/freertos/semphr.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/semphr.h
@@ -1062,6 +1062,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
  * by a task), return NULL.
  *
+ * Note: On SMP systems, the return value may be invalidated by other core(s).
  */
 #if __DOXYGEN__ || ( ( configUSE_MUTEXES == 1 ) && ( INCLUDE_xSemaphoreGetMutexHolder == 1 ) )
     #define xSemaphoreGetMutexHolderFromISR( xSemaphore )    xQueueGetMutexHolderFromISR( ( xSemaphore ) )


### PR DESCRIPTION
## Description

Add documentation guidance for `xSemaphoreGetMutexHolderFromISR()` and `xSemaphoreGetMutexHolderFromISR()` during SMP operation. These functions are reliable on unicore systems but racy on SMP systems.

## Related

Addresses #18913 

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
