### PR TITLE
fix(esp_rom): join ESP_ROM_ELF_DIR when generating gdb symbols (IDFGH-17465) (IDFGH-18226)

### DIFF
--- a/components/esp_rom/gen_gdbinit.py
+++ b/components/esp_rom/gen_gdbinit.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import os
+import posixpath
 import sys
 from textwrap import indent
 
@@ -46,10 +47,13 @@ def generate_gdbinit_rom_add_symbols(target: str) -> str:
     for i, k in enumerate(roms[target], 1):
         indent_str = base_ident * i
         rom_file = f'{target}_rev{k["rev"]}_rom.elf'
+        # GDB wants a POSIX path. posixpath.join inserts '/' even when
+        # ESP_ROM_ELF_DIR has no trailing separator (common on Windows).
+        rom_path = posixpath.join(rom_elfs_dir, rom_file)
         build_date_addr = int(k['build_date_str_addr'], base=16)
         r.append(indent(f'# if $_streq((char *) {hex(build_date_addr)}, "{k["build_date_str"]}")', indent_str))
         r.append(indent(get_rom_if_condition_str(build_date_addr, k['build_date_str']), indent_str))
-        r.append(indent(f'add-symbol-file {rom_elfs_dir}{rom_file}', indent_str + base_ident))
+        r.append(indent(f'add-symbol-file {rom_path}', indent_str + base_ident))
         r.append(indent('else', indent_str))
         if i == len(roms[target]):
             # In case no one known ROM ELF fits - print warning

--- a/components/esp_rom/test_esp_rom.py
+++ b/components/esp_rom/test_esp_rom.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
+import importlib.util
 import json
 import os
 
@@ -54,3 +55,36 @@ def test_roms_validate_build_date() -> None:
             build_date_str = get_string_from_elf_by_addr(rom_file, int(k['build_date_str_addr'], base=16))
             assert len(build_date_str) == 11
             assert build_date_str == k['build_date_str']
+
+
+def test_gen_gdbinit_joins_rom_elf_dir() -> None:
+    module_path = os.path.join(os.path.dirname(ROMS_JSON), 'gen_gdbinit.py')
+    spec = importlib.util.spec_from_file_location('gen_gdbinit', module_path)
+    assert spec is not None and spec.loader is not None
+    gen_gdbinit = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gen_gdbinit)
+
+    rom_dir = '/tmp/esp-rom-elfs/20241011'
+    old = os.environ.get('ESP_ROM_ELF_DIR')
+    os.environ['ESP_ROM_ELF_DIR'] = rom_dir
+    try:
+        out = gen_gdbinit.generate_gdbinit_rom_add_symbols('esp32c3')
+    finally:
+        if old is None:
+            os.environ.pop('ESP_ROM_ELF_DIR', None)
+        else:
+            os.environ['ESP_ROM_ELF_DIR'] = old
+
+    assert f'add-symbol-file {rom_dir}/esp32c3_rev' in out
+    assert f'add-symbol-file {rom_dir}esp32c3_rev' not in out
+
+    os.environ['ESP_ROM_ELF_DIR'] = rom_dir + '/'
+    try:
+        out_slash = gen_gdbinit.generate_gdbinit_rom_add_symbols('esp32c3')
+    finally:
+        if old is None:
+            os.environ.pop('ESP_ROM_ELF_DIR', None)
+        else:
+            os.environ['ESP_ROM_ELF_DIR'] = old
+
+    assert f'add-symbol-file {rom_dir}/esp32c3_rev' in out_slash


### PR DESCRIPTION
## Description

`components/esp_rom/gen_gdbinit.py` built `add-symbol-file` paths by concatenating `ESP_ROM_ELF_DIR` with the ROM ELF filename. The Windows export scripts do not always give that directory a trailing separator, so GDB was told to load:

```
C:/Espressif/tools/esp-rom-elfs/20241011esp32c3_rev101_rom.elf
```

instead of:

```
C:/Espressif/tools/esp-rom-elfs/20241011/esp32c3_rev101_rom.elf
```

Join with `posixpath.join` after the existing Windows-to-POSIX slash rewrite, matching the `os.path.join` already used in `test_esp_rom.py`. A trailing slash on `ESP_ROM_ELF_DIR` still produces a single separator.

Fixes #18418 (IDFGH-17465).

## Testing

- Reproduced the missing-separator path on Windows with `ESP_ROM_ELF_DIR=C:\Espressif\tools\esp-rom-elfs\20241011` and `generate_gdbinit_rom_add_symbols('esp32c3')`. Before: `.../20241011esp32c3_rev101_rom.elf`. After: `.../20241011/esp32c3_rev101_rom.elf`.
- Same generator with a trailing slash still emits `.../20241011/esp32c3_rev...`.
- Added `test_gen_gdbinit_joins_rom_elf_dir` in `components/esp_rom/test_esp_rom.py` (no compiler / ROM ELF files required).
- `ruff check` / `ruff format --check` on the two changed files: clean.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fix to GDB init path string generation in esp_rom tooling; no runtime firmware, auth, or data-handling impact.
> 
> **Overview**
> Fixes broken ROM ELF paths in generated GDB `add-symbol-file` commands when `ESP_ROM_ELF_DIR` has no trailing separator (typical on Windows), where the directory and filename were concatenated into a single invalid path.
> 
> **`gen_gdbinit.py`** now builds each ROM path with `posixpath.join` after the existing backslash-to-slash rewrite, so GDB always gets a POSIX path with a `/` between the directory and `*_rom.elf` filename; a trailing slash on the env var still works.
> 
> Adds **`test_gen_gdbinit_joins_rom_elf_dir`** to assert the generator emits joined paths and never the old concatenated form, with and without a trailing slash on `ESP_ROM_ELF_DIR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5faae5029abd8dd11510df81356cebb7a3fa8fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->