### PR TITLE
fix(usb): reset ROM CDC descriptor on app startup (IDFGH-18155)

### DIFF
--- a/components/esp_usb_cdc_rom_console/usb_console.c
+++ b/components/esp_usb_cdc_rom_console/usb_console.c
@@ -29,6 +29,7 @@
 #include "esp_rom_sys.h"
 #include "esp_rom_caps.h"
 #ifdef CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/usb/usb_common.h"
 #include "esp32s2/rom/usb/usb_dc.h"
 #include "esp32s2/rom/usb/cdc_acm.h"
 #include "esp32s2/rom/usb/usb_dfu.h"
@@ -273,6 +274,11 @@ void esp_usb_console_before_restart(void)
  */
 static void esp_usb_console_rom_cleanup(void)
 {
+#ifdef CONFIG_IDF_TARGET_ESP32S2
+    /* Reset the descriptor pointer left by the second-stage bootloader before
+     * its RAM image is reclaimed by the application heap. */
+    rom_usb_cdc_set_descriptor_patch();
+#endif
     usb_dev_deinit();
     usb_dw_ctrl_deinit();
     uart_acm_dev = NULL;


### PR DESCRIPTION
## Description

Fix the ESP32-S2 ROM USB CDC console descriptor lifetime across the second-stage bootloader → application transition.

The bootloader calls `rom_usb_cdc_set_descriptor_patch()`, leaving the ROM `rom_usb_curr_desc` pointer referring to descriptor storage owned by the bootloader image. Once the application reclaims that RAM as heap, the first host descriptor request can dereference reclaimed memory. The issue reporter reproduced this as USB enumeration failure and a deterministic heap-poison crash.

This change calls `rom_usb_cdc_set_descriptor_patch()` from the application's ROM-console cleanup path, guarded by `CONFIG_IDF_TARGET_ESP32S2`, so the ROM descriptor pointer is reset to descriptor data valid in the application before USB is reinitialized without introducing an S2-only ROM symbol into the shared ESP32-S3 path.

## Related

Addresses defect 1 of #18841.

## Testing

- Built `examples/system/console/basic` for ESP32-S2 with `CONFIG_ESP_CONSOLE_USB_CDC=y`.
- Built the same ESP32-S2 configuration with `CONFIG_HEAP_POISONING_COMPREHENSIVE=y`.
- After review identified the missing target guard, added `CONFIG_IDF_TARGET_ESP32S2` around the descriptor-reset call.
- Rebuilt the final guarded source for both ESP32-S2 and ESP32-S3; both target builds passed on the fork runner.
- The exact descriptor-reset approach is also hardware-validated by the #18841 reporter; this PR's own validation is build-level rather than a claim of independent hardware reproduction.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All upstream CI checks pass (currently awaiting maintainer approval for fork workflows).
- [x] Documentation is not required for this internal lifetime fix.
- [x] No additional automated unit test is practical for the ROM/bootloader lifetime transition; the reproduction is hardware-level.
- [x] Code is limited to the ESP32-S2 descriptor-reset path; ESP32-S3 is verified to build without the S2-only symbol.
- [x] Git history is clean and contains one commit.