### PR TITLE
fix(ledc): wait for a pending duty update before reconfiguring a channel on ESP32

### DIFF
--- a/components/esp_driver_ledc/include/driver/ledc.h
+++ b/components/esp_driver_ledc/include/driver/ledc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -526,8 +526,9 @@ esp_err_t ledc_fade_stop(ledc_mode_t speed_mode, ledc_channel_t channel);
 #endif //SOC_LEDC_SUPPORT_FADE_STOP
 
 /**
- * @brief A thread-safe API to set duty for LEDC channel and return when duty updated.
+ * @brief A thread-safe API to set duty for LEDC channel and update it.
  *
+ * @note  The new duty takes effect from the next PWM cycle, see ledc_update_duty().
  * @note  For ESP32, hardware does not support any duty change while a fade operation is running in progress on that channel.
  *        Other duty operations will have to wait until the fade operation has finished.
  *

--- a/components/esp_driver_ledc/src/ledc.c
+++ b/components/esp_driver_ledc/src/ledc.c
@@ -181,6 +181,12 @@ static void _ledc_fade_hw_acquire(ledc_mode_t mode, ledc_channel_t channel)
     ledc_fade_t *fade = s_ledc_fade_rec[mode][channel];
     if (fade) {
         xSemaphoreTake(fade->ledc_fade_sem, portMAX_DELAY);
+#if !SOC_LEDC_SUPPORT_FADE_STOP
+        // Reconfiguring a channel while its last duty update is still pending corrupts that update
+        while (ledc_ll_get_duty_start(p_ledc_obj[mode]->ledc_hal.dev, mode, channel)) {
+            vTaskDelay(1);
+        }
+#endif
         portENTER_CRITICAL(&ledc_spinlock);
         ledc_ll_enable_interrupt(p_ledc_obj[mode]->ledc_hal.dev, LEDC_LL_EVENT_CHANNEL_DUTY_CHANGE_END(mode, channel), false);
         portEXIT_CRITICAL(&ledc_spinlock);

--- a/components/esp_driver_ledc/test_apps/ledc/main/test_ledc.cpp
+++ b/components/esp_driver_ledc/test_apps/ledc/main/test_ledc.cpp
@@ -385,6 +385,50 @@ TEST_CASE("LEDC fast switching duty with fade_no_wait", "[ledc]")
     fade_teardown();
 }
 
+#if !SOC_LEDC_SUPPORT_FADE_STOP
+static void fade_after_duty_update_test(ledc_mode_t speed_mode, bool thread_safe_update)
+{
+    ledc_channel_config_t ledc_ch_config = initialize_channel_config();
+    ledc_ch_config.speed_mode = speed_mode;
+    ledc_ch_config.duty = 0;
+    ledc_timer_config_t ledc_time_config = create_default_timer_config();
+    ledc_time_config.speed_mode = speed_mode;
+    TEST_ESP_OK(ledc_timer_config(&ledc_time_config));
+    TEST_ESP_OK(ledc_channel_config(&ledc_ch_config));
+    TEST_ESP_OK(ledc_fade_func_install(0));
+
+    TEST_ESP_OK(ledc_set_duty_and_update(speed_mode, LEDC_CHANNEL_0, 4000, 0));
+    vTaskDelay(5 / portTICK_PERIOD_MS);
+    if (thread_safe_update) {
+        TEST_ESP_OK(ledc_set_duty_and_update(speed_mode, LEDC_CHANNEL_0, 0, 0));
+    } else {
+        TEST_ESP_OK(ledc_set_duty(speed_mode, LEDC_CHANNEL_0, 0));
+        TEST_ESP_OK(ledc_update_duty(speed_mode, LEDC_CHANNEL_0));
+    }
+
+    int64_t fade_start = esp_timer_get_time();
+    TEST_ESP_OK(ledc_set_fade_time_and_start(speed_mode, LEDC_CHANNEL_0, 3000, 200, LEDC_FADE_NO_WAIT));
+    TEST_ASSERT_LESS_THAN(20000, esp_timer_get_time() - fade_start);
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+    TEST_ASSERT_INT32_WITHIN(300, 1500, ledc_get_duty(speed_mode, LEDC_CHANNEL_0));
+    vTaskDelay(150 / portTICK_PERIOD_MS);
+    TEST_ASSERT_EQUAL_INT32(3000, ledc_get_duty(speed_mode, LEDC_CHANNEL_0));
+
+    ledc_fade_func_uninstall();
+    ledc_ch_config.deconfigure = true;
+    TEST_ESP_OK(ledc_channel_config(&ledc_ch_config));
+}
+
+TEST_CASE("LEDC fade started right after duty update", "[ledc]")
+{
+    ledc_mode_t speed_mode_list[LEDC_SPEED_MODE_MAX] = SPEED_MODE_LIST;
+    for (int i = 0; i < LEDC_SPEED_MODE_MAX; i++) {
+        fade_after_duty_update_test(speed_mode_list[i], true);
+        fade_after_duty_update_test(speed_mode_list[i], false);
+    }
+}
+#endif
+
 #if SOC_LEDC_SUPPORT_FADE_STOP
 TEST_CASE("LEDC fade stop test", "[ledc]")
 {

--- a/components/esp_hal_ledc/esp32/include/hal/ledc_ll.h
+++ b/components/esp_hal_ledc/esp32/include/hal/ledc_ll.h
@@ -573,6 +573,20 @@ static inline void ledc_ll_set_duty_start(ledc_dev_t *hw, ledc_mode_t speed_mode
 }
 
 /**
+ * @brief Get whether the last duty update or fade is still in progress
+ *
+ * @param hw Beginning address of the peripheral registers
+ * @param speed_mode LEDC speed_mode, high-speed mode or low-speed mode
+ * @param channel_num LEDC channel index (0-7), select from ledc_channel_t
+ *
+ * @return True if duty_start has not been self-cleared yet
+ */
+static inline bool ledc_ll_get_duty_start(ledc_dev_t *hw, ledc_mode_t speed_mode, ledc_channel_t channel_num)
+{
+    return hw->channel_group[speed_mode].channel[channel_num].conf1.duty_start;
+}
+
+/**
  * @brief Set output idle level
  *
  * @param hw Beginning address of the peripheral registers


### PR DESCRIPTION
## Description

On ESP32, `duty_start` stays set until a duty update or fade completes, and `ledc_ll_set_duty_start()` waits for it inside `ledc_spinlock`. The update started by `ledc_set_duty_and_update()`, `ledc_update_duty()` or `ledc_channel_config()` is still pending when they return, so a fade started right after one of them reads a stale duty, writes its fade parameters into the pending update, and then spins for the whole fade with interrupts disabled. Long enough fades trigger the interrupt watchdog.

The fade service now waits for a pending update to complete before reconfiguring the channel. The wait is ESP32 only, since the other targets allow reconfiguring while an update is in progress. An update started outside the fade service has no completion event to wait on (`ledc_update_duty()` and `ledc_channel_config()` take no semaphore and may run from an ISR), so it polls with `vTaskDelay(1)`, and only ever waits in the sequence that is broken today.

`ledc_set_duty_and_update()` behaviour is unchanged; its description no longer claims that it returns once the duty is updated.

This is the same pattern as #2082, which was originally fixed by making `ledc_set_duty_and_update()` wait for the update; e1750862264 later made it non-blocking again, and d87de032dfc turned the resulting corrupted update into a spin with interrupts disabled.

To reproduce on ESP32 (8-bit, 1 kHz, fade service installed):

```c
ledc_set_duty_and_update(MODE, CHANNEL, 200, 0);
vTaskDelay(pdMS_TO_TICKS(10));
ledc_set_duty_and_update(MODE, CHANNEL, 0, 0);
ledc_set_fade_time_and_start(MODE, CHANNEL, 255, 400, LEDC_FADE_NO_WAIT); // spins ~400 ms, then INT WDT
```

## Testing

Added `LEDC fade started right after duty update`, covering both speed modes and both routes (`ledc_set_duty_and_update()`, and `ledc_set_duty()` + `ledc_update_duty()`). On an ESP32 (rev v3.0) against v6.1 it fails without the change (the fade call blocked for 42.8 s) and passes with it.

Also passing with the change on the same board: set and get duty, fade with time, fade with step, fade install with low speed mode only, fast switching duty (fade_wait_done / fade_no_wait), output idle level, memory leak, iterate over all channel and timer configs, timer pause and resume. Builds for esp32s3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LEDC fade synchronization on ESP32 only; could add brief delays before fades but fixes a serious hang/WDT failure mode.
> 
> **Overview**
> Fixes an **ESP32-only** race where starting a fade immediately after `ledc_set_duty_and_update()`, `ledc_update_duty()`, or channel config could reconfigure hardware while `duty_start` was still set, corrupting the in-flight update and leaving the driver spinning with interrupts disabled (interrupt watchdog on long fades).
> 
> On targets without `SOC_LEDC_SUPPORT_FADE_STOP`, `_ledc_fade_hw_acquire()` now **polls** `ledc_ll_get_duty_start()` (new HAL helper) until the pending duty update completes before touching the channel. `ledc_set_duty_and_update()` behavior is unchanged; its docs now state duty applies on the **next PWM cycle** rather than implying the call blocks until updated.
> 
> Adds **`LEDC fade started right after duty update`** (both speed modes, thread-safe and split set/update paths) for ESP32-class targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d195e56f3c692cccf6d6aaa78279d4c4b0c7dba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->