### PR TITLE
fix(bt/bluedroid): delete unused AVRCP acceptor RCB when A2DP open fails (IDFGH-18197)

### DIFF
--- a/components/bt/host/bluedroid/bta/av/bta_av_act.c
+++ b/components/bt/host/bluedroid/bta/av/bta_av_act.c
@@ -1348,6 +1348,7 @@ void bta_av_sig_chg(tBTA_AV_DATA *p_data)
     int     xx;
     UINT8   mask;
     tBTA_AV_LCB *p_lcb = NULL;
+    tBTA_AV_RCB *p_rcb = NULL;
 
     APPL_TRACE_DEBUG("bta_av_sig_chg event: %d", event);
     if (event == AVDT_CONNECT_IND_EVT) {
@@ -1422,6 +1423,20 @@ void bta_av_sig_chg(tBTA_AV_DATA *p_data)
                         (bdcmp(p_cb->p_scb[xx]->peer_addr, p_data->str_msg.bd_addr) == 0)) {
                     p_cb->p_scb[xx]->disc_rsn = p_data->str_msg.hdr.offset;
                     bta_av_ssm_execute(p_cb->p_scb[xx], BTA_AV_AVDT_DISCONNECT_EVT, NULL);
+                }
+            }
+        }
+
+        /* The acceptor RCB of this link gets its shdl only when a stream opens. If no stream
+         * opened, nothing deletes the RCB and its AVCTP ccb leaks until the device reboots. */
+        if (p_lcb && p_lcb->lidx != 0 && p_lcb->lidx != (BTA_AV_NUM_LINKS + 1)) {
+            for (xx = 0; xx < BTA_AV_NUM_RCB; xx++) {
+                p_rcb = &p_cb->rcb[xx];
+                if (p_rcb->handle != BTA_AV_RC_HANDLE_NONE && p_rcb->lidx == p_lcb->lidx &&
+                        p_rcb->shdl == 0 && !(p_rcb->status & BTA_AV_RC_CONN_MASK)) {
+                    APPL_TRACE_DEBUG("bta_av_sig_chg: delete unused rcb[%d] handle:%d lidx:%d", xx,
+                                     p_rcb->handle, p_rcb->lidx);
+                    bta_av_del_rc(p_rcb);
                 }
             }
         }


### PR DESCRIPTION
## Problem

Bluedroid leaks one AVCTP ccb on every failed A2DP open. After `AVCT_NUM_CONN = 3` failed opens,
every `AVCT_CreateConn()` fails with `BT_AVCT: Out of ccbs` and AVRCP is dead until the device is
rebooted. With the default `AVCT_NUM_CONN = 3` this takes only
two failed opens.

The visible symptom on an A2DP source is that AVRCP never connects any more, so absolute volume
cannot be sent: the sink stays at whatever volume it selected and the stream is silent although
`ESP_A2D_AUDIO_STATE_STARTED` is reported.

## Fix

Delete the RCB of the link in the disconnect branch of `bta_av_sig_chg()` if it is still
stream-less (`shdl == 0`) and not connected (`BTA_AV_RC_CONN_MASK` clear). The global acceptor RCB
(`lidx == BTA_AV_NUM_LINKS + 1`) and RCBs bound to a stream are left alone, so the normal
connect / disconnect / reconnect paths are unchanged.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches A2DP/AVRCP teardown in Bluedroid on AVDTP disconnect; wrong RCB selection could affect RC reconnect, but guards limit cleanup to unused, unconnected acceptor RCBs for that link.
> 
> **Overview**
> When an incoming AVDTP signal channel comes up, Bluedroid creates an AVRCP **acceptor** RCB for that link (`shdl` stays 0 until a stream opens). If A2DP setup fails and the signal drops before any stream opens, that RCB was never torn down, leaking an **AVCTP** control block on each failure until AVRCP could no longer connect.
> 
> **`bta_av_sig_chg()`** now runs after the existing disconnect cleanup: for the freed link (not the global listen RCB at `lidx == BTA_AV_NUM_LINKS + 1`), it walks RCBs tied to the same `lidx` and calls **`bta_av_del_rc()`** when the RCB is still stream-less (`shdl == 0`) and not marked connected (`BTA_AV_RC_CONN_MASK` clear). RCBs already bound to a stream or the global acceptor are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35cf3fa42b068f89d08bc1d63acc87c212dec6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->