### PR TITLE
fix(esp_eth): avoid per-frame descriptor ring scan in RX task (IDFGH-18183)

### DIFF
--- a/components/esp_eth/src/mac/esp_eth_mac_esp.c
+++ b/components/esp_eth/src/mac/esp_eth_mac_esp.c
@@ -615,7 +615,7 @@ static void emac_esp32_rx_task(void *arg)
     while (1) {
         // block indefinitely until got notification from underlay event
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-        do {
+        while (1) {
             /* set max expected frame len */
             uint32_t frame_len = ETH_MAX_PACKET_SIZE;
             buffer = emac_esp_dma_alloc_recv_buf(emac->emac_dma_hndl, &frame_len);
@@ -645,9 +645,21 @@ static void emac_esp32_rx_task(void *arg)
                 ESP_LOGE(TAG, "no mem for receive buffer");
                 /* ensures that interface to EMAC does not get stuck with unprocessed frames */
                 emac_esp_dma_flush_recv_frame(emac->emac_dma_hndl);
-            }
-            emac_esp_dma_get_remain_frames(emac->emac_dma_hndl, &emac->frames_remain, &emac->free_rx_descriptor);
+            } else {
+                /* no valid frame: either the ring is drained or an erroneous frame was flushed with frames still behind it */
+                emac_esp_dma_get_remain_frames(emac->emac_dma_hndl, &emac->frames_remain, &emac->free_rx_descriptor);
+                if (emac->frames_remain == 0) {
 #if CONFIG_ETH_SOFT_FLOW_CONTROL
+                    /* ring drained, release any standing pause before idling */
+                    emac_hal_send_pause_frame(&emac->hal, false);
+#endif
+                    break;
+                }
+                /* erroneous frame flushed; keep draining the frames behind it */
+                continue;
+            }
+#if CONFIG_ETH_SOFT_FLOW_CONTROL
+            emac_esp_dma_get_remain_frames(emac->emac_dma_hndl, &emac->frames_remain, &emac->free_rx_descriptor);
             // we need to do extra checking of remained frames in case there are no unhandled frames left, but pause frame is still undergoing
             if ((emac->free_rx_descriptor < emac->flow_control_low_water_mark) && emac->do_flow_ctrl && emac->frames_remain) {
                 emac_hal_send_pause_frame(&emac->hal, true);
@@ -655,7 +667,7 @@ static void emac_esp32_rx_task(void *arg)
                 emac_hal_send_pause_frame(&emac->hal, false);
             }
 #endif
-        } while (emac->frames_remain);
+        }
     }
 }
 


### PR DESCRIPTION
The RX task's drain loop called emac_esp_dma_get_remain_frames() after every received frame, an O(backlog) walk of the descriptor ring with a cache invalidate per descriptor. Under sustained load the scan cost grows with the backlog, so the deeper the backlog gets, the more time goes into scanning instead of draining, until the task can no longer keep up and the DMA drops frames continuously.

The loop only needs to know whether at least one more complete frame is waiting, which emac_esp_dma_alloc_recv_buf() already answers by checking a single descriptor, so the loop now exits on that instead. The full remain-frames count is kept only under CONFIG_ETH_SOFT_FLOW_CONTROL, which genuinely needs it for the pause-frame watermarks.

Measured on ESP32-P4 (20 RX descriptors, 16k pkt/s bidirectional AVB load): ~3000 missed frames/s before, 0 after, with dmamissedfr confirming. Discussion and measurements in #18800.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path RX task behavior for all Ethernet users; incorrect drain/exit logic could drop frames or leave pause asserted, though the change is narrowly scoped to loop control.
> 
> **Overview**
> **Reworks the EMAC RX drain loop** so it no longer calls `emac_esp_dma_get_remain_frames()` after every received frame to decide whether to keep draining.
> 
> The inner loop now relies on `emac_esp_dma_alloc_recv_buf()` to detect whether another frame is ready. When allocation returns no buffer and `frame_len` is zero, it only then scans remaining frames to distinguish an empty ring from a bad descriptor with more frames behind it; with soft flow control enabled it clears any standing pause before idling when the ring is drained.
> 
> **`emac_esp_dma_get_remain_frames()` is limited to** that empty-or-continue path and to `CONFIG_ETH_SOFT_FLOW_CONTROL`, where descriptor counts are still needed for pause-frame watermarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc48f3ac4155daa9d87654addf02dbc8180247e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->