### PR TITLE
fix(spi_flash): busy-wait instead of vTaskDelay when yield disabled (IDFGH-18129)

### DIFF
--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -339,7 +339,9 @@ static esp_err_t spi_flash_os_check_yield(void *arg, uint32_t chip_status, uint3
 static esp_err_t spi_flash_os_yield(void *arg, uint32_t* out_status)
 {
     if (likely(xTaskGetSchedulerState() == taskSCHEDULER_RUNNING)) {
-#ifdef CONFIG_SPI_FLASH_ERASE_YIELD_TICKS
+#ifndef CONFIG_SPI_FLASH_YIELD_DURING_ERASE
+        esp_rom_delay_us(pdTICKS_TO_MS(1) * 1000);
+#elif CONFIG_SPI_FLASH_ERASE_YIELD_TICKS
         vTaskDelay(CONFIG_SPI_FLASH_ERASE_YIELD_TICKS);
 #else
         vTaskDelay(1);


### PR DESCRIPTION
## Description

When `CONFIG_SPI_FLASH_YIELD_DURING_ERASE` is disabled, `spi_flash_os_yield()` still
called `vTaskDelay()`, forcing a blocking task context switch even though yielding during
erase was explicitly turned off.

This change keeps that wait but replaces `vTaskDelay()` when `CONFIG_SPI_FLASH_YIELD_DURING_ERASE` is disabled with a one-tick busy-wait via `esp_rom_delay_us()`, matching the duration of the previous `vTaskDelay(1)`

## Testing

- ESP-WROOM-32UE module (ESP32), RTOS scheduler running, `CONFIG_SPI_FLASH_YIELD_DURING_ERASE=n`.
  Triggered a large flash erase right after the cyclic-write wear-level guards were exhausted;
  verified the erase completes correctly and the watchdog does not fire.
- Build check of `components/spi_flash/test_apps/no_flash_delay` (uses `CONFIG_SPI_FLASH_YIELD_DURING_ERASE=n`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SPI flash erase timing/scheduling for the no-yield config path, which can affect watchdog behavior during long erases. Scope is small and limited to that non-default setting.
> 
> **Overview**
> Fixes `spi_flash_os_yield()` so that with **`CONFIG_SPI_FLASH_YIELD_DURING_ERASE` disabled**, it no longer forces a FreeRTOS context switch via `vTaskDelay()`.
> 
> It now uses a one-tick **`esp_rom_delay_us()`** busy-wait instead, matching the previous delay duration while honoring the no-yield setting. When yield is enabled, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec592dc2acbcf0cdf1a9b64a04320f0e8b29376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->