### PR TITLE
docs(esp_eth): drop unreachable return code from esp_eth_phy_802_3_reset_hw (IDFGH-18139)

### DIFF
--- a/components/esp_eth/include/esp_eth_phy_802_3.h
+++ b/components/esp_eth/include/esp_eth_phy_802_3.h
@@ -205,7 +205,6 @@ esp_err_t esp_eth_phy_802_3_del(phy_802_3_t *phy_802_3);
  * @param phy_802_3 IEEE 802.3 PHY object infostructure
  * @return
  *      - ESP_OK: reset Ethernet PHY successfully
- *      - ESP_ERR_NOT_ALLOWED: reset GPIO not defined
  */
 esp_err_t esp_eth_phy_802_3_reset_hw(phy_802_3_t *phy_802_3);
 


### PR DESCRIPTION
## Description

`esp_eth_phy_802_3_reset_hw()` documents a return code it cannot return. This deletes that one documentation line; no code changes.

The documented promise, `components/esp_eth/include/esp_eth_phy_802_3.h:208`:

```
 *      - ESP_ERR_NOT_ALLOWED: reset GPIO not defined
```

The implementation, `components/esp_eth/src/phy/esp_eth_phy_802_3.c:487-507`:

```c
esp_err_t esp_eth_phy_802_3_reset_hw(phy_802_3_t *phy_802_3)
{
    esp_err_t ret = ESP_OK;
    if (phy_802_3->reset_gpio_num >= 0) {
        /* ... GPIO toggling and delays ... */
        return ESP_OK;
    }

    return ret;
}
```

`ret` is assigned once, at `esp_eth_phy_802_3.c:489`, and no statement between there and `esp_eth_phy_802_3.c:506` assigns to it. So the `reset_gpio_num < 0` case — the case the deleted line describes — returns `ESP_OK` from line 506.

`ESP_ERR_NOT_ALLOWED` is defined at `components/esp_common/include/esp_err.h:37`. `git grep ESP_ERR_NOT_ALLOWED -- components/esp_eth` returns exactly one hit: `esp_eth_phy_802_3.h:208`, the line this PR deletes. No source file in the component mentions it.

### Which side is wrong

`components/esp_eth/include/esp_eth_phy.h:280` documents `reset_gpio_num` as `-1 means no hardware reset`, which reads as a supported configuration rather than a misuse. On that reading the code is right and this doc line is the remains of an intention that was dropped, so I have changed only the comment. If it is the other way round — if `esp_eth_phy_802_3_reset_hw()` is meant to return `ESP_ERR_NOT_ALLOWED` when no reset GPIO is configured — then this patch is the wrong fix and the change belongs at `esp_eth_phy_802_3.c:506` instead. Please contradict me if that is the case and I will send that version instead.

One wording point I have deliberately left alone: after this deletion the remaining `ESP_OK: reset Ethernet PHY successfully` at `esp_eth_phy_802_3.h:207` still covers the `reset_gpio_num < 0` path, where no reset is performed. I am happy to reword it in this PR if you would prefer that.

### Not built, not run

Nothing in this PR was compiled or executed. Every claim above is a claim about the text of the named files at the lines cited, read at master `08e0d30a74ad0bfd5a34933142b80f45619ee410`.

### Spotted, not fixed

Two more of the same shape, found while reading and deliberately kept out of this diff:

- `components/esp_driver_sdmmc/include/esp_private/sd_host_private.h:281-284` documents a full `esp_err_t` return contract above the `void sd_host_slot_enable_clk_cmd11(...)` declaration at line 286; the block is a copy of the `esp_err_t` function at line 273.
- `components/esp_eth/include/esp_eth_clock.h:36` documents `@param clk_id` while the parameter is named `clock_id` at line 43; the next function in the same file writes `@param clock_id` correctly at line 48.

Happy to send either as its own PR if you want them. I have not changed them here.

## Related

No related issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header comment-only change with no behavioral impact.
> 
> **Overview**
> Removes a **stale `@return` bullet** from `esp_eth_phy_802_3_reset_hw()` in `esp_eth_phy_802_3.h` so the header matches behavior: the function never returns `ESP_ERR_NOT_ALLOWED` when no reset GPIO is configured (`reset_gpio_num < 0` still returns `ESP_OK`).
> 
> **No runtime or API code changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cca03943041339635e96714cf519c7a53e5f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->