### PR TITLE
ci(docker): shallow clone IDF for tag-pinned images (IDFGH-18100)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "CLONE_BRANCH_OR_TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
           echo "TAG_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          echo "CLONE_SHALLOW=1" >> $GITHUB_ENV
       - name: Set variables (release branches)
         if: ${{ github.ref_type == 'branch' && startsWith(github.ref_name, 'release/') }}
         run: |
@@ -52,6 +53,7 @@ jobs:
           echo "CLONE_BRANCH_OR_TAG: $CLONE_BRANCH_OR_TAG"
           echo "CHECKOUT_REF: $CHECKOUT_REF"
           echo "TAG_NAME: $TAG_NAME"
+          echo "CLONE_SHALLOW: $CLONE_SHALLOW"
 
       # The following steps are the standard boilerplate from
       # https://github.com/marketplace/actions/build-and-push-docker-images
@@ -76,6 +78,7 @@ jobs:
           build-args: |
             IDF_CLONE_URL=${{ github.server_url }}/${{ github.repository }}.git
             IDF_CLONE_BRANCH_OR_TAG=${{ env.CLONE_BRANCH_OR_TAG }}
+            IDF_CLONE_SHALLOW=${{ env.CLONE_SHALLOW }}
 
       - name: Update Docker Hub repository description (master branch)
         if: ${{ github.ref_type == 'branch' && github.ref_name == 'master' }}


### PR DESCRIPTION
> **Edit:** an earlier version of this description claimed a tag-pinned image "can never move off its tag" and that its history "can't be used for anything". That was wrong — see *What this costs* below. The change is a trade-off, not a free win, and I've rewritten this to say so.

## What this changes

`tools/docker/Dockerfile` already supports `IDF_CLONE_SHALLOW` (and documents it) — the publish workflow just never passes it. This sets it **for tag builds only**; `release/*` and `master` images keep the full clone.

Because the Dockerfile uses `${IDF_CLONE_SHALLOW:+...}`, leaving the variable empty on branch builds is already the "full clone" path, so branch images are unaffected.

## Why

`espressif/idf:v6.0.2` is 9.61 GB unpacked and 3.3 GB of that is ESP-IDF's own git history:

```
/opt/esp/idf          3.8G
  └─ .git             3.3G
  └─ components       441M
/opt/esp/tools        4.4G
/opt/esp/python_env    98M
```

That costs real wall-clock on every pull, because a `docker pull` on a CI runner is dominated by layer decompression rather than download. In one of our runs every layer had finished downloading 25s in, and the last `Pull complete` landed at 118s:

| layer | compressed | extract |
|---|---:|---:|
| `ubuntu:24.04` | 29.7 MB | 6.7s |
| apt deps | 260.1 MB | 31.5s |
| `build-essential` | 21.5 MB | 0.8s |
| **git clone** | **3533.6 MB** | **31.4s** |
| `idf_tools` install | 1429.6 MB | 47.4s |

## What this costs

A full clone at a tag is **not** pinned to that tag. `git clone -b v6.0.2` without `--depth` fetches every ref and merely *checks out* the tag, so the current image genuinely can move between revisions offline. Measured inside `espressif/idf:v6.0.2`:

```
commits in history : 50774
tags available     : 185
remote branches    : 26
is shallow         : false
git checkout v5.4  : SUCCESS (offline)
```

After this change that becomes 1 commit, 1 tag, 0 remote branches, and `git checkout v5.4` fails. Recovery is not cheap either — `git fetch --unshallow` took ~113s in my test, restored 50774 commits but only 32 of the 185 tags, and still didn't make `git checkout v5.4` work, because `--depth` implies `--single-branch` and the refspec never widens.

So this trades in-image access to other IDF revisions for ~3.3 GB and ~31s off every pull.

## Why I think the trade is worth making — though it's your call

- ESP-IDF publishes a Docker tag per version, so the normal way to get v5.4 is `docker pull espressif/idf:v5.4` rather than checking it out inside a v6.0.2 image.
- The Dockerfile already exposes `IDF_CHECKOUT_REF` for building an image at a specific commit, which covers the "I need an exact revision" case at build time.
- `release/*` and `master` images keep full history under this change — those are the ones where moving between revisions in-image seems most plausible.

If the in-image history is worth more than the pull cost, an additional `-slim` tag would give CI users the win without changing the default. Happy to rework it that way.

## Verification

Built `v6.0.2` both ways on linux/amd64:

| | size |
|---|---:|
| current | 9.61 GB |
| `+ IDF_CLONE_SHALLOW=1` | **6.02 GB** |

- `/opt/esp/idf/.git`: 3.3 GB → 142 MB
- `git describe --tags` still returns `v6.0.2`, so the version IDF stamps into `esp_app_desc` is unchanged
- A real ESP32-S3 project (`idf.py build`) produces the same firmware: the two `.bin` files differ by **73 bytes**, all of it the build timestamp and the ELF SHA-256 in the app descriptor

One note for anyone doing this downstream: the submodule git metadata has to stay. Stripping `.git/modules` breaks `git_submodule_check` at cmake configure time, because git then sees populated-but-uninitialised submodules. The plain `--recursive --depth=1 --shallow-submodules` clone the Dockerfile already does is fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change for tag builds; branch images are unaffected and the Dockerfile already supported the flag.
> 
> **Overview**
> **Tag-published Docker images** (`v*.*`) now pass `IDF_CLONE_SHALLOW=1` into the existing `tools/docker` build, enabling the Dockerfile’s shallow `--depth=1` clone path that was already documented but unused in CI.
> 
> **`release/*` and `master` builds are unchanged** — they never set `CLONE_SHALLOW`, so `IDF_CLONE_SHALLOW` stays empty and images still get a full IDF git history. The workflow only adds env wiring for tag runs, logs `CLONE_SHALLOW` in the check step, and forwards it as the `IDF_CLONE_SHALLOW` build-arg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5722ad44ae98fdc266c36cfe22f05a3cab79d89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->