### PR TITLE
feat(mac): format utilties for OUI

### DIFF
--- a/components/esp_hw_support/include/esp_mac.h
+++ b/components/esp_hw_support/include/esp_mac.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,11 @@
 #ifndef MAC2STR
 #define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
 #define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
+#endif
+
+#ifndef MAC2OUI
+#define MAC2OUI(a) (a)[0], (a)[1], (a)[2]
+#define MACOUI "%02x:%02x:%02x"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

Provide a simple way to format an ESP-MAC as an Organizationally unique identifier(OUI).

An OUI often reflects the hardware manufacturer of a specific Network Interface Controller(NIC), without identifying any specific NIC.


## Related

A device MAC address often falls under GDPR personal data, a BSSID might, but an OUI almost never does.

Make OUI formatting as simple as MAC formatting to improve data minimization(EU CRA Annex I, 2G), see also #18709

## Testing

I formatted some MACs and OUIs, and verified I could still [lookup access points with only OUI](https://www.wireshark.org/tools/oui-lookup.html).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Code is well-commented, especially in complex areas. (It's rather simple)
- [X] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive header macros with no behavior change to MAC APIs; same low-risk surface as the existing MAC2STR helpers.
> 
> **Overview**
> Adds **OUI formatting helpers** in `esp_mac.h`, mirroring the existing `MAC2STR` / `MACSTR` pattern so callers can print only the first three octets of a MAC (e.g. `printf(MACOUI, MAC2OUI(mac))`).
> 
> The block is wrapped in `#ifndef MAC2OUI` to avoid clashes if another header already defines the same names. The SPDX copyright range is updated to 2021–2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76bceb1964de5fa73ef06cfd80a49be2579ba1be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->