### PR TITLE
lwip: fix dhcpserver.c build with DHCPS_DEBUG=1 (%x vs u32_t) (IDFGH-18269)

### DIFF
--- a/components/lwip/apps/dhcpserver/dhcpserver.c
+++ b/components/lwip/apps/dhcpserver/dhcpserver.c
@@ -5,6 +5,7 @@
  */
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <assert.h>
 #include "lwip/dhcp.h"
@@ -1320,7 +1321,7 @@ POOL_CHECK:
 
 #if DHCPS_DEBUG
         DHCPS_LOG("dhcps: xid changed\n");
-        DHCPS_LOG("dhcps: client_address.addr = %x\n", dhcps->client_address.addr);
+        DHCPS_LOG("dhcps: client_address.addr = %" PRIx32 "\n", dhcps->client_address.addr);
 #endif
         return ret;
     }


### PR DESCRIPTION
## Description



DHCPS_LOG("dhcps: client_address.addr = %x\n", dhcps->client_address.addr) passes a u32_t to a %x conversion. uint32_t is `long unsigned int` on every ESP toolchain (riscv32-esp-elf, xtensa-esp32-elf, xtensa-esp32s3-elf), and IDF appends -Werror by default (tools/cmake/build.cmake), so the component fails to build as soon as DHCPS_DEBUG is set to 1:

  dhcpserver.c: In function 'parse_msg':
  dhcpserver.c: error: format '%x' expects argument of type 'unsigned int',
  but argument 2 has type 'u32_t' {aka 'long unsigned int'} [-Werror=format=]

Use PRIx32, matching the convention already used elsewhere in components/lwip (apps/ping/ping_sock.c). The debug path is off by default, which is why this has gone unnoticed; every other DHCPS_LOG call in the file is int-compatible, so this one line is the only blocker.

Reproduced and fix-verified on v6.0.1-7-g2b900d1222 (esp32c6 and esp32s3 both fail to build with DHCPS_DEBUG=1 before the change and build clean after); the same unchanged line is present on master.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
https://github.com/tyeth/esp-idf/issues/1
<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

https://github.com/tyeth/esp-idf/issues/1

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

See https://github.com/tyeth/esp-idf/issues/1

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ x] 🚨 This PR does not introduce breaking changes.
- [ x] All CI checks (GH Actions) pass. [hopefully]
- [ x] Documentation is updated as needed.
- [ x] Tests are updated or added as necessary.
- [ x] Code is well-commented, especially in complex areas.
- [ x] Git history is clean — commits are squashed to the minimum necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only printf format fix with no change to DHCP server logic or default (non-debug) builds.
> 
> **Overview**
> Fixes a **build break when `DHCPS_DEBUG` is enabled** in the lwIP DHCP server: a debug log in `parse_msg` printed `client_address.addr` with `%x` while the value is `u32_t` (`long unsigned int` on ESP-IDF toolchains), which triggers `-Werror=format` under default IDF builds.
> 
> The change adds `#include <inttypes.h>` and uses `%" PRIx32 "` for that log line, consistent with other lwIP code. **Runtime DHCP behavior is unchanged**; only the optional debug path is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462700efb82a9eab3fec9226cbcf7a9e2ee64d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->