### PR TITLE
fix(sta2eth): URL-decode SSID/password in manual config web form (IDFGH-18181)

### DIFF
--- a/examples/network/sta2eth/main/manual_config.c
+++ b/examples/network/sta2eth/main/manual_config.c
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
 #include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
 #include "esp_wifi.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
@@ -16,6 +18,28 @@ static httpd_handle_t s_web_server = NULL;
 static EventGroupHandle_t *s_flags = NULL;
 static int s_success_bit;
 
+/* Query values are still percent-encoded; each byte may expand to three (%XX) */
+#define WIFI_QUERY_VAL_ENCODED_MAX (MAX_PASSPHRASE_LEN * 3 + 1)
+
+/* Decodes '+' as space and %XX as the corresponding byte, in place */
+static void url_decode(char *str)
+{
+    char *dst = str;
+    while (*str) {
+        if (*str == '+') {
+            *dst++ = ' ';
+            str++;
+        } else if (*str == '%' && isxdigit((unsigned char)str[1]) && isxdigit((unsigned char)str[2])) {
+            char hex[3] = { str[1], str[2], '\0' };
+            *dst++ = (char) strtol(hex, NULL, 16);
+            str += 3;
+        } else {
+            *dst++ = *str++;
+        }
+    }
+    *dst = '\0';
+}
+
 bool is_provisioned(void)
 {
     wifi_config_t wifi_cfg;
@@ -23,7 +47,7 @@ bool is_provisioned(void)
         return false;
     }
 
-    if (strlen((const char *) wifi_cfg.sta.ssid)) {
+    if (strnlen((const char *) wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid)) > 0) {
         return true;
     }
 
@@ -45,19 +69,28 @@ static esp_err_t http_get_handler(httpd_req_t *req)
         buf = malloc(buf_len);
         if (httpd_req_get_url_query_str(req, buf, buf_len) == ESP_OK) {
             ESP_LOGI(TAG, "Found URL query => %s", buf);
-            char param[32];
-            wifi_config_t wifi_cfg = {};
+            char param[WIFI_QUERY_VAL_ENCODED_MAX];
+            wifi_config_t wifi_cfg = {0};
 
             if (httpd_query_key_value(buf, "ssid", param, sizeof(param)) == ESP_OK) {
+                url_decode(param);
                 ESP_LOGI(TAG, "ssid=%s", param);
-                strncpy((char *)wifi_cfg.sta.ssid, param, sizeof(wifi_cfg.sta.ssid));
+                size_t ssid_len = strlen(param);
+                if (ssid_len > 0 && ssid_len <= sizeof(wifi_cfg.sta.ssid)) {
+                    memcpy(wifi_cfg.sta.ssid, param, ssid_len);
+                }
             }
             if (httpd_query_key_value(buf, "password", param, sizeof(param)) == ESP_OK) {
+                url_decode(param);
                 ESP_LOGI(TAG, "password=%s", param);
-                strncpy((char *)wifi_cfg.sta.password, param, sizeof(wifi_cfg.sta.password));
+                size_t pass_len = strlen(param);
+                if (pass_len > 0 && pass_len <= sizeof(wifi_cfg.sta.password)) {
+                    memcpy(wifi_cfg.sta.password, param, pass_len);
+                }
             }
 
-            if (strlen((char *)wifi_cfg.sta.ssid) > 0 && strlen((char *)wifi_cfg.sta.password)) {
+            if (strnlen((char *)wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid)) > 0 &&
+                    strnlen((char *)wifi_cfg.sta.password, sizeof(wifi_cfg.sta.password)) > 0) {
                 httpd_resp_set_type(req, "text/html");
                 esp_wifi_set_mode(WIFI_MODE_STA);
                 if (esp_wifi_set_storage(WIFI_STORAGE_FLASH) == ESP_OK &&


### PR DESCRIPTION
## Description

## Related

Closes #13428

## Testing

Verified manually on ESP32-S3 with a stored SSID containing spaces and `!@#%^()_+`, confirming it now saves and connects correctly through the web form.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

## Summary
The `sta2eth` example's manual WiFi configuration web form (`main/manual_config.c`)
read the `ssid` and `password` query parameters as raw strings, without decoding
URL encoding. SSIDs/passwords containing spaces or special characters
(e.g. `!@#%^()_+`) were saved corrupted, since browsers URL-encode form data
submitted via GET.

## Fix
- Added a `url_decode()` helper that decodes `+` as space and `%XX` escapes in place.
- Applied it to both the `ssid` and `password` fields before saving them via `esp_wifi_set_config()`.
- Sized the query-value buffer for worst-case percent-encoding (`MAX_PASSPHRASE_LEN * 3 + 1`) so encoded SSIDs/passwords are not truncated before `url_decode`.
- Copied decoded credentials with length-checked `memcpy` into the full `ssid[32]` / `password[64]` fields so a 32-byte SSID is not truncated, and used bounded `strnlen` for provisioned/submit checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only HTTP handler change with safer string handling; no core auth or infrastructure impact.
> 
> **Overview**
> Fixes corrupted Wi‑Fi credentials when users submit the **sta2eth** manual provisioning page with SSIDs or passwords that contain spaces or special characters (browsers percent-encode GET query values).
> 
> Adds in-place **`url_decode()`** (`+` → space, `%XX` → byte) and runs it on **`ssid`** and **`password`** before **`esp_wifi_set_config()`**. Replaces the fixed 32-byte query buffer with **`WIFI_QUERY_VAL_ENCODED_MAX`** so fully encoded passphrases are not truncated prior to decode, and copies decoded values with length-checked **`memcpy`** plus **`strnlen`** for provision/submit checks instead of **`strncpy`** / unbounded **`strlen`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79b84110eb6673a3c862383cd2ddda7db2bb4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->