### PR TITLE
fix(tcp_transport): clear stale TLS client session (IDFGH-18254)

### DIFF
--- a/components/tcp_transport/host_test/main/CMakeLists.txt
+++ b/components/tcp_transport/host_test/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "test_socks_transport.cpp" "test_websocket_transport.cpp"
+idf_component_register(SRCS "test_socks_transport.cpp" "test_ssl_transport.cpp" "test_websocket_transport.cpp"
                         REQUIRES tcp_transport mocked_transport
                         INCLUDE_DIRS "$ENV{IDF_PATH}/tools"
                         WHOLE_ARCHIVE)
@@ -7,6 +7,9 @@ idf_component_get_property(lwip_component lwip COMPONENT_LIB)
 idf_component_get_property(esp_timer_component esp_timer COMPONENT_LIB)
 idf_component_get_property(tcp_transport_component tcp_transport COMPONENT_LIB)
 target_link_libraries(${tcp_transport_component} PUBLIC ${lwip_component} ${esp_timer_component})
+idf_component_get_property(esp_tls_component esp-tls COMPONENT_LIB)
+# The mocked esp-tls component does not expose the session ticket Kconfig option.
+target_compile_definitions(${esp_tls_component} PUBLIC CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS=1)
 target_compile_options(${COMPONENT_LIB} PUBLIC -fsanitize=address -fconcepts)
 target_link_options(${COMPONENT_LIB} PUBLIC -fsanitize=address)
 

--- a/components/tcp_transport/host_test/main/test_ssl_transport.cpp
+++ b/components/tcp_transport/host_test/main/test_ssl_transport.cpp
@@ -21,17 +21,26 @@ namespace {
 esp_tls_client_session_t saved_session{};
 esp_tls_client_session_t *session_to_save;
 esp_tls_t *fake_tls = reinterpret_cast<esp_tls_t *>(&saved_session);
+bool connect_called;
+bool connect_config_present;
+esp_tls_client_session_t *connected_session;
+esp_tls_t *connected_tls;
 
 int connect_callback(const char *, int, int, const esp_tls_cfg_t *cfg, esp_tls_t *tls, int)
 {
-    REQUIRE(cfg != nullptr);
-    REQUIRE(cfg->client_session == nullptr);
-    REQUIRE(tls == fake_tls);
+    connect_called = true;
+    connect_config_present = cfg != nullptr;
+    connected_session = cfg ? cfg->client_session : nullptr;
+    connected_tls = tls;
     return -1;
 }
 
-void expect_connect_without_client_session(esp_transport_handle_t transport)
+void expect_connect_with_client_session(esp_transport_handle_t transport, esp_tls_client_session_t *expected_session)
 {
+    connect_called = false;
+    connect_config_present = false;
+    connected_session = nullptr;
+    connected_tls = nullptr;
     esp_tls_init_ExpectAndReturn(fake_tls);
     esp_tls_conn_new_sync_Stub(connect_callback);
     esp_tls_get_error_handle_ExpectAnyArgsAndReturn(ESP_FAIL);
@@ -39,6 +48,10 @@ void expect_connect_without_client_session(esp_transport_handle_t transport)
 
     REQUIRE(esp_transport_connect(transport, "localhost", 443, 100) == -1);
     Mockesp_tls_Verify();
+    REQUIRE(connect_called);
+    REQUIRE(connect_config_present);
+    REQUIRE(connected_session == expected_session);
+    REQUIRE(connected_tls == fake_tls);
 }
 
 } // namespace
@@ -54,7 +67,7 @@ extern "C" void esp_tls_free_client_session(esp_tls_client_session_t *)
 {
 }
 
-TEST_CASE("TLS session ticket operations clear the configured client session", "[tcp_transport][tls]")
+TEST_CASE("TLS session ticket operations update the configured client session", "[tcp_transport][tls]")
 {
     Mockesp_tls_Init();
     session_to_save = &saved_session;
@@ -63,6 +76,11 @@ TEST_CASE("TLS session ticket operations clear the configured client session", "
 
     REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_SAVE) == ESP_OK);
     REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_USE) == ESP_OK);
