### PR TITLE
fix(http_client): default Content-Type for post field (IDFGH-18153)

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -2065,7 +2065,7 @@ esp_err_t esp_http_client_set_post_field(esp_http_client_handle_t client, const 
     ESP_LOGD(TAG, "set post file length = %d", len);
     if (client->post_data) {
         char *value = NULL;
-        if ((err = esp_http_client_get_header(client, "Content-Type", &value)) != ESP_OK) {
+        if ((err = esp_http_client_get_header(client, "Content-Type", &value)) != ESP_OK && err != ESP_ERR_NOT_FOUND) {
             return err;
         }
         if (value == NULL) {

--- a/components/esp_http_client/test_apps/main/test_http_client.c
+++ b/components/esp_http_client/test_apps/main/test_http_client.c
@@ -188,6 +188,46 @@ TEST_CASE("esp_http_client_set_header() should not return error if header value 
     esp_http_client_cleanup(client);
 }
 
+TEST_CASE("set_post_field adds default Content-Type when missing", "[esp_http_client]")
+{
+    const esp_http_client_config_t config = {
+        .url = "http://localhost",
+    };
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    TEST_ASSERT_NOT_NULL(client);
+
+    const char post_data[] = "foo=bar";
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_set_post_field(client, post_data, strlen(post_data)));
+
+    char *content_type = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_get_header(client, "Content-Type", &content_type));
+    TEST_ASSERT_NOT_NULL(content_type);
+    TEST_ASSERT_EQUAL_STRING("application/x-www-form-urlencoded", content_type);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_cleanup(client));
+}
+
+TEST_CASE("set_post_field preserves explicit Content-Type", "[esp_http_client]")
+{
+    const esp_http_client_config_t config = {
+        .url = "http://localhost",
+    };
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    TEST_ASSERT_NOT_NULL(client);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_set_header(client, "Content-Type", "application/json"));
+
+    const char post_data[] = "{}";
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_set_post_field(client, post_data, strlen(post_data)));
+
+    char *content_type = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_get_header(client, "Content-Type", &content_type));
+    TEST_ASSERT_NOT_NULL(content_type);
+    TEST_ASSERT_EQUAL_STRING("application/json", content_type);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_http_client_cleanup(client));
+}
+
 TEST_CASE("set_url() to a different host strips Authorization header", "[esp_http_client]")
 {
     esp_http_client_config_t config = {


### PR DESCRIPTION
## Description

Fix `esp_http_client_set_post_field()` so an absent `Content-Type` header is treated as the defaultable case instead of returning `ESP_ERR_NOT_FOUND` before the documented default can be applied.

The function now continues only for `ESP_ERR_NOT_FOUND`; other errors from `esp_http_client_get_header()` are still propagated. If no Content-Type is present, the existing `application/x-www-form-urlencoded` default path runs. An explicitly configured Content-Type remains unchanged.

## Related

Fixes #18980.

## Testing

- Added a regression test for an absent Content-Type and the default `application/x-www-form-urlencoded` value.
- Added a regression test verifying an explicit `application/json` Content-Type is preserved.
- Built `components/esp_http_client/test_apps` successfully on the fork CI runner.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All upstream CI checks pass (currently awaiting maintainer approval for fork workflows).
- [x] Documentation is not required for this behavior restoration.
- [x] Tests are updated or added as necessary.
- [x] Code change is intentionally minimal.
- [x] Git history is clean and contains one commit.