### PR TITLE
freertos: yield immediately after unicore self deletion (IDFGH-18104)

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/tasks.c
+++ b/components/freertos/FreeRTOS-Kernel/tasks.c
@@ -1472,7 +1472,12 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 if( xSelfDelete == pdTRUE )
                 {
                     configASSERT( taskIS_SCHEDULER_SUSPENDED() == pdFALSE );
-                    portYIELD_WITHIN_API();
+
+                    #if ( configNUMBER_OF_CORES == 1 )
+                        portYIELD();
+                    #else
+                        portYIELD_WITHIN_API();
+                    #endif
                 }
                 else
                 {


### PR DESCRIPTION
### Description
Fix a failure where a task deleting itself can continue executing long enough to return from its task entry function in a unicore Xtensa build.

In the current self-delete path, vTaskDelete() calls portYIELD_WITHIN_API(). On the Xtensa port, this requests a yield through the cross-core interrupt mechanism and then it returns. In a unicore Clang -O2 build, the deleted task can return from vTaskDelete() and subsequently return from its entry function before the pending yield interrupt is serviced, resulting in an IllegalInstruction panic.

For unicore builds, portYIELD() should be used instead. This performs the intended context switch immediately and does not return through the deleted task’s execution path.

The existing portYIELD_WITHIN_API() behavior is preserved for multicore builds, where the code executes inside the SMP-only kernel critical section and the yield must remain deferred.

This fixes #18460.

### Testing
Tested on ESP32-S3 with ESP-IDF v6.0 and an AITRIP ESP32-S3-DevKitC-1-N8R2.

### Test results

**Clang 20.1.1, -O2, unicore, original code**
Result: IllegalInstruction

**Clang 20.1.1, -O2, unicore, patched**
Result: Pass

**Clang 20.1.1, -Og, unicore, patched**
Result: Pass

**GCC, -O2, unicore, patched**
Result: Pass

**Clang 20.1.1, -O2, dual-core, patched**
Result: Build pass

**Official FreeRTOS "FreeRTOS Delete Tasks" test, GCC -O2, unicore, patched**
Result: Pass
        

The official FreeRTOS deletion test completed with:

FreeRTOS Delete Tasks:PASS
1 Tests 0 Failures 0 Ignored


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduler yield behavior on the task self-delete path in the kernel, but only for unicore builds and multicore behavior is unchanged.
> 
> **Overview**
> Fixes a unicore bug where a task that deletes itself could keep running after `vTaskDelete()` and return from its entry function before a deferred yield runs (e.g. Xtensa Clang `-O2`), causing an **IllegalInstruction** panic.
> 
> In the self-delete reschedule path in `tasks.c`, **`portYIELD()`** is used when `configNUMBER_OF_CORES == 1` so the context switch happens immediately instead of via **`portYIELD_WITHIN_API()`**. Multicore builds still use **`portYIELD_WITHIN_API()`** so yield stays deferred while inside the SMP-only kernel critical section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7298f57dbd10ba7ce816f7977c2e148f0daddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->