### PR TITLE
fix(esp_lcd): yield from SPI ISR when color trans done callback wakes a task (IDFGH-18223)

### DIFF
--- a/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
+++ b/components/esp_lcd/spi/esp_lcd_panel_io_spi.c
@@ -441,7 +441,9 @@ static void lcd_spi_post_trans_color_cb(spi_transaction_t *trans)
 
     if (lcd_trans->flags.en_trans_done_cb) {
         if (spi_panel_io->on_color_trans_done) {
-            spi_panel_io->on_color_trans_done(&spi_panel_io->base, NULL, spi_panel_io->user_ctx);
+            if (spi_panel_io->on_color_trans_done(&spi_panel_io->base, NULL, spi_panel_io->user_ctx)) {
+                portYIELD_FROM_ISR();
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`lcd_spi_post_trans_color_cb()` invokes the user's `on_color_trans_done` callback but discards its return value, although the callback type is documented to return "whether a high priority task has been waken up by this function" (`esp_lcd_types.h`).

The spi_master ISR only calls `portYIELD_FROM_ISR()` based on its own internal wake-ups (tasks blocked in `spi_device_get_trans_result`). In the typical esp_lcd pattern — a rendering task blocked on a semaphore that `on_color_trans_done` gives from ISR — nobody waits on the driver's result queue, so no yield ever happens and the woken task only runs at the next FreeRTOS tick. With the default `CONFIG_FREERTOS_HZ=100` that is up to 10 ms of dead time per color transfer.

Measured on ESP32-C3 (ST7789 240x280 @ SPI 80 MHz, frame rendered as 10 DMA bands, semaphore given in the callback): ~6.5 ms average extra latency per band, ~65 ms per frame, while the SPI transfer itself only takes 13.4 ms. Frame rate 11.2 FPS before / 28.4 FPS after the fix.

The i80 backend already honors the contract (`esp_lcd_panel_io_i80.c`: `need_yield` → `portYIELD_FROM_ISR()`); this change brings the SPI backend in line.

## Fix

Use the callback's return value and call `portYIELD_FROM_ISR()` when it reports a wake-up, matching the i80 backend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single ISR-path change aligned with existing esp_lcd callback contract and i80 behavior; no API or data-handling changes.
> 
> **Overview**
> The SPI LCD panel IO post-transaction ISR now **honors the return value** of `on_color_trans_done`, which is documented to indicate whether a higher-priority task was woken (e.g. via a semaphore give from the callback).
> 
> When the callback reports a wake-up, **`portYIELD_FROM_ISR()`** is invoked so rendering tasks blocked on that signal can run immediately instead of waiting until the next FreeRTOS tick—behavior that the **i80** backend already implemented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2b8e58f34c2d17ce058a2f9b4fc0af3dc0b611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->