### PR TITLE
docs(esp_eth): fix @param name in esp_eth_clock_set_target_time (IDFGH-18146)

### DIFF
--- a/components/esp_eth/include/esp_eth_clock.h
+++ b/components/esp_eth/include/esp_eth_clock.h
@@ -33,7 +33,7 @@ typedef struct {
 /**
  * @brief Set the target time for the PTP clock.
  *
- * @param clk_id Identifier of the clock to set the target time for
+ * @param clock_id Identifier of the clock to set the target time for
  * @param tp Pointer to the target time
  *
  * @return


### PR DESCRIPTION
## Description

The doxygen block for `esp_eth_clock_set_target_time()` documents a parameter the function does not have. One word changed, no code.

Line numbers below are the ones at master `08e0d30a74ad0bfd5a34933142b80f45619ee410`, before this patch.

`components/esp_eth/include/esp_eth_clock.h:33-43`:

```c
/**
 * @brief Set the target time for the PTP clock.
 *
 * @param clk_id Identifier of the clock to set the target time for
 * @param tp Pointer to the target time
 *
 * @return
 *     - 0: Success
 *     - -1: Failure
 */
int esp_eth_clock_set_target_time(clockid_t clock_id, struct timespec *tp);
```

The parameter is `clock_id` in the declaration at `esp_eth_clock.h:43` and in the definition at `components/esp_eth/src/eth_clock/esp_eth_clock.c:243`. The block at `esp_eth_clock.h:36` calls it `clk_id`.

The file already disagrees with itself: the next function documents `@param clock_id` correctly at `esp_eth_clock.h:48`, for the same `clockid_t` first parameter of `esp_eth_clock_register_target_cb` at `esp_eth_clock.h:54`.

Checked mechanically against the declaration each block precedes, the file has 6 `@param` entries and `clk_id` at line 36 is the only one naming no parameter of its function. After this patch, none are.

Worth stating because it is easy to get wrong: `clk_id` is a real identifier elsewhere — the struct field `soc_module_clk_t clk_id` at `components/esp_hal_emac/include/hal/emac_clk.h:20`, used as `info->clk_id` in `components/esp_eth/src/mac/esp_eth_mac_esp.c:326`. It has nothing to do with this function's parameter.

The whole block is inside `#ifdef SOC_EMAC_IEEE1588V2_SUPPORTED`, opened at `esp_eth_clock.h:17` and closed at `esp_eth_clock.h:77`.

### Not built, not run

Nothing here was compiled or executed. No target hardware, no simulator, no test, and doxygen itself was not run. Every statement above is a statement about the text of the named files at the named lines, read at master `08e0d30a74ad0bfd5a34933142b80f45619ee410`.

## Related

Third of a short series of one-line documentation fixes in this repository, after #18972 (`components/esp_eth`) and #18974 (`components/esp_driver_sdmmc`); no code dependency between them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header comment-only change with no code, build, or behavioral impact.
> 
> **Overview**
> Fixes a **Doxygen `@param` mismatch** for `esp_eth_clock_set_target_time()` in `esp_eth_clock.h`: the first parameter is documented as `clock_id` instead of `clk_id`, matching the function signature and the adjacent `esp_eth_clock_register_target_cb` docs.
> 
> **Documentation only** — no runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff6b0bc8443178a93ac49f4ac37e6ff1838a1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->