### PR TITLE
docs(sdmmc): drop esp_err_t doc from void sd_host_slot_enable_clk_cmd11 (IDFGH-18141)

### DIFF
--- a/components/esp_driver_sdmmc/include/esp_private/sd_host_private.h
+++ b/components/esp_driver_sdmmc/include/esp_private/sd_host_private.h
@@ -277,11 +277,6 @@ esp_err_t sd_host_slot_set_cclk_always_on_internal(sd_host_sdmmc_slot_t *slot, b
  *
  * @param[in] slot       SD Host Slot handle
  * @param[in] enable     enable or not
- *
- * @return
- *        - ESP_OK:              On success
- *        - ESP_ERR_INVALID_ARG: Invalid arguments
- *        - ESP_ERR_NOT_FOUND:   Command not found
  */
 void sd_host_slot_enable_clk_cmd11(sd_host_sdmmc_slot_t *slot, bool enable);
 


### PR DESCRIPTION
## Description

`sd_host_slot_enable_clk_cmd11()` is declared `void`, but its doxygen block documents three `esp_err_t` return codes. This deletes those five comment lines; no code changes.

Every line number below is the one at master `08e0d30a74ad0bfd5a34933142b80f45619ee410`, before this patch.

`components/esp_driver_sdmmc/include/esp_private/sd_host_private.h:275-286`:

```c
/**
 * @brief Enable clock and cmd11 mode
 *
 * @param[in] slot       SD Host Slot handle
 * @param[in] enable     enable or not
 *
 * @return
 *        - ESP_OK:              On success
 *        - ESP_ERR_INVALID_ARG: Invalid arguments
 *        - ESP_ERR_NOT_FOUND:   Command not found
 */
void sd_host_slot_enable_clk_cmd11(sd_host_sdmmc_slot_t *slot, bool enable);
```

The declaration at `sd_host_private.h:286` is `void`, and the definition at `components/esp_driver_sdmmc/src/sd_host_sdmmc.c:836` is `void` too.

The four documented codes at `sd_host_private.h:281-284` are byte-identical to `sd_host_private.h:268-271`, which document the real `esp_err_t sd_host_slot_set_cclk_always_on_internal()` declared at `sd_host_private.h:273`, directly above — the two four-line extracts compare equal with `cmp`. The block reads as a copy that came down with the `@param` lines while the return type did not.

The rest of the header agrees with the deletion: it declares 16 functions, 5 of them `void`, and `sd_host_slot_enable_clk_cmd11` at line 286 is the only `void` one carrying `@return`. The other four — `sd_host_fill_dma_descriptors` at line 307, `sd_host_dma_stop` at line 314, `sd_host_dma_resume` at line 321, `sd_host_dma_prepare` at line 331 — document `@brief` and `@param` only. All 11 non-`void` declarations do carry `@return`.

### Which side is wrong

The body at `sd_host_sdmmc.c:836-841` calls `sd_host_slot_clock_update_command(slot, true)` at `sd_host_sdmmc.c:839` and discards its result; that function is `static esp_err_t`, declared at `sd_host_sdmmc.c:51` and defined at `sd_host_sdmmc.c:1005`. So you may well decide the signature is what is wrong here and not the comment, in which case this patch is the wrong fix — please say so and I will send that one instead.

I have not made that change myself because it is not a one-liner: both call sites, `components/esp_driver_sdmmc/src/sd_trans_sdmmc.c:57` and `:68`, are inside `static void handle_voltage_switch_stage2()` at `sd_trans_sdmmc.c:54`, which is itself `void`. It does have somewhere to put an error — it assigns the voltage-switch callback's failure to `cmd->error` at `sd_trans_sdmmc.c:63` — but routing a clock-update failure there is a behaviour change and a decision for you, not a documentation fix.

### Not built, not run

Nothing here was compiled or executed. No target hardware, no simulator, no test run. Every statement above is a statement about the text of three files at the lines named, read at master `08e0d30a74ad0bfd5a34933142b80f45619ee410`. That the deletion cannot change any compiled artefact is an argument about doxygen, not a measurement I made.

### Spotted, not fixed

`components/esp_eth/include/esp_eth_clock.h:36` documents `@param clk_id`, but the parameter is named `clock_id` in the declaration at `esp_eth_clock.h:43` — `int esp_eth_clock_set_target_time(clockid_t clock_id, struct timespec *tp);`. The next function in the same file gets it right, `@param clock_id` at `esp_eth_clock.h:48`, so the file contradicts itself. I have not touched it here: it is in `esp_eth` rather than `esp_driver_sdmmc`, and it wants its own branch. Happy to send it as a separate PR whenever you want it.

## Related

#18972 is the same kind of one-line documentation fix, in `components/esp_eth`. No code dependency between the two.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a private header; no compiled code or behavior is affected.
> 
> **Overview**
> Removes the **@return** block (and its `ESP_OK` / `ESP_ERR_*` lines) from the Doxygen for `sd_host_slot_enable_clk_cmd11` in `sd_host_private.h`, so the comment matches the **`void`** declaration and implementation. No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1730d793d88011556f7c6e8d49cfed053be42ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->