+    esp_tls_client_session_t *expected_session = nullptr;
+
+    SECTION("when the saved session is used") {
+        expected_session = &saved_session;
+    }
 
     SECTION("when saving the replacement session fails") {
         REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_SAVE) == ESP_OK);
@@ -78,5 +96,5 @@ TEST_CASE("TLS session ticket operations clear the configured client session", "
         REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_FREE) == ESP_OK);
     }
 
-    expect_connect_without_client_session(transport.get());
+    expect_connect_with_client_session(transport.get(), expected_session);
 }

--- a/components/tcp_transport/host_test/main/test_ssl_transport.cpp
+++ b/components/tcp_transport/host_test/main/test_ssl_transport.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <memory>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+
+extern "C" {
+#include "Mockesp_tls.h"
+#include "esp_transport.h"
+#include "esp_transport_ssl.h"
+}
+
+using unique_transport = std::unique_ptr<std::remove_pointer_t<esp_transport_handle_t>, decltype(&esp_transport_destroy)>;
+
+namespace {
+
+esp_tls_client_session_t saved_session{};
+esp_tls_client_session_t *session_to_save;
+esp_tls_t *fake_tls = reinterpret_cast<esp_tls_t *>(&saved_session);
+
+int connect_callback(const char *, int, int, const esp_tls_cfg_t *cfg, esp_tls_t *tls, int)
+{
+    REQUIRE(cfg != nullptr);
+    REQUIRE(cfg->client_session == nullptr);
+    REQUIRE(tls == fake_tls);
+    return -1;
+}
+
+void expect_connect_without_client_session(esp_transport_handle_t transport)
+{
+    esp_tls_init_ExpectAndReturn(fake_tls);
+    esp_tls_conn_new_sync_Stub(connect_callback);
+    esp_tls_get_error_handle_ExpectAnyArgsAndReturn(ESP_FAIL);
+    esp_tls_conn_destroy_ExpectAndReturn(fake_tls, 0);
+
+    REQUIRE(esp_transport_connect(transport, "localhost", 443, 100) == -1);
+    Mockesp_tls_Verify();
+}
+
+} // namespace
+
+extern "C" esp_tls_client_session_t *esp_tls_get_client_session(esp_tls_t *)
+{
+    esp_tls_client_session_t *session = session_to_save;
+    session_to_save = nullptr;
+    return session;
+}
+
+extern "C" void esp_tls_free_client_session(esp_tls_client_session_t *)
+{
+}
+
+TEST_CASE("TLS session ticket operations clear the configured client session", "[tcp_transport][tls]")
+{
+    Mockesp_tls_Init();
+    session_to_save = &saved_session;
+    unique_transport transport{esp_transport_ssl_init(), esp_transport_destroy};
+    REQUIRE(transport);
+
+    REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_SAVE) == ESP_OK);
+    REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_USE) == ESP_OK);
+
+    SECTION("when saving the replacement session fails") {
+        REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_SAVE) == ESP_OK);
+        SECTION("when attempting to use the missing replacement") {
+            REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_USE) == ESP_ERR_INVALID_STATE);
+        }
+        SECTION("without attempting to use the missing replacement") {
+            // SAVE must clear the configured session without relying on USE.
+        }
+    }
+
+    SECTION("when the saved session is freed") {
+        REQUIRE(esp_transport_ssl_session_ticket_operation(transport.get(), ESP_TRANSPORT_SESSION_TICKET_FREE) == ESP_OK);
+    }
+
+    expect_connect_without_client_session(transport.get());
+}

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -679,16 +679,19 @@ esp_err_t esp_transport_ssl_session_ticket_operation(esp_transport_handle_t t, e
             break;
         case ESP_TRANSPORT_SESSION_TICKET_SAVE:
             esp_tls_free_client_session(ssl->session_ticket);
+            ssl->cfg.client_session = NULL;
             ssl->session_ticket = esp_tls_get_client_session(ssl->tls);
             break;
         case ESP_TRANSPORT_SESSION_TICKET_USE:
             if (ssl->session_ticket == NULL) {
+                ssl->cfg.client_session = NULL;
                 return ESP_ERR_INVALID_STATE;
             }
             ssl->cfg.client_session = ssl->session_ticket;
             break;
         case ESP_TRANSPORT_SESSION_TICKET_FREE:
             esp_tls_free_client_session(ssl->session_ticket);
+            ssl->cfg.client_session = NULL;
             ssl->session_ticket = NULL;
             break;
     }

