### PR TITLE
fix(usb): keep CDC ISR callbacks in IRAM (IDFGH-18154)

### DIFF
--- a/components/esp_usb_cdc_rom_console/linker.lf
+++ b/components/esp_usb_cdc_rom_console/linker.lf
@@ -9,6 +9,8 @@ entries:
         usb_console:esp_usb_console_osglue_dis_int (noflash)
         usb_console:esp_usb_console_osglue_ena_int (noflash)
         usb_console:esp_usb_console_interrupt (noflash)
+        usb_console:esp_usb_console_available_for_read (noflash)
+        usb_console:esp_usb_console_write_available (noflash)
         usb_console:esp_usb_console_poll_interrupts (noflash)
         usb_console:esp_usb_console_cdc_acm_cb (noflash)
         usb_console:esp_usb_console_dfu_detach_cb (noflash)


### PR DESCRIPTION
## Description

Keep the remaining ESP32-S2 ROM USB CDC console callbacks that are reachable from the IRAM-registered USB interrupt path out of flash.

With `CONFIG_ESP_CONSOLE_USB_CDC_SUPPORT_ETS_PRINTF=y`, the USB ISR remains active while the flash cache can be disabled. `esp_usb_console_available_for_read()` and `esp_usb_console_write_available()` were not covered by the existing `(noflash)` linker entries, so an interrupt could branch into `.flash.text` during a cache-off window.

This change adds both callbacks to the existing ROM USB console `(noflash)` linker fragment.

## Related

Addresses defect 2 of #18841.

## Testing

- Built `examples/system/console/basic` for ESP32-S2 with USB CDC console and ETS printf support enabled.
- Inspected the resulting ELF with `xtensa-esp32s2-elf-objdump` and verified both `esp_usb_console_available_for_read` and `esp_usb_console_write_available` are placed in `.iram0.text`.
- The #18841 reporter independently reproduced the cache-disabled crash and reports the same linker fix resolves it on hardware.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All upstream CI checks pass (currently awaiting maintainer approval for fork workflows).
- [x] Documentation is not required for this linker placement fix.
- [x] The resulting symbol placement was explicitly verified.
- [x] The change is limited to two linker entries.
- [x] Git history is clean and contains one commit.