### PR TITLE
Fix default value type of FATFS_PRINT_LLI and FATFS_PRINT_FLOAT (IDFGH-18122)

### DIFF
--- a/components/fatfs/Kconfig
+++ b/components/fatfs/Kconfig
@@ -240,12 +240,12 @@ menu "FAT Filesystem support"
     config FATFS_PRINT_LLI
         depends on !FATFS_USE_STRFUNC_NONE
         bool "Make fatfs f_printf() support long long argument"
-        default 0
+        default n
 
     config FATFS_PRINT_FLOAT
         depends on !FATFS_USE_STRFUNC_NONE
         bool "Make fatfs f_printf() support floating point argument"
-        default 0
+        default n
 
     choice FATFS_STRF_ENCODE_CHOICE
         prompt "FatFS string functions: convert character encoding"


### PR DESCRIPTION
## Description

Fixes compiler warning:
```
FATFS_PRINT_LLI: 'default 0' is not a valid bool value (only 'y' and 'n' are 
allowed). Value is treated as 'n'.
```
and
```
FATFS_PRINT_FLOAT: 'default 0' is not a valid bool value (only 'y' and 'n' are 
allowed). Value is treated as 'n'.
```

Functionality unchanged, just the format of the defaults are aligned with the type of the value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kconfig-only default syntax fix with no functional or build logic changes beyond silencing warnings.
> 
> **Overview**
> Fixes Kconfig warnings for **`FATFS_PRINT_LLI`** and **`FATFS_PRINT_FLOAT`** in `components/fatfs/Kconfig` by changing their defaults from **`default 0`** to **`default n`**, which is the correct syntax for `bool` options.
> 
> Runtime behavior is unchanged: Kconfig already treated `0` as disabled (`n`), and `ffconf.h` still maps these symbols to `FF_PRINT_LLI` / `FF_PRINT_FLOAT` the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4188ab1026a5e59301ba9260edfd854746a891f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->