### PR TITLE
esp_lcd: Enable DMA for PSRAM in SPI transactions (IDFGH-18159)

### DIFF
--- a/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
+++ b/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
@@ -393,6 +393,10 @@ static esp_err_t panel_io_spi_tx_color(esp_lcd_panel_io_t *io, int lcd_cmd, cons
         lcd_trans->flags.dc_gpio_level = spi_panel_io->flags.dc_data_level; // set D/C level in data phase
         lcd_trans->base.length = chunk_size * 8; // transaction length is in bits
         lcd_trans->base.tx_buffer = color;
+        if (esp_ptr_external_ram(color)) {
+            // Allow the SPI master to DMA directly from PSRAM
+            lcd_trans->base.flags |= SPI_TRANS_DMA_USE_PSRAM;
+        }
         if (spi_panel_io->flags.octal_mode) {
             // use 8 lines for transmitting command, address and data
             lcd_trans->base.flags |= (SPI_TRANS_MULTILINE_CMD | SPI_TRANS_MULTILINE_ADDR | SPI_TRANS_MODE_OCT);


### PR DESCRIPTION
We found in our project that when the image buffer was in PSRAM that the lcd driver was allocated 8k blocks of memory in DRAM fragmenting our DRAM enough to cause other issues.

This is a workaround to make the lcd driver use DMA to avoid the DRAM allocations (and therefore the fragmentation).

We would like get this option merged upstream if possible.

I could make it a KConfig option so that users can opt-in to the functionality.

I welcome feedback on this issue.

Cheers!