--- a/tools/mocks/esp-tls/mock/mock_config.yaml
+++ b/tools/mocks/esp-tls/mock/mock_config.yaml
@@ -1,6 +1,7 @@
 
 :cmock:
   :plugins:
+    - callback
     - expect
     - expect_any_args
     - return_thru_ptr


### PR DESCRIPTION
## Summary

Clear `cfg.client_session` when a saved TLS session is freed or replaced, and when `USE` finds no saved session.

A previous `USE` can publish a session pointer into the connection configuration. If a subsequent `SAVE` frees that session but fails to obtain a replacement, the configuration retains the freed pointer. The next connection can then dereference it during the TLS handshake. Explicit `FREE` has the same stale-pointer problem.

Add a Catch2 regression test that inspects the configuration passed to the next TLS connection after:
- a failed replacement `SAVE`, both with and without a subsequent `USE`;
- an explicit `FREE`.

Enable CMock callbacks for the ESP-TLS mock and propagate the session-ticket definition from that mock component so the mock, transport, and test use the same configuration layout.

Fixes #19033.

## Validation

- Full ESP32 build of `components/tcp_transport/test_apps` with `CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS=y`: passed (710 build steps). No hardware execution was performed.
- Host-test CMake configuration: passed; verified the session-ticket definition is present for the ESP-TLS mock, transport, and new test.
- Generated the actual ESP-TLS mocks with the repository's CMock generator and compiled the new C++ test translation unit against the generated header: passed (MinGW, with a local BSD-header shim). This is a compile-only check, not execution of the Linux test suite.
- Applicable pre-commit checks: passed except the stock error-code registration hook, which reports Windows backslash paths as unregistered against CMake forward-slash paths. Re-running that check with in-memory path normalization passed; its source was not changed by this PR.
- The Linux Catch2/ASan host-test suite was not run: this environment is Windows without a usable Linux runtime. Linux CI validation is still needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS session-ticket handling so connection config no longer retains freed session pointers; limited scope but affects handshake configuration on reconnect.
> 
> **Overview**
> Fixes a **stale `client_session` pointer** in the SSL transport when TLS session tickets are saved, used, or freed. After `USE`, `cfg.client_session` could still reference memory that `SAVE` or `FREE` had already released (including when a replacement `SAVE` fails to obtain a new session), so the next connect could pass a dangling pointer into the TLS handshake.
> 
> **`esp_transport_ssl_session_ticket_operation`** now sets `ssl->cfg.client_session` to `NULL` on `SAVE` (before replacing the ticket), on failed `USE` (no saved ticket), and on `FREE`.
> 
> Adds a **Catch2 host test** (`test_ssl_transport.cpp`) that stubs `esp_tls_conn_new_sync` and asserts the `esp_tls_cfg_t` passed on the next connect matches the expected session pointer for normal use, failed replacement save, explicit free, and save-without-use paths. Host-test **CMake** registers the new test and defines `CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS=1` on the mocked `esp-tls` component; the **ESP-TLS CMock** config enables the **callback** plugin for connect stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931a886e780bdcaebbbf3b392aa75b6bfdd4c19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->