### PR TITLE
feat(driver_twai): support queueless TX with tx_queue_depth 0 (IDFGH-18205)

### DIFF
--- a/components/esp_driver_twai/esp_twai_onchip.c
+++ b/components/esp_driver_twai/esp_twai_onchip.c
@@ -50,6 +50,7 @@ typedef struct {
     intr_handle_t intr_hdl;
     intr_handle_t timer_intr_hdl;
     twai_frame_queue_t tx_queue;
+    SemaphoreHandle_t idle_sem;
     EventGroupHandle_t event_group;
     twai_clock_source_t curr_clk_src;
     uint32_t src_freq_hz;
@@ -258,7 +259,15 @@ static void _node_isr_main(void *arg)
         }
         // node recover from busoff, restart remain tx transaction
         if ((e_data.old_sta == TWAI_ERROR_BUS_OFF) && (e_data.new_sta == TWAI_ERROR_ACTIVE)) {
-            if (_node_start_tx_batch_from_isr(twai_ctx, &do_yield)) {
+            if (twai_ctx->idle_sem) {
+                // permit mode: the frame in flight (if any) is lost, hand its permit back
+                memset(twai_ctx->p_curr_tx, 0, sizeof(twai_ctx->p_curr_tx));
+                if (atomic_exchange(&twai_ctx->hw_busy, false)) {
+                    BaseType_t sem_yield = pdFALSE;
+                    xSemaphoreGiveFromISR(twai_ctx->idle_sem, &sem_yield);
+                    do_yield |= sem_yield;
+                }
+            } else if (_node_start_tx_batch_from_isr(twai_ctx, &do_yield)) {
                 atomic_store(&twai_ctx->hw_busy, true);
             } else {
                 _node_mark_tx_idle(twai_ctx);
@@ -299,19 +308,28 @@ static void _node_isr_main(void *arg)
             uint32_t slot_event = tx_done_events & -tx_done_events; // get the lowest event bit
             uint8_t tx_idx = __builtin_ctz(slot_event) / 2;
             assert((tx_idx < twai_ctx->tx_slot_num) && twai_ctx->p_curr_tx[tx_idx]);
+            const twai_frame_t *done_frame = twai_ctx->p_curr_tx[tx_idx];
+            twai_ctx->p_curr_tx[tx_idx] = NULL;
+            if (twai_ctx->idle_sem) {
+                // permit mode: the node is fully idle again before the permit is handed back,
+                // so a transmit from inside `on_tx_done` can take it and start the next frame at once
+                atomic_store(&twai_ctx->hw_busy, false);
+                BaseType_t sem_yield = pdFALSE;
+                xSemaphoreGiveFromISR(twai_ctx->idle_sem, &sem_yield);
+                do_yield |= sem_yield;
+            }
             if (twai_ctx->cbs.on_tx_done) {
                 twai_tx_done_event_data_t tx_ev = {
                     .is_tx_success = (events & TWAI_HAL_EVENT_TX_SUCC_SLOT(tx_idx)),  // find 'on_error_cb' if not success
-                    .done_tx_frame = twai_ctx->p_curr_tx[tx_idx],
+                    .done_tx_frame = done_frame,
                 };
                 do_yield |= twai_ctx->cbs.on_tx_done(&twai_ctx->api_base, &tx_ev, twai_ctx->user_data);
             }
-            twai_ctx->p_curr_tx[tx_idx] = NULL;
             tx_done_events &= ~slot_event;
         }
 
         // start a new TX batch only when all hardware TX buffers from this batch are done
-        if (_node_is_tx_all_done(twai_ctx) && (atomic_load(&twai_ctx->state) != TWAI_ERROR_BUS_OFF)) {
+        if (!twai_ctx->idle_sem && _node_is_tx_all_done(twai_ctx) && (atomic_load(&twai_ctx->state) != TWAI_ERROR_BUS_OFF)) {
             if (!_node_start_tx_batch_from_isr(twai_ctx, &do_yield)) {
                 _node_mark_tx_idle(twai_ctx);
                 xEventGroupSetBitsFromISR(twai_ctx->event_group, TWAI_IDLE_EVENT_BIT, &do_yield);
@@ -369,6 +387,9 @@ static void _node_destroy(twai_onchip_ctx_t *twai_ctx)
         esp_intr_free(twai_ctx->timer_intr_hdl);
     }
     twai_frame_queue_del(twai_ctx->tx_queue);
+    if (twai_ctx->idle_sem) {
+        vSemaphoreDeleteWithCaps(twai_ctx->idle_sem);
+    }
     if (twai_ctx->event_group) {
         // xEventGroupSetBitsFromISR is not done immediately, need flush it before deleting
         _node_flush_pended_set_bits();
@@ -594,7 +615,8 @@ static esp_err_t _node_get_status(twai_node_handle_t node, twai_node_status_t *s
         status_ret->state = atomic_load(&twai_ctx->state);
         status_ret->tx_error_count = twai_hal_get_tec(twai_ctx->hal);
         status_ret->rx_error_count = twai_hal_get_rec(twai_ctx->hal);
-        status_ret->tx_queue_remaining = twai_frame_queue_get_free_space(twai_ctx->tx_queue);
+        // in permit mode the permit itself is the only free slot
+        status_ret->tx_queue_remaining = twai_ctx->idle_sem ? uxSemaphoreGetCount(twai_ctx->idle_sem) : twai_frame_queue_get_free_space(twai_ctx->tx_queue);
     }
     if (record_ret) {
         *record_ret = twai_ctx->history;
@@ -618,6 +640,26 @@ static esp_err_t _node_queue_tx(twai_node_handle_t node, const twai_frame_t *fra
     ESP_RETURN_ON_FALSE_ISR((!frame->header.brs) || (twai_ctx->valid_fd_timing), ESP_ERR_INVALID_ARG, TAG, "brs can't be used without config data_timing");
     ESP_RETURN_ON_FALSE_ISR(!twai_ctx->hal->enable_listen_only, ESP_ERR_NOT_SUPPORTED, TAG, "node is config as listen only");
     ESP_RETURN_ON_FALSE_ISR(atomic_load(&twai_ctx->state) != TWAI_ERROR_BUS_OFF, ESP_ERR_INVALID_STATE, TAG, "node is bus off");
+
+    if (twai_ctx->idle_sem) {
+        // permit mode: take the single TX permit, then go straight to the hardware.
+        // Nothing is ever held in the driver, so a frame not yet transmitted is still the caller's to drop.
+        BaseType_t yield_required = pdFALSE;
+        BaseType_t taken;
+        if (xPortInIsrContext()) {
+            taken = xSemaphoreTakeFromISR(twai_ctx->idle_sem, &yield_required);
+        } else {
+            taken = xSemaphoreTake(twai_ctx->idle_sem, (timeout == -1) ? portMAX_DELAY : pdMS_TO_TICKS(timeout));
+        }
+        ESP_RETURN_ON_FALSE_ISR(taken == pdTRUE, ESP_ERR_TIMEOUT, TAG, "tx busy");
+        atomic_store(&twai_ctx->hw_busy, true);
+        twai_ctx->p_curr_tx[0] = frame;
+        _node_start_trans(twai_ctx, 0);
+        if (yield_required) {
+            portYIELD_FROM_ISR();
+        }
+        return ESP_OK;
+    }
 
     xEventGroupClearBits(twai_ctx->event_group, TWAI_IDLE_EVENT_BIT); //going to send, clear the idle event
     bool false_var = false;
@@ -647,6 +689,13 @@ static esp_err_t _node_wait_tx_all_done(twai_node_handle_t node, int timeout)
     twai_onchip_ctx_t *twai_ctx = __containerof(node, twai_onchip_ctx_t, api_base);
     TickType_t ticks_to_wait = (timeout == -1) ? portMAX_DELAY : pdMS_TO_TICKS(timeout);
     ESP_RETURN_ON_FALSE(atomic_load(&twai_ctx->state) != TWAI_ERROR_BUS_OFF, ESP_ERR_INVALID_STATE, TAG, "node is bus off");
+
+    if (twai_ctx->idle_sem) {
+        // permit mode: holding the permit means nothing is in flight, give it straight back
+        ESP_RETURN_ON_FALSE(xSemaphoreTake(twai_ctx->idle_sem, ticks_to_wait) == pdTRUE, ESP_ERR_TIMEOUT, TAG, "wait tx timeout");
+        xSemaphoreGive(twai_ctx->idle_sem);
+        return ESP_OK;
+    }
 
     // either hw_busy or tx_queue is not empty, means tx is not finished
     // otherwise, hardware is idle, return immediately
@@ -687,7 +736,6 @@ static esp_err_t _node_create_sleep_retention_cb(void *obj)
 esp_err_t twai_new_node_onchip(const twai_onchip_node_config_t *node_config, twai_node_handle_t *node_ret)
 {
     esp_err_t ret = ESP_OK;
-    ESP_RETURN_ON_FALSE((node_config->tx_queue_depth > 0) || node_config->flags.enable_listen_only, ESP_ERR_INVALID_ARG, TAG, "tx_queue_depth at least 1");
     ESP_RETURN_ON_FALSE(!node_config->intr_priority || (BIT(node_config->intr_priority) & ESP_INTR_FLAG_LOWMED), ESP_ERR_INVALID_ARG, TAG, "Invalid intr_priority level");
 #if !SOC_TWAI_SUPPORT_SLEEP_RETENTION
     ESP_RETURN_ON_FALSE(!node_config->flags.sleep_allow_pd, ESP_ERR_NOT_SUPPORTED, TAG, "sleep retention is not supported on this target");
@@ -713,7 +761,14 @@ esp_err_t twai_new_node_onchip(const twai_onchip_node_config_t *node_config, twa
     // state is in bus_off before enabled
     atomic_store(&node->state, TWAI_ERROR_BUS_OFF);
     if (!node_config->flags.enable_listen_only) {
-        ESP_GOTO_ON_ERROR(twai_frame_queue_new(&node->tx_queue, node_config->tx_queue_depth, TWAI_MALLOC_CAPS), err, TAG, "no_mem");
+        if (node_config->tx_queue_depth) {
+            ESP_GOTO_ON_ERROR(twai_frame_queue_new(&node->tx_queue, node_config->tx_queue_depth, TWAI_MALLOC_CAPS), err, TAG, "no_mem");
+        } else {
+            // no queue: a single TX permit lets one frame at a time go directly to the hardware
+            node->idle_sem = xSemaphoreCreateBinaryWithCaps(TWAI_MALLOC_CAPS);
+            ESP_GOTO_ON_FALSE(node->idle_sem, ESP_ERR_NO_MEM, err, TAG, "no_mem");
+            xSemaphoreGive(node->idle_sem);
+        }
     }
     node->event_group = xEventGroupCreateWithCaps(TWAI_MALLOC_CAPS);
     ESP_GOTO_ON_FALSE(node->event_group, ESP_ERR_NO_MEM, err, TAG, "no_mem");

--- a/components/esp_driver_twai/include/esp_twai_onchip.h
+++ b/components/esp_driver_twai/include/esp_twai_onchip.h
@@ -28,7 +28,8 @@ typedef struct {
     twai_timing_basic_config_t data_timing; /**< Optional, timing configuration for FD data stage */
     uint32_t timestamp_resolution_hz;       /**< Timebase frequency (in Hz), used for RX frame timestamps and scheduled TX trigger times, set 0 to disable the timestamp feature */
     int8_t fail_retry_cnt;                  /**< Hardware retry limit if failed, range [-1:15], -1 for re-trans forever */
-    uint32_t tx_queue_depth;                /**< Depth of the transmit queue */
+    uint32_t tx_queue_depth;                /**< Depth of the transmit queue, set 0 to send without a queue, so that only one frame is
+                                                 accepted at a time and `twai_node_transmit` blocks until the hardware is free */
     int intr_priority;                      /**< Interrupt priority, [0:3] */
     struct {
         uint32_t enable_self_test: 1;       /**< Transmission does not require acknowledgment. Use this mode for self testing */


### PR DESCRIPTION
Adds a `tx_queue_depth == 0` mode to the on-chip TWAI driver. Instead of a TX queue, the node holds a single TX permit, so a submitted frame goes straight to the hardware and is never parked in the driver.

## Why

We want to manage the transmit queue entirely in the application, mainly so that a frame which has not gone out yet is still ours to reorder or drop. The driver's frame queue gives no way to do that — `twai_frame_queue` has no remove and no flush — so the only way to keep a frame retractable is to never hand it over in the first place.

`tx_queue_depth = 1` is not a substitute: one frame in hardware plus one in the queue is effectively a queue of two, and the queued one is already out of reach.

## How

- `tx_queue_depth == 0` (and not listen-only) creates a binary semaphore, given once, in place of `tx_queue`. It means "one frame in flight", independent of `tx_slot_num`.
- `twai_node_transmit()` takes the permit, blocking up to its timeout (ISR-safe take on the ISR path), then starts the transaction directly.
- The TX-done ISR returns the node to idle and hands the permit back **before** invoking `on_tx_done`, so transmitting from inside that callback picks the permit straight back up and starts the next frame with no driver-side hop. Doing the whole idle transition before the handoff also means there is no read-then-act after it — everything is ordered by the permit itself.
- `twai_node_transmit_wait_all_done()` just acquires and releases the permit, which is exact, so `TWAI_IDLE_EVENT_BIT` is unused in this mode. That also keeps the chain-submit path from reaching the non-ISR `xEventGroupClearBits()` call in `_node_queue_tx()`.
- Bus-off recovery hands the permit back if a frame was in flight.
- `tx_queue_remaining` reports the permit count: 1 when a frame can be submitted without blocking, 0 while busy.

The queue path is unchanged. The one line that moved on it is in the TX-done ISR loop, which now hoists `done_tx_frame` and clears `p_curr_tx[tx_idx]` before the callback rather than after, so both modes share one path. That is behaviourally identical for the queue mode: `hw_busy` is still true during the callback, so a transmit from inside it takes the queue path and its second-chance CAS fails either way, and nothing else reads `p_curr_tx` from a callback.

## Status

Draft — this is not heavily tested. It was built and smoke-tested on ESP32-S3 against v6.1 in an application that uses TWAI, then rebased onto master; there are no new unit tests yet.

Opening it mainly to find out whether this is a direction you'd want in the driver at all, and whether the ISR ordering above reads correctly to you. Happy to add test coverage and docs if the approach is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
