### PR TITLE
Fix default value type of BT_NIMBLE_MESH_PROVISIONER (IDFGH-18121)

### DIFF
--- a/components/bt/host/nimble/Kconfig.in
+++ b/components/bt/host/nimble/Kconfig.in
@@ -1460,7 +1460,7 @@ menu "NimBLE Mesh"
 
     config BT_NIMBLE_MESH_PROVISIONER
         bool "Enable BLE mesh provisioner"
-        default 0
+        default n
         depends on BT_NIMBLE_MESH
         help
             Enable mesh provisioner.


### PR DESCRIPTION
## Description

Fixes compiler warning:
```
BT_NIMBLE_MESH_PROVISIONER: 'default 0' is not a valid bool value (only 'y' and 
'n' are allowed). Value is treated as 'n'.
```

Functionality unchanged, just the format of the default is aligned with the type of the value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kconfig-only syntax fix; mesh provisioner default remains off and no runtime code paths change.
> 
> **Overview**
> Updates **`BT_NIMBLE_MESH_PROVISIONER`** in `components/bt/host/nimble/Kconfig.in` so its default is **`default n`** instead of **`default 0`**, which is invalid for a `bool` Kconfig symbol.
> 
> This removes the Kconfig warning that `0` is not allowed for bools (only `y`/`n`); the option still defaults to disabled, matching the prior effective behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d03b774ed0cb2c725a947b761d96c6f9618c711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->