### PR TITLE
fix(ppa): decide engine idleness under the engine spinlock (IDFGH-18236)

### DIFF
--- a/components/esp_driver_ppa/src/ppa_core.c
+++ b/components/esp_driver_ppa/src/ppa_core.c
@@ -96,17 +96,14 @@ static esp_err_t ppa_engine_acquire(const ppa_engine_config_t *config, ppa_engin
     if (config->engine == PPA_ENGINE_TYPE_SRM) {
         if (!s_platform.srm) {
             ppa_srm_engine_t *srm_engine = heap_caps_calloc(1, sizeof(ppa_srm_engine_t), PPA_MEM_ALLOC_CAPS);
-            SemaphoreHandle_t srm_sem = xSemaphoreCreateBinaryWithCaps(PPA_MEM_ALLOC_CAPS);
             dma2d_descriptor_t *srm_tx_dma_desc = (dma2d_descriptor_t *)heap_caps_aligned_calloc(alignment, 1, s_platform.dma_desc_mem_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
             dma2d_descriptor_t *srm_rx_dma_desc = (dma2d_descriptor_t *)heap_caps_aligned_calloc(alignment, 1, s_platform.dma_desc_mem_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-            if (srm_engine && srm_sem && srm_tx_dma_desc && srm_rx_dma_desc) {
+            if (srm_engine && srm_tx_dma_desc && srm_rx_dma_desc) {
                 srm_engine->dma_tx_desc = srm_tx_dma_desc;
                 srm_engine->dma_rx_desc = srm_rx_dma_desc;
                 srm_engine->base.platform = &s_platform;
                 srm_engine->base.type = PPA_ENGINE_TYPE_SRM;
                 srm_engine->base.spinlock = (portMUX_TYPE)portMUX_INITIALIZER_UNLOCKED;
-                srm_engine->base.sem = srm_sem;
-                xSemaphoreGive(srm_engine->base.sem);
                 STAILQ_INIT(&srm_engine->base.trans_stailq);
                 s_platform.srm = srm_engine;
                 s_platform.srm_engine_ref_count++;
@@ -118,9 +115,6 @@ static esp_err_t ppa_engine_acquire(const ppa_engine_config_t *config, ppa_engin
                 ret = ESP_ERR_NO_MEM;
                 ESP_LOGE(TAG, "no mem to register PPA SRM engine");
                 free(srm_engine);
-                if (srm_sem) {
-                    vSemaphoreDeleteWithCaps(srm_sem);
-                }
                 free(srm_tx_dma_desc);
                 free(srm_rx_dma_desc);
             }
@@ -141,19 +135,16 @@ static esp_err_t ppa_engine_acquire(const ppa_engine_config_t *config, ppa_engin
     } else if (config->engine == PPA_ENGINE_TYPE_BLEND) {
         if (!s_platform.blending) {
             ppa_blend_engine_t *blending_engine = heap_caps_calloc(1, sizeof(ppa_blend_engine_t), PPA_MEM_ALLOC_CAPS);
-            SemaphoreHandle_t blending_sem = xSemaphoreCreateBinaryWithCaps(PPA_MEM_ALLOC_CAPS);
             dma2d_descriptor_t *blending_tx_bg_dma_desc = (dma2d_descriptor_t *)heap_caps_aligned_calloc(alignment, 1, s_platform.dma_desc_mem_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
             dma2d_descriptor_t *blending_tx_fg_dma_desc = (dma2d_descriptor_t *)heap_caps_aligned_calloc(alignment, 1, s_platform.dma_desc_mem_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
             dma2d_descriptor_t *blending_rx_dma_desc = (dma2d_descriptor_t *)heap_caps_aligned_calloc(alignment, 1, s_platform.dma_desc_mem_size, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-            if (blending_engine && blending_sem && blending_tx_bg_dma_desc && blending_tx_fg_dma_desc && blending_rx_dma_desc) {
+            if (blending_engine && blending_tx_bg_dma_desc && blending_tx_fg_dma_desc && blending_rx_dma_desc) {
                 blending_engine->dma_tx_bg_desc = blending_tx_bg_dma_desc;
                 blending_engine->dma_tx_fg_desc = blending_tx_fg_dma_desc;
                 blending_engine->dma_rx_desc = blending_rx_dma_desc;
                 blending_engine->base.platform = &s_platform;
                 blending_engine->base.type = PPA_ENGINE_TYPE_BLEND;
                 blending_engine->base.spinlock = (portMUX_TYPE)portMUX_INITIALIZER_UNLOCKED;
-                blending_engine->base.sem = blending_sem;
-                xSemaphoreGive(blending_engine->base.sem);
                 STAILQ_INIT(&blending_engine->base.trans_stailq);
                 s_platform.blending = blending_engine;
                 s_platform.blend_engine_ref_count++;
@@ -162,9 +153,6 @@ static esp_err_t ppa_engine_acquire(const ppa_engine_config_t *config, ppa_engin
                 ret = ESP_ERR_NO_MEM;
                 ESP_LOGE(TAG, "no mem to register PPA Blending engine");
                 free(blending_engine);
-                if (blending_sem) {
-                    vSemaphoreDeleteWithCaps(blending_sem);
-                }
                 free(blending_tx_bg_dma_desc);
                 free(blending_tx_fg_dma_desc);
                 free(blending_rx_dma_desc);
@@ -267,7 +255,6 @@ static esp_err_t ppa_engine_release(ppa_engine_t *ppa_engine)
             s_platform.srm = NULL;
             free(srm_engine->dma_tx_desc);
             free(srm_engine->dma_rx_desc);
-            vSemaphoreDeleteWithCaps(srm_engine->base.sem);
 #if CONFIG_PM_ENABLE
             if (srm_engine->base.pm_lock) {
                 ret = esp_pm_lock_delete(srm_engine->base.pm_lock);
@@ -286,7 +273,6 @@ static esp_err_t ppa_engine_release(ppa_engine_t *ppa_engine)
             free(blending_engine->dma_tx_bg_desc);
             free(blending_engine->dma_tx_fg_desc);
             free(blending_engine->dma_rx_desc);
-            vSemaphoreDeleteWithCaps(blending_engine->base.sem);
 #if CONFIG_PM_ENABLE
             if (blending_engine->base.pm_lock) {
                 ret = esp_pm_lock_delete(blending_engine->base.pm_lock);
@@ -485,51 +471,51 @@ esp_err_t ppa_do_operation(ppa_client_handle_t ppa_client, ppa_engine_t *ppa_eng
 {
     esp_err_t ret = ESP_OK;
     esp_err_t pm_lock_ret __attribute__((unused));
+    bool start_now = false;
 
+    if (mode == PPA_TRANS_MODE_BLOCKING) {
+        // A recycled transaction element may still hold the give from a previous
+        // non-blocking use (the ISR gives it unconditionally and nobody took it);
+        // clear it, or the wait below returns before this transaction has finished
+        xSemaphoreTake(trans_elm->sem, 0);
+    }
+
+    // Send transaction into PPA engine queue. Whether it starts now or is chained
+    // by the ISR is decided under the engine spinlock, together with the insert:
+    // the ISR makes the matching "queue empty -> engine idle" decision under the
+    // same lock, so a submission from another core cannot slip in between the
+    // ISR's decision and the engine becoming idle (see ppa_transaction_done_cb)
     portENTER_CRITICAL(&ppa_client->spinlock);
-    // Send transaction into PPA engine queue
     portENTER_CRITICAL(&ppa_engine_base->spinlock);
     STAILQ_INSERT_TAIL(&ppa_engine_base->trans_stailq, trans_elm, entry);
+    if (!ppa_engine_base->busy) {
+        ppa_engine_base->busy = true;
+        start_now = true;
+    }
     portEXIT_CRITICAL(&ppa_engine_base->spinlock);
     ppa_client->trans_cnt++;
     portEXIT_CRITICAL(&ppa_client->spinlock);
 
-    TickType_t ticks_to_wait = (mode == PPA_TRANS_MODE_NON_BLOCKING) ? 0 : portMAX_DELAY;
-    if (xSemaphoreTake(ppa_engine_base->sem, ticks_to_wait) == pdTRUE) {
-        // Check if the transaction has already been started from the ISR
-        // If so, then the transaction should have been removed from queue at this moment (transaction completed)
-        bool found = false;
-        ppa_trans_t *temp = NULL;
-        portENTER_CRITICAL(&ppa_engine_base->spinlock);
-        STAILQ_FOREACH(temp, &ppa_engine_base->trans_stailq, entry) {
-            if (temp == trans_elm) {
-                found = true;
-                break;
-            }
-        }
-        portEXIT_CRITICAL(&ppa_engine_base->spinlock);
-        if (found) {
+    if (start_now) {
+        // The engine was idle, so the queue held nothing but this transaction
 #if CONFIG_PM_ENABLE
-            pm_lock_ret = esp_pm_lock_acquire(ppa_engine_base->pm_lock);
-            assert((pm_lock_ret == ESP_OK) && "acquire pm_lock failed");
+        pm_lock_ret = esp_pm_lock_acquire(ppa_engine_base->pm_lock);
+        assert((pm_lock_ret == ESP_OK) && "acquire pm_lock failed");
 #endif
-            ret = ppa_dma2d_enqueue(trans_elm);
-            if (ret != ESP_OK) {
-                portENTER_CRITICAL(&ppa_engine_base->spinlock);
-                STAILQ_REMOVE(&ppa_engine_base->trans_stailq, trans_elm, ppa_trans_s, entry);
-                portEXIT_CRITICAL(&ppa_engine_base->spinlock);
-                xSemaphoreGive(ppa_engine_base->sem);
+        ret = ppa_dma2d_enqueue(trans_elm);
+        if (ret != ESP_OK) {
+            portENTER_CRITICAL(&ppa_engine_base->spinlock);
+            STAILQ_REMOVE(&ppa_engine_base->trans_stailq, trans_elm, ppa_trans_s, entry);
+            ppa_engine_base->busy = false;
+            portEXIT_CRITICAL(&ppa_engine_base->spinlock);
 #if CONFIG_PM_ENABLE
-                pm_lock_ret = esp_pm_lock_release(ppa_engine_base->pm_lock);
-                assert((pm_lock_ret == ESP_OK) && "release pm_lock failed");
+            pm_lock_ret = esp_pm_lock_release(ppa_engine_base->pm_lock);
+            assert((pm_lock_ret == ESP_OK) && "release pm_lock failed");
 #endif
-                portENTER_CRITICAL(&ppa_client->spinlock);
-                ppa_client->trans_cnt--;
-                portEXIT_CRITICAL(&ppa_client->spinlock);
-                goto err;
-            }
-        } else {
-            xSemaphoreGive(ppa_engine_base->sem);
+            portENTER_CRITICAL(&ppa_client->spinlock);
+            ppa_client->trans_cnt--;
+            portEXIT_CRITICAL(&ppa_client->spinlock);
+            goto err;
         }
     }
 
@@ -558,6 +544,11 @@ bool ppa_transaction_done_cb(dma2d_channel_handle_t dma2d_chan, dma2d_event_data
     // Remove this transaction from transaction queue
     STAILQ_REMOVE(&engine_base->trans_stailq, trans_elm, ppa_trans_s, entry);
     next_start_trans = STAILQ_FIRST(&engine_base->trans_stailq);
+    if (!next_start_trans) {
+        // Nothing queued: the engine goes idle HERE, under the same lock a
+        // submitting task takes to insert and check (ppa_do_operation)
+        engine_base->busy = false;
+    }
     portEXIT_CRITICAL_ISR(&engine_base->spinlock);
 
     portENTER_CRITICAL_ISR(&client->spinlock);
@@ -571,12 +562,10 @@ bool ppa_transaction_done_cb(dma2d_channel_handle_t dma2d_chan, dma2d_event_data
     client->trans_cnt--;
     portEXIT_CRITICAL_ISR(&client->spinlock);
 
-    // If there is next trans in PPA engine queue, send it to DMA queue; otherwise, release the engine semaphore
+    // If there is next trans in PPA engine queue, send it to DMA queue; otherwise the engine is idle (flag cleared above)
     if (next_start_trans) {
         ppa_dma2d_enqueue(next_start_trans);
     } else {
-        xSemaphoreGiveFromISR(engine_base->sem, &HPTaskAwoken);
-        need_yield |= (HPTaskAwoken == pdTRUE);
 #if CONFIG_PM_ENABLE
         esp_err_t pm_lock_ret = esp_pm_lock_release(engine_base->pm_lock);
         assert(pm_lock_ret == ESP_OK);

--- a/components/esp_driver_ppa/src/ppa_priv.h
+++ b/components/esp_driver_ppa/src/ppa_priv.h
@@ -62,7 +62,7 @@ struct ppa_engine_t {
     ppa_platform_t *platform;                     // PPA driver platform
     ppa_engine_type_t type;                       // Type of the PPA engine
     portMUX_TYPE spinlock;                        // Engine level spinlock
-    SemaphoreHandle_t sem;                        // Semaphore for whether the engine is processing a transaction
+    bool busy;                                    // Whether the engine has a transaction running or queued; only read/written under `spinlock`
     STAILQ_HEAD(trans, ppa_trans_s) trans_stailq; // link head of pending transactions for the PPA engine
 #if CONFIG_PM_ENABLE
     esp_pm_lock_handle_t pm_lock;                 // Power management lock


### PR DESCRIPTION

## Summary

`esp_driver_ppa` can strand a queued transaction when the submitting task runs on a different core from the PPA/2D-DMA interrupt. The engine's "idle" state is a binary semaphore that the completion ISR gives only *after* leaving the engine spinlock, while `ppa_do_operation` inserts its transaction under that spinlock and then tries the semaphore with a zero timeout. A task on the other core can insert between the ISR's "queue empty" decision and its give, find the semaphore still taken, assume the ISR will chain-start the transaction, and be left at the head of an idle engine's queue. It only starts when a later submission's completion picks it up. A lone last submission never completes, and a caller waiting on its done callback blocks forever.

On the ISR's own core the two steps cannot interleave, which is why single-core users never see it.

## Reproduction

ESP32-P4 (v1.3), IDF v5.5.5 and master. PPA/2D-DMA interrupt on core 0 (allocated where the client was registered). A core-1 task submits single SRM transactions (rotation 0, 480×40 RGB565, `PPA_TRANS_MODE_NON_BLOCKING`) spaced at the transaction's own measured duration ±60 µs, so that submissions land inside the completion interrupt, each tagged with its index in `user_data`; the `on_trans_done` callback counts completions that arrive out of index order and their latency.

| submitting task | before | after |
|---|---|---|
| core 1 | ~130 stranded per 20000 (completed out of order, ~3 durations late — only after the next submission ran) | 0 |
| core 0 | 0 | 0 |

In the original application (a two-core render pipeline: raster + PPA rotate on core 1, simulation on core 0) the last strip rotate of a frame was stranded about once a minute and the frame loop deadlocked on its completion.

## Fix

Replace the engine semaphore with a `busy` flag that both sides read and write only under the engine spinlock. The submitter inserts and, if the engine is idle, marks it busy and starts the transaction itself; the ISR clears the flag in the same critical section in which it finds the queue empty. Behaviour is otherwise unchanged: at most one transaction runs per engine, FIFO order, the ISR chains the next queued transaction.

Also in this commit: blocking mode clears a stale give on the recycled per-transaction semaphore. The ISR gives `trans_elm->sem` unconditionally and non-blocking callers never take it, so a later blocking operation on a recycled element returned before its transaction had finished.

## Notes

Possibly related open reports, though they look like different mechanisms: #19023 (blocking SRM call never returns under DSI scan-out for some 270° geometries) and #18999 (`dma2d_connect` reset-bit hang under sustained load).

I have signed the contributor agreement / will sign when prompted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PPA transaction scheduling and synchronization across cores; incorrect locking could still strand ops or affect PM lock lifetime, though the fix is narrowly scoped to engine idle detection.
> 
> **Overview**
> Fixes a **multi-core race** where non-blocking PPA submissions from a different core than the completion ISR could leave a transaction at the head of an **idle** engine queue (never started until a later submission), including possible **permanent deadlock** on the last transaction of a frame.
> 
> **Engine scheduling** no longer uses a per-engine binary semaphore. `ppa_engine_t` now has a **`busy` flag** updated only under the engine spinlock: `ppa_do_operation` enqueues, sets `busy` and kicks DMA when the engine was idle; `ppa_transaction_done_cb` clears `busy` in the same critical section when the queue becomes empty (instead of giving the semaphore after releasing the lock). PM lock behavior when the queue drains is unchanged.
> 
> **Blocking mode**: before waiting on the per-transaction semaphore, the driver **drains a stale give** on recycled transaction elements (ISR always gives; non-blocking callers never take).
> 
> SRM/blend engine registration teardown no longer allocates or frees the removed engine semaphores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15abeb729a291ebfae26bccb22cb6191ab044e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->