### PR TITLE
fix(twai): Skip RX pullup on input-only pads

### DIFF
--- a/components/esp_driver_twai/esp_twai_onchip.c
+++ b/components/esp_driver_twai/esp_twai_onchip.c
@@ -116,7 +116,9 @@ static esp_err_t _node_config_io(twai_onchip_ctx_t *node, const twai_onchip_node
 
     uint64_t reserve_mask = 0;
     // Set RX pin
-    gpio_set_pull_mode(node_config->io_cfg.rx, GPIO_PULLUP_ONLY);    // pullup to avoid noise if no connection to transceiver
+    if (GPIO_IS_VALID_OUTPUT_GPIO(node_config->io_cfg.rx)) {
+        gpio_set_pull_mode(node_config->io_cfg.rx, GPIO_PULLUP_ONLY);    // pullup (if possible) to avoid noise if no connection to transceiver
+    }
     gpio_matrix_input(node_config->io_cfg.rx, twai_periph_signals[node->ctrlr_id].rx_sig, false);
 
     // Set TX pin


### PR DESCRIPTION
Input-only pads (e.g. ESP32 GPIO 34-39) have no internal pullup, so the unconditional `gpio_set_pull_mode` in `_node_config_io` fails on every TWAI node init when RX is on such a pad and prints:

```
E (1947) gpio: gpio_pullup_en(89): GPIO number error (input-only pad has no internal PU)
```

The failure is harmless, so just guard the call with `GPIO_IS_VALID_OUTPUT_GPIO`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GPIO setup guard in TWAI driver init; no change to RX signal routing or TWAI protocol behavior.
> 
> **Overview**
> **TWAI on-chip RX GPIO init** no longer always enables an internal pull-up on the RX pin during `_node_config_io`.
> 
> `gpio_set_pull_mode(..., GPIO_PULLUP_ONLY)` is now called only when `GPIO_IS_VALID_OUTPUT_GPIO(rx)` is true, so input-only pads (e.g. ESP32 GPIO 34–39) skip pull configuration. **Matrix routing for RX is unchanged** — `gpio_matrix_input` still runs for any valid RX GPIO.
> 
> This removes the harmless but noisy `gpio_pullup_en: GPIO number error (input-only pad has no internal PU)` log on every node init when TWAI RX is wired to an input-only pad.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae020275e074a6c3da3fce4ebf5a8ffb5a25c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
