### PR TITLE
ci(docker): publish image layers with zstd compression (IDFGH-18099)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,10 @@ jobs:
           push: true
           tags: ${{ env.DOCKERHUB_REPO }}:${{ env.TAG_NAME }}
           platforms: ${{ env.BUILD_PLATFORMS }}
+          # Pulling this image is bound by layer decompression, not by download.
+          # zstd decompresses ~5x faster than gzip and is ~13% smaller on this
+          # image's contents, so it cuts pull time without removing anything.
+          outputs: type=image,compression=zstd,force-compression=true,oci-mediatypes=true
           build-args: |
             IDF_CLONE_URL=${{ github.server_url }}/${{ github.repository }}.git
             IDF_CLONE_BRANCH_OR_TAG=${{ env.CLONE_BRANCH_OR_TAG }}


### PR DESCRIPTION
## Problem

Pulling `espressif/idf` on a CI runner is bound by layer **decompression**, not by network. From one of our GitHub Actions runs pulling `espressif/idf:v6.0.2`:

- all 8 layers reported `Download complete` by **25s**
- the last `Pull complete` landed at **118s**

So roughly **93 of those 118 seconds were gzip decompression** of a 9.61 GB image. Nothing about that is specific to our project — it's paid by every CI job that pulls this image.

## Change

Publish the OCI layers compressed with zstd instead of gzip.

## Measurement

Benchmarked on real image content — `/opt/esp/tools/xtensa-esp-elf` taken straight out of `espressif/idf:v6.0.2`, 1160.7 MB uncompressed — single-threaded decompression, 3 runs each:

| | compressed size | decompress |
|---|---:|---|
| `gzip -6` | 333.8 MB | 6s / 5s / 6s |
| `zstd -3` | **289.3 MB** | **1s / 1s / 1s** |

zstd is roughly **5× faster to decompress and ~13% smaller** on this content. Extrapolating to the full image, the ~93s decompression above should fall to somewhere around 15–20s, with nothing removed from the image and no change to what it contains.

This also composes with any size reduction rather than competing with it.

## Compatibility — the reason to weigh this rather than just merge it

zstd layers are emitted as `application/vnd.oci.image.layer.v1.tar+zstd` with OCI media types, so **Docker clients older than 23.0 cannot pull them**. For a base image with this much reach that may be too aggressive as a blanket change. If so, the same benefit is available to CI users via an additional tag (e.g. a `-zstd` variant) rather than switching the default.

I don't have visibility into your Docker Hub tooling, so that trade-off is yours to make — happy to rework this into a separate tag if you'd prefer.

## Verification

I validated the `outputs:` syntax locally against an OCI registry (not Docker Hub) before proposing it:

```
layer: application/vnd.oci.image.layer.v1.tar+zstd  27.3 MB
layer: application/vnd.oci.image.layer.v1.tar+zstd  67.1 MB
```

and confirmed a stock `docker pull` + `docker run` of the result works. I also checked that keeping `push: true` / `tags:` alongside `outputs:` behaves correctly, which is why this is a one-line addition rather than a rewrite of the step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the default published image is encoded; older Docker clients cannot pull zstd layers, which may affect some downstream users of `espressif/idf`.
> 
> **Overview**
> The Docker **build and push** step now sets `outputs: type=image,compression=zstd,force-compression=true,oci-mediatypes=true` so published `espressif/idf` layers use **zstd** instead of the default **gzip**, with short inline comments explaining the pull-time rationale.
> 
> This is intended to speed up CI pulls (decompression-bound on large layers) without changing image contents. **Docker clients before 23.0** cannot pull zstd OCI layers—a compatibility trade-off called out in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5db7f512c259555cdda83dc3dc8aae6a84f97fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->